### PR TITLE
fix: incorrect code block short ligatures

### DIFF
--- a/packages/blocks/src/code-block/style.css
+++ b/packages/blocks/src/code-block/style.css
@@ -16,6 +16,7 @@ code-block {
 
 .affine-code-block-container pre {
   font-family: var(--affine-font-mono);
+  font-variant-ligatures: none;
 }
 
 .affine-code-block-container .container {

--- a/packages/blocks/src/paragraph-block/style.css
+++ b/packages/blocks/src/paragraph-block/style.css
@@ -94,6 +94,7 @@ code {
   background: var(--affine-code-background);
   color: var(--affine-code-color);
   font-family: var(--affine-font-mono);
+  font-variant-ligatures: none;
   padding: 0 5px;
   border-radius: 5px;
   font-size: calc(var(--affine-font-base) - 4px);


### PR DESCRIPTION
Fix #502

This is ligatures in the `Space Mono`, maybe space mono is not suitable as a code font

![Screenshot 2023-01-02 at 10 30 07 PM](https://user-images.githubusercontent.com/18554747/210244871-26ff9dcf-4478-405b-be86-ba298bfafc7c.png)

![Screenshot 2023-01-02 at 10 35 22 PM](https://user-images.githubusercontent.com/18554747/210245469-17256a4f-decc-4347-9695-2c8e1343fc7f.png)
