### PR TITLE
fix: clipboard state when first block is divider

### DIFF
--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -197,8 +197,13 @@ export class PasteManager {
         selectedBlock?.text?.insertList(insertTexts, endIndex);
         selectedBlock &&
           this._addBlocks(blocks[0].children, selectedBlock, 0, addBlockIds);
-
-        parent && this._addBlocks(blocks.slice(1), parent, index, addBlockIds);
+        if (blocks[0].flavour === 'affine:divider') {
+          parent &&
+            this._addBlocks(blocks.slice(0), parent, index, addBlockIds);
+        } else {
+          parent &&
+            this._addBlocks(blocks.slice(1), parent, index, addBlockIds);
+        }
         let lastId = selectedBlock?.id;
         let position = endIndex + insertLen;
         if (addBlockIds.length > 0) {

--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -197,6 +197,7 @@ export class PasteManager {
         selectedBlock?.text?.insertList(insertTexts, endIndex);
         selectedBlock &&
           this._addBlocks(blocks[0].children, selectedBlock, 0, addBlockIds);
+        //This is a temporary processing of the divider block, subsequent refactoring of the divider will remove it
         if (blocks[0].flavour === 'affine:divider') {
           parent &&
             this._addBlocks(blocks.slice(0), parent, index, addBlockIds);


### PR DESCRIPTION
When dragging and selecting, if the first block is a divider, copying and pasting will miss the first line