### PR TITLE
fix: pnpm publish check

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:playground": "pnpm --filter @blocksuite/playground build",
     "clean": "rm -rf dist packages/{blocks,editor,playground,shared,store}/dist",
     "bump": "pnpm --recursive exec pnpm version minor && pnpm version minor --git-tag-version false",
-    "publish": "pnpm --recursive --filter=!@blocksuite/playground exec pnpm publish"
+    "publish": "pnpm --recursive --filter=!@blocksuite/playground exec pnpm publish --no-git-checks"
   },
   "keywords": [],
   "author": "toeverything",


### PR DESCRIPTION
Skip pnpm git check

The v0.2.1 has been published at https://github.com/toeverything/blocksuite/actions/runs/3233683639/jobs/5295850799