### PR TITLE
refactor(blocks): add type shims for third-party CJS dependencies

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -24,10 +24,22 @@
     "quill-cursors": "^4.0.0"
   },
   "exports": {
-    "./dist/*": "./dist/*",
-    ".": "./src/index.ts",
-    "./std": "./src/std.ts",
-    "./models": "./src/models.ts"
+    "./dist/*": {
+      "development": "./src/*",
+      "import": "./dist/*"
+    },
+    ".": {
+      "development": "./src/index.ts",
+      "import": "./dist/index.js"
+    },
+    "./std": {
+      "development": "./src/std.ts",
+      "import": "./dist/std.js"
+    },
+    "./models": {
+      "development": "./src/models.ts",
+      "import": "./dist/models.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
@@ -1,7 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { Quill as QuillType } from 'quill';
-import Q from 'quill';
+import Quill from 'quill';
 import {
   ALLOWED_SCHEMES,
   showLinkPopover,
@@ -13,8 +12,6 @@ import {
   hotkey,
 } from '../../utils/index.js';
 import { LinkIcon } from './link-icon.js';
-
-const Quill = Q as unknown as typeof QuillType;
 
 // TODO fix Blot types
 type Blot = {

--- a/packages/blocks/src/__internal__/rich-text/link-node/mock-select-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/mock-select-node.ts
@@ -1,6 +1,4 @@
-import type { Quill as QuillType } from 'quill';
-import Q from 'quill';
-const Quill = Q as unknown as typeof QuillType;
+import Quill from 'quill';
 
 const Inline = Quill.import('blots/inline');
 export class MockSelectNode extends Inline {

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -1,7 +1,7 @@
 import { html, css } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
+import Quill from 'quill';
 import type { Quill as QuillType } from 'quill';
-import Q from 'quill';
 import QuillCursors from 'quill-cursors';
 import type { BaseBlockModel } from '@blocksuite/store';
 import type { BlockHost } from '../utils/index.js';
@@ -9,8 +9,6 @@ import { createKeyboardBindings } from './keyboard.js';
 
 import Syntax from '../../code-block/components/syntax-code-block.js';
 import { NonShadowLitElement } from '../utils/lit.js';
-
-const Quill = Q as unknown as typeof QuillType;
 
 Quill.register('modules/cursors', QuillCursors);
 const Clipboard = Quill.import('modules/clipboard');

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -1,6 +1,5 @@
-import Hotkeys from 'hotkeys-js';
-import type { Hotkeys as HotkeysType, KeyHandler } from 'hotkeys-js';
-const hotkeys = Hotkeys as unknown as HotkeysType;
+import hotkeys from 'hotkeys-js';
+import type { KeyHandler } from 'hotkeys-js';
 
 hotkeys.filter = () => true;
 

--- a/packages/blocks/src/code-block/components/syntax-code-block.ts
+++ b/packages/blocks/src/code-block/components/syntax-code-block.ts
@@ -1,10 +1,10 @@
-import Q from 'quill';
+import Quill from 'quill';
 import type { Quill as QuillType } from 'quill';
+
 // @ts-ignore
 import type hljs from 'highlight.js';
 import { assertExists } from '../../__internal__/index.js';
 
-const Quill = Q as unknown as typeof QuillType;
 const Module = Quill.import('core/module');
 const CodeBlock = Quill.import('formats/code-block');
 const CodeToken = Quill.import('modules/syntax');

--- a/packages/blocks/src/shape-block/utils/rectangle-helpers.ts
+++ b/packages/blocks/src/shape-block/utils/rectangle-helpers.ts
@@ -6,11 +6,7 @@ import { Vec } from './vec.js';
 import { getShapeStyle } from './shape-style.js';
 import type { ShapeStyles } from '../../__internal__/index.js';
 
-import PF from 'perfect-freehand';
-import type { getStroke as getStrokeType } from 'perfect-freehand';
-import * as DPF from 'perfect-freehand';
-const getStrokePoints = DPF.getStrokePoints;
-const getStroke = PF as unknown as typeof getStrokeType;
+import { getStroke, getStrokePoints } from 'perfect-freehand';
 
 function getRectangleDrawPoints(
   id: string,

--- a/packages/blocks/src/shape-block/utils/triangle-helpers.ts
+++ b/packages/blocks/src/shape-block/utils/triangle-helpers.ts
@@ -6,12 +6,7 @@ import { Vec } from './vec.js';
 import type { ShapeStyles } from '../../__internal__/index.js';
 import { getShapeStyle } from './shape-style.js';
 import { getOffsetPolygon } from './polygon-utils.js';
-
-import PF from 'perfect-freehand';
-import type { getStroke as getStrokeType } from 'perfect-freehand';
-import * as DPF from 'perfect-freehand';
-const getStrokePoints = DPF.getStrokePoints;
-const getStroke = PF as unknown as typeof getStrokeType;
+import { getStroke, getStrokePoints } from 'perfect-freehand';
 
 export function getTrianglePoints(size: number[], offset = 0, rotation = 0) {
   const [w, h] = size;

--- a/packages/blocks/src/shims.d.ts
+++ b/packages/blocks/src/shims.d.ts
@@ -1,0 +1,16 @@
+// type shims for https://github.com/toeverything/blocksuite/issues/398
+// remove this until hotkeys-js and quill turned to `type: "module"`
+
+declare module 'hotkeys-js' {
+  import hotkeys = require('hotkeys-js/index');
+  export type * from 'hotkeys-js/index' assert { 'resolution-mode': 'require' };
+  declare const hotkeysDefault: typeof hotkeys.default;
+  export default hotkeysDefault;
+}
+
+declare module 'quill' {
+  import quill = require('quill/index');
+  export type * from 'quill/index' assert { 'resolution-mode': 'require' };
+  declare const quillDefault: typeof quill.default;
+  export default quillDefault;
+}

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'url';
 let DEFAULT_ROOM = '';
 // Refs: https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables
 if (process.env.VERCEL === '1') {
@@ -18,6 +20,16 @@ process.env.VITE_DEFAULT_ROOM = DEFAULT_ROOM;
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@blocksuite/blocks': path.resolve(
+        fileURLToPath(new URL('../blocks/src', import.meta.url))
+      ),
+      '@blocksuite/blocks/*': path.resolve(
+        fileURLToPath(new URL('../blocks/src/*', import.meta.url))
+      ),
+    },
+  },
   // enable if want debug with jwst backend
   // server: {
   //   proxy: {


### PR DESCRIPTION
Fixes: #398 

- add a d.ts shim to extend `hotkeys-js` and `quill` to make them compatible with `moduleResolution: 'NodeNext'`. The repairment is a little hack, I can't explain how it works certainty, but I guess `require` and `assert { 'resolution-mode': 'require' }` makes TS treat the d.ts in dependencies as a CJS module and made interop.
- avoid using default import of `perfect-freehand` anymore, and that's what the documentation does https://www.npmjs.com/package/perfect-freehand.
- add a `development` user condition to keep the source code importing in development mode by Vite. Vite already supports `development` condition by default (https://vitejs.dev/config/shared-options.html#resolve-conditions) and it has higher priority.