### PR TITLE
search feature

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,6 +14,7 @@
   "author": "toeverything",
   "license": "MPL-2.0",
   "dependencies": {
+    "flexsearch": "0.7.21",
     "idb-keyval": "^6.2.0",
     "lib0": "^0.2.52",
     "y-indexeddb": "^9.0.9",
@@ -23,6 +24,7 @@
     "yjs": "^13.5.41"
   },
   "devDependencies": {
+    "@types/flexsearch": "^0.7.3",
     "@types/quill": "^2.0.9",
     "cross-env": "^7.0.3"
   },

--- a/packages/store/src/__tests__/space.spec.ts
+++ b/packages/store/src/__tests__/space.spec.ts
@@ -324,3 +324,36 @@ describe('store.toJSXElement works', async () => {
     `);
   });
 });
+
+describe('store.search works', async () => {
+  it('store search matching', () => {
+    const store = new Store(getStoreOptions());
+    const space = store.createSpace(defaultSpaceId).register(BlockSchema);
+
+    space.addBlock({ flavour: 'affine:page', title: 'hello' });
+
+    space.addBlock({
+      flavour: 'affine:paragraph',
+      text: new space.Text(
+        space,
+        '英特尔第13代酷睿i7-1370P移动处理器现身Geekbench，14核心和5GHz'
+      ),
+    });
+
+    space.addBlock({
+      flavour: 'affine:paragraph',
+      text: new space.Text(
+        space,
+        '索尼考虑移植《GT赛车7》，又一PlayStation独占IP登陆PC平台'
+      ),
+    });
+
+    expect(store.search('处理器')).toStrictEqual([
+      { field: 'content', result: ['1'] },
+    ]);
+
+    expect(store.search('索尼')).toStrictEqual([
+      { field: 'content', result: ['2'] },
+    ]);
+  });
+});

--- a/packages/store/src/search.ts
+++ b/packages/store/src/search.ts
@@ -61,14 +61,13 @@ export class Indexer {
   }
 
   search(query: QueryContent) {
-    this._indexer.search(query as string);
+    return this._indexer.search(query as string);
   }
 
   private _handleSpaceIndexing(spaceId: string, space?: YMap<YBlock>) {
     if (space) {
       space.forEach((block, key) => {
         this._refreshIndex(spaceId, key, 'add', space.get(key));
-        console.log(block, key);
       });
 
       space.observeDeep(events => {
@@ -105,11 +104,6 @@ export class Indexer {
             block.get('prop:title') || block.get('prop:text')
           );
           if (content) {
-            console.log({
-              content,
-              reference: '',
-              tags: [space],
-            });
             this._indexer.add(id, {
               content,
               reference: '',

--- a/packages/store/src/search.ts
+++ b/packages/store/src/search.ts
@@ -1,0 +1,152 @@
+import { Document as DocumentIndexer, DocumentSearchOptions } from 'flexsearch';
+import { Doc, Map as YMap, Text as YText } from 'yjs';
+import type { YBlock } from './space';
+
+export type QueryContent = string | Partial<DocumentSearchOptions<boolean>>;
+
+function tokenizeZh(text: string) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const tokenizer = Intl?.v8BreakIterator;
+  if (tokenizer) {
+    const it = tokenizer(['zh-CN'], { type: 'word' });
+    it.adoptText(text);
+    const words = [];
+
+    let cur = 0,
+      prev = 0;
+
+    while (cur < text.length) {
+      prev = cur;
+      cur = it.next();
+      words.push(text.substring(prev, cur));
+    }
+
+    return words;
+  }
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\x00-\x7F]/g, '').split('');
+}
+
+export type IndexMetadata = Readonly<{
+  content: string | undefined;
+  reference: string | undefined;
+  tags: string[];
+}>;
+
+export class Indexer {
+  readonly _doc: Doc;
+  readonly _indexer: DocumentIndexer<IndexMetadata>;
+
+  constructor(doc: Doc) {
+    this._doc = doc;
+    this._indexer = new DocumentIndexer<IndexMetadata>({
+      document: {
+        id: 'id',
+        index: ['content', 'reference'],
+        tag: 'tags',
+      },
+      encode: tokenizeZh,
+      tokenize: 'forward',
+      context: true,
+    });
+
+    Array.from(doc.share.keys())
+      .map(k => [k, this._getSpace(k)] as const)
+      .forEach(([spaceId, space]) => this._handleSpaceIndexing(spaceId, space));
+  }
+
+  onCreateSpace(spaceId: string) {
+    this._handleSpaceIndexing(spaceId, this._getSpace(spaceId));
+  }
+
+  search(query: QueryContent) {
+    this._indexer.search(query as string);
+  }
+
+  private _handleSpaceIndexing(spaceId: string, space?: YMap<YBlock>) {
+    if (space) {
+      space.forEach((block, key) => {
+        this._refreshIndex(spaceId, key, 'add', space.get(key));
+        console.log(block, key);
+      });
+
+      space.observeDeep(events => {
+        const keys = events.flatMap(e => {
+          // eslint-disable-next-line no-bitwise
+          if ((e.path?.length | 0) > 0) {
+            return [[e.path[0], 'update'] as [string, 'update']];
+          }
+          return Array.from(e.changes.keys.entries()).map(
+            ([k, { action }]) => [k, action] as [string, typeof action]
+          );
+        });
+
+        if (keys.length) {
+          keys.forEach(([key, action]) => {
+            this._refreshIndex(spaceId, key, action, space.get(key));
+          });
+        }
+      });
+    }
+  }
+
+  private _refreshIndex(
+    space: string,
+    id: string,
+    action: 'add' | 'update' | 'delete',
+    block?: YBlock
+  ) {
+    switch (action) {
+      case 'add':
+      case 'update': {
+        if (block) {
+          const content = this._toContent(
+            block.get('prop:title') || block.get('prop:text')
+          );
+          if (content) {
+            console.log({
+              content,
+              reference: '',
+              tags: [space],
+            });
+            this._indexer.add(id, {
+              content,
+              reference: '',
+              tags: [space],
+            });
+          }
+        }
+
+        break;
+      }
+      case 'delete': {
+        this._indexer.remove(id);
+        break;
+      }
+    }
+  }
+
+  private _toContent(obj: unknown) {
+    if (obj) {
+      if (typeof obj === 'string') {
+        return obj;
+      } else if (obj instanceof YText) {
+        return obj.toJSON();
+      }
+    }
+    return undefined;
+  }
+
+  private _getSpace(key: string): YMap<YBlock> | undefined {
+    try {
+      // we only indexing blocks in spaces
+      if (key.startsWith('space:')) {
+        return this._doc.getMap(key);
+      }
+      return undefined;
+    } catch (_) {
+      return undefined;
+    }
+  }
+}

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -5,6 +5,7 @@ import * as Y from 'yjs';
 import type { DocProvider, DocProviderConstructor } from './doc-providers';
 import { serializeYDoc, yDocToJSXNode } from './utils/jsx';
 import { uuidv4 } from './utils/id-generator';
+import { Indexer, QueryContent } from './search';
 
 export interface SerializedStore {
   [key: string]: {
@@ -27,6 +28,8 @@ export class Store {
   readonly spaces = new Map<string, Space>();
   readonly awareness: Awareness;
   readonly idGenerator: IdGenerator;
+  readonly _indexer: Indexer;
+
   constructor({
     room = DEFAULT_ROOM,
     providers = [],
@@ -39,6 +42,11 @@ export class Store {
       ProviderConstructor =>
         new ProviderConstructor(room, this.doc, { awareness: this.awareness })
     );
+    this._indexer = new Indexer(this.doc);
+  }
+
+  search(query: QueryContent) {
+    this._indexer.search(query);
   }
 
   getSpace(spaceId: string) {
@@ -51,6 +59,8 @@ export class Store {
       spaceId,
       new Space(spaceId, this.doc, this.awareness, this.idGenerator)
     );
+    this._indexer.onCreateSpace(spaceId);
+
     return this.getSpace(spaceId);
   }
 

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -46,7 +46,7 @@ export class Store {
   }
 
   search(query: QueryContent) {
-    this._indexer.search(query);
+    return this._indexer.search(query);
   }
 
   getSpace(spaceId: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,10 @@ importers:
 
   packages/store:
     specifiers:
+      '@types/flexsearch': ^0.7.3
       '@types/quill': ^2.0.9
       cross-env: ^7.0.3
+      flexsearch: 0.7.21
       idb-keyval: ^6.2.0
       lib0: ^0.2.52
       y-indexeddb: ^9.0.9
@@ -105,6 +107,7 @@ importers:
       y-websocket: ^1.4.5
       yjs: ^13.5.41
     dependencies:
+      flexsearch: 0.7.21
       idb-keyval: 6.2.0
       lib0: 0.2.52
       y-indexeddb: 9.0.9_yjs@13.5.41
@@ -113,6 +116,7 @@ importers:
       y-websocket: 1.4.5_yjs@13.5.41
       yjs: 13.5.41
     devDependencies:
+      '@types/flexsearch': 0.7.3
       '@types/quill': 2.0.9
       cross-env: 7.0.3
 
@@ -740,6 +744,10 @@ packages:
 
   /@types/chai/4.3.3:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
+
+  /@types/flexsearch/0.7.3:
+    resolution: {integrity: sha512-HXwADeHEP4exXkCIwy2n1+i0f1ilP1ETQOH5KDOugjkTFZPntWo0Gr8stZOaebkxsdx+k0X/K6obU/+it07ocg==}
     dev: true
 
   /@types/is-ci/3.0.0:
@@ -2052,6 +2060,10 @@ packages:
   /flatted/3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
+
+  /flexsearch/0.7.21:
+    resolution: {integrity: sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==}
+    dev: false
 
   /fs-extra/7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}


### PR DESCRIPTION
this pr add basic indexing quality local search feature into @blocksuite/store

the indexing service will refresh index all prop:text and prop:title in a block when they add/update/remove, at this time indexing feature support ascii words and cjk tokenize, if user use non-chromium core, tokenize function will fallback to char based tokenize

<img width="718" alt="image" src="https://user-images.githubusercontent.com/25152247/204341899-355d09f7-341b-4fb9-8158-db39329095b3.png">


in future we will implement a native version in rust with same apis, and must allow add more custom props from outside