### PR TITLE
refactor: id generator

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,7 +1,7 @@
 import '@blocksuite/blocks';
 import '@blocksuite/editor';
-import { createEditor, createDebugMenu, BlockSchema } from '@blocksuite/editor';
-import { Workspace, Page } from '@blocksuite/store';
+import { BlockSchema, createDebugMenu, createEditor } from '@blocksuite/editor';
+import { Generator, Page, Workspace } from '@blocksuite/store';
 import { getOptions } from './utils';
 import './style.css';
 
@@ -28,6 +28,10 @@ function subscribePage(workspace: Workspace) {
 }
 
 async function main() {
+  if (isE2E) {
+    // we need a predictable id generator in test environment
+    options.idGenerator = Generator.AutoIncrement;
+  }
   const workspace = new Workspace(options).register(BlockSchema);
   // @ts-ignore
   [window.workspace, window.blockSchema] = [workspace, BlockSchema];

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -29,7 +29,9 @@ function subscribePage(workspace: Workspace) {
 
 async function main() {
   if (isE2E) {
-    // we need a predictable id generator in test environment
+    // We need a predictable id generator in test environment.
+    // Keep in mind that the collaboration will cause playground crash,
+    //  because the id will conflict for both starting at 0.
     options.idGenerator = Generator.AutoIncrement;
   }
   const workspace = new Workspace(options).register(BlockSchema);

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -31,7 +31,7 @@ async function main() {
   if (isE2E) {
     // We need a predictable id generator in test environment.
     // Keep in mind that the collaboration will cause playground crash,
-    //  because the id will conflict for both starting at 0.
+    //  because all clients' id starting at 0.
     options.idGenerator = Generator.AutoIncrement;
   }
   const workspace = new Workspace(options).register(BlockSchema);

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -1,11 +1,10 @@
 import {
-  createAutoIncrementIdGenerator,
   createWebsocketDocProvider,
   DebugDocProvider,
   DocProviderConstructor,
+  Generator,
   IndexedDBDocProvider,
   StoreOptions,
-  uuidv4,
 } from '@blocksuite/store';
 
 const params = new URLSearchParams(location.search);
@@ -54,12 +53,9 @@ export function getOptions(): Pick<
     }
   });
 
-  /**
-   * Specified using "uuidv4" when providers have indexeddb.
-   * Because when persistent data applied to ydoc, we need generator different id for block.
-   * Otherwise, the block id will conflict.
-   */
-  const idGenerator = forceUUIDv4 ? uuidv4 : createAutoIncrementIdGenerator();
+  const idGenerator = forceUUIDv4
+    ? Generator.UUIDv4
+    : Generator.AutoIncrementByClientId;
 
   return {
     room,

--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -1,13 +1,7 @@
 // checkout https://vitest.dev/guide/debugging.html for debugging tests
 
 import { assert, describe, expect, it } from 'vitest';
-import {
-  BaseBlockModel,
-  Signal,
-  Workspace,
-  Page,
-  createAutoIncrementIdGenerator,
-} from '..';
+import { BaseBlockModel, Signal, Workspace, Page, Generator } from '..';
 
 // Use manual per-module import/export to support vitest environment on Node.js
 import { PageBlockModel } from '../../../blocks/src/page-block/page-model';
@@ -19,7 +13,7 @@ import type { PageMeta } from '../workspace';
 import { assertExists } from '../utils/utils';
 
 function createTestOptions() {
-  const idGenerator = createAutoIncrementIdGenerator();
+  const idGenerator = Generator.AutoIncrement;
   return { idGenerator };
 }
 
@@ -101,45 +95,6 @@ describe.concurrent('addBlock', () => {
         'sys:children': [],
         'sys:flavour': 'affine:page',
         'sys:id': '0',
-      },
-    });
-  });
-
-  it('can set custom idGenerator', async () => {
-    const options = {
-      ...createTestOptions(),
-      idGenerator: (() => {
-        const keys = ['7', '100', '2'];
-        let i = 0;
-        return () => keys[i++];
-      })(),
-    };
-    const workspace = new Workspace(options).register(BlockSchema);
-    const page = await createPage(workspace);
-
-    page.addBlock({ flavour: 'affine:page' });
-    page.addBlock({ flavour: 'affine:paragraph' });
-    page.addBlock({ flavour: 'affine:paragraph' });
-
-    assert.deepEqual(serialize(page)[spaceId], {
-      '7': {
-        'sys:children': ['100', '2'],
-        'sys:flavour': 'affine:page',
-        'sys:id': '7',
-      },
-      '100': {
-        'sys:children': [],
-        'sys:flavour': 'affine:paragraph',
-        'sys:id': '100',
-        'prop:text': '',
-        'prop:type': 'text',
-      },
-      '2': {
-        'sys:children': [],
-        'sys:flavour': 'affine:paragraph',
-        'sys:id': '2',
-        'prop:text': '',
-        'prop:type': 'text',
       },
     });
   });

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -17,8 +17,21 @@ export interface SerializedStore {
 }
 
 export enum Generator {
+  /**
+   * Default mode, generator for the unpredictable id
+   */
   UUIDv4 = 'uuidV4',
+  /**
+   * This generator is trying to fix the real-time collaboration on debug mode.
+   * This will make generator predictable and won't make conflict
+   * @link https://docs.yjs.dev/api/faq#i-get-a-new-clientid-for-every-session-is-there-a-way-to-make-it-static-for-a-peer-accessing-the-doc
+   */
   AutoIncrementByClientId = 'autoIncrementByClientId',
+  /**
+   * **Warning**: This generator mode will crash the collaborative feature
+   *  if multiple client are adding new blocks.
+   * Use this mode only if you know what you're doing.
+   */
   AutoIncrement = 'autoIncrement',
 }
 
@@ -57,10 +70,7 @@ export class Store {
         );
         break;
       }
-      case Generator.UUIDv4: {
-        this.idGenerator = uuidv4;
-        break;
-      }
+      case Generator.UUIDv4:
       default: {
         this.idGenerator = uuidv4;
         break;

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -29,7 +29,7 @@ export enum Generator {
   AutoIncrementByClientId = 'autoIncrementByClientId',
   /**
    * **Warning**: This generator mode will crash the collaborative feature
-   *  if multiple client are adding new blocks.
+   *  if multiple clients are adding new blocks.
    * Use this mode only if you know what you're doing.
    */
   AutoIncrement = 'autoIncrement',

--- a/packages/store/src/utils/id-generator.ts
+++ b/packages/store/src/utils/id-generator.ts
@@ -7,6 +7,13 @@ export function createAutoIncrementIdGenerator(): IdGenerator {
   return () => (i++).toString();
 }
 
+export function createAutoIncrementIdGeneratorByClientId(
+  clientId: number
+): IdGenerator {
+  let i = 0;
+  return () => `${clientId}:${i++}`;
+}
+
 export function uuidv4() {
   return uuidv4IdGenerator();
 }


### PR DESCRIPTION
I had a meeting with @doodlewind, and the conclusion is the error that the reason caused the collaborative mode and URL paste crash is the **default generator** in the playground. This will let all clients create a block starting from 0, and the editor will crash.

Fixes: https://github.com/toeverything/blocksuite/issues/217, https://github.com/toeverything/blocksuite/issues/287