### PR TITLE
build: restrict node version and add packageManager to force agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "blocksuite",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=16.9.0"
+  },
+  "packageManager": "pnpm@7.23.0",
   "scripts": {
     "serve": "pnpm --filter @blocksuite/store serve",
     "dev": "run-p serve dev:playground",


### PR DESCRIPTION
Set node version's lower limit to `16.9.0` as `corepack` is added since then.