### PR TITLE
fix: unexpected behaviour of markdown shortcut when creating code block and inline code

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/shortcuts.ts
+++ b/packages/blocks/src/__internal__/rich-text/shortcuts.ts
@@ -230,7 +230,7 @@ export class Shortcuts {
     },
     {
       name: 'code',
-      pattern: /(?:`)([^`]+?)(?:`)$/g,
+      pattern: /(?:`)(`{2,}?|[^`]+)(?:`)$/g,
       action: (
         model: BaseBlockModel,
         quill: Quill,
@@ -266,7 +266,7 @@ export class Shortcuts {
     },
     {
       name: 'codeblock',
-      pattern: /^```/g,
+      pattern: /^```[a-zA-Z0-9]*$/g,
       action: (
         model: BaseBlockModel,
         quill: Quill,

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -63,7 +63,6 @@ test('use more than three backticks can not create code block', async ({
   await focusRichText(page);
   await page.keyboard.type('`````');
   await page.keyboard.type(' ');
-  await page.pause();
 
   const codeBlockLocator = page.locator('affine-code');
   await expect(codeBlockLocator).toBeHidden();

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -40,6 +40,39 @@ test('use markdown syntax can create code block', async ({ page }) => {
   await expect(locator).toBeVisible();
 });
 
+test('use markdown syntax with trailing characters can create code block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+
+  await focusRichText(page);
+  await page.keyboard.type('```JavaScript');
+  await page.keyboard.type(' ');
+
+  const locator = page.locator('affine-code');
+  await expect(locator).toBeVisible();
+});
+
+test('use more than three backticks can not create code block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+
+  await focusRichText(page);
+  await page.keyboard.type('`````');
+  await page.keyboard.type(' ');
+  await page.pause();
+
+  const codeBlockLocator = page.locator('affine-code');
+  await expect(codeBlockLocator).toBeHidden();
+  const inlineCodelocator = page.locator('code');
+  await expect(inlineCodelocator).toBeVisible();
+  const codes = await inlineCodelocator.innerText();
+  expect(codes).toEqual('```');
+});
+
 test('use shortcut can create code block', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);


### PR DESCRIPTION
Now following markdown can create code block
> \`\`\`
> \`\`\`javascript
> \`\`\`kkkk
> \`\`\`122k1212

Following markdown will create an inline code
> \`\`\`\`\`
