### PR TITLE
feat: add edge of a line test case

### DIFF
--- a/packages/shared/src/operations.ts
+++ b/packages/shared/src/operations.ts
@@ -136,7 +136,7 @@ export function handleKeyDown(
       return false;
     }
     // if cursor is at the edge of a block, it may out of the textContainer after keydown
-    if (checkIfEdgeOfALine(range)) {
+    if (isAtLineEdge(range)) {
       const {
         height,
         left,

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -8,6 +8,7 @@ import {
   pressEnter,
   shiftTab,
   getCursorBlockIdAndHeight,
+  fillLine,
 } from './utils/actions';
 import { assertSelectedBlockCount } from './utils/asserts';
 import { expect } from '@playwright/test';
@@ -116,12 +117,7 @@ test('cursor move up at edge of the second line', async ({ page }) => {
   await pressEnter(page);
   const [id, height] = await getCursorBlockIdAndHeight(page);
   if (id && height) {
-    let nextHeight;
-    // type until current block height is changed, means has new line
-    do {
-      await page.keyboard.type('a');
-      [, nextHeight] = await getCursorBlockIdAndHeight(page);
-    } while (nextHeight === height);
+    await fillLine(page, true);
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('ArrowUp');
     const [currentId] = await getCursorBlockIdAndHeight(page);
@@ -137,12 +133,7 @@ test('cursor move down at edge of the last line', async ({ page }) => {
   await page.keyboard.press('ArrowUp');
   const [, height] = await getCursorBlockIdAndHeight(page);
   if (id && height) {
-    let nextHeight;
-    // type until current block height is changed, means has new line
-    do {
-      await page.keyboard.type('a');
-      [, nextHeight] = await getCursorBlockIdAndHeight(page);
-    } while (nextHeight === height);
+    await fillLine(page, true);
     await page.keyboard.press('ArrowLeft');
     await page.keyboard.press('ArrowDown');
     const [currentId] = await getCursorBlockIdAndHeight(page);

--- a/tests/utils/actions.ts
+++ b/tests/utils/actions.ts
@@ -166,3 +166,23 @@ export async function getCursorBlockIdAndHeight(page: Page) {
     return [null, null];
   });
 }
+
+/**
+ * fill a line by keep triggering key input
+ * @param page
+ * @param toNext if true, fill until soft wrap
+ */
+export async function fillLine(page: Page, toNext = false) {
+  const [id, height] = await getCursorBlockIdAndHeight(page);
+  if (id && height) {
+    let nextHeight;
+    // type until current block height is changed, means has new line
+    do {
+      await page.keyboard.type('a');
+      [, nextHeight] = await getCursorBlockIdAndHeight(page);
+    } while (nextHeight === height);
+    if (!toNext) {
+      page.keyboard.press('Backspace');
+    }
+  }
+}


### PR DESCRIPTION
* add test case that firstly move cursor up at the edge of second line, then move cursor down at the edge of last line.
* fix: correctly jump into next block on keydown. 
* fix: possible error on keydown.
