### PR TITLE
fix: cant reach the last block in nesting

### DIFF
--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -60,7 +60,8 @@ export type DragHandleGetModelStateWithCursorCallback = (
   pageY: number,
   cursor: number,
   size?: number,
-  skipX?: boolean
+  skipX?: boolean,
+  dragging?: boolean
 ) => EditingState | null;
 
 @customElement('affine-drag-handle')
@@ -253,6 +254,7 @@ export class DragHandle extends LitElement {
       y,
       this._cursor,
       5,
+      false,
       true
     );
     if (modelState) {

--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -211,6 +211,10 @@ export class DragHandle extends LitElement {
       e.pageY,
       true
     );
+    if (isFirefox) {
+      this._currentPageX = e.pageX;
+      this._currentPageY = e.pageY;
+    }
     if (clickDragState) {
       this._cursor = clickDragState.index;
       this.setSelectedBlocks([

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -182,24 +182,22 @@ function binarySearchBlockEditingState(
 
         if (!options?.skipX) {
           if (dragging) {
-            if (block.parentIndex && block.depth) {
+            if (block.depth) {
               let depth = Math.floor((blockRect.left - x) / 26);
               if (depth > 0) {
-                let item = getBlockAndRect(blocks, block.parentIndex);
+                assertExists(block.parentIndex);
+                let result = getBlockAndRect(blocks, block.parentIndex);
 
-                while (
-                  depth > 1 &&
-                  item.block.parentIndex &&
-                  item.block.depth
-                ) {
-                  item = getBlockAndRect(blocks, item.block.parentIndex);
+                while (depth > 1 && result.block.depth) {
+                  assertExists(result.block.parentIndex);
+                  result = getBlockAndRect(blocks, result.block.parentIndex);
                   depth -= 1;
                 }
 
                 return {
                   index: mid,
-                  position: item.blockRect,
-                  model: item.block,
+                  position: result.blockRect,
+                  model: result.block,
                 };
               }
             }

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -28,6 +28,9 @@ export class BaseBlockModel<Props = unknown>
   text?: TextType;
   sourceId?: string;
 
+  parentIndex?: number;
+  depth?: number;
+
   constructor(
     page: Page,
     props: Pick<BlockSuiteInternal.IBaseBlockProps, 'id'>


### PR DESCRIPTION
## Before
If we want to move A after B, but not a child of B. The current move can only be a child of B, if B is the last block.

<img width="270" alt="Screenshot 2023-01-12 at 4 30 29 PM" src="https://user-images.githubusercontent.com/27926/212016623-cfd53d53-2731-461c-b3b4-b06eb090ea0e.png">

## After

May not be very good in user experience

https://user-images.githubusercontent.com/27926/212127387-83f54f4e-44f7-4b52-8aa8-9f4f68f2b6a2.mov

