### PR TITLE
Add IndexDBProvider

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,16 +1,34 @@
 import '@blocksuite/blocks';
 import '@blocksuite/editor';
 import { createEditor } from '@blocksuite/editor';
-import { DebugProvider } from '@blocksuite/store';
+import { DebugProvider, IndexedDBProvider } from '@blocksuite/store';
 import './style.css';
 
 const params = new URLSearchParams(location.search);
 const room = params.get('room') ?? '';
+/**
+ * Specified by `?providers=debug` or `?providers=indexeddb,debug`
+ * Default is debug (using webrtc)
+ */
+const providersFromParam = (params.get('providers') ?? 'debug')
+  .split(',')
+  .map(providerName => {
+    switch (providerName) {
+      case 'debug':
+        return DebugProvider;
+      case 'indexeddb':
+        return IndexedDBProvider;
+      default:
+        throw new TypeError(
+          `Unknown provider ("${providerName}") supplied in search param ?providers=... (for example "debug" and "indexeddb")`
+        );
+    }
+  });
 
 window.onload = () => {
   const editor = createEditor({
     room,
-    providers: [DebugProvider],
+    providers: providersFromParam,
   });
   document.body.appendChild(editor);
 };

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -13,6 +13,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "lib0": "^0.2.52",
+    "y-indexeddb": "^9.0.9",
     "y-protocols": "^1.0.5",
     "y-webrtc": "^10.2.3",
     "yjs": "^13.5.41"

--- a/packages/store/src/providers.ts
+++ b/packages/store/src/providers.ts
@@ -1,34 +1,77 @@
 import * as Y from 'yjs';
 import { WebrtcProvider } from 'y-webrtc';
+// In the future, consider making y-indexdb a separate package sync provider.
+import { IndexeddbPersistence } from 'y-indexeddb';
 import { Awareness } from 'y-protocols/awareness';
 
