### PR TITLE
fix: skip empty line when merge multiple lines format

### DIFF
--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -166,6 +166,11 @@ export const getFormat = () => {
   for (let i = 1; i < models.length - 1; i++) {
     const richText = getRichTextByModel(models[i]);
     assertExists(richText);
+    const content = richText.quill.getText();
+    if (!content || content === '\n') {
+      // empty line should not be included
+      continue;
+    }
     const format = richText.quill.getFormat(0, richText.quill.getLength() - 1);
     formatArr.push(format);
   }


### PR DESCRIPTION
Fix format will fail if there has an empty line


https://user-images.githubusercontent.com/18554747/208399223-c28c3b53-d2fe-4a71-8bff-6c1971e238e2.mov


This issue is also be mentioned at https://github.com/toeverything/blocksuite/pull/358