### PR TITLE
fix: reserve selection after format

### DIFF
--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -222,10 +222,6 @@ export function handleFormat(space: Space, e: KeyboardEvent, key: string) {
       const { index, length } = range;
       const format = quill.getFormat(range);
       models[0].text?.format(index, length, { [key]: !format[key] });
-      quill.setSelection(index + length, 0);
-      if (key === 'code' || key === 'link') {
-        quill.format(key, false);
-      }
     } else {
       formatModelsByRange(models, space, key);
     }

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -52,8 +52,9 @@ test('single line rich-text inline code hotkey', async ({ page }) => {
   await redoByKeyboard(page);
   await assertTextFormat(page, 0, 0, { code: true });
 
+  // the format should be removed after trigger the hotkey again
   await inlineCode(page);
-  await assertTextFormat(page, 0, 0, { code: true });
+  await assertTextFormat(page, 0, 0, {});
 });
 
 test('type character jump out code node', async ({ page }) => {
@@ -63,7 +64,6 @@ test('type character jump out code node', async ({ page }) => {
   await page.keyboard.type('Hello');
   await selectAllByKeyboard(page);
   await inlineCode(page);
-  await page.keyboard.press('ArrowLeft');
   await page.keyboard.press('ArrowRight');
   await page.keyboard.type('block suite', { delay: 10 });
   // block suite should not be code
@@ -117,9 +117,9 @@ test('single line rich-text strikethrough hotkey', async ({ page }) => {
   await redoByClick(page);
   await assertTextFormat(page, 0, 0, { strike: true });
 
-  // trigger hotkey twice
+  // the format should be removed after trigger the hotkey again
   await strikethrough(page);
-  await assertTextFormat(page, 0, 0, { strike: true });
+  await assertTextFormat(page, 0, 0, {});
 });
 
 test('format list to h1', async ({ page }) => {


### PR DESCRIPTION
Reserve selection after formatting

https://user-images.githubusercontent.com/18554747/204356593-37629a9d-c65d-4b6a-bf88-ef92e1552839.mov

Note: multiple line format not updated due to weird selection behavior

https://user-images.githubusercontent.com/18554747/204356986-8c9ceba0-a3bd-4439-9a3a-12abc9e8025e.mp4


