### PR TITLE
fix(blocks): set supressWarning to true of quill-cursors

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -10,7 +10,7 @@ import { createKeyboardBindings } from './keyboard.js';
 import Syntax from '../../code-block/components/syntax-code-block.js';
 import { NonShadowLitElement } from '../utils/lit.js';
 
-Quill.register('modules/cursors', QuillCursors);
+Quill.register('modules/cursors', QuillCursors, true);
 const Clipboard = Quill.import('modules/clipboard');
 
 class EmptyClipboard extends Clipboard {


### PR DESCRIPTION
## why
clean blocking for https://github.com/toeverything/blocksuite/pull/621, stop the re-registry warning when performing HMR. And, all the other quill registry has set `supressWarning` to `true` so I guess this is not an exception. I tested the official example of quill-curosrs https://github.com/reedsy/quill-cursors/tree/main/example and tweaked it with many re-register, seems like everything is fine.