### PR TITLE
fix: Failed to resolve entry for package @blocksuite/store

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -2,7 +2,7 @@
   "name": "@blocksuite/store",
   "version": "0.3.0-alpha.13",
   "description": "BlockSuite data store built for general purpose state management.",
-  "main": "src/index.ts",
+  "main": "dist/store/src/index.js",
   "scripts": {
     "serve": "cross-env PORT=4444 node node_modules/y-webrtc/bin/server.js",
     "serve:websocket": "cross-env HOST=localhost PORT=1234 npx y-websocket",
@@ -34,8 +34,8 @@
     "lit": "^2.3.1"
   },
   "exports": {
-    "./src/*": "./src/*.ts",
-    ".": "./src/index.ts"
+    "./src/*": "./dist/store/src/*.js",
+    ".": "./dist/store/src/index.js"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This bug happened after I upgrade from 0.3.0-alpha.7 to 0.3.0-alpha.13

This PR fix this when importing the package:

```
[ERROR] [plugin vite:dep-scan] Failed to resolve entry for package "@blocksuite/store". The package may have incorrect main/module/exports specified in its package.json.

    node_modules/.pnpm/esbuild@0.16.10/node_modules/esbuild/lib/main.js:1357:21:
      1357 │         let result = await callback({
```

I tried modify package.json in node_modules like this to fix it. But there may be better ways, like change this?

```json
  "publishConfig": {
    "access": "public",
    "main": "dist/index.js",
    "types": "dist/index.d.ts",
    "exports": {
      "./src/*": "./dist/*.js",
      ".": "./dist/index.js"
    }
  }
```

Seems you have changed the dist folder structure since 0.3.0-alpha.7 version

![截屏2022-12-20 13 19 47](https://user-images.githubusercontent.com/3746270/208589782-9f38399a-1fe7-48a6-b5e5-130a5c3c772d.png)
