### PR TITLE
Revert "fix: use flex in children container (#586)"

### DIFF
--- a/packages/blocks/src/__internal__/utils/components.ts
+++ b/packages/blocks/src/__internal__/utils/components.ts
@@ -92,8 +92,6 @@ export function BlockChildrenContainer(
     <style>
       .affine-block-children-container {
         padding-left: 26px;
-        display: flex;
-        flex-direction: column;
       }
     </style>
     <div class="affine-block-children-container">

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -37,10 +37,10 @@ import { DragHandle } from '../../components/drag-handle.js';
 
 function intersects(rect: DOMRect, selectionRect: DOMRect, offset: IPoint) {
   return (
-    rect.left < selectionRect.right + offset.x &&
-    rect.right > selectionRect.left + offset.x &&
-    rect.top < selectionRect.bottom + offset.y &&
-    rect.bottom > selectionRect.top + offset.y
+    rect.left <= selectionRect.right + offset.x &&
+    rect.right >= selectionRect.left + offset.x &&
+    rect.top <= selectionRect.bottom + offset.y &&
+    rect.bottom >= selectionRect.top + offset.y
   );
 }
 

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -97,7 +97,7 @@ test('should format quick bar be able to format text', async ({ page }) => {
   await assertStoreMatchJSX(
     page,
     `<affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -139,7 +139,7 @@ test('should format quick bar be able to format text', async ({ page }) => {
   await assertStoreMatchJSX(
     page,
     `<affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -187,7 +187,7 @@ test('should format quick bar be able to format text when select multiple line',
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -232,7 +232,7 @@ test('should format quick bar be able to format text when select multiple line',
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -293,7 +293,7 @@ test('should format quick bar be able to link text', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -327,7 +327,7 @@ test('should format quick bar be able to link text', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -372,7 +372,7 @@ test('should format quick bar be able to change to heading paragraph type', asyn
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -395,7 +395,7 @@ test('should format quick bar be able to change to heading paragraph type', asyn
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -421,7 +421,7 @@ test('should format quick bar be able to change to heading paragraph type', asyn
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -90,7 +90,7 @@ test('multi line rich-text inline code hotkey', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -141,7 +141,7 @@ test('multi line rich-text inline code hotkey', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -165,7 +165,7 @@ test('multi line rich-text inline code hotkey', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -251,7 +251,7 @@ test('should single line format hotkey work', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text={
@@ -290,7 +290,7 @@ test('should single line format hotkey work', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text={
@@ -338,7 +338,7 @@ test('should multiple line format hotkey work', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -405,7 +405,7 @@ test('should multiple line format hotkey work', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text={
@@ -474,7 +474,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text="hello"
@@ -488,7 +488,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text="hello"
@@ -502,7 +502,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:list
     prop:checked={false}
@@ -517,7 +517,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:list
     prop:checked={false}
@@ -532,7 +532,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text="hello"
@@ -572,7 +572,7 @@ test('should cut work single line', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text="ho"
@@ -588,7 +588,7 @@ test('should cut work single line', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,40]"
+  prop:xywh="[0,0,720,32]"
 >
   <affine:paragraph
     prop:text="hello"
@@ -613,7 +613,7 @@ test('should cut work multiple line', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="19"
@@ -629,7 +629,7 @@ test('should cut work multiple line', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"

--- a/tests/link.spec.ts
+++ b/tests/link.spec.ts
@@ -68,7 +68,7 @@ test('basic link', async ({ page }) => {
     `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,40]"
+    prop:xywh="[0,0,720,32]"
   >
     <affine:paragraph
       prop:text={

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -160,7 +160,7 @@ test('nested list blocks', async ({ page }) => {
     /*xml*/ `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,104]"
+    prop:xywh="[0,0,720,96]"
   >
     <affine:list
       prop:checked={false}
@@ -191,7 +191,7 @@ test('nested list blocks', async ({ page }) => {
     /*xml*/ `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,104]"
+    prop:xywh="[0,0,720,96]"
   >
     <affine:list
       prop:checked={false}
@@ -228,7 +228,7 @@ test('basic indent and unindent', async ({ page }) => {
     /*xml*/ `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,80]"
+    prop:xywh="[0,0,720,72]"
   >
     <affine:paragraph
       prop:text="text1"
@@ -248,7 +248,7 @@ test('basic indent and unindent', async ({ page }) => {
     /*xml*/ `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,80]"
+    prop:xywh="[0,0,720,72]"
   >
     <affine:paragraph
       prop:text="text1"
@@ -270,7 +270,7 @@ test('basic indent and unindent', async ({ page }) => {
     /*xml*/ `
 <affine:page>
   <affine:frame
-    prop:xywh="[0,0,720,80]"
+    prop:xywh="[0,0,720,72]"
   >
     <affine:paragraph
       prop:text="text1"
@@ -299,7 +299,7 @@ test('should indent todo block preserve todo status', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,80]"
+  prop:xywh="[0,0,720,72]"
 >
   <affine:paragraph
     prop:text="text1"
@@ -319,7 +319,7 @@ test('should indent todo block preserve todo status', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,80]"
+  prop:xywh="[0,0,720,72]"
 >
   <affine:paragraph
     prop:text="text1"

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -268,7 +268,7 @@ test('should indent and unindent works with children', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,160]"
+  prop:xywh="[0,0,720,152]"
 >
   <affine:paragraph
     prop:text="123"
@@ -299,7 +299,7 @@ test('should indent and unindent works with children', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,160]"
+  prop:xywh="[0,0,720,152]"
 >
   <affine:paragraph
     prop:text="123"
@@ -339,7 +339,7 @@ test('paragraph with child block should work at enter', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,80]"
+  prop:xywh="[0,0,720,72]"
 >
   <affine:paragraph
     prop:text="123"
@@ -360,7 +360,7 @@ test('paragraph with child block should work at enter', async ({ page }) => {
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"
@@ -404,7 +404,7 @@ test('should delete paragraph block child can hold cursor in correct position', 
     page,
     `
 <affine:frame
-  prop:xywh="[0,0,720,120]"
+  prop:xywh="[0,0,720,112]"
 >
   <affine:paragraph
     prop:text="123"

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -46,7 +46,7 @@ export const defaultStore: SerializedStore = {
       'sys:flavour': 'affine:frame',
       'sys:id': '1',
       'sys:children': ['2'],
-      'prop:xywh': '[0,0,720,40]',
+      'prop:xywh': '[0,0,720,32]',
     },
     '2': {
       'sys:flavour': 'affine:paragraph',


### PR DESCRIPTION
Fixes: https://github.com/toeverything/blocksuite/issues/671

This reverts commit e4483a0447977394294a61c53efaedc9e7c4df84.