### PR TITLE
fix: uniform event handler outside of rich text

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
@@ -4,15 +4,13 @@ import { showLinkPopover } from '../../../components/link-popover/index.js';
 import {
   getRichTextByModel,
   getStartModelBySelection,
-  hotkey,
   isRangeSelection,
 } from '../../utils/index.js';
 import './link-node';
 import { MockSelectNode } from './mock-select-node.js';
 import { assertExists } from '@blocksuite/global/utils';
 
-// Disable hotkey to fix common hotkey(ctrl+c, ctrl+v, etc) not working at edit link popover
-export const createLink = hotkey.withDisabledHotkeyFn(async (page: Page) => {
+export const createLink = async (page: Page) => {
   if (!isRangeSelection()) {
     // TODO maybe allow user creating a link with text
     return;
@@ -67,4 +65,4 @@ export const createLink = hotkey.withDisabledHotkeyFn(async (page: Page) => {
 
   page.captureSync();
   startModel.text?.format(range.index, range.length, { link });
-});
+};

--- a/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
@@ -10,16 +10,14 @@ import './link-node';
 import { MockSelectNode } from './mock-select-node.js';
 import { assertExists } from '@blocksuite/global/utils';
 
-export const createLink = async (page: Page) => {
-  if (!isRangeSelection()) {
-    // TODO maybe allow user creating a link with text
-    return;
-  }
+export async function createLink(page: Page) {
+  // TODO may allow user creating a link with text
+  if (!isRangeSelection()) return;
+
   const startModel = getStartModelBySelection();
   const richText = getRichTextByModel(startModel);
-  if (!richText) {
-    return;
-  }
+  if (!richText) return;
+
   const { quill } = richText;
   const range = quill.getSelection();
   // TODO fix selection with multiple lines
@@ -58,11 +56,10 @@ export const createLink = async (page: Page) => {
   const linkState = await showLinkPopover({ anchorEl: mockSelectDom });
 
   quill.formatText(range, { 'mock-select': false });
-  if (linkState.type !== 'confirm') {
-    return;
-  }
+  if (linkState.type !== 'confirm') return;
+
   const link = linkState.link;
 
   page.captureSync();
   startModel.text?.format(range.index, range.length, { link });
-};
+}

--- a/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
@@ -6,11 +6,7 @@ import {
   ALLOWED_SCHEMES,
   showLinkPopover,
 } from '../../../components/link-popover/index.js';
-import {
-  getDefaultPageBlock,
-  getModelByElement,
-  hotkey,
-} from '../../utils/index.js';
+import { getDefaultPageBlock, getModelByElement } from '../../utils/index.js';
 import { LinkIcon } from './link-icon.js';
 import { assertExists } from '@blocksuite/global/utils';
 

--- a/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/link-node.ts
@@ -72,28 +72,26 @@ export class LinkNodeComponent extends LitElement {
     assertExists(blot);
     const text = blot.domNode.textContent ?? undefined;
 
-    hotkey.withDisabledHotkey(async () => {
-      const linkState = await showLinkPopover({
-        anchorEl: e.target as HTMLElement,
-        text,
-        link: this.href,
-        showMask: false,
-        interactionKind: 'hover',
-      });
-      if (linkState.type === 'confirm') {
-        const link = linkState.link;
-        const newText = linkState.text;
-        const isUpdateText = newText !== text;
-        assertExists(blot);
-        this._updateLink(blot, link, isUpdateText ? newText : undefined);
-        return;
-      }
-      if (linkState.type === 'remove') {
-        assertExists(blot);
-        this._updateLink(blot, false);
-        return;
-      }
+    const linkState = await showLinkPopover({
+      anchorEl: e.target as HTMLElement,
+      text,
+      link: this.href,
+      showMask: false,
+      interactionKind: 'hover',
     });
+    if (linkState.type === 'confirm') {
+      const link = linkState.link;
+      const newText = linkState.text;
+      const isUpdateText = newText !== text;
+      assertExists(blot);
+      this._updateLink(blot, link, isUpdateText ? newText : undefined);
+      return;
+    }
+    if (linkState.type === 'remove') {
+      assertExists(blot);
+      this._updateLink(blot, false);
+      return;
+    }
   }
 
   /**

--- a/packages/blocks/src/__internal__/utils/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture.ts
@@ -6,6 +6,7 @@ import {
 } from './selection.js';
 import { debounce } from './std.js';
 import { MOVE_DETECT_THRESHOLD } from './consts.js';
+import { isInsideBlockContainer, isPageTitleElement } from './query.js';
 
 export interface IPoint {
   x: number;
@@ -77,39 +78,6 @@ function toSelectionEvent(
   return selectionEvent;
 }
 
-export function isPageTitle(e: Event) {
-  return (
-    e.target instanceof HTMLTextAreaElement &&
-    e.target.classList.contains('affine-default-page-block-title')
-  );
-}
-export function isInput(e: Event) {
-  return e.target instanceof HTMLTextAreaElement;
-}
-export function isInsideBlockContainer(e: Event) {
-  const defaultBlockContainer = document.querySelector(
-    '.affine-default-page-block-container'
-  );
-  const edgelessBlockContainer = document.querySelector(
-    '.affine-edgeless-page-block-container'
-  );
-  return (
-    (e.target instanceof Node &&
-      defaultBlockContainer &&
-      defaultBlockContainer.contains(e.target)) ||
-    (e.target instanceof Node &&
-      edgelessBlockContainer &&
-      edgelessBlockContainer.contains(e.target))
-  );
-}
-
-function tryPreventDefault(e: MouseEvent) {
-  // workaround page title click
-  if (!isInput(e)) {
-    e.preventDefault();
-  }
-}
-
 export function initMouseEventHandlers(
   container: HTMLElement,
   onContainerDragStart: (e: SelectionEvent) => void,
@@ -135,7 +103,9 @@ export function initMouseEventHandlers(
     );
 
   const mouseDownHandler = (e: MouseEvent) => {
-    tryPreventDefault(e);
+    if (!isPageTitleElement(e.target)) {
+      e.preventDefault();
+    }
     const rect = getBoundingClientRect();
 
     startX = e.clientX - rect.left;
@@ -150,7 +120,9 @@ export function initMouseEventHandlers(
   };
 
   const mouseMoveHandler = (e: MouseEvent) => {
-    tryPreventDefault(e);
+    if (!isPageTitleElement(e.target)) {
+      e.preventDefault();
+    }
     const rect = getBoundingClientRect();
 
     const a = { x: startX, y: startY };
@@ -182,7 +154,9 @@ export function initMouseEventHandlers(
   };
 
   const mouseUpHandler = (e: MouseEvent) => {
-    tryPreventDefault(e);
+    if (!isPageTitleElement(e.target)) {
+      e.preventDefault();
+    }
 
     if (!isDragging)
       onContainerClick(
@@ -194,7 +168,8 @@ export function initMouseEventHandlers(
       );
 
     const horizontalElement = getClosestHorizontalEditor(e.clientY);
-    if (!isInsideBlockContainer(e) && horizontalElement) {
+
+    if (!isInsideBlockContainer(e.target) && horizontalElement) {
       let containerDom = document.querySelector(
         '.affine-default-page-block-container'
       );

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -44,6 +44,11 @@ function shouldFilter(event: KeyboardEvent) {
       event.preventDefault();
       return false;
     }
+    // Some event dispatch from body
+    // for example, press backspace to remove block-level selection
+    if (event.target === document.body) {
+      return false;
+    }
     return true;
   }
   // if (

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -1,31 +1,59 @@
 import hotkeys from 'hotkeys-js';
 import type { KeyHandler } from 'hotkeys-js';
+import {
+  isCaptionElement,
+  isInsideRichText,
+  isPageTitleElement,
+} from './query.js';
 
 hotkeys.filter = (event: KeyboardEvent) => {
-  const target = event.target;
-  if (
-    target &&
-    target instanceof Element &&
-    ['INPUT'].includes(target.tagName) &&
-    shouldFilter(event)
-  ) {
+  if (shouldFilter(event)) {
     return false;
   }
   return true;
 };
 
-const shouldFilter = (event: KeyboardEvent) => {
+const isUndoRedo = (event: KeyboardEvent) => {
   // If undo or redo: when event.shiftKey is false => undo, when event.shiftKey is true => redo
   if (event.metaKey && !event.altKey && event.key === 'z') {
     return true;
   }
-
-  if (event.key === 'Backspace') {
-    return true;
-  }
-
   return false;
 };
+function shouldFilter(event: KeyboardEvent) {
+  const target = event.target;
+  // Not sure if this is the right thing to do
+  if (!target) {
+    return true;
+  }
+  // Skip input element
+  // including
+  // - code block language search input
+  // - image caption
+  // - link create/edit popover
+  if (!isInsideRichText(event.target)) {
+    // TODO Remove ad-hoc
+    // This ad-hoc should be moved to the caption input for processing
+    // Enter on caption should jump out of input
+    // See also `hotkey.addListener(ENTER, handler)`
+    if (isCaptionElement(event.target) && event.key === 'Enter') {
+      return false;
+    }
+    // undo/redo should work in page title
+    if (isPageTitleElement(event.target) && isUndoRedo(event)) {
+      event.preventDefault();
+      return false;
+    }
+    return true;
+  }
+  // if (
+  //   target instanceof Element &&
+  //   ['INPUT', 'EDIT-LINK-PANEL'].includes(target.tagName)
+  // ) {
+  //   return true;
+  // }
+  return false;
+}
 
 const SCOPE = {
   AFFINE_PAGE: 'affine:page',

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -13,13 +13,14 @@ hotkeys.filter = (event: KeyboardEvent) => {
   return true;
 };
 
-const isUndoRedo = (event: KeyboardEvent) => {
+function isUndoRedo(event: KeyboardEvent) {
   // If undo or redo: when event.shiftKey is false => undo, when event.shiftKey is true => redo
   if (event.metaKey && !event.altKey && event.key === 'z') {
     return true;
   }
   return false;
-};
+}
+
 function shouldFilter(event: KeyboardEvent) {
   const target = event.target;
   // Not sure if this is the right thing to do

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -398,7 +398,7 @@ export function getAllBlocks() {
 export function isInsideRichText(element: unknown): element is RichText {
   // Fool-proofing
   if (element instanceof Event) {
-    throw new Error('Do you want "event.target"?');
+    throw new Error('Did you mean "event.target"?');
   }
 
   if (!element || !(element instanceof Element)) {

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -394,3 +394,58 @@ export function getAllBlocks() {
     );
   });
 }
+
+export function isInsideRichText(element: unknown): element is RichText {
+  // Fool-proofing
+  if (element instanceof Event) {
+    throw new Error('Do you want "event.target"?');
+  }
+
+  if (!element || !(element instanceof Element)) {
+    return false;
+  }
+  const richText = element.closest('rich-text');
+  return !!richText;
+}
+
+export function isPageTitleElement(
+  element: unknown
+): element is HTMLTextAreaElement {
+  return (
+    element instanceof HTMLTextAreaElement &&
+    element.classList.contains('affine-default-page-block-title')
+  );
+}
+
+export function isCaptionElement(node: unknown): node is HTMLInputElement {
+  if (!(node instanceof Element)) {
+    return false;
+  }
+  return node.classList.contains('affine-embed-wrapper-caption');
+}
+
+/**
+ * This function is slightly different from {@link isInsideRichText}.
+ * It include all of element in editor.
+ * This is very useful when wanting to handle edges between blocks.
+ *
+ * See also {@link isInsideRichText} or {@link isPageTitleElement}
+ */
+export function isInsideBlockContainer(element: unknown): element is Node {
+  const defaultBlockContainer = document.querySelector(
+    '.affine-default-page-block-container'
+  );
+  const edgelessBlockContainer = document.querySelector(
+    '.affine-edgeless-page-block-container'
+  );
+  if (!(element instanceof Node)) {
+    return false;
+  }
+  if (defaultBlockContainer) {
+    return defaultBlockContainer.contains(element);
+  }
+  if (edgelessBlockContainer) {
+    return edgelessBlockContainer.contains(element);
+  }
+  return false;
+}

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -17,12 +17,6 @@ import './button';
 import { ArrowDownIcon, CopyIcon } from './icons.js';
 import { formatQuickBarStyle } from './styles.js';
 
-const onCopy = () => {
-  // Will forward to the `CopyCutManager`
-  document.dispatchEvent(new ClipboardEvent('copy'));
-  toast('Copied to clipboard');
-};
-
 @customElement('format-quick-bar')
 export class FormatQuickBar extends LitElement {
   static styles = formatQuickBarStyle;
@@ -114,6 +108,12 @@ export class FormatQuickBar extends LitElement {
       return;
     }
     clearTimeout(this.paragraphPanelTimer);
+  }
+
+  private _onCopy() {
+    // Will forward to the `CopyCutManager`
+    this.dispatchEvent(new ClipboardEvent('copy', { bubbles: true }));
+    toast('Copied to clipboard');
   }
 
   private _paragraphPanelTemplate() {
@@ -215,7 +215,7 @@ export class FormatQuickBar extends LitElement {
     const actionItems = html`<format-bar-button
       class="has-tool-tip"
       data-testid="copy"
-      @click=${() => onCopy()}
+      @click=${() => this._onCopy()}
     >
       ${CopyIcon}
       <tool-tip inert role="tooltip">Copy</tool-tip>

--- a/packages/blocks/src/components/link-popover/link-popover.ts
+++ b/packages/blocks/src/components/link-popover/link-popover.ts
@@ -247,11 +247,19 @@ export class LinkPopover extends LitElement {
         ${this.previewLink}
       </div>
       <span class="affine-link-popover-dividing-line"></span>
-      <icon-button class="has-tool-tip" @click=${this._onUnlink}>
+      <icon-button
+        class="has-tool-tip"
+        data-testid="unlink"
+        @click=${this._onUnlink}
+      >
         ${UnlinkIcon}
         <tool-tip inert role="tooltip">Remove</tool-tip>
       </icon-button>
-      <icon-button class="has-tool-tip" @click=${this._onEdit}>
+      <icon-button
+        class="has-tool-tip"
+        data-testid="edit"
+        @click=${this._onEdit}
+      >
         ${EditIcon}
         <tool-tip inert role="tooltip">Edit link</tool-tip>
       </icon-button>

--- a/packages/blocks/src/components/link-popover/styles.ts
+++ b/packages/blocks/src/components/link-popover/styles.ts
@@ -99,9 +99,10 @@ export const linkPopoverStyle = css`
   .overlay-mask {
     position: fixed;
     top: 0;
-    bottom: 0;
     left: 0;
-    right: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: var(--affine-z-index-popover);
   }
   .affine-edit-text-area {
     border: 1px solid var(--affine-border-color);

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -15,10 +15,10 @@ import {
   getBlockElementByModel,
   getAllBlocks,
   getDefaultPageBlock,
-  isInput,
   IPoint,
   doesInSamePath,
   getCurrentRange,
+  isPageTitleElement,
 } from '../../__internal__/index.js';
 import type { RichText } from '../../__internal__/rich-text/rich-text.js';
 import {
@@ -351,7 +351,7 @@ export class DefaultSelectionManager {
 
   private _onContainerDragStart = (e: SelectionEvent) => {
     this.state.resetStartRange(e);
-    if (isInput(e.raw)) return;
+    if (isPageTitleElement(e.raw.target)) return;
     if (isEmbed(e)) {
       this.state.type = 'embed';
       this._embedResizeManager.onStart(e);

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -15,13 +15,13 @@ import {
   getStartModelBySelection,
   hotkey,
   HOTKEYS,
-  isPageTitle,
   getRichTextByModel,
   Point,
   resetNativeSelection,
   BLOCK_ID_ATTR,
   BLOCK_SERVICE_LOADING_ATTR,
   BLOCK_CHILDREN_CONTAINER_PADDING_LEFT,
+  isCaptionElement,
 } from '../../__internal__/utils/index.js';
 import type { PageBlockModel } from '../page-model.js';
 import {
@@ -483,10 +483,9 @@ export function bindHotkeys(
 
   hotkey.addListener(ENTER, e => {
     const { type, selectedBlocks } = selection.state;
-    const targetInput = e.target as HTMLElement;
-    const isCaption = targetInput.classList.contains(
-      'affine-embed-wrapper-caption'
-    );
+    const targetInput = e.target;
+    // TODO caption ad-hoc should be moved to the caption input for processing
+    const isCaption = isCaptionElement(targetInput);
     // select blocks or focus caption input, then enter will create a new block.
     if ((type === 'block' && selectedBlocks.length) || isCaption) {
       e.stopPropagation();
@@ -549,9 +548,6 @@ export function bindHotkeys(
   });
 
   hotkey.addListener(SELECT_ALL, e => {
-    if (isPageTitle(e)) {
-      return;
-    }
     e.preventDefault();
     handleSelectAll(selection);
     selection.state.type = 'block';

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -1,6 +1,6 @@
 import { formatConfig, paragraphConfig } from './const.js';
 import type { Page } from '@blocksuite/store';
-import { hotkey, HOTKEYS, isPageTitle } from '../../__internal__/index.js';
+import { hotkey, HOTKEYS } from '../../__internal__/index.js';
 import { updateSelectedTextType } from './container-operations.js';
 
 const { UNDO, REDO } = HOTKEYS;
@@ -8,12 +8,6 @@ const { UNDO, REDO } = HOTKEYS;
 export function bindCommonHotkey(page: Page) {
   formatConfig.forEach(({ hotkey: hotkeyStr, action }) => {
     hotkey.addListener(hotkeyStr, e => {
-      // workaround page title
-      e.preventDefault();
-      // TODO also disable hotkey when focus on other input
-      if (isPageTitle(e)) {
-        return;
-      }
       if (page.awareness.isReadonly()) {
         return;
       }
@@ -32,15 +26,9 @@ export function bindCommonHotkey(page: Page) {
   });
 
   hotkey.addListener(UNDO, e => {
-    if (isPageTitle(e)) {
-      e.preventDefault();
-    }
     page.undo();
   });
   hotkey.addListener(REDO, e => {
-    if (isPageTitle(e)) {
-      e.preventDefault();
-    }
     page.redo();
   });
   // !!!

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -8,6 +8,8 @@ const { UNDO, REDO } = HOTKEYS;
 export function bindCommonHotkey(page: Page) {
   formatConfig.forEach(({ hotkey: hotkeyStr, action }) => {
     hotkey.addListener(hotkeyStr, e => {
+      // Prevent quill default behavior
+      e.preventDefault();
       if (page.awareness.isReadonly()) {
         return;
       }

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -2,7 +2,6 @@ import { BaseBlockModel, Page, Text } from '@blocksuite/store';
 import {
   almostEqual,
   ExtendedModel,
-  isPageTitle,
   RootBlockModel,
 } from '../../__internal__/index.js';
 import { asyncFocusRichText } from '../../__internal__/utils/common-operations.js';
@@ -167,8 +166,6 @@ export function transformBlock(
  * Do nothing when selection is collapsed or not multi block selected
  */
 export function handleMultiBlockBackspace(page: Page, e: KeyboardEvent) {
-  // workaround page title
-  if (isPageTitle(e)) return;
   if (isNoneSelection()) return;
   if (isCollapsedSelection()) return;
   if (!isMultiBlockRange()) return;

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -54,21 +54,34 @@ export class ClipboardEventDispatcher {
     return document.activeElement?.closest('editor-container') != null;
   }
 
+  private _isValidEvent(e: ClipboardEvent) {
+    if (isInsideRichText(e.target)) {
+      return true;
+    }
+    // Ad-hoc for copy from format quick bar copy button
+    if (
+      e.target instanceof Element &&
+      e.target.tagName === 'FORMAT-QUICK-BAR'
+    ) {
+      return true;
+    }
+    // Some copy event dispatch from body
+    // for example, copy block-level selection
+    if (e.target === document.body) {
+      return true;
+    }
+    return false;
+  }
+
   private _copyHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e.target)) {
-      // Ad-hoc for copy from format quick bar copy button
-      if (
-        e.target instanceof Element &&
-        e.target.tagName === 'FORMAT-QUICK-BAR'
-      ) {
-        // should handle, do noting
-      } else return;
+    if (!this._isValidEvent(e)) {
+      return;
     }
     this.signals.copy.emit(e);
   }
 
   private _cutHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e.target)) {
+    if (!this._isValidEvent(e)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {
@@ -76,7 +89,7 @@ export class ClipboardEventDispatcher {
     }
   }
   private _pasteHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e.target)) {
+    if (!this._isValidEvent(e)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -56,7 +56,13 @@ export class ClipboardEventDispatcher {
 
   private _copyHandler(e: ClipboardEvent) {
     if (!isInsideRichText(e.target)) {
-      return;
+      // Ad-hoc for copy from format quick bar copy button
+      if (
+        e.target instanceof Element &&
+        e.target.tagName === 'FORMAT-QUICK-BAR'
+      ) {
+        // should handle, do noting
+      } else return;
     }
     this.signals.copy.emit(e);
   }

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -1,4 +1,4 @@
-import { isPageTitle } from '@blocksuite/blocks/std';
+import { isInsideRichText } from '@blocksuite/blocks/std';
 import { Signal } from '@blocksuite/store';
 import { ClipboardAction } from './types.js';
 
@@ -26,7 +26,6 @@ export class ClipboardEventDispatcher {
     clipboardTarget.addEventListener(ClipboardAction.copy, this._copyHandler);
     clipboardTarget.addEventListener(ClipboardAction.cut, this._cutHandler);
     clipboardTarget.addEventListener(ClipboardAction.paste, this._pasteHandler);
-    // TODO fix break popover input
     document.addEventListener(ClipboardAction.copy, this._copyHandler);
     document.addEventListener(ClipboardAction.cut, this._cutHandler);
     document.addEventListener(ClipboardAction.paste, this._pasteHandler);
@@ -56,14 +55,14 @@ export class ClipboardEventDispatcher {
   }
 
   private _copyHandler(e: ClipboardEvent) {
-    if (isPageTitle(e)) {
+    if (!isInsideRichText(e)) {
       return;
     }
     this.signals.copy.emit(e);
   }
 
   private _cutHandler(e: ClipboardEvent) {
-    if (isPageTitle(e)) {
+    if (!isInsideRichText(e)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {
@@ -71,7 +70,7 @@ export class ClipboardEventDispatcher {
     }
   }
   private _pasteHandler(e: ClipboardEvent) {
-    if (isPageTitle(e)) {
+    if (!isInsideRichText(e)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -55,14 +55,14 @@ export class ClipboardEventDispatcher {
   }
 
   private _copyHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e)) {
+    if (!isInsideRichText(e.target)) {
       return;
     }
     this.signals.copy.emit(e);
   }
 
   private _cutHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e)) {
+    if (!isInsideRichText(e.target)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {
@@ -70,7 +70,7 @@ export class ClipboardEventDispatcher {
     }
   }
   private _pasteHandler(e: ClipboardEvent) {
-    if (!isInsideRichText(e)) {
+    if (!isInsideRichText(e.target)) {
       return;
     }
     if (ClipboardEventDispatcher.editorElementActive()) {

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -10,54 +10,40 @@ export class ClipboardEventDispatcher {
   };
 
   constructor(clipboardTarget: HTMLElement) {
-    this._copyHandler = this._copyHandler.bind(this);
-    this._cutHandler = this._cutHandler.bind(this);
-    this._pasteHandler = this._pasteHandler.bind(this);
     this.initClipboardTargetEvent(clipboardTarget);
   }
 
   initClipboardTargetEvent(clipboardTarget: HTMLElement) {
-    if (!clipboardTarget) {
-      return;
-    }
+    if (!clipboardTarget) return;
 
     this.disposeClipboardTargetEvent(clipboardTarget);
 
-    clipboardTarget.addEventListener(ClipboardAction.copy, this._copyHandler);
-    clipboardTarget.addEventListener(ClipboardAction.cut, this._cutHandler);
-    clipboardTarget.addEventListener(ClipboardAction.paste, this._pasteHandler);
-    document.addEventListener(ClipboardAction.copy, this._copyHandler);
-    document.addEventListener(ClipboardAction.cut, this._cutHandler);
-    document.addEventListener(ClipboardAction.paste, this._pasteHandler);
+    clipboardTarget.addEventListener(ClipboardAction.copy, this._onCopy);
+    clipboardTarget.addEventListener(ClipboardAction.cut, this._onCut);
+    clipboardTarget.addEventListener(ClipboardAction.paste, this._onPaste);
+    document.addEventListener(ClipboardAction.copy, this._onCopy);
+    document.addEventListener(ClipboardAction.cut, this._onCut);
+    document.addEventListener(ClipboardAction.paste, this._onPaste);
   }
 
   disposeClipboardTargetEvent(clipboardTarget: HTMLElement) {
-    if (!clipboardTarget) {
-      return;
-    }
+    if (!clipboardTarget) return;
 
-    clipboardTarget.removeEventListener(
-      ClipboardAction.copy,
-      this._copyHandler
-    );
-    clipboardTarget.removeEventListener(ClipboardAction.cut, this._cutHandler);
-    clipboardTarget.removeEventListener(
-      ClipboardAction.paste,
-      this._pasteHandler
-    );
-    document.removeEventListener(ClipboardAction.copy, this._copyHandler);
-    document.removeEventListener(ClipboardAction.cut, this._cutHandler);
-    document.removeEventListener(ClipboardAction.paste, this._pasteHandler);
+    clipboardTarget.removeEventListener(ClipboardAction.copy, this._onCopy);
+    clipboardTarget.removeEventListener(ClipboardAction.cut, this._onCut);
+    clipboardTarget.removeEventListener(ClipboardAction.paste, this._onPaste);
+    document.removeEventListener(ClipboardAction.copy, this._onCopy);
+    document.removeEventListener(ClipboardAction.cut, this._onCut);
+    document.removeEventListener(ClipboardAction.paste, this._onPaste);
   }
 
   static editorElementActive(): boolean {
     return document.activeElement?.closest('editor-container') != null;
   }
 
-  private _isValidEvent(e: ClipboardEvent) {
-    if (isInsideRichText(e.target)) {
-      return true;
-    }
+  private _isValidClipboardEvent(e: ClipboardEvent) {
+    if (isInsideRichText(e.target)) return true;
+
     // Ad-hoc for copy from format quick bar copy button
     if (
       e.target instanceof Element &&
@@ -73,29 +59,27 @@ export class ClipboardEventDispatcher {
     return false;
   }
 
-  private _copyHandler(e: ClipboardEvent) {
-    if (!this._isValidEvent(e)) {
-      return;
-    }
-    this.signals.copy.emit(e);
-  }
+  private _onCopy = (e: ClipboardEvent) => {
+    if (!this._isValidClipboardEvent(e)) return;
 
-  private _cutHandler(e: ClipboardEvent) {
-    if (!this._isValidEvent(e)) {
-      return;
-    }
+    this.signals.copy.emit(e);
+  };
+
+  private _onCut = (e: ClipboardEvent) => {
+    if (!this._isValidClipboardEvent(e)) return;
+
     if (ClipboardEventDispatcher.editorElementActive()) {
       this.signals.cut.emit(e);
     }
-  }
-  private _pasteHandler(e: ClipboardEvent) {
-    if (!this._isValidEvent(e)) {
-      return;
-    }
+  };
+
+  private _onPaste = (e: ClipboardEvent) => {
+    if (!this._isValidClipboardEvent(e)) return;
+
     if (ClipboardEventDispatcher.editorElementActive()) {
       this.signals.paste.emit(e);
     }
-  }
+  };
 
   dispose(clipboardTarget: HTMLElement) {
     this.signals.copy.dispose();

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -15,6 +15,8 @@ import {
   dragBetweenIndices,
   switchReadonly,
   SHORT_KEY,
+  captureHistory,
+  focusTitle,
 } from './utils/actions/index.js';
 import {
   defaultStore,
@@ -241,6 +243,41 @@ test('undo/redo twice after adding block twice', async ({ page }) => {
 
   await redoByKeyboard(page);
   await assertRichTexts(page, ['hello', 'world']);
+});
+
+test('should undo/redo work on title', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusTitle(page);
+  await page.keyboard.type('title');
+  await focusRichText(page);
+  await page.keyboard.type('hello world');
+  await captureHistory(page);
+  let i = 5;
+  while (i--) {
+    await page.keyboard.press('Backspace');
+  }
+
+  await focusTitle(page);
+  await captureHistory(page);
+  await page.keyboard.type(' something');
+  await undoByKeyboard(page);
+  await assertTitle(page, 'title');
+  await assertRichTexts(page, ['hello ']);
+
+  await undoByKeyboard(page);
+  await assertTitle(page, 'title');
+  await assertRichTexts(page, ['hello world']);
+
+  await focusTitle(page);
+  await redoByKeyboard(page);
+  await assertTitle(page, 'title');
+  await assertRichTexts(page, ['hello ']);
+
+  await focusTitle(page);
+  await redoByKeyboard(page);
+  await assertTitle(page, 'title something');
+  await assertRichTexts(page, ['hello ']);
 });
 
 test.skip('undo multi frames', async ({ page }) => {

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -55,6 +55,10 @@ test('clipboard paste html', async ({ page }) => {
     ({ clipData }) => {
       const dT = new DataTransfer();
       const e = new ClipboardEvent('paste', { clipboardData: dT });
+      Object.defineProperty(e, 'target', {
+        writable: false,
+        value: document.body,
+      });
       e.clipboardData?.setData('text/html', clipData['text/html']);
       document
         .getElementsByTagName('editor-container')[0]

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -62,7 +62,7 @@ test('clipboard paste html', async ({ page }) => {
       e.clipboardData?.setData('text/html', clipData['text/html']);
       document
         .getElementsByTagName('editor-container')[0]
-        .clipboard['_clipboardEventDispatcher']['_pasteHandler'](e);
+        .clipboard['_clipboardEventDispatcher']['_onPaste'](e);
     },
     { clipData }
   );

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -15,7 +15,7 @@ import {
   selectAllByKeyboard,
   undoByKeyboard,
 } from './utils/actions/index.js';
-import { assertRichTexts } from './utils/asserts.js';
+import { assertKeyboardWorkInInput, assertRichTexts } from './utils/asserts.js';
 
 test('use debug menu can create code block', async ({ page }) => {
   await enterPlaygroundRoom(page);
@@ -103,6 +103,7 @@ test('change code language can work', async ({ page }) => {
   await page.click(codeLangSelector);
   const locator = page.locator('.lang-list-button-container');
   await expect(locator).toBeVisible();
+  await assertKeyboardWorkInInput(page, page.locator('#filter-input'));
 
   await page.keyboard.type('rust');
   await page.click(

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   assertImageOption,
   assertImageSize,
+  assertKeyboardWorkInInput,
   assertRichDragButton,
   assertRichImage,
   assertRichTexts,
@@ -119,6 +120,10 @@ test('enter shortcut on focusing embed block and its caption', async ({
   await assertImageOption(page);
 
   await focusCaption(page);
+  await assertKeyboardWorkInInput(
+    page,
+    page.locator('.affine-embed-wrapper-caption')
+  );
   await page.keyboard.press('Enter', { delay: 50 });
   await page.keyboard.type('aa');
   await assertRichTexts(page, ['aa']);

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -9,6 +9,7 @@ import {
   assertTitle,
   assertPageTitleFocus,
   assertStoreMatchJSX,
+  assertKeyboardWorkInInput,
 } from './utils/asserts.js';
 import {
   clickBlockTypeMenuItem,
@@ -89,6 +90,8 @@ test('backspace and arrow on title', async ({ page }) => {
 
   await redoByKeyboard(page);
   await assertTitle(page, 'hll');
+  const title = page.locator('.affine-default-page-block-title');
+  await assertKeyboardWorkInInput(page, title);
 });
 
 test('backspace on line start of the first block', async ({ page }) => {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -7,6 +7,7 @@ import { pressEnter, SHORT_KEY } from './keyboard.js';
 const NEXT_FRAME_TIMEOUT = 100;
 const DEFAULT_PLAYGROUND = 'http://localhost:5173/';
 const RICH_TEXT_SELECTOR = '.ql-editor';
+const TITLE_SELECTOR = '.affine-default-page-block-title';
 
 function shamefullyIgnoreConsoleMessage(message: ConsoleMessage): boolean {
   if (!process.env.CI) {
@@ -102,6 +103,12 @@ export async function clearLog(page: Page) {
   await page.evaluate(() => console.clear());
 }
 
+export async function captureHistory(page: Page) {
+  await page.evaluate(() => {
+    window.page.captureSync();
+  });
+}
+
 export async function resetHistory(page: Page) {
   await page.evaluate(() => {
     const space = window.page;
@@ -150,6 +157,11 @@ export async function initEmptyCodeBlockState(page: Page) {
   });
   await page.waitForSelector(`[data-block-id="${ids.codeBlockId}"] rich-text`);
   return ids;
+}
+
+export async function focusTitle(page: Page) {
+  const locator = page.locator(TITLE_SELECTOR);
+  await locator.click();
 }
 
 export async function focusRichText(page: Page, i = 0) {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -272,7 +272,7 @@ export async function pasteContent(
       };
       document
         .getElementsByTagName('editor-container')[0]
-        .clipboard['_clipboardEventDispatcher']['_pasteHandler'](
+        .clipboard['_clipboardEventDispatcher']['_onPaste'](
           e as unknown as ClipboardEvent
         );
     },

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -260,6 +260,7 @@ export async function pasteContent(
   await page.evaluate(
     ({ clipData }) => {
       const e = {
+        target: document.body,
         preventDefault: () => null,
         stopPropagation: () => null,
         clipboardData: {

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -20,6 +20,7 @@ import {
   redoByKeyboard,
   SHORT_KEY,
 } from './actions/keyboard.js';
+import { captureHistory } from './actions/misc.js';
 
 export const defaultStore: SerializedStore = {
   'space:meta': {
@@ -471,17 +472,19 @@ export async function assertLocatorVisible(
 /**
  * Assert basic keyboard operation works in input
  *
- * Will clear the input value.
+ * NOTICE:
+ *   - it will clear the input value.
+ *   - it will pollute undo/redo history.
  */
 export async function assertKeyboardWorkInInput(page: Page, locator: Locator) {
   await expect(locator).toBeVisible();
   await locator.focus();
   // Clear input before test
   await locator.clear();
-
   // type/backspace
   await page.keyboard.type('1234');
   await expect(locator).toHaveValue('1234');
+  await captureHistory(page);
   await page.keyboard.press('Backspace');
   await expect(locator).toHaveValue('123');
 


### PR DESCRIPTION
fix https://github.com/toeverything/blocksuite/issues/619 https://github.com/toeverything/blocksuite/issues/682

- Filter most of the events whose target is non-rich-text from hotkey (fix most of the keyboard issues in non rich text input)
- Clear workaround for input and title in event hander
- Add test for #682 
- Add test for non-rich-text input, including
  - create/edit link input
  - code block language search input
  - image caption input
