### PR TITLE
test: add some link test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ const config: PlaywrightTestConfig = {
   use: {
     browserName: 'chromium',
     viewport: { width: 900, height: 600 },
+    actionTimeout: 5 * 1000,
   },
 };
 

--- a/tests/link.spec.ts
+++ b/tests/link.spec.ts
@@ -87,3 +87,66 @@ test('basic link', async ({ page }) => {
 </affine:page>`
   );
 });
+
+const createLinkBlock = async (page: Page, str: string, link: string) => {
+  const id = await page.evaluate(
+    ([str, link]) => {
+      const { space } = window.store;
+      const pageId = space.addBlock({
+        flavour: 'affine:page',
+        title: 'title',
+      });
+      const groupId = space.addBlock({ flavour: 'affine:group' }, pageId);
+
+      const text = space.Text.fromDelta(space, [
+        { insert: 'Hello' },
+        { insert: str, attributes: { link } },
+      ]);
+      const id = space.addBlock(
+        { flavour: 'affine:paragraph', type: 'text', text: text },
+        groupId
+      );
+      return id;
+    },
+    [str, link]
+  );
+  return id;
+};
+
+test('text added after a link should not have link formatting', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  // await initEmptyState(page);
+  const id = await createLinkBlock(page, 'link text', 'http://example.com');
+  await focusRichText(page, 0);
+  await page.keyboard.type('after link');
+  await assertStoreMatchJSX(
+    page,
+    // XXX This snapshot is not exactly correct, but it's close enough for now.
+    // The first text after the link should not have the link formatting.
+    `
+<affine:paragraph
+  prop:text={
+    <>
+      <text
+        insert="Hello"
+      />
+      <text
+        insert="link text"
+        link="http://example.com"
+      />
+      <text
+        insert="a"
+        link={false}
+      />
+      <text
+        insert="fter link"
+      />
+    </>
+  }
+  prop:type="text"
+/>`,
+    id
+  );
+});

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -63,12 +63,17 @@ export async function enterPlaygroundWithList(page: Page) {
 }
 
 export async function initEmptyState(page: Page) {
-  await page.evaluate(() => {
+  const id = await page.evaluate(() => {
     const space = window.store.space;
     const pageId = space.addBlock({ flavour: 'affine:page' });
     const groupId = space.addBlock({ flavour: 'affine:group' }, pageId);
-    space.addBlock({ flavour: 'affine:paragraph' }, groupId);
+    const paragraphId = space.addBlock(
+      { flavour: 'affine:paragraph' },
+      groupId
+    );
+    return { pageId, groupId, paragraphId };
   });
+  return id;
 }
 
 export async function focusRichText(page: Page, i = 0) {

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -295,9 +295,14 @@ export async function assertMatchMarkdown(page: Page, text: string) {
   expect(actual).toEqual(text);
 }
 
-export async function assertStoreMatchJSX(page: Page, snapshot: string) {
-  const element = (await page.evaluate(() =>
-    window.store.toJSXElement()
+export async function assertStoreMatchJSX(
+  page: Page,
+  snapshot: string,
+  id?: string
+) {
+  const element = (await page.evaluate(
+    id => window.store.toJSXElement(id),
+    id
   )) as JSXElement;
 
   // Fix symbol can not be serialized, we need to set $$typeof manually


### PR DESCRIPTION
- Add `actionTimeout` for playwright test
- `initEmptyState` now will return block id
- `assertStoreMatchJSX` now support specify id so that simplify snapshot size
