### PR TITLE
test/add list selection test case

### DIFF
--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -18,7 +18,7 @@ import {
   undoByClick,
   redoByClick,
   clearLog,
-  getListIcon,
+  clickListIcon,
   waitNextFrame,
   selectAllByKeyboard,
   dragBetweenIndices,
@@ -357,18 +357,18 @@ test('Click the list icon to select', async ({ page }) => {
   await initEmptyState(page);
   await initThreeList(page);
   await assertRichTexts(page, ['123', '456', '789']);
-  await getListIcon(page, 0);
+  await clickListIcon(page, 0);
   await copyByKeyboard(page);
   await pasteByKeyboard(page);
   await assertRichTexts(page, ['123', '123', '456', '789']);
-  await getListIcon(page, 2);
+  await clickListIcon(page, 2);
   await copyByKeyboard(page);
   await pasteByKeyboard(page);
   await assertRichTexts(page, ['123', '123', '456', '789', '456', '789']);
-  await getListIcon(page, 4);
+  await clickListIcon(page, 4);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '123', '456', '789', '\n']);
-  await getListIcon(page, 1);
+  await clickListIcon(page, 1);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '\n', '456', '789', '\n']);
 });

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { Page, test } from '@playwright/test';
 import {
   enterPlaygroundRoom,
   focusRichText,
@@ -18,7 +18,6 @@ import {
   undoByClick,
   redoByClick,
   clearLog,
-  clickListIcon,
   waitNextFrame,
   selectAllByKeyboard,
   dragBetweenIndices,
@@ -351,6 +350,11 @@ test('select text leaving a few words in the last line and delete', async ({
   const textOne = await getQuillSelectionText(page);
   expect(textOne).toBe('abc89\n');
 });
+
+async function clickListIcon(page: Page, i = 0) {
+  const locator = page.locator('.affine-list-block__prefix').nth(i);
+  await locator.click();
+}
 
 test('Click the list icon to select', async ({ page }) => {
   await enterPlaygroundRoom(page);

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -18,6 +18,7 @@ import {
   undoByClick,
   redoByClick,
   clearLog,
+  getListIcon,
   waitNextFrame,
   selectAllByKeyboard,
   dragBetweenIndices,
@@ -356,14 +357,18 @@ test('Click the list icon to select', async ({ page }) => {
   await initEmptyState(page);
   await initThreeList(page);
   await assertRichTexts(page, ['123', '456', '789']);
-  await page.mouse.click(100, 165);
+  await getListIcon(page, 0);
   await copyByKeyboard(page);
   await pasteByKeyboard(page);
-  await page.mouse.click(100, 230);
+  await assertRichTexts(page, ['123', '123', '456', '789']);
+  await getListIcon(page, 2);
   await copyByKeyboard(page);
   await pasteByKeyboard(page);
-  await page.mouse.click(100, 290);
+  await assertRichTexts(page, ['123', '123', '456', '789', '456', '789']);
+  await getListIcon(page, 4);
   await page.keyboard.press('Backspace', { delay: 50 });
-  await page.mouse.click(100, 200);
+  await assertRichTexts(page, ['123', '123', '456', '789', '\n']);
+  await getListIcon(page, 1);
   await page.keyboard.press('Backspace', { delay: 50 });
+  await assertRichTexts(page, ['123', '\n', '456', '789', '\n']);
 });

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -372,7 +372,9 @@ test('Click the list icon to select', async ({ page }) => {
   await clickListIcon(page, 4);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '123', '456', '789', '\n']);
+  //This should be ['123', '123', '456', '789'],but there is another bug affecting it
   await clickListIcon(page, 1);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '\n', '456', '789', '\n']);
+  //This should be ['123','456','789'],but there is another bug affecting it
 });

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -372,9 +372,11 @@ test('Click the list icon to select', async ({ page }) => {
   await clickListIcon(page, 4);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '123', '456', '789', '\n']);
+  //TODO:FIX ME!!!!!
   //This should be ['123', '123', '456', '789'],but there is another bug affecting it
   await clickListIcon(page, 1);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['123', '\n', '456', '789', '\n']);
+  //TODO:FIX ME!!!!!
   //This should be ['123','456','789'],but there is another bug affecting it
 });

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -21,6 +21,9 @@ import {
   waitNextFrame,
   selectAllByKeyboard,
   dragBetweenIndices,
+  initThreeList,
+  copyByKeyboard,
+  pasteByKeyboard,
 } from './utils/actions';
 import { expect } from '@playwright/test';
 import {
@@ -346,4 +349,21 @@ test('select text leaving a few words in the last line and delete', async ({
   await page.keyboard.type('abc');
   const textOne = await getQuillSelectionText(page);
   expect(textOne).toBe('abc89\n');
+});
+
+test('Click the list icon to select', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyState(page);
+  await initThreeList(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+  await page.mouse.click(100, 165);
+  await copyByKeyboard(page);
+  await pasteByKeyboard(page);
+  await page.mouse.click(100, 230);
+  await copyByKeyboard(page);
+  await pasteByKeyboard(page);
+  await page.mouse.click(100, 290);
+  await page.keyboard.press('Backspace', { delay: 50 });
+  await page.mouse.click(100, 200);
+  await page.keyboard.press('Backspace', { delay: 50 });
 });

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -116,10 +116,6 @@ export async function initThreeList(page: Page) {
   await page.keyboard.press('Tab', { delay: 50 });
   await page.keyboard.type('789');
 }
-export async function clickListIcon(page: Page, i = 0) {
-  const locator = page.locator('.affine-list-block__prefix').nth(i);
-  await locator.click();
-}
 
 export async function getQuillSelectionIndex(page: Page) {
   return await page.evaluate(() => {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -116,7 +116,7 @@ export async function initThreeList(page: Page) {
   await page.keyboard.press('Tab', { delay: 50 });
   await page.keyboard.type('789');
 }
-export async function getListIcon(page: Page, i = 0) {
+export async function clickListIcon(page: Page, i = 0) {
   const locator = page.locator('.affine-list-block__prefix').nth(i);
   await locator.click();
 }

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -116,6 +116,10 @@ export async function initThreeList(page: Page) {
   await page.keyboard.press('Tab', { delay: 50 });
   await page.keyboard.type('789');
 }
+export async function getListIcon(page: Page, i = 0) {
+  const locator = page.locator('.affine-list-block__prefix').nth(i);
+  await locator.click();
+}
 
 export async function getQuillSelectionIndex(page: Page) {
   return await page.evaluate(() => {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -105,6 +105,18 @@ export async function initThreeParagraphs(page: Page) {
   await page.keyboard.type('789');
 }
 
+export async function initThreeList(page: Page) {
+  await focusRichText(page);
+  await page.keyboard.type('-');
+  await page.keyboard.press('Space', { delay: 50 });
+  await page.keyboard.type('123');
+  await pressEnter(page);
+  await page.keyboard.type('456');
+  await pressEnter(page);
+  await page.keyboard.press('Tab', { delay: 50 });
+  await page.keyboard.type('789');
+}
+
 export async function getQuillSelectionIndex(page: Page) {
   return await page.evaluate(() => {
     const selection = window.getSelection() as Selection;


### PR DESCRIPTION
Used to test whether the list can be selected when the list icon is clicked
![selection](https://user-images.githubusercontent.com/102217452/201300041-c703fe65-138a-489f-9ce0-97ccd74057a8.gif)


Related to https://github.com/toeverything/blocksuite/pull/181