### PR TITLE
fix: paste at the start of line

### DIFF
--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -209,7 +209,7 @@ export class PasteManager {
       }
       const addBlockIds: string[] = [];
       if (selectedBlock && !matchFlavours(selectedBlock, ['affine:page'])) {
-        const endIndex = lastBlock.endPos || selectedBlock?.text?.length || 0;
+        const endIndex = lastBlock.endPos ?? (selectedBlock?.text?.length || 0);
         const insertTexts = blocks[0].text;
         const insertLen = insertTexts.reduce(
           (len: number, value: Record<string, unknown>) => {


### PR DESCRIPTION
fix: The text will be inserted from the end of the line when pasting at the start of a line