### PR TITLE
fix:selection test fails on windows

### DIFF
--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -38,7 +38,7 @@ test('click on blank area', async ({ page }) => {
   const above123 = await page.evaluate(() => {
     const paragraph = document.querySelector('[data-block-id="2"] p');
     const bbox = paragraph?.getBoundingClientRect() as DOMRect;
-    return { x: bbox.left, y: bbox.top - 5 };
+    return { x: bbox.left, y: bbox.top + 5 };
   });
   await page.mouse.click(above123.x, above123.y);
   await assertSelection(page, 0, 0, 0);
@@ -46,7 +46,7 @@ test('click on blank area', async ({ page }) => {
   const above456 = await page.evaluate(() => {
     const paragraph = document.querySelector('[data-block-id="3"] p');
     const bbox = paragraph?.getBoundingClientRect() as DOMRect;
-    return { x: bbox.left, y: bbox.top - 5 };
+    return { x: bbox.left, y: bbox.top + 5 };
   });
   await page.mouse.click(above456.x, above456.y);
   await assertSelection(page, 1, 0, 0);
@@ -54,7 +54,7 @@ test('click on blank area', async ({ page }) => {
   const below789 = await page.evaluate(() => {
     const paragraph = document.querySelector('[data-block-id="4"] p');
     const bbox = paragraph?.getBoundingClientRect() as DOMRect;
-    return { x: bbox.left, y: bbox.bottom + 5 };
+    return { x: bbox.left, y: bbox.bottom - 5 };
   });
   await page.mouse.click(below789.x, below789.y);
   await assertSelection(page, 2, 0, 0);


### PR DESCRIPTION
In the original code, the clicked area on windows is the gap in the middle of the list, and the list is not clicked.
Now,I update click area of test to pass the test.
![image](https://user-images.githubusercontent.com/102217452/201060224-3a6b21f3-5528-4c7a-865c-aef30e7e68b8.png)
