### PR TITLE
Fix: restore selection after transform block

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -103,7 +103,7 @@ export class RichText extends LitElement {
     // the character should not be inserted into the code or link node.
     // So we check and remove the corresponding format manually.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.quill.on('text-change', delta => {
+    this.quill.on('text-change', (delta: any) => {
       const selectorMap = {
         code: 'code',
         link: 'link-node',

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -91,7 +91,8 @@ export class RichText extends LitElement {
     });
 
     page.attachRichText(model.id, this.quill);
-    page.awareness.updateLocalCursor();
+    // TODO it can cause cursor flickering, by need to evaluate impact
+    // page.awareness.updateLocalCursor();
     this.model.propsUpdated.on(() => this.requestUpdate());
 
     if (this.modules.syntax) {
@@ -102,7 +103,7 @@ export class RichText extends LitElement {
     // the character should not be inserted into the code or link node.
     // So we check and remove the corresponding format manually.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.quill.on('text-change', (delta: any) => {
+    this.quill.on('text-change', delta => {
       const selectorMap = {
         code: 'code',
         link: 'link-node',

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -91,8 +91,7 @@ export class RichText extends LitElement {
     });
 
     page.attachRichText(model.id, this.quill);
-    // TODO it can cause cursor flickering, by need to evaluate impact
-    // page.awareness.updateLocalCursor();
+    page.awareness.updateLocalCursor();
     this.model.propsUpdated.on(() => this.requestUpdate());
 
     if (this.modules.syntax) {

--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -1,14 +1,13 @@
 import type { Page } from '@blocksuite/store';
 import type { Quill } from 'quill';
-import { matchFlavours } from './std.js';
+import { matchFlavours, sleep } from './std.js';
 import type { ExtendedModel } from './types.js';
 
 // XXX: workaround quill lifecycle issue
-export function asyncFocusRichText(page: Page, id: string) {
-  setTimeout(() => {
-    const adapter = page.richTextAdapters.get(id);
-    adapter?.quill.focus();
-  });
+export async function asyncFocusRichText(page: Page, id: string) {
+  await sleep();
+  const adapter = page.richTextAdapters.get(id);
+  adapter?.quill.focus();
 }
 
 export function isCollapsedAtBlockStart(quill: Quill) {

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -357,7 +357,9 @@ export function getTextNodeBySelectedBlock(selectedBlock: SelectedBlock) {
   const blockElement = getBlockById(selectedBlock.id);
   const offset = selectedBlock.startPos ?? selectedBlock.endPos ?? 0;
   if (!blockElement) {
-    throw new Error('Failed to get block element');
+    throw new Error(
+      'Failed to get block element, block id: ' + selectedBlock.id
+    );
   }
   const richText = blockElement.querySelector('rich-text');
   if (!richText) {

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -145,6 +145,7 @@ export class FormatQuickBar extends LitElement {
             }
             updateSelectedTextType(flavour, type, this.page);
             this.paragraphType = type;
+            this.positionUpdated.emit();
           }}
         >
           ${icon}
@@ -193,6 +194,7 @@ export class FormatQuickBar extends LitElement {
             });
             // format state need to update after format
             this.format = getFormat();
+            this.positionUpdated.emit();
           }}
         >
           ${icon}

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -13,7 +13,6 @@ import {
 } from '../../__internal__/utils/index.js';
 import './button';
 import './format-bar-node';
-import type { FormatQuickBar } from './format-bar-node.js';
 
 export const showFormatQuickBar = async ({
   anchorEl,
@@ -21,7 +20,7 @@ export const showFormatQuickBar = async ({
   container = document.body,
   abortController = new AbortController(),
 }: {
-  anchorEl:
+  anchorEl?:
     | {
         getBoundingClientRect: () => DOMRect;
         // contextElement?: Element;
@@ -33,9 +32,7 @@ export const showFormatQuickBar = async ({
 }) => {
   // Init format quick bar
 
-  const formatQuickBar = document.createElement(
-    'format-quick-bar'
-  ) as FormatQuickBar;
+  const formatQuickBar = document.createElement('format-quick-bar');
   formatQuickBar.abortController = abortController;
   const positionUpdatedSignal = new Signal();
   formatQuickBar.positionUpdated = positionUpdatedSignal;
@@ -44,17 +41,18 @@ export const showFormatQuickBar = async ({
 
   // Once performance problems occur, it can be mitigated increasing throttle limit
   const updatePos = throttle(() => {
+    const positioningEl = anchorEl ?? getCurrentRange();
+
     const positioningPoint =
-      anchorEl instanceof Range
-        ? calcPositionPointByRange(anchorEl, direction)
-        : anchorEl.getBoundingClientRect();
+      positioningEl instanceof Range
+        ? calcPositionPointByRange(positioningEl, direction)
+        : positioningEl.getBoundingClientRect();
 
     // TODO maybe use the editor container as the boundary rect to avoid the format bar being covered by other elements
     const boundaryRect = document.body.getBoundingClientRect();
     const formatBarRect =
       formatQuickBar.formatQuickBarElement.getBoundingClientRect();
     // Add offset to avoid the quick bar being covered by the window border
-
     const gapY = 5;
     const isBottom = direction.includes('bottom');
     const safeCoordinate = calcSafeCoordinate({

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -100,9 +100,7 @@ export const showFormatQuickBar = async ({
 
   // Handle selection change
 
-  const selectionChangeHandler = async () => {
-    // XXX wait for the selection to be updated
-    await sleep(100);
+  const selectionChangeHandler = () => {
     const selection = document.getSelection();
     if (!selection || selection.type === 'Caret') {
       abortController.abort();

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -100,7 +100,9 @@ export const showFormatQuickBar = async ({
 
   // Handle selection change
 
-  const selectionChangeHandler = () => {
+  const selectionChangeHandler = async () => {
+    // XXX wait for the selection to be updated
+    await sleep(100);
     const selection = document.getSelection();
     if (!selection || selection.type === 'Caret') {
       abortController.abort();

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -87,19 +87,6 @@ export const showFormatQuickBar = async ({
   positionUpdatedSignal.on(updatePos);
   window.addEventListener('resize', updatePos, { passive: true });
 
-  // Handle click outside
-
-  const clickAwayListener = (e: MouseEvent) => {
-    if (e.target === formatQuickBar) {
-      // Prevent selection loss
-      e.preventDefault();
-      return;
-    }
-    abortController.abort();
-    window.removeEventListener('mousedown', clickAwayListener);
-  };
-  window.addEventListener('mousedown', clickAwayListener);
-
   // Handle selection change
 
   const selectionChangeHandler = () => {

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -91,6 +91,8 @@ export const showFormatQuickBar = async ({
 
   const clickAwayListener = (e: MouseEvent) => {
     if (e.target === formatQuickBar) {
+      // Prevent selection loss
+      e.preventDefault();
       return;
     }
     abortController.abort();

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -11,8 +11,8 @@ import {
   sleep,
   throttle,
 } from '../../__internal__/utils/index.js';
-import './button';
-import './format-bar-node';
+import './button.js';
+import './format-bar-node.js';
 
 export const showFormatQuickBar = async ({
   anchorEl,

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -356,14 +356,13 @@ export class DefaultSelectionManager {
 
   private _showFormatQuickBar(e: SelectionEvent) {
     if (this.state.type === 'native') {
-      const { anchor, direction, selectedType } =
-        getNativeSelectionMouseDragInfo(e);
+      const { direction, selectedType } = getNativeSelectionMouseDragInfo(e);
       if (selectedType === 'Caret') {
         // If nothing is selected, then we should not show the format bar
         return;
       }
 
-      showFormatQuickBar({ anchorEl: anchor, direction });
+      showFormatQuickBar({ direction });
     } else if (this.state.type === 'block') {
       // TODO handle block selection
       // const direction = getDragDirection(e);
@@ -456,7 +455,7 @@ export class DefaultSelectionManager {
     if (this._container.readonly) {
       return;
     }
-    showFormatQuickBar({ anchorEl: range, direction: 'center-bottom' });
+    showFormatQuickBar({ direction: 'center-bottom' });
   };
 
   private _onContainerContextMenu = (e: SelectionEvent) => {

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -410,33 +410,33 @@ export function bindHotkeys(
     model && focusNextBlock(model, 'start');
   });
 
-  hotkey.addListener(H1, () =>
-    updateSelectedTextType('affine:paragraph', 'h1', page)
-  );
-  hotkey.addListener(H2, () =>
-    updateSelectedTextType('affine:paragraph', 'h2', page)
-  );
-  hotkey.addListener(H3, () =>
-    updateSelectedTextType('affine:paragraph', 'h3', page)
-  );
-  hotkey.addListener(H4, () =>
-    updateSelectedTextType('affine:paragraph', 'h4', page)
-  );
-  hotkey.addListener(H5, () =>
-    updateSelectedTextType('affine:paragraph', 'h5', page)
-  );
-  hotkey.addListener(H6, () =>
-    updateSelectedTextType('affine:paragraph', 'h6', page)
-  );
-  hotkey.addListener(NUMBERED_LIST, () =>
-    updateSelectedTextType('affine:list', 'numbered', page)
-  );
-  hotkey.addListener(BULLETED, () =>
-    updateSelectedTextType('affine:list', 'bulleted', page)
-  );
-  hotkey.addListener(TEXT, () =>
-    updateSelectedTextType('affine:paragraph', 'text', page)
-  );
+  hotkey.addListener(H1, () => {
+    updateSelectedTextType('affine:paragraph', 'h1', page);
+  });
+  hotkey.addListener(H2, () => {
+    updateSelectedTextType('affine:paragraph', 'h2', page);
+  });
+  hotkey.addListener(H3, () => {
+    updateSelectedTextType('affine:paragraph', 'h3', page);
+  });
+  hotkey.addListener(H4, () => {
+    updateSelectedTextType('affine:paragraph', 'h4', page);
+  });
+  hotkey.addListener(H5, () => {
+    updateSelectedTextType('affine:paragraph', 'h5', page);
+  });
+  hotkey.addListener(H6, () => {
+    updateSelectedTextType('affine:paragraph', 'h6', page);
+  });
+  hotkey.addListener(NUMBERED_LIST, () => {
+    updateSelectedTextType('affine:list', 'numbered', page);
+  });
+  hotkey.addListener(BULLETED, () => {
+    updateSelectedTextType('affine:list', 'bulleted', page);
+  });
+  hotkey.addListener(TEXT, () => {
+    updateSelectedTextType('affine:paragraph', 'text', page);
+  });
   hotkey.addListener(SHIFT_UP, e => {
     // TODO expand selection up
   });

--- a/packages/blocks/src/page-block/edgeless/selection-manager/default.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager/default.ts
@@ -176,13 +176,12 @@ export class DefaultSelectionController extends SelectionController<DefaultMouse
 
   onContainerDragEnd(e: SelectionEvent): void {
     if (this.isActive) {
-      const { anchor, direction, selectedType } =
-        getNativeSelectionMouseDragInfo(e);
+      const { direction, selectedType } = getNativeSelectionMouseDragInfo(e);
       if (selectedType === 'Caret') {
         // If nothing is selected, then we should not show the format bar
         return;
       }
-      showFormatQuickBar({ anchorEl: anchor, direction });
+      showFormatQuickBar({ direction });
     } else if (this.blockSelectionState.type === 'single') {
       if (!this._frameSelectionState) {
         this._page.captureSync();

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -149,7 +149,7 @@ export function transformBlock(
   const index = parent.children.indexOf(model);
   page.deleteBlock(model);
   const id = page.addBlock(blockProps, parent, index);
-  // asyncFocusRichText(page, id);
+  asyncFocusRichText(page, id);
   return id;
 }
 
@@ -347,6 +347,7 @@ export function handleSelectAll(selection: DefaultSelectionManager) {
   resetNativeSelection(null);
 }
 
+// TODO should show format bar after select all
 function initQuickBarEventHandlersAfterSelectAll(nearestCommonAncestor: Node) {
   nearestCommonAncestor.addEventListener(
     'mousemove',

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -118,6 +118,7 @@ export async function updateSelectedTextType(
     } else {
       const oldId = model.id;
       const newId = transformBlock(page, model, flavour, type);
+
       // Replace selected block id
       const blocks = selectedBlocks.filter(block => block.id === oldId);
       // Because selectedBlocks maybe contains same block when only select one block, so we need to replace all of them
@@ -126,8 +127,8 @@ export async function updateSelectedTextType(
       });
     }
   });
-  // XXX FIXME: wait for page update
-  await sleep(100);
+  // Wait for ui update
+  await sleep();
   restoreSelection(selectedBlocks);
 }
 
@@ -148,7 +149,7 @@ export function transformBlock(
   const index = parent.children.indexOf(model);
   page.deleteBlock(model);
   const id = page.addBlock(blockProps, parent, index);
-  asyncFocusRichText(page, id);
+  // asyncFocusRichText(page, id);
   return id;
 }
 

--- a/packages/blocks/src/page-block/utils/cursor.ts
+++ b/packages/blocks/src/page-block/utils/cursor.ts
@@ -70,11 +70,10 @@ export function getDragDirection(e: SelectionEvent): DragDirection {
  *
  * @example
  * ```ts
- * const { selectedType, direction, anchor } = getNativeSelectionMouseDragInfo(e);
+ * const { selectedType, direction } = getNativeSelectionMouseDragInfo(e);
  * if (selectedType === 'Caret') {
  *   return;
  * }
- * const rect = anchor.getBoundingClientRect();
  * ```
  */
 export function getNativeSelectionMouseDragInfo(e: SelectionEvent) {
@@ -89,7 +88,7 @@ export function getNativeSelectionMouseDragInfo(e: SelectionEvent) {
     // So we need to check the length of the range
     curRange.toString().length === 0;
   const selectedType: SelectedBlockType = isSelectedNothing ? 'Caret' : 'Text';
-  return { selectedType, direction, anchor: curRange };
+  return { selectedType, direction };
 }
 
 export function calcPositionPointByRange(

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -388,10 +388,8 @@ test('should format quick bar be able to change to heading paragraph type', asyn
     groupId
   );
 
-  // XXX wait for selection restore
-  await page.waitForTimeout(100);
-  const textBtnLocator = page.locator(`[data-testid=text]`);
-  await textBtnLocator.click();
+  const textBtn = page.locator(`[data-testid=text]`);
+  await textBtn.click();
 
   await assertStoreMatchJSX(
     page,
@@ -414,8 +412,6 @@ test('should format quick bar be able to change to heading paragraph type', asyn
 </affine:group>`,
     groupId
   );
-  // XXX wait for selection restore
-  await page.waitForTimeout(100);
   // The paragraph button should prevent selection after click
   await assertSelection(page, 1, 0, 3);
 });

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page, test } from '@playwright/test';
 import {
+  convertToBulletedListByClick,
   dragBetweenIndices,
   enterPlaygroundRoom,
   initEmptyParagraphState,
@@ -524,7 +525,13 @@ test('should format quick bar follow scroll', async ({ page }) => {
   const boldBtn = formatQuickBar.locator(`[data-testid=bold]`);
   await assertLocatorVisible(page, formatQuickBar);
   await boldBtn.click();
-  await page.mouse.move(0, 0);
+  await scrollToBottom(page);
+  await assertLocatorVisible(page, formatQuickBar, false);
+
+  // should format bar follow scroll after transform text type
+  await scrollToTop(page);
+  await assertLocatorVisible(page, formatQuickBar);
+  await convertToBulletedListByClick(page);
   await scrollToBottom(page);
   await assertLocatorVisible(page, formatQuickBar, false);
 });

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -388,14 +388,11 @@ test('should format quick bar be able to change to heading paragraph type', asyn
     groupId
   );
 
-  // TODO FIXME: The paragraph transform should not lost selection
-  // Remove next line after fix
-  await dragBetweenIndices(page, [1, 0], [1, 3]);
-  await paragraphBtn.hover();
-  // End of workaround
+  // XXX wait for selection restore
+  await page.waitForTimeout(100);
+  const textBtnLocator = page.locator(`[data-testid=text]`);
+  await textBtnLocator.click();
 
-  const textBtn = page.locator(`[data-testid=text]`);
-  await textBtn.click();
   await assertStoreMatchJSX(
     page,
     `
@@ -417,9 +414,10 @@ test('should format quick bar be able to change to heading paragraph type', asyn
 </affine:group>`,
     groupId
   );
-
-  // TODO FIXME: The paragraph button should prevent selection after click
-  // await assertSelection(page, 1, 0, 3);
+  // XXX wait for selection restore
+  await page.waitForTimeout(100);
+  // The paragraph button should prevent selection after click
+  await assertSelection(page, 1, 0, 3);
 });
 
 test('should format quick bar be able to copy', async ({ page }) => {

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -505,8 +505,8 @@ test('should format quick bar follow scroll', async ({ page }) => {
   await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
 
-  for (let i = 0; i < 30; i++) {
-    await page.keyboard.press('Enter');
+  for (let i = 0; i < 20; i++) {
+    await pressEnter(page);
   }
   page.keyboard.type('bottom');
 


### PR DESCRIPTION
- Restore selection after transform block

https://user-images.githubusercontent.com/18554747/209319944-db96fe6c-4350-4d10-84de-fe45e84dc6cc.mov

- Format bar will following current range always now.

- [x] Wait block update is too trick so we need a better solution.

Also mentioned at https://github.com/toeverything/blocksuite/pull/358