### PR TITLE
feat: paste divider from outside blocksuite

### DIFF
--- a/packages/editor/src/managers/clipboard/content-parser/parse-html.ts
+++ b/packages/editor/src/managers/clipboard/content-parser/parse-html.ts
@@ -122,6 +122,14 @@ export class ParserHtml {
               node
             );
           break;
+        case 'HR':
+          result = this._contentParser.getParserHtmlText2Block(
+            'commonParser'
+          )?.({
+            element: node,
+            flavour: 'affine:divider',
+          });
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Now we can copy divider from elsewhere and paste it inside blocksuite.