### PR TITLE
fix: peer cursor updates sometimes does not emit "change" event

### DIFF
--- a/packages/store/src/text-adapter.ts
+++ b/packages/store/src/text-adapter.ts
@@ -393,6 +393,7 @@ export class RichTextAdapter {
     return {
       anchor,
       focus,
+      _rawSelection: selection,
     };
   }
 

--- a/packages/store/src/text-adapter.ts
+++ b/packages/store/src/text-adapter.ts
@@ -393,7 +393,7 @@ export class RichTextAdapter {
     return {
       anchor,
       focus,
-      _rawSelection: selection,
+      selection,
     };
   }
 


### PR DESCRIPTION
See the bug in the demo video:

https://user-images.githubusercontent.com/584378/212094208-835d253c-0743-41fa-a755-c80aba3260c6.mp4

The cursor indicator on the right pane does not being updated when the peer user is typing in the left pane.

Root cause:
- When typing on the left, we will set cursor to local state as `Y.RelativePosition`. This value will NOT change when typing due to RelativePosition's internal implementation. 
- We have `AwarenessAdapter` in blocksuite that listens to `change` events emitted by awareness. On receiving the update on the right pane, it will deep-compare the updated state with the previous value. Since the relative position is still the same, the `change` event will not be emitted.

The proposed solution in this pr appends a hidden `_rawSelection` to the cursor state. It should fix the deep compare issue.


https://user-images.githubusercontent.com/584378/212096366-f2707374-9a1a-4088-a417-1347d16ec46b.mp4