-export abstract class Provider {
+/**
+ * Different examples of providers could include webrtc sync,
+ * database sync like SQLite / LevelDB, or even web IndexDB.
+ *
+ * Usually a class will also implement {@link SyncProviderConstructor}.
+ */
+export interface SyncProvider {
   awareness?: Awareness;
-  abstract connect: () => void;
-  abstract disconnect: () => void;
-  abstract clearData: () => Promise<void>;
-  abstract destroy: () => void;
+  connect: () => void;
+  disconnect: () => void;
+  clearData: () => Promise<void>;
+  destroy: () => void;
 }
 
-export type ProviderFactory = new (
-  room: string,
-  ydoc: Y.Doc,
-  options?: { awareness?: Awareness }
-) => Provider;
+/** See {@link SyncProvider} */
+export interface SyncProviderConstructor {
+  new (
+    room: string,
+    ydoc: Y.Doc,
+    options?: { awareness?: Awareness }
+  ): SyncProvider;
+}
 
-// type FactoryOptions = ConstructorParameters<ProviderFactory>;
-
-export class DebugProvider extends WebrtcProvider implements Provider {
+export class DebugProvider extends WebrtcProvider implements SyncProvider {
   constructor(room: string, doc: Y.Doc, options?: { awareness?: Awareness }) {
     super(room, doc, {
-      awareness: options?.awareness,
+      awareness: options?.awareness ?? null,
       signaling: [
+        // When using playground from blocksuite repo, this comes from "serve" script in "@blocksuite/store" package.
+        // We use our own sync server because a local service for sync makes everything much faster for dev.
         'ws://localhost:4444',
+        // // Default config from yjs (but these are kinda slow by comparison to self host sync ~100ms-+1000ms latency observed).
+        // // This slowness is also avoided in order to improve test reliability in CI.
         // 'wss://y-webrtc-signaling-us.herokuapp.com',
         // 'wss://y-webrtc-signaling-eu.herokuapp.com',
       ],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any);
+      // YJS has broken default types. 🥲
+      ...({} as {
+        // calling each one of these null to make TypeScript happy, because YJS is wrong.
+        filterBcConns: null;
+        maxConns: null;
+        password: null;
+        peerOpts: null;
+      }),
+    });
+  }
+
+  public clearData() {
+    // Do nothing for now
+    return Promise.resolve();
+  }
+}
+
+export class IndexedDBProvider
+  extends IndexeddbPersistence
+  implements SyncProvider
+{
+  constructor(room: string, doc: Y.Doc, options?: { awareness?: Awareness }) {
+    super(room, doc);
+  }
+
+  // Consider whether "connect" and "disconnect" are good to put on the SyncProvider
+  connect() {
+    // not necessary as it will be set up in indexdb persistence
+  }
+
+  disconnect() {
+    // not necessary as it will be set up in indexdb persistence
   }
 
   public clearData() {

--- a/packages/store/src/space.ts
+++ b/packages/store/src/space.ts
@@ -73,7 +73,27 @@ export class Space {
 
     const aware = awareness ?? new Awareness(this.doc);
     this.awareness = new AwarenessAdapter(this, aware);
-    this._yBlocks.observeDeep(this._yBlocksObserver);
+
+    // all the events that happen at _any_ level (potentially deep inside the structure).
+    // So, we apply a listener at the top level for the flat structure of the current
+    // page/space container.
+    const handleYEventsAndSignalUpdate = (
+      events: Y.YEvent<YBlock | Y.Text>[]
+    ) => {
+      for (const event of events) {
+        this._handleYEvent(event);
+      }
+      this.signals.updated.emit();
+    };
+
+    // Consider if we need to expose the ability to temporarily unobserve this._yBlocks.
+    // "unobserve" is potentially necessary to make sure we don't  create
+    // an infinite loop when sync to remote then back to client.
+    // `action(a) -> YDoc' -> YEvents(a) -> YRemoteDoc' -> YEvents(a) -> YDoc'' -> ...`
+    // We could unobserve in order to short circuit by ignoring the sync of remote
+    // events we actually generated locally.
+    // this._yBlocks.unobserveDeep(handleYEventsAndSignalUpdate);
+    this._yBlocks.observeDeep(handleYEventsAndSignalUpdate);
 
     this._history = new Y.UndoManager([this._yBlocks], {
       trackedOrigins: new Set([this.doc.clientID]),
@@ -481,11 +501,4 @@ export class Space {
       }
     }
   }
-
-  private _yBlocksObserver = (events: Y.YEvent<YBlock | Y.Text>[]) => {
-    for (const event of events) {
-      this._handleYEvent(event);
-    }
-    this.signals.updated.emit();
-  };
 }

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,7 +1,7 @@
 import { PrefixedBlockProps, Space } from './space';
 import { Awareness } from 'y-protocols/awareness.js';
 import * as Y from 'yjs';
-import type { Provider, ProviderFactory } from './providers';
+import type { SyncProvider, SyncProviderConstructor } from './providers';
 import { serializeYDoc, yDocToJSXNode } from './utils/jsx';
 
 export interface SerializedStore {
@@ -12,7 +12,7 @@ export interface SerializedStore {
 
 export interface StoreOptions {
   room?: string;
-  providers?: ProviderFactory[];
+  providers?: SyncProviderConstructor[];
   awareness?: Awareness;
 }
 
@@ -20,7 +20,7 @@ const DEFAULT_ROOM = 'virgo-default';
 
 export class Store {
   readonly doc = new Y.Doc();
-  readonly providers: Provider[] = [];
+  readonly providers: SyncProvider[] = [];
   readonly spaces = new Map<string, Space>();
 
   constructor({
@@ -30,7 +30,8 @@ export class Store {
   }: StoreOptions = {}) {
     const aware = awareness ?? new Awareness(this.doc);
     this.providers = providers.map(
-      Provider => new Provider(room, this.doc, { awareness: aware })
+      ProviderConstructor =>
+        new ProviderConstructor(room, this.doc, { awareness: aware })
     );
 
     // FIXME

--- a/packages/store/src/text-adapter.ts
+++ b/packages/store/src/text-adapter.ts
@@ -89,6 +89,25 @@ export class PrelimText {
   }
 }
 
+declare module 'yjs' {
+  interface Text {
+    /**
+     * Specific addition used by @blocksuite/store
+     * When set, we know it hasn't been applied to quill.
+     * When specified, we call this a "controlled operation".
+     *
+     * Consider renaming this to closer indicate this is simply a "controlled operation",
+     * since we may not actually use this information.
+     */
+    meta?:
+      | { split: true }
+      | { join: true }
+      | { format: true }
+      | { delete: true }
+      | { clear: true };
+  }
+}
+
 export class Text {
   private _space: Space;
   private _yText: Y.Text;
@@ -135,7 +154,6 @@ export class Text {
   insert(content: string, index: number, attributes?: Object) {
     this._transact(() => {
       this._yText.insert(index, content, attributes);
-      // @ts-ignore
       this._yText.meta = { split: true };
     });
   }
@@ -150,7 +168,6 @@ export class Text {
           insertTexts[i].attributes as Object | undefined
         );
       }
-      // @ts-ignore
       this._yText.meta = { split: true };
     });
   }
@@ -161,7 +178,6 @@ export class Text {
       const delta = yOther.toDelta();
       delta.splice(0, 0, { retain: this._yText.length });
       this._yText.applyDelta(delta);
-      // @ts-ignore
       this._yText.meta = { join: true };
     });
   }
@@ -169,7 +185,6 @@ export class Text {
   format(index: number, length: number, format: any) {
     this._transact(() => {
       this._yText.format(index, length, format);
-      // @ts-ignore
       this._yText.meta = { format: true };
     });
   }
@@ -177,7 +192,6 @@ export class Text {
   delete(index: number, length: number) {
     this._transact(() => {
       this._yText.delete(index, length);
-      // @ts-ignore
       this._yText.meta = { delete: true };
     });
   }
@@ -185,7 +199,6 @@ export class Text {
   clear() {
     this._transact(() => {
       this._yText.delete(0, this._yText.length);
-      // @ts-ignore
       this._yText.meta = { clear: true };
     });
   }
@@ -276,11 +289,12 @@ export class RichTextAdapter {
   private _yObserver = (event: Y.YTextEvent) => {
     const isFromLocal = event.transaction.origin === this.doc.clientID;
     const isFromRemote = !isFromLocal;
-    // @ts-ignore
     const isControlledOperation = !!event.target?.meta;
 
     // update quill if the change is from remote or using controlled operation
-    if (isFromRemote || isControlledOperation) {
+    const quillMustApplyUpdate = isFromRemote || isControlledOperation;
+
+    if (quillMustApplyUpdate) {
       const eventDelta = event.delta;
       // We always explicitly set attributes, otherwise concurrent edits may
       // result in quill assuming that a text insertion shall inherit existing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,11 +95,13 @@ importers:
     specifiers:
       '@types/quill': ^2.0.9
       lib0: ^0.2.52
+      y-indexeddb: ^9.0.9
       y-protocols: ^1.0.5
       y-webrtc: ^10.2.3
       yjs: ^13.5.41
     dependencies:
       lib0: 0.2.52
+      y-indexeddb: 9.0.9_yjs@13.5.41
       y-protocols: 1.0.5
       y-webrtc: 10.2.3
       yjs: 13.5.41
@@ -3633,6 +3635,15 @@ packages:
         optional: true
     dev: false
     optional: true
+
+  /y-indexeddb/9.0.9_yjs@13.5.41:
+    resolution: {integrity: sha512-GcJbiJa2eD5hankj46Hea9z4hbDnDjvh1fT62E5SpZRsv8GcEemw34l1hwI2eknGcv5Ih9JfusT37JLx9q3LFg==}
+    peerDependencies:
+      yjs: ^13.0.0
+    dependencies:
+      lib0: 0.2.52
+      yjs: 13.5.41
+    dev: false
 
   /y-protocols/1.0.5:
     resolution: {integrity: sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==}


### PR DESCRIPTION
Please don't squash. Please use "rebase and merge" if you like the commit messages.

We refactor a couple more places with TypeScript types.
We have also added a wrapper around `yjs`'s `IndexeddbPersistence` as `IndexedDBProvider` for store.