### PR TITLE
fix: optimize `isForward` detection in `SelectionManager`

### DIFF
--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -29,9 +29,6 @@ export function getBlockById<T extends ElementTagName>(
   return container.querySelector<T>(`[${ATTR}="${id}"]` as T);
 }
 
-/*
-Be cautious!! If BlockSuite is embedded in other container, MouseEvent.clientX, MouseEvent.clientY will change
- */
 export function getBlockByPoint(point: IPoint): Element | null | undefined {
   return document.elementFromPoint(point.x, point.y)?.closest(`[${ATTR}]`);
 }

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -29,6 +29,9 @@ export function getBlockById<T extends ElementTagName>(
   return container.querySelector<T>(`[${ATTR}="${id}"]` as T);
 }
 
+/*
+Be cautious!! If BlockSuite is embedded in other container, MouseEvent.clientX, MouseEvent.clientY will change
+ */
 export function getBlockByPoint(point: IPoint): Element | null | undefined {
   return document.elementFromPoint(point.x, point.y)?.closest(`[${ATTR}]`);
 }

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -2,7 +2,6 @@ import type { BaseBlockModel, Page } from '@blocksuite/store';
 import type { RichText } from '../rich-text/rich-text.js';
 import type { IPoint, SelectionEvent } from './gesture.js';
 import {
-  getBlockByPoint,
   getBlockElementByModel,
   getContainerByModel,
   getCurrentRange,
@@ -428,15 +427,9 @@ export function handleNativeRangeDragMove(
   startRange: Range | null,
   e: SelectionEvent
 ) {
-  const startBlock = getBlockByPoint(e.start);
-  assertExists(startBlock);
-  const startRect = startBlock.getBoundingClientRect();
-
   const isDownward = e.y > e.start.y + MOVE_DETECT_THRESHOLD;
-  const ifCrossUpperSideOfCurrentBlock = e.y > startRect.top;
   const isRightward = e.x > e.start.x;
-  const isForward =
-    isDownward || (ifCrossUpperSideOfCurrentBlock && isRightward);
+  const isForward = isDownward || (e.y === e.start.y && isRightward);
   assertExists(startRange);
   const { startContainer, startOffset, endContainer, endOffset } = startRange;
   let currentRange = caretRangeFromPoint(e.raw.clientX, e.raw.clientY);


### PR DESCRIPTION
1. Related to #588, in #588, multiple lines of one content block was not considered, which will cause back select failure
2. Fix: When BlockSuite is embedded in other container, can't get correct start container by `SelectionEvent.start.x`, `SelectionEvent.start.y`,