### PR TITLE
fix: line number for wrapped lines

### DIFF
--- a/packages/blocks/src/code-block/components/syntax-code-block.ts
+++ b/packages/blocks/src/code-block/components/syntax-code-block.ts
@@ -25,7 +25,7 @@ function addLineNumber(
 }
 
 class SyntaxCodeBlock extends CodeBlock {
-  private _domNode!: HTMLElement;
+  readonly domNode!: HTMLElement;
   private _observer: MutationObserver | null = null;
   private _lastHasWrap = false;
 
@@ -54,16 +54,16 @@ class SyntaxCodeBlock extends CodeBlock {
     this._observer = new MutationObserver(e => {
       this.updateLineNumber(codeBlockElement, true);
     });
-    this._observer.observe(this._domNode, { attributes: true });
+    this._observer.observe(this.domNode, { attributes: true });
   }
 
   highlight(highlight: (text: string) => string, forceRefresh: boolean) {
-    const text = this._domNode.textContent;
+    const text = this.domNode.textContent;
     assertExists(text);
     if (this.cachedText !== text || forceRefresh) {
       if (text.trim().length > 0 || this.cachedText == null) {
-        this._domNode.innerHTML = highlight(text);
-        this._domNode.normalize();
+        this.domNode.innerHTML = highlight(text);
+        this.domNode.normalize();
         this.attach();
       }
       this.cachedText = text;
@@ -71,9 +71,9 @@ class SyntaxCodeBlock extends CodeBlock {
   }
 
   private _getCtx() {
-    const fontSize = window.getComputedStyle(this._domNode).fontSize;
+    const fontSize = window.getComputedStyle(this.domNode).fontSize;
     const fontFamily = window
-      .getComputedStyle(this._domNode)
+      .getComputedStyle(this.domNode)
       .fontFamily.split(',')[0];
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
@@ -82,10 +82,10 @@ class SyntaxCodeBlock extends CodeBlock {
   }
 
   updateLineNumber(codeBlockElement: HTMLElement, forceRefresh = false) {
-    const text = this._domNode.textContent;
+    const text = this.domNode.textContent;
     assertExists(text);
     const ctx = this._getCtx();
-    const hasWrap = this._domNode.classList.contains('wrap');
+    const hasWrap = this.domNode.classList.contains('wrap');
 
     if (
       text === this.cachedTextLineNumber &&
@@ -104,8 +104,8 @@ class SyntaxCodeBlock extends CodeBlock {
     }
 
     const lines = text.split('\n');
-    const clientWidth = this._domNode.clientWidth;
-    const lineHeight = window.getComputedStyle(this._domNode).lineHeight;
+    const clientWidth = this.domNode.clientWidth;
+    const lineHeight = window.getComputedStyle(this.domNode).lineHeight;
     let lineNum = 0;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];


### PR DESCRIPTION
Before change, the code block line number is calculated by number of `\n`, when there are long lines, and when they are wrapped, the line number will be more than number of `\n`, it causes line number less than actual lines, as shown below.
<img width="781" alt="image" src="https://user-images.githubusercontent.com/20554850/212226274-0956cd56-2514-43b4-8f9c-5a9c18af7004.png">

After, line numbers only cares how much start lines there are, exceeding part are filled up by calculating

https://user-images.githubusercontent.com/20554850/212226891-11c8075d-5a54-4bb5-be89-3197a6979493.mov

