### PR TITLE
fix: should keep first line format when pasted into a new line

### DIFF
--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -278,7 +278,8 @@ export class DefaultSelectionManager {
         if (parentIndex !== -1) {
           block.parentIndex = parentIndex;
         }
-        block.children && dfs(block.children, depth + 1, result.length - 1);
+        block.children.length &&
+          dfs(block.children, depth + 1, result.length - 1);
       }
     };
 

--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -217,14 +217,15 @@ export class PasteManager {
           },
           0
         );
-        selectedBlock?.text?.insertList(insertTexts, endIndex);
-        selectedBlock &&
-          this._addBlocks(blocks[0].children, selectedBlock, 0, addBlockIds);
         //This is a temporary processing of the divider block, subsequent refactoring of the divider will remove it
         if (
           blocks[0].flavour === 'affine:divider' ||
           blocks[0].flavour === 'affine:embed'
         ) {
+          selectedBlock?.text?.insertList(insertTexts, endIndex);
+          selectedBlock &&
+            this._addBlocks(blocks[0].children, selectedBlock, 0, addBlockIds);
+
           parent &&
             this._addBlocks(blocks.slice(0), parent, index, addBlockIds);
           const lastBlockModel = this._editor.page.getBlockById(lastBlock.id);
@@ -239,6 +240,31 @@ export class PasteManager {
             this._editor.page.deleteBlock(lastBlockModel);
           }
         } else {
+          const lastBlockModel = this._editor.page.getBlockById(lastBlock.id);
+
+          // if current paragraph is an empty frame, delete it after inserting other blocks.
+          if (
+            endIndex === 0 &&
+            insertLen > 0 &&
+            parent &&
+            lastBlockModel &&
+            matchFlavours(lastBlockModel, ['affine:paragraph']) &&
+            lastBlockModel?.text?.length === 0 &&
+            lastBlockModel?.children.length === 0
+          ) {
+            this._addBlocks(blocks.slice(0, 1), parent, index, addBlockIds);
+            this._editor.page.deleteBlock(lastBlockModel);
+          } else {
+            selectedBlock?.text?.insertList(insertTexts, endIndex);
+            selectedBlock &&
+              this._addBlocks(
+                blocks[0].children,
+                selectedBlock,
+                0,
+                addBlockIds
+              );
+          }
+
           parent &&
             this._addBlocks(blocks.slice(1), parent, index, addBlockIds);
         }

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -1,20 +1,23 @@
 import './utils/declare-test-window.js';
 import { test } from '@playwright/test';
 import {
+  SHORT_KEY,
+  backsapce,
+  copyByKeyboard,
+  dragBetweenCoords,
   enterPlaygroundRoom,
   focusRichText,
-  setQuillSelection,
-  pasteContent,
-  undoByClick,
   importMarkdown,
-  dragBetweenCoords,
-  setSelection,
-  pressEnter,
   initEmptyParagraphState,
-  resetHistory,
-  copyByKeyboard,
   pasteByKeyboard,
-  SHORT_KEY,
+  pasteContent,
+  pressEnter,
+  pressShiftTab,
+  pressTab,
+  resetHistory,
+  setQuillSelection,
+  setSelection,
+  undoByClick,
 } from './utils/actions/index.js';
 import {
   assertBlockTypes,
@@ -23,6 +26,7 @@ import {
   assertSelection,
   assertText,
   assertTextFormats,
+  assertStoreMatchJSX,
 } from './utils/asserts.js';
 
 test('clipboard copy paste', async ({ page }) => {
@@ -68,8 +72,7 @@ test('markdown format parse', async ({ page }) => {
   await resetHistory(page);
 
   let clipData = {
-    'text/plain': `# text
-# h1
+    'text/plain': `# h1
 
 ## h2
 
@@ -98,7 +101,6 @@ test('markdown format parse', async ({ page }) => {
   };
   await pasteContent(page, clipData);
   await assertBlockTypes(page, [
-    'text',
     'h1',
     'h2',
     'h3',
@@ -114,7 +116,6 @@ test('markdown format parse', async ({ page }) => {
     'quote',
   ]);
   await assertRichTexts(page, [
-    'text',
     'h1',
     'h2',
     'h3',
@@ -302,4 +303,111 @@ test('copy & paste outside editor', async ({ page }) => {
   await focusRichText(page);
   await pasteByKeyboard(page);
   await assertRichTexts(page, ['123']);
+});
+
+test('should keep first line format when pasted into a new line', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await page.keyboard.type('-');
+  await page.keyboard.press('Space', { delay: 50 });
+  await page.keyboard.type('1');
+  await pressEnter(page);
+  await pressTab(page);
+  await page.keyboard.type('2');
+  await pressEnter(page);
+  await page.keyboard.type('3');
+  await pressEnter(page);
+  await pressShiftTab(page);
+  await page.keyboard.type('4');
+
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:page>
+  <affine:frame
+    prop:xywh="[0,0,720,130]"
+  >
+    <affine:list
+      prop:checked={false}
+      prop:text="1"
+      prop:type="bulleted"
+    >
+      <affine:list
+        prop:checked={false}
+        prop:text="2"
+        prop:type="bulleted"
+      />
+      <affine:list
+        prop:checked={false}
+        prop:text="3"
+        prop:type="bulleted"
+      />
+    </affine:list>
+    <affine:list
+      prop:checked={false}
+      prop:text="4"
+      prop:type="bulleted"
+    />
+  </affine:frame>
+</affine:page>`
+  );
+
+  await setSelection(page, 5, 1, 3, 0);
+  await copyByKeyboard(page);
+
+  await focusRichText(page, 3);
+  await pressEnter(page);
+  await backsapce(page);
+  await pasteByKeyboard(page);
+
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:page>
+  <affine:frame
+    prop:xywh="[0,0,720,170]"
+  >
+    <affine:list
+      prop:checked={false}
+      prop:text="1"
+      prop:type="bulleted"
+    >
+      <affine:list
+        prop:checked={false}
+        prop:text="2"
+        prop:type="bulleted"
+      />
+      <affine:list
+        prop:checked={false}
+        prop:text="3"
+        prop:type="bulleted"
+      />
+    </affine:list>
+    <affine:list
+      prop:checked={false}
+      prop:text="4"
+      prop:type="bulleted"
+    />
+    <affine:list
+      prop:checked={false}
+      prop:text="1"
+      prop:type="bulleted"
+    >
+      <affine:list
+        prop:checked={false}
+        prop:text="2"
+        prop:type="bulleted"
+      />
+      <affine:list
+        prop:checked={false}
+        prop:text="3"
+        prop:type="bulleted"
+      />
+    </affine:list>
+  </affine:frame>
+</affine:page>`
+  );
 });

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -75,6 +75,10 @@ export const withPressKey = async (
   await page.keyboard.up(key);
 };
 
+export async function backsapce(page: Page) {
+  await page.keyboard.press('Backspace', { delay: 50 });
+}
+
 export async function pressEnter(page: Page) {
   // avoid flaky test by simulate real user input
   await page.keyboard.press('Enter', { delay: 50 });


### PR DESCRIPTION
Related: #197 

`insertBlocks` method may need to be refactored.