### PR TITLE
test/add list selection test case

### DIFF
--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -12,6 +12,7 @@ import {
   addGroupByClick,
   initThreeParagraphs,
   initEmptyState,
+  initThreeList,
   undoByKeyboard,
   resetHistory,
   redoByKeyboard,
@@ -21,6 +22,8 @@ import {
   waitNextFrame,
   selectAllByKeyboard,
   dragBetweenIndices,
+  copyByKeyboard,
+  pasteByKeyboard,
 } from './utils/actions';
 import { expect } from '@playwright/test';
 import {
@@ -346,4 +349,20 @@ test('select text leaving a few words in the last line and delete', async ({
   await page.keyboard.type('abc');
   const textOne = await getQuillSelectionText(page);
   expect(textOne).toBe('abc89\n');
+});
+test('Click the list icon to select', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyState(page);
+  await initThreeList(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+  await page.mouse.click(100, 165);
+  await copyByKeyboard(page);
+  await pasteByKeyboard(page);
+  await page.mouse.click(100, 230);
+  await copyByKeyboard(page);
+  await pasteByKeyboard(page);
+  await page.mouse.click(100, 290);
+  await page.keyboard.press('Backspace', { delay: 50 });
+  await page.mouse.click(100, 200);
+  await page.keyboard.press('Backspace', { delay: 50 });
 });

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -104,6 +104,17 @@ export async function initThreeParagraphs(page: Page) {
   await pressEnter(page);
   await page.keyboard.type('789');
 }
+export async function initThreeList(page: Page) {
+  await focusRichText(page);
+  await page.keyboard.type('-');
+  await page.keyboard.press('Space', { delay: 50 });
+  await page.keyboard.type('123');
+  await pressEnter(page);
+  await page.keyboard.type('456');
+  await pressEnter(page);
+  await page.keyboard.press('Tab', { delay: 50 });
+  await page.keyboard.type('789');
+}
 
 export async function getQuillSelectionIndex(page: Page) {
   return await page.evaluate(() => {


### PR DESCRIPTION
Used to test whether the list can be selected when the list icon is clicked.
![selection](https://user-images.githubusercontent.com/102217452/201295451-158b956b-5a34-4a3d-96e6-2aa9145e58e8.gif)
