### PR TITLE
Fix: typo on format replace

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -101,7 +101,7 @@ export class RichText extends LitElement {
     this.quill.on('text-change', delta => {
       const selectorMap = {
         code: 'code',
-        link: 'link-code',
+        link: 'link-node',
       } as const;
       let attr = '';
       if (delta.ops[1]?.attributes?.code) {

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -103,7 +103,7 @@ export class RichText extends LitElement {
         code: 'code',
         link: 'link-node',
       } as const;
-      let attr = '';
+      let attr: keyof typeof selectorMap | null = null;
       if (delta.ops[1]?.attributes?.code) {
         attr = 'code';
       }
@@ -113,7 +113,7 @@ export class RichText extends LitElement {
       // only length is 2 need to be handled
       if (delta.ops.length === 2 && delta.ops[1]?.insert && attr) {
         const retain = delta.ops[0].retain;
-        const selector = selectorMap[attr as keyof typeof selectorMap];
+        const selector = selectorMap[attr];
         if (retain !== undefined) {
           const currentLeaf = this.quill.getLeaf(
             retain + Number(delta.ops[1]?.insert.toString().length)
@@ -126,9 +126,16 @@ export class RichText extends LitElement {
           const nextParentElement = nextLeaf[0]?.domNode?.parentElement;
           const nextEmbedElement = nextParentElement?.closest(selector);
           const insertedString = delta.ops[1]?.insert.toString();
+
+          // if insert to the same node, no need to handle
+          // For example,
+          // `inline |code`
+          //         ⬆️ should not remove format when insert to inside the format
           if (
-            (nextEmbedElement && nextEmbedElement !== currentEmbedElement) ||
-            !nextEmbedElement
+            // At the end of the node, need to remove format
+            !nextEmbedElement ||
+            // At the edge of the node, need to remove format
+            nextEmbedElement !== currentEmbedElement
           ) {
             model.text?.replace(
               retain,

--- a/tests/link.spec.ts
+++ b/tests/link.spec.ts
@@ -29,23 +29,23 @@ test('basic link', async ({ page }) => {
   await selectAllByKeyboard(page);
   await pressCreateLinkShortCut(page);
 
-  const linkPopoverLocator = page.locator('.overlay-container');
-  expect(await linkPopoverLocator.isVisible()).toBe(true);
+  const linkPopoverLocator = page.locator('.affine-link-popover');
+  await expect(linkPopoverLocator).toBeVisible();
   const linkPopoverInput = page.locator('.affine-link-popover-input');
-  expect(await linkPopoverInput.isVisible()).toBe(true);
+  await expect(linkPopoverInput).toBeVisible();
   await page.keyboard.type(link);
   await pressEnter(page);
-  expect(await linkPopoverLocator.isVisible()).toBe(false);
+  await expect(linkPopoverLocator).not.toBeVisible();
 
   const linkLocator = page.locator(`text="${linkText}"`);
   await expect(linkLocator).toHaveAttribute('href', link);
 
   // Hover link
-  expect(await linkPopoverLocator.isVisible()).toBe(false);
+  await expect(linkPopoverLocator).not.toBeVisible();
   await linkLocator.hover();
   // wait for popover delay open
   await page.waitForTimeout(200);
-  expect(await linkPopoverLocator.isVisible()).toBe(true);
+  await expect(linkPopoverLocator).toBeVisible();
 
   // Edit link
   const text2 = 'link2';
@@ -55,7 +55,7 @@ test('basic link', async ({ page }) => {
   await pressEnter(page);
 
   const editLinkPopoverLocator = page.locator('.affine-link-edit-popover');
-  expect(await editLinkPopoverLocator.isVisible()).toBe(true);
+  await expect(editLinkPopoverLocator).toBeVisible();
   await page.keyboard.press('Tab');
   await page.keyboard.type(text2);
   await page.keyboard.press('Tab');

--- a/tests/utils/actions/click.ts
+++ b/tests/utils/actions/click.ts
@@ -48,6 +48,10 @@ export async function switchShapeType(page: Page, shapeType: string) {
   await page.selectOption('select[aria-label="switch shape type"]', shapeType);
 }
 
+export async function switchReadonly(page: Page) {
+  await page.click('button[aria-label="toggle readonly"]');
+}
+
 export async function activeEmbed(page: Page) {
   await page.click('.resizable-img');
 }


### PR DESCRIPTION
Fix when editing the link text, it will split into pieces.

See more details:

https://user-images.githubusercontent.com/18554747/208391062-26c4450d-ec33-438e-b5e4-eff3a3d25266.mov

Related to https://github.com/toeverything/blocksuite/pull/148

Due to https://github.com/toeverything/blocksuite/pull/162





