### PR TITLE
refactor: use random room by default

### DIFF
--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -1,10 +1,9 @@
 import { BaseBlockModel, Utils } from '@blocksuite/store';
 import type { Detail } from './types.js';
 
+// workaround ts(2775)
 export function assertExists<T>(val: T | null | undefined): asserts val is T {
-  if (val === null || val === undefined) {
-    throw new Error('val does not exist');
-  }
+  Utils.assertExists(val);
 }
 
 export const assertFlavours = Utils.assertFlavours;

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -3,7 +3,7 @@ import type { Detail } from './types.js';
 
 // workaround ts(2775)
 export function assertExists<T>(val: T | null | undefined): asserts val is T {
-  Utils.assertExists(val);
+  return Utils.assertExists(val);
 }
 
 export const assertFlavours = Utils.assertFlavours;

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -1,9 +1,10 @@
 import { BaseBlockModel, Utils } from '@blocksuite/store';
 import type { Detail } from './types.js';
 
-// workaround ts(2775)
 export function assertExists<T>(val: T | null | undefined): asserts val is T {
-  return Utils.assertExists(val);
+  if (val === null || val === undefined) {
+    throw new Error('val does not exist');
+  }
 }
 
 export const assertFlavours = Utils.assertFlavours;

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -49,12 +49,12 @@ export function getBlockEditingStateByPosition(
       continue;
     }
 
-    let blockRect;
+    let blockRect: DOMRect | null = null;
     if (block.type === 'image') {
       const hoverImage = hoverDom?.querySelector('img');
-      blockRect = hoverImage?.getBoundingClientRect();
+      blockRect = hoverImage?.getBoundingClientRect() ?? null;
     } else {
-      blockRect = hoverDom?.getBoundingClientRect();
+      blockRect = hoverDom?.getBoundingClientRect() ?? null;
     }
 
     assertExists(blockRect);

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -58,6 +58,7 @@ export function getBlockEditingStateByPosition(
     }
 
     assertExists(blockRect);
+
     if (isPointIn(blockRect, x, y)) {
       return {
         position: blockRect,

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -7,15 +7,9 @@ import {
 } from '@blocksuite/store';
 
 const params = new URLSearchParams(location.search);
-// We need to split room between different PR, branches, and local version
-const room: string =
-  params.get('room') ??
-  (import.meta.env.VITE_DEFAULT_ROOM
-    ? import.meta.env.VITE_DEFAULT_ROOM
-    : window.location.origin + window.location.pathname);
-const url = new URL(window.location.href);
+const room = params.get('room') ?? Math.random().toString(16).slice(2, 8);
 export const defaultMode =
-  url.searchParams.get('mode') === 'edgeless' ? 'edgeless' : 'page';
+  params.get('mode') === 'edgeless' ? 'edgeless' : 'page';
 export const initParam = params.get('init');
 export const isE2E = room.startsWith('playwright');
 export const isBase64 =


### PR DESCRIPTION
We should make collaborative opt-in in the playground, so as to avoid the `?init` conflict. So in this case, only the playground URL with the same `room` param will be explicitly assigned to the same room.
