### PR TITLE
fix: select all with hot key at the start of the line

### DIFF
--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -32,10 +32,10 @@ import { EmbedResizeManager } from './embed-resize-manager.js';
 
 function intersects(rect: DOMRect, selectionRect: DOMRect, offset: IPoint) {
   return (
-    rect.left < selectionRect.right + offset.x &&
-    rect.right > selectionRect.left + offset.x &&
-    rect.top < selectionRect.bottom + offset.y &&
-    rect.bottom > selectionRect.top + offset.y
+    rect.left <= selectionRect.right + offset.x &&
+    rect.right >= selectionRect.left + offset.x &&
+    rect.top <= selectionRect.bottom + offset.y &&
+    rect.bottom >= selectionRect.top + offset.y
   );
 }
 


### PR DESCRIPTION
fix bug: CMD-A loses the cursor when the cursor is at the beginning of the line