### PR TITLE
fix: code block unexpectedly get focus, clean redundant code

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -130,9 +130,8 @@ export class RichText extends NonShadowLitElement {
     page.awareness.updateLocalCursor();
     this.model.propsUpdated.on(() => this.requestUpdate());
 
-    if (this.modules.syntax) {
-      this.quill.formatText(0, this.quill.getLength(), 'code-block', true);
-      this.quill.format('code-block', true);
+    if (this.modules.syntax && this.quill.getText() === '\n') {
+      this.quill.focus();
     }
     // If you type a character after the code or link node,
     // the character should not be inserted into the code or link node.
@@ -202,10 +201,6 @@ export class RichText extends NonShadowLitElement {
     // Update placeholder if block`s type changed
     this.quill?.root.setAttribute('data-placeholder', this.placeholder ?? '');
     this.quill?.root.setAttribute('contenteditable', `${!this.host.readonly}`);
-    if (this.modules.syntax) {
-      //@ts-ignore
-      this.quill.theme.modules.syntax.setLang(this.modules.syntax.language);
-    }
   }
 
   render() {

--- a/packages/blocks/src/code-block/components/syntax-code-block.ts
+++ b/packages/blocks/src/code-block/components/syntax-code-block.ts
@@ -80,25 +80,14 @@ SyntaxCodeBlock.className = 'ql-syntax';
 
 class Syntax extends Module {
   private _language = 'javascript';
-  private _codeBlockElement: HTMLElement;
-
   static register() {
     Quill.register(CodeToken, true);
     Quill.register(SyntaxCodeBlock, true);
   }
 
-  setLang(lang: string) {
-    if (this._language === lang) {
-      return;
-    }
-    this._language = lang;
-    this.highlight(true, this._codeBlockElement);
-  }
-
   constructor(quill: QuillType, options: SyntaxCodeBlockOptions) {
     super(quill, options);
     this._language = options.language;
-    this._codeBlockElement = options.codeBlockElement;
     if (typeof this.options.highlight !== 'function') {
       throw new Error(
         'Syntax module requires highlight.js. Please include the library on the page before Quill.'


### PR DESCRIPTION
When AFFiNE stored code blocks and refresh, code block will unexpectedly get focus, now this behavior is fixed by distinguishing whether the code block is empty. It's not ideal as AFFiNE  may store empty code block, still causing code block getting focus, better solution in the future maybe  tracking the `source` of a code block. 