### PR TITLE
fix: package entry path after publish

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -39,11 +39,11 @@
   },
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.js",
+    "main": "dist/store/src/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-      "./src/*": "./dist/*.js",
-      ".": "./dist/index.js"
+      "./src/*": "./dist/store/src/*.js",
+      ".": "./dist/store/src/index.js"
     }
   }
 }


### PR DESCRIPTION
This bug happened after I upgrade from 0.3.0-alpha.7 to 0.3.0-alpha.13

This PR fix this when importing the package:

```
[ERROR] [plugin vite:dep-scan] Failed to resolve entry for package "@blocksuite/store". The package may have incorrect main/module/exports specified in its package.json.

    node_modules/.pnpm/esbuild@0.16.10/node_modules/esbuild/lib/main.js:1357:21:
      1357 │         let result = await callback({
```

I tried to modify package.json in devclient's node_modules like this to fix it.

Seems you have changed the dist folder structure of store package, since 0.3.0-alpha.7 version

![截屏2022-12-20 13 19 47](https://user-images.githubusercontent.com/3746270/208589782-9f38399a-1fe7-48a6-b5e5-130a5c3c772d.png)

And currently the index.d.ts is missing in the dist.

So a better solution is to restore the structure.
