### PR TITLE
Fix: Boundary case of native dragging between block components

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -14,6 +14,8 @@ import {
 } from './query';
 import { Rect } from './rect';
 import type { SelectionEvent } from './gesture';
+import type { DragDirection } from '../../page-block/utils';
+import { getDragDirection } from '../../page-block/utils';
 
 const SCROLL_THRESHOLD = 100;
 
@@ -357,15 +359,15 @@ export function handleNativeRangeDragMove(
   startRange: Range | null,
   e: SelectionEvent
 ) {
-  let isForward = true;
   assertExists(startRange);
   const { startContainer, startOffset, endContainer, endOffset } = startRange;
   let currentRange = caretRangeFromPoint(e.raw.clientX, e.raw.clientY);
-  if (currentRange?.comparePoint(endContainer, endOffset) === 1) {
-    isForward = false;
-    currentRange?.setEnd(endContainer, endOffset);
-  } else {
+  const direction: DragDirection = getDragDirection(e);
+  const isForward = ['left-bottom', 'right-bottom'].includes(direction);
+  if (isForward) {
     currentRange?.setStart(startContainer, startOffset);
+  } else {
+    currentRange?.setEnd(endContainer, endOffset);
   }
   if (currentRange) {
     currentRange = fixCurrentRangeToText(
@@ -663,6 +665,7 @@ function getCurrentCharIndex(
   const currentCharIndex = wordText.indexOf(currentChar);
   return [currentCharIndex, wordText] as const;
 }
+
 /**
  * left first search all leaf text nodes
  * @example

--- a/packages/blocks/src/page-block/utils/cursor.ts
+++ b/packages/blocks/src/page-block/utils/cursor.ts
@@ -49,11 +49,11 @@ export function getDragDirection(
   const startY = e.start.y;
   const endX = isSelectionEvent(e) ? e.x : e.end.x;
   const endY = isSelectionEvent(e) ? e.y : e.end.y;
-  return endX > startX
-    ? endY > startY
+  return endX >= startX
+    ? endY >= startY
       ? 'right-bottom'
       : 'right-top'
-    : endY > startY
+    : endY >= startY
     ? 'left-bottom'
     : 'left-top';
 }


### PR DESCRIPTION
`comparePoint()` is unstable when dragging across HTMLELement. During native dragging, wrong `isForward` derived by it will cause [failure of focuing TextNode ](https://github.com/toeverything/blocksuite/blob/3a07c6f540f5dd9c8bc1ae2bf5f05cca7dcbf196/packages/blocks/src/__internal__/utils/selection.ts#L74).  Use `getDragDirection()` to cover this case. 

# Before
https://user-images.githubusercontent.com/20554850/204439699-db0a36f2-3821-4651-a75e-b56785b7b3c2.mov
# After
https://user-images.githubusercontent.com/20554850/204439704-305efdf8-87bf-4467-90e0-8327efee514c.mov