### PR TITLE
test: simplify keyboard operation

### DIFF
--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -16,7 +16,7 @@ import {
   formatType,
   clickBlockTypeMenuItem,
   SHORT_KEY,
-  SECONDARY_KEY,
+  MODIFIER_KEY,
   resetHistory,
   readClipboardText,
 } from './utils/actions/index.js';
@@ -469,7 +469,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 
   // XXX wait for group to be updated
   await page.waitForTimeout(10);
-  await page.keyboard.press(`${SHORT_KEY}+${SECONDARY_KEY}+1`);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+1`);
   await assertStoreMatchJSX(
     page,
     `
@@ -483,7 +483,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  await page.keyboard.press(`${SHORT_KEY}+${SECONDARY_KEY}+6`);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+6`);
   await assertStoreMatchJSX(
     page,
     `
@@ -497,7 +497,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  await page.keyboard.press(`${SHORT_KEY}+${SECONDARY_KEY}+8`);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+8`);
   await assertStoreMatchJSX(
     page,
     `
@@ -512,7 +512,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  await page.keyboard.press(`${SHORT_KEY}+${SECONDARY_KEY}+9`);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+9`);
   await assertStoreMatchJSX(
     page,
     `
@@ -527,7 +527,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  await page.keyboard.press(`${SHORT_KEY}+${SECONDARY_KEY}+0`);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+0`);
   await assertStoreMatchJSX(
     page,
     `

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -4,9 +4,26 @@ const IS_MAC = process.platform === 'darwin';
 // const IS_WINDOWS = process.platform === 'win32';
 // const IS_LINUX = !IS_MAC && !IS_WINDOWS;
 
+/**
+ * The key will be 'Meta' on Macs and 'Control' on other platforms
+ * @example
+ * ```ts
+ * await page.keyboard.press(`${SHORT_KEY}+a`);
+ * ```
+ */
 export const SHORT_KEY = IS_MAC ? 'Meta' : 'Control';
-export const SECONDARY_KEY = IS_MAC ? 'Alt' : 'Shift';
+/**
+ * The key will be 'Alt' on Macs and 'Shift' on other platforms
+ * @example
+ * ```ts
+ * await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+1`);
+ * ```
+ */
+export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
+/**
+ * @deprecated Use {@link SHORT_KEY} directly
+ */
 async function keyDownCtrlOrMeta(page: Page) {
   if (IS_MAC) {
     await page.keyboard.down('Meta');
@@ -15,6 +32,9 @@ async function keyDownCtrlOrMeta(page: Page) {
   }
 }
 
+/**
+ * @deprecated Use {@link SHORT_KEY} directly
+ */
 async function keyUpCtrlOrMeta(page: Page) {
   if (IS_MAC) {
     await page.keyboard.up('Meta');
@@ -23,6 +43,9 @@ async function keyUpCtrlOrMeta(page: Page) {
   }
 }
 
+/**
+ * @deprecated Use {@link MODIFIER_KEY} directly
+ */
 async function keyDownOptionMeta(page: Page) {
   if (IS_MAC) {
     await page.keyboard.down('Alt');
@@ -31,6 +54,9 @@ async function keyDownOptionMeta(page: Page) {
   }
 }
 
+/**
+ * @deprecated Use {@link MODIFIER_KEY} directly
+ */
 async function keyUpOptionMeta(page: Page) {
   if (IS_MAC) {
     await page.keyboard.up('Alt');
@@ -52,31 +78,19 @@ export async function pressEnter(page: Page) {
 }
 
 export async function undoByKeyboard(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('z');
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+z`);
 }
 
 export async function formatType(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await keyDownOptionMeta(page);
-  await page.keyboard.press('1');
-  await keyUpOptionMeta(page);
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+1`);
 }
 
 export async function redoByKeyboard(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Shift');
-  await page.keyboard.press('z');
-  await page.keyboard.up('Shift');
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+Shift+z`);
 }
 
 export async function selectAllByKeyboard(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('a');
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+a`);
 }
 
 export async function pressTab(page: Page) {
@@ -84,28 +98,37 @@ export async function pressTab(page: Page) {
 }
 
 export async function pressShiftTab(page: Page) {
-  await page.keyboard.down('Shift');
-  await page.keyboard.press('Tab', { delay: 50 });
-  await page.keyboard.up('Shift');
+  await page.keyboard.press('Shift+Tab', { delay: 50 });
 }
 
 export async function pressShiftEnter(page: Page) {
-  await page.keyboard.down('Shift');
-  await page.keyboard.press('Enter', { delay: 50 });
-  await page.keyboard.up('Shift');
+  await page.keyboard.press('Shift+Enter', { delay: 50 });
 }
 
 export async function inlineCode(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('e', { delay: 50 });
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+e`, { delay: 50 });
 }
 
 export async function strikethrough(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Shift');
-  await page.keyboard.press('s', { delay: 50 });
-  await keyUpCtrlOrMeta(page);
+  await page.keyboard.press(`${SHORT_KEY}+Shift+s`, { delay: 50 });
+}
+
+export async function copyByKeyboard(page: Page) {
+  await page.keyboard.press(`${SHORT_KEY}+c`, { delay: 50 });
+}
+
+export async function pasteByKeyboard(page: Page) {
+  const doesEditorActive = await page.evaluate(() =>
+    document.activeElement?.closest('editor-container')
+  );
+  if (!doesEditorActive) {
+    await page.click('editor-container');
+  }
+  await page.keyboard.press(`${SHORT_KEY}+v`, { delay: 50 });
+}
+
+export async function createCodeBlock(page: Page) {
+  await page.keyboard.press(`${SHORT_KEY}+Alt+c`);
 }
 
 export async function getCursorBlockIdAndHeight(
@@ -145,42 +168,4 @@ export async function fillLine(page: Page, toNext = false) {
       page.keyboard.press('Backspace');
     }
   }
-}
-
-export async function copyByKeyboard(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('c', { delay: 50 });
-  await keyUpCtrlOrMeta(page);
-}
-
-export async function cutByKeyboard(page: Page) {
-  const doesEditorActive = await page.evaluate(
-    () => document.activeElement?.closest('editor-container') != null
-  );
-  if (!doesEditorActive) {
-    await page.click('editor-container');
-  }
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('x', { delay: 50 });
-  await keyUpCtrlOrMeta(page);
-}
-
-export async function pasteByKeyboard(page: Page) {
-  const doesEditorActive = await page.evaluate(() =>
-    document.activeElement?.closest('editor-container')
-  );
-  if (!doesEditorActive) {
-    await page.click('editor-container');
-  }
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.press('v', { delay: 50 });
-  await keyUpCtrlOrMeta(page);
-}
-
-export async function createCodeBlock(page: Page) {
-  await keyDownCtrlOrMeta(page);
-  await page.keyboard.down('Alt');
-  await page.keyboard.press('c');
-  await page.keyboard.up('Alt');
-  await keyUpCtrlOrMeta(page);
 }


### PR DESCRIPTION
- simplify keyboard operation
- add test for mock selection node
  - it should not be stored to y doc