### PR TITLE
fix: match `removeHotKeys` in divider

### DIFF
--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -524,6 +524,10 @@ export class DefaultPageBlockComponent extends LitElement implements BlockHost {
       HOTKEYS.BULLETED,
       HOTKEYS.NUMBERED_LIST,
       HOTKEYS.TEXT,
+      HOTKEYS.UP,
+      HOTKEYS.DOWN,
+      HOTKEYS.LEFT,
+      HOTKEYS.RIGHT,
     ]);
   }
 


### PR DESCRIPTION
add removeHotKeys for divider