### PR TITLE
Fix/support-create-from-element

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blocksuite/blocks",
   "version": "0.2.19",
-  "type": "module",
   "description": "Default BlockSuite editable blocks.",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/blocks/src/__internal__/utils/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture.ts
@@ -141,8 +141,8 @@ export function initMouseEventHandlers(
   };
 
   const contextMenuHandler = (e: MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+    // e.preventDefault();
+    // e.stopPropagation();
   };
 
   const dblClickHandler = (e: MouseEvent) => {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -139,7 +139,10 @@ export class EdgelessPageBlockComponent
       tryUpdateGroupSize(this.store, this.viewport.zoom);
     });
 
-    this._initViewport();
+    requestAnimationFrame(() => {
+      this._initViewport();
+      this.requestUpdate();
+    });
     // XXX: should be called after rich text components are mounted
     this._clearSelection();
   }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blocksuite/editor",
   "version": "0.2.19",
-  "type": "module",
   "description": "Default BlockSuite-based editor built for AFFiNE.",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/editor/src/components/editor-container/editor-container.ts
+++ b/packages/editor/src/components/editor-container/editor-container.ts
@@ -33,7 +33,7 @@ export class EditorContainer extends LitElement {
   private _placeholderInput!: HTMLInputElement;
 
   @state()
-  placeholderModel = new BlockSchema.page(this.store, {});
+  placeholderModel: PageBlockModel | undefined;
 
   @state()
   unsubscribe = [] as (() => void)[];
@@ -49,8 +49,9 @@ export class EditorContainer extends LitElement {
 
   private init() {
     if (!this.store) {
-      throw new Error("EditorContainer's store is not set");
+      this.store = new Store().register(BlockSchema);
     }
+    this.placeholderModel = new BlockSchema.page(this.store, {});
 
     this.unsubscribe.forEach(fn => fn());
     this.subscribeStore();

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -50,7 +50,5 @@ export const createEditor = (options: EditorOptions = {}): EditorContainer => {
     return editor;
   }
   // 3. Use default store
-  const store = new Store().register(BlockSchema);
-  editor.store = store;
   return editor;
 };

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blocksuite/store",
   "version": "0.2.19",
-  "type": "module",
   "description": "BlockSuite data store built for general purpose state management.",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
- Support create editor from custom element without store config
- Remove module mark
  - Due to our not regular enough esm config
![img_v2_d00b01cf-158f-488e-a4d7-4c01076fbdcg](https://user-images.githubusercontent.com/18554747/197936109-e97c38d9-c7d6-4be7-a738-0466a2ba3236.jpg)

> ## Mandatory file extensions[#](https://nodejs.org/api/esm.html#mandatory-file-extensions)
> A file extension must be provided when using the import keyword to resolve relative or absolute specifiers. Directory indexes (e.g. './startup/index.js') must also be fully specified.
> This behavior matches how import behaves in browser environments, assuming a typically configured server.
