### PR TITLE
feat: support set remote flag

### DIFF
--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -234,9 +234,6 @@ export class DefaultPageBlockComponent
         container: this,
       });
     }
-    if (changedProperties.has('readonly')) {
-      this.page.awareness.setReadonly(this.readonly);
-    }
 
     this._tryUpdateMetaTitle();
     super.update(changedProperties);

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -70,17 +70,19 @@ export class EditorContainer extends NonShadowLitElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.page.awareness.signals.update.on(msg => {
-      if (msg.id !== this.page.doc.clientID) {
-        return;
-      }
-      if (
-        typeof this.page.awareness.isReadonly() === 'boolean' &&
-        this.readonly !== this.page.awareness.isReadonly()
-      ) {
-        this.readonly = this.page.awareness.isReadonly();
-      }
-    });
+    this._disposables.add(
+      this.page.awareness.signals.update.on(msg => {
+        if (msg.id !== this.page.doc.clientID) {
+          return;
+        }
+        if (
+          typeof this.page.awareness.isReadonly() === 'boolean' &&
+          this.readonly !== this.page.awareness.isReadonly()
+        ) {
+          this.readonly = this.page.awareness.isReadonly();
+        }
+      })
+    );
 
     // Question: Why do we prevent this?
     this._disposables.add(

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -61,8 +61,26 @@ export class EditorContainer extends NonShadowLitElement {
     return this;
   }
 
+  protected update(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('readonly')) {
+      this.page.awareness.setReadonly(this.readonly);
+    }
+    super.update(changedProperties);
+  }
+
   override connectedCallback() {
     super.connectedCallback();
+    this.page.awareness.signals.update.on(msg => {
+      if (msg.id !== this.page.doc.clientID) {
+        return;
+      }
+      if (
+        typeof this.page.awareness.isReadonly() === 'boolean' &&
+        this.readonly !== this.page.awareness.isReadonly()
+      ) {
+        this.readonly = this.page.awareness.isReadonly();
+      }
+    });
 
     // Question: Why do we prevent this?
     this._disposables.add(

--- a/packages/global/src/index.d.ts
+++ b/packages/global/src/index.d.ts
@@ -19,6 +19,7 @@ declare module NodeJS {
 type PropsWithId<Props> = Props & { id: string };
 
 type BlockSuiteFlags = {
+  enable_set_remote_flag: boolean;
   enable_drag_handle: boolean;
   readonly: Record<string, boolean>;
 };

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -210,6 +210,20 @@ export class DebugMenu extends LitElement {
     window.history.pushState({}, '', url);
   }
 
+  private _setReadonlyOthers() {
+    const clients = [...this.page.awareness.getStates().keys()].filter(
+      id => id !== this.page.workspace.doc.clientID
+    );
+    if (this.page.awareness.getFlag('enable_set_remote_flag')) {
+      clients.forEach(id => {
+        this.page.awareness.setRemoteFlag(id, 'readonly', {
+          ...(this.page.awareness.getFlag('readonly') ?? {}),
+          [this.page.prefixedId]: true,
+        });
+      });
+    }
+  }
+
   firstUpdated() {
     this.page.signals.historyUpdated.on(() => {
       this.canUndo = this.page.canUndo;
@@ -380,6 +394,9 @@ export class DebugMenu extends LitElement {
                 ${this.connected ? 'Disconnect' : 'Connect'}
               </sl-menu-item>
               <sl-menu-item @click=${this._addFrame}> Add Frame </sl-menu-item>
+              <sl-menu-item @click=${this._setReadonlyOthers}>
+                Set Others Readonly
+              </sl-menu-item>
               <sl-menu-item @click=${this._toggleReadonly}>
                 Toggle Readonly
               </sl-menu-item>

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -50,6 +50,7 @@ export function getOptions(): Pick<
     providers,
     idGenerator,
     defaultFlags: {
+      enable_set_remote_flag: true,
       enable_drag_handle: true,
       readonly: {
         'space:page0': false,

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -115,7 +115,7 @@ export class AwarenessAdapter<
   public isReadonly(): boolean {
     const rd = this.getFlag('readonly');
     if (rd && typeof rd === 'object') {
-      return (rd as Record<string, boolean>)[this.space.prefixedId];
+      return Boolean((rd as Record<string, boolean>)[this.space.prefixedId]);
     } else {
       return false;
     }

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -38,8 +38,8 @@ interface AwarenessState<
   cursor?: SelectionRange;
   user?: UserInfo;
   flags: Flags;
-  changeRequest?: Request<Flags>[];
-  changeResponse?: Response[];
+  request?: Request<Flags>[];
+  response?: Response[];
 }
 
 interface AwarenessMessage<
@@ -195,7 +195,7 @@ export class AwarenessAdapter<
 
   private _handleRemoteFlags() {
     const nextTick: (() => void)[] = [];
-    const localState = this.awareness.getLocalState();
+    const localState = this.awareness.getLocalState() as AwarenessState<Flags>;
     const request = (localState?.request ?? []) as Request<Flags>[];
     const selfResponse = [] as Response[];
     const fakeDirtyResponse = [] as Response[];

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -100,7 +100,7 @@ export class AwarenessAdapter<
   }
 
   public getFlag<Key extends keyof Flags>(field: Key): Flags[Key] | undefined {
-    const flags = this.awareness.getLocalState()?.flags;
+    const flags = this.awareness.getLocalState()?.flags ?? {};
     return flags[field];
   }
 

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -190,8 +190,7 @@ export class AwarenessAdapter<
   private _handleRemoteFlags() {
     const nextTick: (() => void)[] = [];
     const localState = this.awareness.getLocalState();
-    const request = (this.awareness.getLocalState()?.request ??
-      []) as Request<Flags>[];
+    const request = (localState?.request ?? []) as Request<Flags>[];
     const selfResponse = [] as Response[];
     const fakeDirtyResponse = [] as Response[];
     if (localState && Array.isArray(localState.response)) {

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -39,10 +39,6 @@ interface AwarenessState<
   cursor?: SelectionRange;
   user?: UserInfo;
   flags: Flags;
-  /**
-   * flag request to others
-   * debug use only.
-   */
   changeRequest?: Request<Flags>[];
   changeResponse?: Response[];
 }
@@ -124,6 +120,10 @@ export class AwarenessAdapter<
     field: Key,
     value: Flags[Key]
   ) {
+    if (!this.getFlag('enable_set_remote_flag')) {
+      console.error('set remote flag feature disabled');
+      return;
+    }
     const oldRequest = this.awareness.getLocalState()?.request ?? [];
     this.awareness.setLocalStateField('request', [
       ...oldRequest,
@@ -182,7 +182,9 @@ export class AwarenessAdapter<
     } else {
       this._resetRemoteCursor();
     }
-    this._handleRemoteFlags();
+    if (this.getFlag('enable_set_remote_flag')) {
+      this._handleRemoteFlags();
+    }
   };
 
   private _handleRemoteFlags() {

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -113,9 +113,9 @@ export class AwarenessAdapter<
   }
 
   public isReadonly(): boolean {
-    const readonly = this.getFlag('readonly');
-    if (readonly && typeof readonly === 'object') {
-      return (readonly as Record<string, boolean>)[this.space.prefixedId];
+    const rd = this.getFlag('readonly');
+    if (rd && typeof rd === 'object') {
+      return (rd as Record<string, boolean>)[this.space.prefixedId];
     } else {
       return false;
     }

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -216,6 +216,7 @@ class WorkspaceMeta<
 }
 
 const flagsPreset = {
+  enable_set_remote_flag: true,
   enable_drag_handle: true,
   readonly: {},
 } satisfies BlockSuiteFlags;

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -8,6 +8,7 @@ import type { Awareness } from 'y-protocols/awareness';
 import type { BaseBlockModel } from '../base.js';
 import { BlobStorage, getBlobStorage } from '../blob/index.js';
 import type { BlockSuiteDoc } from '../yjs/index.js';
+import { merge } from 'merge';
 
 export interface PageMeta {
   id: string;
@@ -254,10 +255,7 @@ export class Workspace {
       'space:meta',
       this.doc,
       this._store.awareness,
-      {
-        ...flagsPreset,
-        ...options.defaultFlags,
-      }
+      merge(flagsPreset, options.defaultFlags)
     );
 
     this.signals = {


### PR DESCRIPTION
Fixes: https://github.com/toeverything/blocksuite/issues/694

Since modifying awareness source code is harder than I thought, I implemented a version that uses `local state` to update others flags