### PR TITLE
feat: support bracket autocomplete for native range selected text

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
+++ b/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
@@ -86,28 +86,27 @@ const bracketPairs: BracketPair[] = [
 export function createBracketAutoCompleteBindings(
   model: BaseBlockModel
 ): KeyboardBindings {
-  return bracketPairs.reduce((acc, pair) => {
-    return {
-      ...acc,
-      [pair.name]: {
-        key: pair.left,
-        // Input some brackets need to press shift key
-        shiftKey: null,
-        collapsed: false,
-        handler(range) {
-          if (!model.text) {
-            return ALLOW_DEFAULT;
-          }
-          model.text.insert(pair.left, range.index);
-          model.text.insert(pair.right, range.index + range.length + 1);
+  const bindings: KeyboardBindings = {};
 
-          const curRange = getCurrentRange();
-          // move cursor to the end of the inserted text
-          curRange.setStart(curRange.startContainer, curRange.startOffset + 1);
-          resetNativeSelection(curRange);
-          return PREVENT_DEFAULT;
-        },
+  bracketPairs.forEach(pair => {
+    bindings[pair.name] = {
+      key: pair.left,
+      // Input some brackets need to press shift key
+      shiftKey: null,
+      collapsed: false,
+      handler(range) {
+        if (!model.text) return ALLOW_DEFAULT;
+
+        model.text.insert(pair.left, range.index);
+        model.text.insert(pair.right, range.index + range.length + 1);
+
+        const curRange = getCurrentRange();
+        // move cursor to the end of the inserted text
+        curRange.setStart(curRange.startContainer, curRange.startOffset + 1);
+        resetNativeSelection(curRange);
+        return PREVENT_DEFAULT;
       },
-    } satisfies KeyboardBindings;
-  }, {});
+    };
+  });
+  return bindings;
 }

--- a/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
+++ b/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
@@ -1,0 +1,94 @@
+import type { BaseBlockModel } from '@blocksuite/store';
+import {
+  ALLOW_DEFAULT,
+  getCurrentRange,
+  resetNativeSelection,
+  PREVENT_DEFAULT,
+} from '../index.js';
+import type { KeyboardBindings } from './keyboard.js';
+
+type BracketPair = {
+  name: string;
+  left: string;
+  leftCode: number;
+  right: string;
+  shiftKey?: boolean;
+};
+
+// keyCode refer to https://www.toptal.com/developers/keycode/for/%5B
+const bracketPairs: BracketPair[] = [
+  {
+    name: 'parenthesis',
+    left: '(',
+    leftCode: 57,
+    right: ')',
+    shiftKey: true,
+  },
+  {
+    name: 'square bracket',
+    left: '[',
+    leftCode: 219,
+    right: ']',
+  },
+  {
+    name: 'curly bracket',
+    left: '{',
+    leftCode: 219,
+    right: '}',
+    shiftKey: true,
+  },
+  {
+    name: 'double quote',
+    left: '"',
+    leftCode: 222,
+    right: '"',
+    shiftKey: true,
+  },
+  {
+    name: 'single quote',
+    left: "'",
+    leftCode: 222,
+    right: "'",
+  },
+  {
+    name: 'backtick',
+    left: '`',
+    leftCode: 192,
+    right: '`',
+  },
+  {
+    name: 'angle bracket',
+    left: '<',
+    leftCode: 188,
+    right: '>',
+    shiftKey: true,
+  },
+];
+
+export function createBracketAutoCompleteBindings(
+  model: BaseBlockModel
+): KeyboardBindings {
+  return bracketPairs.reduce((acc, pair) => {
+    return {
+      ...acc,
+      [pair.name]: {
+        key: pair.leftCode,
+        shiftKey: pair.shiftKey,
+        collapsed: false,
+        handler(range) {
+          if (!model.text) {
+            return ALLOW_DEFAULT;
+          }
+          model.text.insert(pair.left, range.index);
+          model.text.insert(pair.right, range.index + range.length + 1);
+
+          const curRange = getCurrentRange();
+          // move cursor to the end of the inserted text
+          curRange.setStart(curRange.startContainer, curRange.startOffset + 1);
+          resetNativeSelection(curRange);
+          return PREVENT_DEFAULT;
+        },
+      },
+    } satisfies KeyboardBindings;
+  }, {});
+}

--- a/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
+++ b/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
@@ -1,67 +1,85 @@
+import { ALLOW_DEFAULT, PREVENT_DEFAULT } from '@blocksuite/global/config';
 import type { BaseBlockModel } from '@blocksuite/store';
-import {
-  ALLOW_DEFAULT,
-  getCurrentRange,
-  resetNativeSelection,
-  PREVENT_DEFAULT,
-} from '../index.js';
+
+import { getCurrentRange, resetNativeSelection } from '../index.js';
 import type { KeyboardBindings } from './keyboard.js';
 
 type BracketPair = {
   name: string;
   left: string;
-  leftCode: number;
   right: string;
-  shiftKey?: boolean;
 };
 
-// keyCode refer to https://www.toptal.com/developers/keycode/for/%5B
 const bracketPairs: BracketPair[] = [
   {
     name: 'parenthesis',
     left: '(',
-    leftCode: 57,
     right: ')',
-    shiftKey: true,
   },
   {
     name: 'square bracket',
     left: '[',
-    leftCode: 219,
     right: ']',
   },
   {
     name: 'curly bracket',
     left: '{',
-    leftCode: 219,
     right: '}',
-    shiftKey: true,
-  },
-  {
-    name: 'double quote',
-    left: '"',
-    leftCode: 222,
-    right: '"',
-    shiftKey: true,
   },
   {
     name: 'single quote',
     left: "'",
-    leftCode: 222,
     right: "'",
   },
   {
-    name: 'backtick',
-    left: '`',
-    leftCode: 192,
-    right: '`',
+    name: 'double quote',
+    left: '"',
+    right: '"',
   },
+  // {
+  //   name: 'backtick',
+  //   left: '`',
+  //   right: '`',
+  // },
   {
     name: 'angle bracket',
     left: '<',
-    leftCode: 188,
     right: '>',
-    shiftKey: true,
+  },
+  {
+    name: 'fullwidth single quote',
+    left: '‘',
+    right: '’',
+  },
+  {
+    name: 'fullwidth double quote',
+    left: '“',
+    right: '”',
+  },
+  {
+    name: 'fullwidth parenthesis',
+    left: '（',
+    right: '）',
+  },
+  {
+    name: 'fullwidth square bracket',
+    left: '【',
+    right: '】',
+  },
+  {
+    name: 'fullwidth angle bracket',
+    left: '《',
+    right: '》',
+  },
+  {
+    name: 'corner bracket',
+    left: '「',
+    right: '」',
+  },
+  {
+    name: 'white corner bracket',
+    left: '『',
+    right: '』',
   },
 ];
 
@@ -72,8 +90,9 @@ export function createBracketAutoCompleteBindings(
     return {
       ...acc,
       [pair.name]: {
-        key: pair.leftCode,
-        shiftKey: pair.shiftKey,
+        key: pair.left,
+        // Input some brackets need to press shift key
+        shiftKey: null,
         collapsed: false,
         handler(range) {
           if (!model.text) {

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -11,6 +11,7 @@ import {
   isMultiBlockRange,
   noop,
 } from '../utils/index.js';
+import { createBracketAutoCompleteBindings } from './bracket-complete.js';
 import { markdownConvert } from './markdown-convert.js';
 import {
   handleBlockEndEnter,
@@ -54,7 +55,7 @@ type KeyboardBinding = {
   ctrlKey?: boolean | null;
 };
 
-type KeyboardBindings = Record<string, KeyboardBinding>;
+export type KeyboardBindings = Record<string, KeyboardBinding>;
 
 interface KeyboardEventThis {
   quill: Quill;
@@ -361,6 +362,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
         return ALLOW_DEFAULT;
       },
     },
+    ...createBracketAutoCompleteBindings(model),
   };
 
   return keyboardBindings;

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -45,6 +45,7 @@ type KeyboardBinding = {
    * See https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
    */
   key: number | string | string[];
+  collapsed?: boolean;
   handler: KeyboardBindingHandler;
   prefix?: RegExp;
   suffix?: RegExp;

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -25,10 +25,10 @@ import {
   tryMatchSpaceHotkey,
 } from './rich-text-operations.js';
 
-interface QuillRange {
-  index: number;
-  length: number;
-}
+// Type definitions is ported from quill
+// https://github.com/quilljs/quill/blob/6159f6480482dde0530920dc41033ebc6611a9e7/modules/keyboard.ts#L15-L46
+
+type QuillRange = RangeStatic;
 
 interface BindingContext {
   collapsed: boolean;

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -632,3 +632,20 @@ test('should ctrl+enter create new block', async ({ page }) => {
   await page.keyboard.press(`${SHORT_KEY}+Enter`);
   await assertRichTexts(page, ['1', '23', '\n']);
 });
+
+test('should bracket complete works', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await type(page, '([{');
+  // type without selection should not trigger bracket complete
+  await assertRichTexts(page, ['([{']);
+
+  await dragBetweenIndices(page, [0, 1], [0, 2]);
+  await type(page, '(');
+  await assertRichTexts(page, ['(([){']);
+
+  await type(page, ')');
+  // Should not trigger bracket complete when type right bracket
+  await assertRichTexts(page, ['(()){']);
+});


### PR DESCRIPTION
fix https://github.com/toeverything/AFFiNE/issues/632

~~but incorrect in CJK input method.~~

~~It may also fail on other keyboard layouts.~~

~~Block by https://github.com/quilljs/quill/issues/1975~~

It does not work with multiple block selection now

