### PR TITLE
feat: remove debug-menu from @blocksuite/blocks to @blocksuite/editor

### DIFF
--- a/packages/blocks/src/__internal__/index.ts
+++ b/packages/blocks/src/__internal__/index.ts
@@ -1,4 +1,3 @@
-import './debug-menu';
 import './rich-text/rich-text';
 
 export * from './utils';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -13,6 +13,8 @@ export * from './list-block';
 export * from './group-block';
 export * as SelectionUtils from './__internal__/utils/selection';
 export * from './__internal__/utils/types';
+export * from './__internal__/utils/common-operations';
+export * from './__internal__/utils/std';
 
 const env =
   typeof globalThis !== 'undefined'

--- a/packages/editor/src/components/debug-menu/debug-menu.ts
+++ b/packages/editor/src/components/debug-menu/debug-menu.ts
@@ -3,12 +3,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import {
   type CommonBlockElement,
+  type GroupBlockModel,
   convertToList,
   createEvent,
-} from '../__internal__';
-import type { BaseBlockModel, Space } from '@blocksuite/store';
-import type { GroupBlockModel } from '../group-block';
-
+} from '@blocksuite/blocks';
+import type { BaseBlockModel, Store } from '@blocksuite/store';
+import type { EditorContainer } from '../editor-container/editor-container';
 // Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc.
 const icons = {
   undo: html`
@@ -123,11 +123,10 @@ const icons = {
 @customElement('debug-menu')
 export class DebugMenu extends LitElement {
   @property()
-  space!: Space;
+  store!: Store;
 
   @property()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  contentParser!: any;
+  editor!: EditorContainer;
 
   @state()
   connected = true;
@@ -141,18 +140,22 @@ export class DebugMenu extends LitElement {
   @state()
   _mode: 'page' | 'edgeless' = 'page';
 
-  // get space() {
-  //   return this.store.space;
-  // }
+  get space() {
+    return this.editor.space;
+  }
+
+  get contentParser() {
+    return this.editor.contentParser;
+  }
 
   private _onToggleConnection() {
-    // if (this.connected === true) {
-    //   this.store.providers.forEach(provide => provide.disconnect());
-    //   this.connected = false;
-    // } else {
-    //   this.store.providers.forEach(provide => provide.connect());
-    //   this.connected = true;
-    // }
+    if (this.connected) {
+      this.store.providers.forEach(provide => provide.disconnect());
+      this.connected = false;
+    } else {
+      this.store.providers.forEach(provide => provide.connect());
+      this.connected = true;
+    }
   }
 
   private _convertToList(listType: 'bulleted' | 'numbered' | 'todo') {

--- a/packages/editor/src/components/editor-container/editor-container.ts
+++ b/packages/editor/src/components/editor-container/editor-container.ts
@@ -129,10 +129,6 @@ export class EditorContainer extends LitElement {
       </style>
       <div class="affine-editor-container">
         ${this.isEmptyPage ? placeholderRoot : blockRoot}
-        <debug-menu
-          .space=${this.space}
-          .contentParser=${this.contentParser}
-        ></debug-menu>
       </div>
     `;
   }

--- a/packages/editor/src/components/index.ts
+++ b/packages/editor/src/components/index.ts
@@ -1,3 +1,5 @@
 import './editor-container/editor-container';
+import './debug-menu/debug-menu';
 
 export * from './editor-container/editor-container';
+export * from './debug-menu/debug-menu';

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,4 +1,4 @@
-import type { Space } from '@blocksuite/store';
+import type { Space, Store } from '@blocksuite/store';
 import type { EditorContainer } from './components';
 
 export * from './components';
@@ -28,4 +28,11 @@ export const createEditor = (space: Space): EditorContainer => {
   const editor = document.createElement('editor-container');
   editor.space = space;
   return editor;
+};
+
+export const createDebugMenu = (store: Store, editor: EditorContainer) => {
+  const debugMenu = document.createElement('debug-menu');
+  debugMenu.store = store;
+  debugMenu.editor = editor;
+  return debugMenu;
 };

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,6 +1,6 @@
 import '@blocksuite/blocks';
 import '@blocksuite/editor';
-import { createEditor } from '@blocksuite/editor';
+import { createEditor, createDebugMenu, BlockSchema } from '@blocksuite/editor';
 import {
   DebugProvider,
   IndexedDBProvider,
@@ -9,7 +9,6 @@ import {
   Store,
 } from '@blocksuite/store';
 import type { SyncProviderConstructor, StoreOptions } from '@blocksuite/store';
-import { BlockSchema } from '@blocksuite/editor';
 
 import './style.css';
 
@@ -76,6 +75,9 @@ window.onload = () => {
       // @ts-ignore
       .register(window.blockSchema);
     const editor = createEditor(space);
+    const debugMenu = createDebugMenu(store, editor);
+
     document.body.appendChild(editor);
+    document.body.appendChild(debugMenu);
   }
 };

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -22,7 +22,6 @@ import {
   initEmptyState,
   dragOverTitle,
   resetHistory,
-  focusTitle,
 } from './utils/actions';
 
 test('init paragraph by page title enter at last', async ({ page }) => {

--- a/tests/utils/actions/click.ts
+++ b/tests/utils/actions/click.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export async function undoByClick(page: Page) {
   await page.click('button[aria-label="undo"]');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -58,7 +58,12 @@ export async function enterPlaygroundWithList(page: Page) {
     window.space = space;
     const editor = document.createElement('editor-container');
     editor.space = space;
+
+    const debugMenu = document.createElement('debug-menu');
+    debugMenu.store = window.store;
+    debugMenu.editor = editor;
     document.body.appendChild(editor);
+    document.body.appendChild(debugMenu);
 
     const pageId = space.addBlock({ flavour: 'affine:page' });
     const groupId = space.addBlock({ flavour: 'affine:group' }, pageId);
@@ -76,9 +81,13 @@ export async function initEmptyState(page: Page) {
       .register(window.blockSchema);
     window.space = space;
     const editor = document.createElement('editor-container');
-
     editor.space = space;
+
+    const debugMenu = document.createElement('debug-menu');
+    debugMenu.store = window.store;
+    debugMenu.editor = editor;
     document.body.appendChild(editor);
+    document.body.appendChild(debugMenu);
 
     const pageId = space.addBlock({ flavour: 'affine:page' });
     const groupId = space.addBlock({ flavour: 'affine:group' }, pageId);


### PR DESCRIPTION
Remove debug-menu from @blocksuite/blocks to @blocksuite/editor
1. @blocksuite/blocks should just purely contain by blocks 
2. Debug-menu depend on Store model, is not exist in block any more