### PR TITLE
feat: attach surface elements to page ydoc

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -278,12 +278,14 @@ export class EdgelessPageBlockComponent
         </div>
         ${hoverRect} ${selectionRect}
         ${selectionState.type !== 'none'
-          ? html` <edgeless-selected-rect
-              .state=${selectionState}
-              .rect=${selectionState.rect}
-              .zoom=${zoom}
-              .readonly=${this.readonly}
-            ></edgeless-selected-rect>`
+          ? html`
+              <edgeless-selected-rect
+                .state=${selectionState}
+                .rect=${selectionState.rect}
+                .zoom=${zoom}
+                .readonly=${this.readonly}
+              ></edgeless-selected-rect>
+            `
           : null}
       </div>
     `;

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -44,14 +44,10 @@ export class SurfaceBlockComponent extends LitElement {
     const container = new SurfaceContainer(this._canvas, yContainer);
     this._container = container;
 
-    const params = new URLSearchParams(location.search);
-    if (params.get('surface') !== null) {
-      page.awareness.setFlag('enable_surface', true);
-    }
-
     if (page.awareness.getFlag('enable_surface')) {
       bindWheelEvents(this._container.renderer, this.mouseRoot);
 
+      const params = new URLSearchParams(location.search);
       if (params.get('init') !== null) {
         const element0 = new RectElement('0');
         element0.setBound(0, 0, 100, 100);

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -1,6 +1,10 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
-import { Renderer, bindWheelEvents, initMockData } from '@blocksuite/phasor';
+import {
+  SurfaceContainer,
+  RectElement,
+  bindWheelEvents,
+} from '@blocksuite/phasor';
 import { BLOCK_ID_ATTR, type BlockHost } from '../__internal__/index.js';
 import '../__internal__/rich-text/rich-text.js';
 import type { SurfaceBlockModel } from './surface-model.js';
@@ -19,7 +23,7 @@ export class SurfaceBlockComponent extends LitElement {
 
   @query('.affine-surface-canvas')
   private _canvas!: HTMLCanvasElement;
-  private _renderer!: Renderer;
+  private _container!: SurfaceContainer;
 
   @property()
   mouseRoot!: HTMLElement;
@@ -38,12 +42,22 @@ export class SurfaceBlockComponent extends LitElement {
     this.model.propsUpdated.on(() => this.requestUpdate());
     this.model.childrenUpdated.on(() => this.requestUpdate());
 
-    this._renderer = new Renderer(this._canvas);
+    const { page } = this.model;
+    const yContainer = page.ySurfaceContainer;
+    const container = new SurfaceContainer(this._canvas, yContainer);
+    this._container = container;
 
     const params = new URLSearchParams(location.search);
-    if (params.get('phasor') !== null) {
-      bindWheelEvents(this._renderer, this.mouseRoot);
-      initMockData(this._renderer, 1000000, 100000, 100000);
+    if (params.get('surface') !== null) {
+      bindWheelEvents(this._container.renderer, this.mouseRoot);
+
+      if (params.get('init') !== null) {
+        const element0 = new RectElement('0');
+        element0.setBound(0, 0, 100, 100);
+        element0.color = 'red';
+        container.addElement(element0);
+        // initMockData(this._container.renderer, 1000000, 100000, 100000);
+      }
     }
   }
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -38,10 +38,7 @@ export class SurfaceBlockComponent extends LitElement {
   @property()
   host!: BlockHost;
 
-  firstUpdated() {
-    this.model.propsUpdated.on(() => this.requestUpdate());
-    this.model.childrenUpdated.on(() => this.requestUpdate());
-
+  private _initContainer() {
     const { page } = this.model;
     const yContainer = page.ySurfaceContainer;
     const container = new SurfaceContainer(this._canvas, yContainer);
@@ -49,16 +46,27 @@ export class SurfaceBlockComponent extends LitElement {
 
     const params = new URLSearchParams(location.search);
     if (params.get('surface') !== null) {
+      page.awareness.setFlag('enable_surface', true);
+    }
+
+    if (page.awareness.getFlag('enable_surface')) {
       bindWheelEvents(this._container.renderer, this.mouseRoot);
 
       if (params.get('init') !== null) {
         const element0 = new RectElement('0');
         element0.setBound(0, 0, 100, 100);
         element0.color = 'red';
-        container.addElement(element0);
-        // initMockData(this._container.renderer, 1000000, 100000, 100000);
+        this._container.addElement(element0);
       }
     }
+  }
+
+  firstUpdated() {
+    this.model.propsUpdated.on(() => this.requestUpdate());
+    this.model.childrenUpdated.on(() => this.requestUpdate());
+
+    // Avoid DOM mutation in SurfaceContainer constructor
+    requestAnimationFrame(() => this._initContainer());
   }
 
   render() {

--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -19,6 +19,7 @@ declare type PropsWithId<Props> = Props & { id: string };
 declare type BlockSuiteFlags = {
   enable_set_remote_flag: boolean;
   enable_drag_handle: boolean;
+  enable_surface: boolean;
   readonly: Record<string, boolean>;
 };
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -9,6 +9,7 @@ import { DebugMenu } from './components/debug-menu.js';
 import {
   defaultMode,
   getOptions,
+  initFeatureFlags,
   initParam,
   isBase64,
   isE2E,
@@ -23,6 +24,7 @@ const options = getOptions();
 function subscribePage(workspace: Workspace) {
   workspace.signals.pageAdded.once(pageId => {
     const page = workspace.getPage(pageId) as Page;
+    initFeatureFlags(page);
 
     const editor = new EditorContainer();
     editor.page = page;

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -3,6 +3,7 @@ import {
   DocProviderConstructor,
   Generator,
   IndexedDBDocProvider,
+  Page,
   StoreOptions,
 } from '@blocksuite/store';
 
@@ -16,6 +17,12 @@ export const initParam = params.get('init');
 export const isE2E = room.startsWith('playwright');
 export const isBase64 =
   /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/;
+
+export function initFeatureFlags(page: Page) {
+  if (params.get('surface') !== null) {
+    page.awareness.setFlag('enable_surface', true);
+  }
+}
 
 /**
  * Provider configuration is specified by `?providers=webrtc` or `?providers=indexeddb,webrtc` in URL params.

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -22,7 +22,7 @@ import {
 import type { PageMeta, Workspace } from './workspace.js';
 import type { BlockSuiteDoc } from '../yjs/index.js';
 import { tryMigrate } from './migrations.js';
-import { matchFlavours } from '@blocksuite/global/utils';
+import { assertExists, matchFlavours } from '@blocksuite/global/utils';
 export type YBlock = Y.Map<unknown>;
 export type YBlocks = Y.Map<YBlock>;
 
@@ -104,6 +104,18 @@ export class Page extends Space<PageData> {
 
   get rootLayer() {
     return Array.isArray(this._root) ? this._root[1] : null;
+  }
+
+  /** @internal used for getting surface block elements for phasor */
+  get ySurfaceContainer() {
+    assertExists(this.rootLayer);
+    const ySurface = this._yBlocks.get(this.rootLayer.id);
+    if (ySurface?.has('elements')) {
+      return ySurface.get('elements') as Y.Map<unknown>;
+    } else {
+      ySurface?.set('elements', new Y.Map());
+      return ySurface?.get('elements') as Y.Map<unknown>;
+    }
   }
 
   get isEmpty() {

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -219,6 +219,7 @@ class WorkspaceMeta<
 const flagsPreset = {
   enable_set_remote_flag: true,
   enable_drag_handle: true,
+  enable_surface: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 


### PR DESCRIPTION
Previously the contents in the canvas context were not attached to YDoc. For now, these elements could be collaboratively updated.

<img width="842" alt="image" src="https://user-images.githubusercontent.com/7312949/212538629-d0f0b148-8b7f-43f0-8c18-bb5dacbecfd0.png">
