### PR TITLE
feat: adjust blob api with affine cloud

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // enable if want debug with jwst backend
+  // server: {
+  //   proxy: {
+  //     '/api': {
+  //       target: 'http://localhost:3000',
+  //       changeOrigin: true,
+  //     },
+  //   },
+  // },
 });

--- a/packages/store/src/blob/index.ts
+++ b/packages/store/src/blob/index.ts
@@ -1,9 +1,11 @@
 import { IndexedDBBlobProvider } from './providers';
 import { BlobStorage } from './storage';
 
-const CLOUD_API = '/api/blobs';
+const CLOUD_API = '/api/workspace';
 
 export const getBlobStorage = async (
+  // Note: In the current backend design, the workspace id is a randomly generated int64 number
+  // so if you need to test or enable blob synchronization, the provided workspace needs to be a number
   workspace?: string,
   cloudApi: string = CLOUD_API
 ) => {

--- a/packages/store/src/blob/providers.ts
+++ b/packages/store/src/blob/providers.ts
@@ -178,12 +178,12 @@ export class BlobCloudSync {
         !signal.aborted
       ) {
         try {
-          const api = `${this._workspace}/${task.id}`;
-
-          const resp = await this._fetcher.head(api);
+          const resp = await this._fetcher.head(
+            `${this._workspace}/blob/${task.id}`
+          );
           if (resp.status === 404) {
             const status = await this._fetcher
-              .post(api, { body: task.blob, retry: 3 })
+              .put(`${this._workspace}/blob`, { body: task.blob, retry: 3 })
               .json<BlobStatus>();
             await this._handleTaskRetry(task, status);
           }
@@ -199,7 +199,7 @@ export class BlobCloudSync {
   }
 
   async get(id: BlobId): Promise<BlobURL | null> {
-    const api = `${this._workspace}/${id}`;
+    const api = `${this._workspace}/blob/${id}`;
     try {
       const blob = await this._fetcher
         .get(api, { throwHttpErrors: true })

--- a/packages/store/src/blob/utils.ts
+++ b/packages/store/src/blob/utils.ts
@@ -1,9 +1,9 @@
 import type { Buffer } from 'buffer';
 import { createStore, del, get, keys, set, clear } from 'idb-keyval';
-import { SHAKE } from 'sha3';
+import { SHA3 } from 'sha3';
 import type { IDBInstance } from './types';
 
-const hash = new SHAKE(128);
+const hash = new SHA3(256);
 
 export function sha3(buffer: Buffer): string {
   hash.reset();


### PR DESCRIPTION
Match blob sync api to newest affine cloud apis

Note1: Now we can access cloud api in same host based on vite proxy config, default disabled.
Note2: In the current backend design, the workspace id is a randomly generated int64 number, so if you need to test or enable blob synchronization, the provided workspace needs to be a number
Note3: current api server run at 100.77.180.48:11001