### PR TITLE
fix: keep cursor to title when deleting at the start of the first block

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -1,7 +1,6 @@
 // operations used in rich-text level
 
 import { Page, Text } from '@blocksuite/store';
-import autosize from 'autosize';
 import type { Quill } from 'quill';
 import {
   ExtendedModel,
@@ -21,16 +20,8 @@ import {
   focusPreviousBlock,
   focusBlockByModel,
   supportsChildren,
-  getPageTitle,
+  getModelByElement,
 } from '../utils/index.js';
-
-function focusTextEndAppendText(input: HTMLTextAreaElement, text = '') {
-  const current = input.value + text;
-  input.focus();
-  input.value = '';
-  input.value = current;
-  autosize.update(input);
-}
 
 export function handleBlockEndEnter(page: Page, model: ExtendedModel) {
   const parent = page.getParent(model);
@@ -289,10 +280,23 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
       } else {
         const richText = getRichTextByModel(model);
         if (richText) {
+          const text = richText.quill.getText().trimEnd();
+          const titleElement = document.querySelector(
+            '.affine-default-page-block-title'
+          ) as HTMLTextAreaElement;
+          const oldTitle = titleElement.value;
+          const title = oldTitle + text;
           page.captureSync();
           page.deleteBlock(model);
-          const text = richText.quill.getText().trimEnd();
-          focusTextEndAppendText(getPageTitle(), text);
+          // model.text?.delete(0, model.text.length);
+          const titleModel = getModelByElement(titleElement);
+          page.updateBlock(titleModel, { title });
+          const oldTitleTextLength = oldTitle.length;
+          titleElement.setSelectionRange(
+            oldTitleTextLength,
+            oldTitleTextLength
+          );
+          titleElement.focus();
         }
       }
     }

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -1,6 +1,7 @@
 // operations used in rich-text level
 
 import { Page, Text } from '@blocksuite/store';
+import autosize from 'autosize';
 import type { Quill } from 'quill';
 import {
   ExtendedModel,
@@ -20,7 +21,16 @@ import {
   focusPreviousBlock,
   focusBlockByModel,
   supportsChildren,
+  getPageTitle,
 } from '../utils/index.js';
+
+function focusTextEndAppendText(input: HTMLTextAreaElement, text = '') {
+  const current = input.value + text;
+  input.focus();
+  input.value = '';
+  input.value = current;
+  autosize.update(input);
+}
 
 export function handleBlockEndEnter(page: Page, model: ExtendedModel) {
   const parent = page.getParent(model);
@@ -276,8 +286,15 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
             page.deleteBlock(model);
           }
         });
+      } else {
+        const richText = getRichTextByModel(model);
+        if (richText) {
+          page.captureSync();
+          page.deleteBlock(model);
+          const text = richText.quill.getText().trimEnd();
+          focusTextEndAppendText(getPageTitle(), text);
+        }
       }
-      return;
     }
 
     // Before

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -401,8 +401,3 @@ export function getAllBlocks() {
     );
   });
 }
-
-export const getPageTitle = () =>
-  document.querySelector(
-    '.affine-default-page-block-title'
-  ) as HTMLTextAreaElement;

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -394,3 +394,8 @@ export function getAllBlocks() {
     );
   });
 }
+
+export const getPageTitle = () =>
+  document.querySelector(
+    '.affine-default-page-block-title'
+  ) as HTMLTextAreaElement;

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -192,7 +192,6 @@ export class DefaultPageBlockComponent
       const newFirstParagraphId = page.addBlock(props, defaultFrame, 0);
       page.updateBlock(model, { title: contentLeft });
       page.workspace.setPageMeta(page.id, { title: contentLeft });
-      autosize.update(this._title);
       asyncFocusRichText(this.page, newFirstParagraphId);
     } else if (e.key === 'ArrowDown' && hasContent) {
       e.preventDefault();

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -107,15 +107,21 @@ test('backspace on line start of the first block', async ({ page }) => {
 
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertTitle(page, 'helloabc');
-  await assertRichTexts(page, ['\n']);
 
+  await pressEnter(page);
+  await assertTitle(page, 'hello');
+  await assertRichTexts(page, ['abc']);
+
+  await page.keyboard.press('Backspace', { delay: 50 });
+  await assertTitle(page, 'helloabc');
+  await assertRichTexts(page, []);
   await undoByClick(page);
   await assertTitle(page, 'hello');
   await assertRichTexts(page, ['abc']);
 
   await redoByClick(page);
   await assertTitle(page, 'helloabc');
-  await assertRichTexts(page, ['\n']);
+  await assertRichTexts(page, []);
 });
 
 test('append new paragraph block by enter', async ({ page }) => {

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -24,6 +24,7 @@ import {
   dragOverTitle,
   resetHistory,
   initThreeParagraphs,
+  redoByClick,
 } from './utils/actions/index.js';
 
 test('init paragraph by page title enter at last', async ({ page }) => {
@@ -88,6 +89,33 @@ test('backspace and arrow on title', async ({ page }) => {
 
   await redoByKeyboard(page);
   await assertTitle(page, 'hll');
+});
+
+test('backspace on line start of the first block', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await page.keyboard.type('hello');
+  await assertTitle(page, 'hello');
+  await resetHistory(page);
+
+  await focusRichText(page, 0);
+  await page.keyboard.type('abc');
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.press('ArrowLeft');
+  await assertSelection(page, 0, 0, 0);
+
+  await page.keyboard.press('Backspace', { delay: 50 });
+  await assertTitle(page, 'helloabc');
+  await assertRichTexts(page, ['\n']);
+
+  await undoByClick(page);
+  await assertTitle(page, 'hello');
+  await assertRichTexts(page, ['abc']);
+
+  await redoByClick(page);
+  await assertTitle(page, 'helloabc');
+  await assertRichTexts(page, ['\n']);
 });
 
 test('append new paragraph block by enter', async ({ page }) => {


### PR DESCRIPTION
Fixes #567 