### PR TITLE
feat: esm-compatible store

### DIFF
--- a/packages/blocks/src/shape-block/utils/utils.ts
+++ b/packages/blocks/src/shape-block/utils/utils.ts
@@ -1,6 +1,6 @@
 // https://github.com/tldraw/tldraw/blob/31f0f02adf58b909f59764f62de09e97542eb2b1/packages/core/src/utils/utils.ts
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Vec } from '@tldraw/vec';
+import Vec from '@tldraw/vec';
 import type { StrokePoint } from 'perfect-freehand';
 import type { Patch } from '../../__internal__';
 import {

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -1,5 +1,4 @@
 import {
-  createWebsocketDocProvider,
   DebugDocProvider,
   DocProviderConstructor,
   Generator,
@@ -43,11 +42,9 @@ export function getOptions(): Pick<
         forceUUIDv4 = true;
         break;
       case 'websocket': {
-        const WebsocketDocProvider = createWebsocketDocProvider(
-          'ws://127.0.0.1:1234'
+        console.warn(
+          'Websocket provider is not maintained in BlockSuite currently.'
         );
-        providers.push(WebsocketDocProvider);
-        forceUUIDv4 = true;
         break;
       }
       default:

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -25,7 +25,6 @@
     "y-indexeddb": "^9.0.9",
     "y-protocols": "^1.0.5",
     "y-webrtc": "^10.2.3",
-    "y-websocket": "^1.4.5",
     "yjs": "^13.5.41"
   },
   "devDependencies": {

--- a/packages/store/src/doc-providers.ts
+++ b/packages/store/src/doc-providers.ts
@@ -2,7 +2,6 @@ import type * as Y from 'yjs';
 import { WebrtcProvider } from 'y-webrtc';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import type { Awareness } from 'y-protocols/awareness';
-import { WebsocketProvider as OriginWebsocketProvider } from 'y-websocket';
 
 /**
  * Different examples of providers could include webrtc sync,
@@ -85,24 +84,4 @@ export class IndexedDBDocProvider
     // Do nothing for now
     return Promise.resolve();
   }
-}
-
-export function createWebsocketDocProvider(url: string) {
-  return class WebsocketProvider
-    extends OriginWebsocketProvider
-    implements DocProvider
-  {
-    constructor(
-      room: string,
-      ydoc: Y.Doc,
-      options?: { awareness?: Awareness }
-    ) {
-      super(url, room, ydoc, options);
-    }
-
-    public clearData() {
-      // Do noting for now
-      return Promise.resolve();
-    }
-  };
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,14 +2,19 @@ export * from './space.js';
 export * from './store.js';
 export * from './base.js';
 export * from './awareness.js';
-export * from './blob';
+export * from './blob/index.js';
 export * from './text-adapter.js';
 export * from './utils/signal.js';
 export * from './utils/disposable.js';
 export * from './doc-providers.js';
-export * from './workspace';
+export * from './workspace/index.js';
 export * as Utils from './utils/utils.js';
-export * from './utils/id-generator.js';
+export {
+  createAutoIncrementIdGenerator,
+  createAutoIncrementIdGeneratorByClientId,
+  uuidv4,
+} from './utils/id-generator.js';
+export type { IdGenerator } from './utils/id-generator.js';
 
 const env =
   typeof globalThis !== 'undefined'

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -19,7 +19,7 @@ import {
   trySyncTextProp,
   toBlockProps,
   matchFlavours,
-} from '../utils/utils';
+} from '../utils/utils.js';
 import type { PageMeta, Workspace } from './workspace';
 
 export type YBlock = Y.Map<unknown>;

--- a/packages/store/src/workspace/search.ts
+++ b/packages/store/src/workspace/search.ts
@@ -1,10 +1,10 @@
-import {
-  Document as DocumentIndexer,
-  DocumentSearchOptions,
-  Index,
-} from 'flexsearch';
+import FlexSearch from 'flexsearch';
+import type { DocumentSearchOptions } from 'flexsearch';
 import { Doc, Map as YMap, Text as YText } from 'yjs';
 import type { YBlock } from './page';
+
+const DocumentIndexer = FlexSearch.Document;
+const Index = FlexSearch.Index;
 
 export type QueryContent = string | Partial<DocumentSearchOptions<boolean>>;
 
@@ -54,7 +54,7 @@ export type IndexMetadata = Readonly<{
 
 export class Indexer {
   private readonly _doc: Doc;
-  private readonly _indexer: DocumentIndexer<IndexMetadata, string[]>;
+  private readonly _indexer: FlexSearch.Document<IndexMetadata, string[]>;
 
   constructor(
     doc: Doc,

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -6,7 +6,7 @@ import { Signal } from '../utils/signal.js';
 import { Indexer, QueryContent } from './search.js';
 import type { Awareness } from 'y-protocols/awareness';
 import type { BaseBlockModel } from '../base';
-import { BlobStorage, getBlobStorage } from '../blob';
+import { BlobStorage, getBlobStorage } from '../blob/index.js';
 
 export interface PageMeta {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,6 @@ importers:
       y-indexeddb: ^9.0.9
       y-protocols: ^1.0.5
       y-webrtc: ^10.2.3
-      y-websocket: ^1.4.5
       yjs: ^13.5.41
     dependencies:
       buffer: 6.0.3
@@ -132,7 +131,6 @@ importers:
       y-indexeddb: 9.0.9_yjs@13.5.41
       y-protocols: 1.0.5
       y-webrtc: 10.2.3
-      y-websocket: 1.4.5_yjs@13.5.41
       yjs: 13.5.41
     devDependencies:
       '@types/flexsearch': 0.7.3
@@ -1003,30 +1001,6 @@ packages:
       - supports-color
     dev: true
 
-  /abstract-leveldown/6.2.3:
-    resolution: {integrity: sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      buffer: 5.7.1
-      immediate: 3.3.0
-      level-concat-iterator: 2.0.1
-      level-supports: 1.0.1
-      xtend: 4.0.2
-    dev: false
-    optional: true
-
-  /abstract-leveldown/6.3.0:
-    resolution: {integrity: sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      buffer: 5.7.1
-      immediate: 3.3.0
-      level-concat-iterator: 2.0.1
-      level-supports: 1.0.1
-      xtend: 4.0.2
-    dev: false
-    optional: true
-
   /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1164,11 +1138,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /async-limiter/1.0.1:
-    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
-    dev: false
-    optional: true
-
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -1214,14 +1183,6 @@ packages:
       node-releases: 2.0.6
       update-browserslist-db: 1.0.9_browserslist@4.21.4
     dev: true
-
-  /buffer/5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
-    optional: true
 
   /buffer/6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -1510,15 +1471,6 @@ packages:
       clone: 1.0.4
     dev: true
 
-  /deferred-leveldown/5.3.0:
-    resolution: {integrity: sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==}
-    engines: {node: '>=6'}
-    dependencies:
-      abstract-leveldown: 6.2.3
-      inherits: 2.0.4
-    dev: false
-    optional: true
-
   /define-properties/1.1.4:
     resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
     engines: {node: '>= 0.4'}
@@ -1572,17 +1524,6 @@ packages:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
-  /encoding-down/6.3.0:
-    resolution: {integrity: sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==}
-    engines: {node: '>=6'}
-    dependencies:
-      abstract-leveldown: 6.3.0
-      inherits: 2.0.4
-      level-codec: 9.0.2
-      level-errors: 2.0.1
-    dev: false
-    optional: true
-
   /enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
@@ -1593,14 +1534,6 @@ packages:
   /err-code/3.0.1:
     resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
     dev: false
-
-  /errno/0.1.8:
-    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
-    hasBin: true
-    dependencies:
-      prr: 1.0.1
-    dev: false
-    optional: true
 
   /error-ex/1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2428,11 +2361,6 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /immediate/3.3.0:
-    resolution: {integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==}
-    dev: false
-    optional: true
-
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -2706,98 +2634,6 @@ packages:
     engines: {node: '>=14.16'}
     dev: false
 
-  /level-codec/9.0.2:
-    resolution: {integrity: sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      buffer: 5.7.1
-    dev: false
-    optional: true
-
-  /level-concat-iterator/2.0.1:
-    resolution: {integrity: sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==}
-    engines: {node: '>=6'}
-    dev: false
-    optional: true
-
-  /level-errors/2.0.1:
-    resolution: {integrity: sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==}
-    engines: {node: '>=6'}
-    dependencies:
-      errno: 0.1.8
-    dev: false
-    optional: true
-
-  /level-iterator-stream/4.0.2:
-    resolution: {integrity: sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==}
-    engines: {node: '>=6'}
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.0
-      xtend: 4.0.2
-    dev: false
-    optional: true
-
-  /level-js/5.0.2:
-    resolution: {integrity: sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==}
-    dependencies:
-      abstract-leveldown: 6.2.3
-      buffer: 5.7.1
-      inherits: 2.0.4
-      ltgt: 2.2.1
-    dev: false
-    optional: true
-
-  /level-packager/5.1.1:
-    resolution: {integrity: sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      encoding-down: 6.3.0
-      levelup: 4.4.0
-    dev: false
-    optional: true
-
-  /level-supports/1.0.1:
-    resolution: {integrity: sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==}
-    engines: {node: '>=6'}
-    dependencies:
-      xtend: 4.0.2
-    dev: false
-    optional: true
-
-  /level/6.0.1:
-    resolution: {integrity: sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      level-js: 5.0.2
-      level-packager: 5.1.1
-      leveldown: 5.6.0
-    dev: false
-    optional: true
-
-  /leveldown/5.6.0:
-    resolution: {integrity: sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==}
-    engines: {node: '>=8.6.0'}
-    requiresBuild: true
-    dependencies:
-      abstract-leveldown: 6.2.3
-      napi-macros: 2.0.0
-      node-gyp-build: 4.1.1
-    dev: false
-    optional: true
-
-  /levelup/4.4.0:
-    resolution: {integrity: sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      deferred-leveldown: 5.3.0
-      level-errors: 2.0.1
-      level-iterator-stream: 4.0.2
-      level-supports: 1.0.1
-      xtend: 4.0.2
-    dev: false
-    optional: true
-
   /levn/0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2925,10 +2761,6 @@ packages:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
     dev: true
 
-  /lodash.debounce/4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-    dev: false
-
   /lodash.isequal/4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     dev: true
@@ -2976,11 +2808,6 @@ packages:
     dependencies:
       yallist: 4.0.0
     dev: true
-
-  /ltgt/2.2.1:
-    resolution: {integrity: sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==}
-    dev: false
-    optional: true
 
   /magic-string/0.26.3:
     resolution: {integrity: sha512-u1Po0NDyFcwdg2nzHT88wSK0+Rih0N1M+Ph1Sp08k8yvFFU3KR72wryS7e1qMPJypt99WB7fIFVCA92mQrMjrg==}
@@ -3088,11 +2915,6 @@ packages:
     hasBin: true
     dev: true
 
-  /napi-macros/2.0.0:
-    resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
-    dev: false
-    optional: true
-
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -3100,12 +2922,6 @@ packages:
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
-
-  /node-gyp-build/4.1.1:
-    resolution: {integrity: sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==}
-    hasBin: true
-    dev: false
-    optional: true
 
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
@@ -3473,11 +3289,6 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
     dev: true
-
-  /prr/1.0.1:
-    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
-    dev: false
-    optional: true
 
   /pseudomap/1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -4369,22 +4180,6 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: true
 
-  /ws/6.2.2:
-    resolution: {integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==}
-    requiresBuild: true
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dependencies:
-      async-limiter: 1.0.1
-    dev: false
-    optional: true
-
   /ws/7.5.9:
     resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}
     engines: {node: '>=8.3.0'}
@@ -4400,12 +4195,6 @@ packages:
     dev: false
     optional: true
 
-  /xtend/4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-    dev: false
-    optional: true
-
   /y-indexeddb/9.0.9_yjs@13.5.41:
     resolution: {integrity: sha512-GcJbiJa2eD5hankj46Hea9z4hbDnDjvh1fT62E5SpZRsv8GcEemw34l1hwI2eknGcv5Ih9JfusT37JLx9q3LFg==}
     peerDependencies:
@@ -4414,18 +4203,6 @@ packages:
       lib0: 0.2.52
       yjs: 13.5.41
     dev: false
-
-  /y-leveldb/0.1.1_yjs@13.5.41:
-    resolution: {integrity: sha512-L8Q0MQmxCQ0qWIOuPzLbWn95TNhrCI7M6LaHnilU4I2IX08e4Dmfg5Tgy4JZ3tnl2aiuZyDOJplHl/msIB/IsA==}
-    requiresBuild: true
-    peerDependencies:
-      yjs: ^13.0.0
-    dependencies:
-      level: 6.0.1
-      lib0: 0.2.52
-      yjs: 13.5.41
-    dev: false
-    optional: true
 
   /y-protocols/1.0.5:
     resolution: {integrity: sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==}
@@ -4446,24 +4223,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - supports-color
-      - utf-8-validate
-    dev: false
-
-  /y-websocket/1.4.5_yjs@13.5.41:
-    resolution: {integrity: sha512-5d9LTSy0GQKqSd/FKRo5DMBlsiTlCipbKcIgPLlno+5xHtfT8bm3uQdcbY9JvLfckojilLZWauXJu0vzDZX05w==}
-    hasBin: true
-    peerDependencies:
-      yjs: ^13.5.6
-    dependencies:
-      lib0: 0.2.52
-      lodash.debounce: 4.0.8
-      y-protocols: 1.0.5
-      yjs: 13.5.41
-    optionalDependencies:
-      ws: 6.2.2
-      y-leveldb: 0.1.1_yjs@13.5.41
-    transitivePeerDependencies:
-      - bufferutil
       - utf-8-validate
     dev: false
 


### PR DESCRIPTION
TLDR:

* All the BlockSuite packages are now ESM compatible.
* Only the `store` package is ready for the SSR environment.
* The WebSocket provider is removed and should be maintained outside of BlockSuite.

---

Previously, only the `blocks` package was released as ESM (with `"type": "module"` enabled) package, whose ESM entry is a standalone bundled one built by Vite. Although the `store` and `editor` packages are publishing the `tsc` transpiled ESM modules as source-only releases, they are not marked as `"type": "module"` because they are using the `import "./foo"` statement instead of `import "./foo.js"`, this violates the standard and is not compatible with Next.

In 31106f728cc07d7b006aae02adccc5ac9358e87e we have added the `.js` suffix to *almost* all import statements (using the [fix-esm-import-path](https://www.npmjs.com/package/fix-esm-import-path) code mod) automatically, enforcing the `import "./foo.js"` convention among there packages. However, this was not 100% complete, and some details must be tweaked. As a result, **this PR has published all the `store`, `blocks`, and `editor` packages as Next-compatible ESM**.

However, this doesn't guarantee that the `import "@blocksuite/blocks"` statement could work in AFFiNE - Due to SSR restrictions, both Lit and Quill have side effects that break in Node, which should fallback to `import()` according to the [best practice](https://nextjs.org/docs/advanced-features/dynamic-import#with-no-ssr). Luckily this works for us since we don't need SSR for the editor.

To support ESM-compatible `store`, Another breaking change is about `y-websocket`. This package breaks SSR and our standard installation for other developers (#294). It could be better to move it out of BlockSuite, maintaining it as a standalone package or inside AFFiNE monorepo. All our encapsulation of this package is only about [10 lines](https://github.com/toeverything/blocksuite/blob/5ba60e6430/packages/store/src/doc-providers.ts#L90-L108), so this should be acceptable.

Although it still takes time to support SSR-ready `blocks` and `editor` packages, the current status still makes sense to us:

1. Having SSR-compatible `store` makes the initialization of the workspace much more manageable. We no longer require an async `import()` wrapper for `new Workspace`.
2. This enables more decent Vite support and makes side-by-side debugging easier (I'm working on it, best practice TBD).

Due to the iteration requirement, this PR will be directly released in the next alpha.

cc @alt1o @lawvs @Himself65 @darkskygit @QiShaoXuan @tzhangchi 