### PR TITLE
fix: restore selection after format multiple lines

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -755,6 +755,35 @@ export function isEmbed(e: SelectionEvent) {
   return false;
 }
 
+/**
+ * Save the current block selection. Can be restored with {@link restoreSelection}.
+ *
+ * See also {@link restoreSelection}
+ *
+ * Note: If only one block is selected, this function will return the same block twice still.
+ * Note: If select multiple blocks, blocks in the middle will be skipped, only the first and last block will be returned.
+ */
+export const saveBlockSelection = (): [SelectedBlock, SelectedBlock] => {
+  const selection = window.getSelection();
+  assertExists(selection);
+  const models = getModelsByRange(getCurrentRange(selection));
+  const startPos = getQuillIndexByNativeSelection(
+    selection.anchorNode,
+    selection.anchorOffset,
+    true
+  );
+  const endPos = getQuillIndexByNativeSelection(
+    selection.focusNode,
+    selection.focusOffset,
+    false
+  );
+
+  return [
+    { id: models[0].id, startPos, children: [] },
+    { id: models[models.length - 1].id, endPos, children: [] },
+  ];
+};
+
 export function restoreSelection(
   rangeOrSelectedBlock: Range | SelectedBlock[]
 ) {

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -763,8 +763,9 @@ export function isEmbed(e: SelectionEvent) {
  * Note: If only one block is selected, this function will return the same block twice still.
  * Note: If select multiple blocks, blocks in the middle will be skipped, only the first and last block will be returned.
  */
-export const saveBlockSelection = (): [SelectedBlock, SelectedBlock] => {
-  const selection = window.getSelection();
+export const saveBlockSelection = (
+  selection = window.getSelection()
+): [SelectedBlock, SelectedBlock] => {
   assertExists(selection);
   const models = getModelsByRange(getCurrentRange(selection));
   const startPos = getQuillIndexByNativeSelection(

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -22,10 +22,20 @@ export interface CommonBlockElement extends HTMLElement {
   model: BaseBlockModel;
 }
 
+/**
+ * type of `window.getSelection().type`
+ *
+ * The attribute must return "None" if this is empty, "Caret" if this's range is collapsed, and "Range" otherwise.
+ *
+ * More details see https://w3c.github.io/selection-api/#dom-selection-type
+ */
+export type DomSelectionType = 'Caret' | 'Range' | 'None';
+
 export interface SelectionInfo {
-  type: string;
+  type: 'Block' | DomSelectionType;
   selectedBlocks: SelectedBlock[];
 }
+
 export interface SelectedBlock {
   id: string;
   startPos?: number;

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -1,21 +1,20 @@
-import type { Page, Text, BaseBlockModel } from '@blocksuite/store';
+import type { BaseBlockModel, Page, Text } from '@blocksuite/store';
 import {
+  almostEqual,
   assertExists,
   assertFlavours,
   ExtendedModel,
-  almostEqual,
   RootBlockModel,
-  SelectedBlock,
 } from '../../__internal__';
 import { asyncFocusRichText } from '../../__internal__/utils/common-operations';
 import {
-  getRichTextByModel,
-  getModelsByRange,
   getBlockElementByModel,
-  getQuillIndexByNativeSelection,
   getCurrentRange,
-  getParentBlockById,
   getModelByElement,
+  getModelsByRange,
+  getParentBlockById,
+  getQuillIndexByNativeSelection,
+  getRichTextByModel,
 } from '../../__internal__/utils/query';
 import {
   isCollapsedSelection,
@@ -24,6 +23,7 @@ import {
   isRangeSelection,
   resetNativeSelection,
   restoreSelection,
+  saveBlockSelection,
 } from '../../__internal__/utils/selection';
 import { DEFAULT_SPACING } from '../edgeless/utils';
 
@@ -124,28 +124,6 @@ export function handleBackspace(page: Page, e: KeyboardEvent) {
     }
   }
 }
-
-export const saveBlockSelection = (): SelectedBlock[] => {
-  const selection = window.getSelection();
-  assertExists(selection);
-  const models = getModelsByRange(getCurrentRange(selection));
-  const startPos = getQuillIndexByNativeSelection(
-    selection.anchorNode,
-    selection.anchorOffset,
-    true
-  );
-  const endPos = getQuillIndexByNativeSelection(
-    selection.focusNode,
-    selection.focusOffset,
-    false
-  );
-  console.log(selection, startPos, endPos);
-
-  return [
-    { id: models[0].id, startPos, children: [] },
-    { id: models[models.length - 1].id, endPos, children: [] },
-  ];
-};
 
 export const getFormat = () => {
   const models = getModelsByRange(getCurrentRange());

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -188,6 +188,7 @@ function formatModelsByRange(
   key: string
 ) {
   const selection = window.getSelection();
+  const selectedBlocks = saveBlockSelection(selection);
   const first = models[0];
   const last = models[models.length - 1];
   const firstRichText = getRichTextByModel(first);
@@ -222,10 +223,7 @@ function formatModelsByRange(
       [key]: !isFormatActive,
     });
   }
-  lastRichText.quill.setSelection(endIndex, 0);
-  if (key === 'code' || key === 'link') {
-    lastRichText.quill.format(key, false);
-  }
+  restoreSelection(selectedBlocks);
 }
 
 export function handleFormat(page: Page, key: string) {
@@ -245,9 +243,7 @@ export function handleFormat(page: Page, key: string) {
       const format = quill.getFormat(range);
       models[0].text?.format(index, length, { [key]: !format[key] });
     } else {
-      const selectedBlocks = saveBlockSelection();
       formatModelsByRange(models, page, key);
-      restoreSelection(selectedBlocks);
     }
   }
 }

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -155,10 +155,6 @@ test('should format quick bar be able to format text when select multiple line',
   await expect(boldBtnLocator).not.toHaveAttribute('active', '');
   await boldBtnLocator.click();
 
-  // TODO FIXME: selection should not be lost after click
-  // Remove next line after fix
-  await dragBetweenIndices(page, [0, 0], [2, 3]);
-
   // The bold button should be active after click
   await expect(boldBtnLocator).toHaveAttribute('active', '');
   await assertStoreMatchJSX(
@@ -204,9 +200,50 @@ test('should format quick bar be able to format text when select multiple line',
     groupId
   );
 
-  // TODO FIXME: The bold button should be inactive after click again
-  // await boldBtnLocator.click();
-  // await assertStoreMatchJSX(page, ``, groupId);
+  await boldBtnLocator.click();
+  await expect(boldBtnLocator).not.toHaveAttribute('active', '');
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:group
+  prop:xywh="[0,0,720,112]"
+>
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          bold={false}
+          insert="123"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          bold={false}
+          insert="456"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          bold={false}
+          insert="789"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+</affine:group>`,
+    groupId
+  );
 });
 
 test('should format quick bar be able to link text', async ({ page }) => {

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -18,6 +18,7 @@ import {
 } from './utils/actions';
 import {
   assertRichTexts,
+  assertStoreMatchJSX,
   assertTextFormat,
   assertTypeFormat,
 } from './utils/asserts';
@@ -72,7 +73,7 @@ test('type character jump out code node', async ({ page }) => {
 
 test('multi line rich-text inline code hotkey', async ({ page }) => {
   await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
+  const { groupId } = await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
   await assertRichTexts(page, ['123', '456', '789']);
 
@@ -81,25 +82,129 @@ test('multi line rich-text inline code hotkey', async ({ page }) => {
   await dragBetweenIndices(page, [0, 1], [2, 2]);
   await inlineCode(page);
 
-  // split at 0,1
-  await assertTextFormat(page, 0, 1, {});
-  await assertTextFormat(page, 0, 2, { code: true });
-
-  // split at 2,2
-  await assertTextFormat(page, 2, 2, {});
-  await assertTextFormat(page, 2, 3, {});
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:group
+  prop:xywh="[0,0,720,112]"
+>
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          insert="1"
+        />
+        <text
+          code={true}
+          insert="23"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          code={true}
+          insert="456"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          code={true}
+          insert="78"
+        />
+        <text
+          insert="9"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+</affine:group>`,
+    groupId
+  );
 
   await undoByClick(page);
-  await assertTextFormat(page, 0, 1, {});
-  await assertTextFormat(page, 0, 2, {});
-  await assertTextFormat(page, 2, 2, {});
-  await assertTextFormat(page, 2, 3, {});
+
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:group
+  prop:xywh="[0,0,720,112]"
+>
+  <affine:paragraph
+    prop:text="123"
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text="456"
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text="789"
+    prop:type="text"
+  />
+</affine:group>`,
+    groupId
+  );
 
   await redoByClick(page);
-  await assertTextFormat(page, 0, 1, {});
-  await assertTextFormat(page, 0, 2, { code: true });
-  await assertTextFormat(page, 2, 2, { code: true });
-  await assertTextFormat(page, 2, 3, {});
+
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:group
+  prop:xywh="[0,0,720,112]"
+>
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          insert="1"
+        />
+        <text
+          code={true}
+          insert="23"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          code={true}
+          insert="456"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text={
+      <>
+        <text
+          code={true}
+          insert="78"
+        />
+        <text
+          insert="9"
+        />
+      </>
+    }
+    prop:type="text"
+  />
+</affine:group>`,
+    groupId
+  );
 });
 
 test('single line rich-text strikethrough hotkey', async ({ page }) => {


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/230

Also related to https://github.com/toeverything/blocksuite/discussions/231


https://user-images.githubusercontent.com/18554747/208319009-4a804023-4632-4d9d-8304-a8b0a5ffecad.mov


There still have some bugs, for example, the format will fail if there has an empty line

https://user-images.githubusercontent.com/18554747/208319163-5f02e066-91c0-4527-a40c-88163fa09b62.mov

Due to the id changed after `transformBlock`, it does not work at updateBlockType

