### PR TITLE
fix: prevent click event from making selection lost

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -78,9 +78,11 @@ export class FormatQuickBar extends LitElement {
     const startModel = models[0];
     this.paragraphType = startModel.type;
     this.page = startModel.page as Page;
-    if (models.length > 1) {
-      // Select multiple models
-    }
+
+    this.addEventListener('mousedown', (e: MouseEvent) => {
+      // Prevent click event from making selection lost
+      e.preventDefault();
+    });
   }
 
   private _onHover() {

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -22,7 +22,17 @@ test('should format quick bar show when select text', async ({ page }) => {
   await dragBetweenIndices(page, [0, 0], [2, 3]);
   const formatQuickBar = page.locator(`.format-quick-bar`);
   await expect(formatQuickBar).toBeVisible();
-  page.mouse.click(0, 0);
+
+  const box = await formatQuickBar.boundingBox();
+  if (!box) {
+    throw new Error("formatQuickBar doesn't exist");
+  }
+  // Click the edge of the format quick bar
+  await page.mouse.click(box.x + 4, box.y + box.height / 2);
+  // Even not any button is clicked, the format quick bar should't be hidden
+  await expect(formatQuickBar).toBeVisible();
+
+  await page.mouse.click(0, 0);
   await expect(formatQuickBar).not.toBeVisible();
 });
 


### PR DESCRIPTION
This pull request fixes the issue with selecting losing when a user clicks the edge of the format bar.