### PR TITLE
Fix: flaky indent test

### DIFF
--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -264,6 +264,7 @@ test('basic indent and unindent', async ({ page }) => {
 </affine:page>`
   );
 
+  await page.waitForTimeout(100);
   await pressShiftTab(page);
   await assertStoreMatchJSX(
     page,


### PR DESCRIPTION
Workaround flaky indent test, aka part of https://github.com/toeverything/blocksuite/issues/216

Now the test has 99% reliability
<img width="936" alt="Screenshot 2022-12-15 at 12 02 11 PM" src="https://user-images.githubusercontent.com/18554747/207769698-293cf84a-44de-4b34-adf8-3363fb0f8ceb.png">
