### PR TITLE
build: make dependencies as externals

### DIFF
--- a/packages/blocks/vite.config.ts
+++ b/packages/blocks/vite.config.ts
@@ -11,7 +11,18 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {},
-      external: ['yjs', '@blocksuite/store'],
+      external: [
+        'yjs',
+        '@blocksuite/store',
+        'highlight.js',
+        '@tldraw/intersect',
+        '@tldraw/vec',
+        'hotkeys-js',
+        'lit',
+        'perfect-freehand',
+        'quill',
+        'quill-cursors',
+      ],
     },
   },
 });


### PR DESCRIPTION
I think we should make all dependencies externals because they are dependencies in the package.json. So the user would download and resolve all the dependencies correctly in their code space