### PR TITLE
fix: adapting parent index of blocks to binarySearchBlockEditingState

### DIFF
--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -278,7 +278,7 @@ export class DefaultSelectionManager {
         if (parentIndex !== -1) {
           block.parentIndex = parentIndex;
         }
-        block.children && dfs(block.children, depth + 1, result.length);
+        block.children && dfs(block.children, depth + 1, result.length - 1);
       }
     };
 


### PR DESCRIPTION
After #681 in which #669 is fixed, the parent index of each block are 1 larger, which is used in `binarySearchBlockEditingState`, causing horizontal dragging fails. This PR is to restore the behavior in #677, ie, supporting dragging in nested level