### PR TITLE
feat: keep deleting forward with cmd+backspace

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -319,6 +319,13 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
       key: 'backspace',
       handler: onBackspace,
     },
+    'shortKey+backspace': {
+      key: 'backspace',
+      // TODO Fix pass `null` to mean any value for the modifier
+      // shortKey: null,
+      shortKey: true,
+      handler: onBackspace,
+    },
     up: {
       key: 'up',
       shiftKey: false,

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -1,9 +1,6 @@
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { toast } from '../../components/toast.js';
-import {
-  handleLineStartBackspace,
-  isAtLineEdge,
-} from '../../__internal__/rich-text/rich-text-operations.js';
+import { isAtLineEdge } from '../../__internal__/rich-text/rich-text-operations.js';
 import {
   asyncFocusRichText,
   focusNextBlock,
@@ -21,7 +18,6 @@ import {
   resetNativeSelection,
   isCaptionElement,
   doesInSamePath,
-  isCollapsedAtBlockStart,
 } from '../../__internal__/utils/index.js';
 import type { PageBlockModel } from '../page-model.js';
 import {
@@ -542,17 +538,8 @@ export function bindHotkeys(
     const { state } = selection;
     if (state.type === 'none') {
       // Will be handled in the `keyboard.onBackspace` function
-      const target = e.target as HTMLElement;
-      const model = getModelByElement(target);
-      const richText = getRichTextByModel(model);
-      assertExists(richText);
-      const quill = richText?.quill;
-      if (isCollapsedAtBlockStart(quill)) {
-        handleLineStartBackspace(page, model);
-        return;
-      }
+      return;
     }
-
     if (state.type === 'native') {
       handleMultiBlockBackspace(page, e);
       return;

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -1,6 +1,9 @@
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { toast } from '../../components/toast.js';
-import { isAtLineEdge } from '../../__internal__/rich-text/rich-text-operations.js';
+import {
+  handleLineStartBackspace,
+  isAtLineEdge,
+} from '../../__internal__/rich-text/rich-text-operations.js';
 import {
   asyncFocusRichText,
   focusNextBlock,
@@ -18,6 +21,7 @@ import {
   resetNativeSelection,
   isCaptionElement,
   doesInSamePath,
+  isCollapsedAtBlockStart,
 } from '../../__internal__/utils/index.js';
 import type { PageBlockModel } from '../page-model.js';
 import {
@@ -538,8 +542,17 @@ export function bindHotkeys(
     const { state } = selection;
     if (state.type === 'none') {
       // Will be handled in the `keyboard.onBackspace` function
-      return;
+      const target = e.target as HTMLElement;
+      const model = getModelByElement(target);
+      const richText = getRichTextByModel(model);
+      assertExists(richText);
+      const quill = richText?.quill;
+      if (isCollapsedAtBlockStart(quill)) {
+        handleLineStartBackspace(page, model);
+        return;
+      }
     }
+
     if (state.type === 'native') {
       handleMultiBlockBackspace(page, e);
       return;

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -9,7 +9,7 @@ export const ALLOW_DEFAULT = true;
 export const HOTKEYS = {
   UNDO: 'command+z,ctrl+z',
   REDO: 'command+shift+z,ctrl+shift+z,ctrl+y',
-  BACKSPACE: 'backspace,command+backspace,ctrl+backspace',
+  BACKSPACE: 'backspace',
   SELECT_ALL: 'command+a,ctrl+a',
   SHIFT_UP: 'shift+up',
   SHIFT_DOWN: 'shift+down',

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -9,7 +9,7 @@ export const ALLOW_DEFAULT = true;
 export const HOTKEYS = {
   UNDO: 'command+z,ctrl+z',
   REDO: 'command+shift+z,ctrl+shift+z,ctrl+y',
-  BACKSPACE: 'backspace',
+  BACKSPACE: 'backspace,command+backspace,ctrl+backspace',
   SELECT_ALL: 'command+a,ctrl+a',
   SHIFT_UP: 'shift+up',
   SHIFT_DOWN: 'shift+down',

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -41,6 +41,26 @@ test('rich-text hotkey scope on single press', async ({ page }) => {
   await assertRichTexts(page, ['\n']);
 });
 
+test('cmd+backspace keep deleting when start of an empty list', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['123', '456', '\n']);
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['123', '456']);
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['123', '\n']);
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['123']);
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['\n']);
+});
+
 test('single line rich-text inline code hotkey', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -19,6 +19,8 @@ import {
   MODIFIER_KEY,
   resetHistory,
   readClipboardText,
+  pressSpace,
+  pressKey,
 } from './utils/actions/index.js';
 import {
   assertRichTexts,
@@ -47,27 +49,35 @@ test('cmd+backspace keep deleting when start of an empty list', async ({
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
+
   await pressEnter(page);
   await page.keyboard.type('---');
-  await page.keyboard.press('Space', { delay: 50 });
+  await pressSpace(page);
   await assertRichTexts(page, ['123', '456', '789', '\n']);
 
+  const cmdBackspace = `${SHORT_KEY}+Backspace`;
+
   // Remove empty line
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 50 });
+  await pressKey(page, cmdBackspace);
   // Remove divider
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await pressKey(page, cmdBackspace);
   // Remove the paragraph remaining by the divider
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['123', '456', '789']);
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['123', '456', '\n']);
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['123', '456']);
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['123', '\n']);
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['123']);
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+
+  await pressKey(page, cmdBackspace);
   await assertRichTexts(page, ['\n']);
 });
 

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -47,8 +47,18 @@ test('cmd+backspace keep deleting when start of an empty list', async ({
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
-  await assertRichTexts(page, ['123', '456', '789']);
+  await pressEnter(page);
+  await page.keyboard.type('---');
+  await page.keyboard.press('Space', { delay: 50 });
+  await assertRichTexts(page, ['123', '456', '789', '\n']);
 
+  // Remove empty line
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 50 });
+  // Remove divider
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  // Remove the paragraph remaining by the divider
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+  await assertRichTexts(page, ['123', '456', '789']);
   await page.keyboard.press(`${SHORT_KEY}+Backspace`);
   await assertRichTexts(page, ['123', '456', '\n']);
   await page.keyboard.press(`${SHORT_KEY}+Backspace`);

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -1,5 +1,4 @@
 import { expect, Locator, Page, test } from '@playwright/test';
-import { SHORT_KEY } from 'utils/actions/keyboard.js';
 import {
   enterPlaygroundRoom,
   focusRichText,
@@ -38,9 +37,17 @@ test.describe('slash menu should show and hide correctly', () => {
       // Click outside
       await page.mouse.click(0, 50);
     }
-    await focusRichText(page);
     // Clear input
-    await page.keyboard.press(`${SHORT_KEY}+Backspace`);
+    await page.evaluate(paragraphId => {
+      const { page } = window;
+      const block = page.getBlockById(paragraphId);
+      if (!block) {
+        throw new Error('Block not found, id: ' + paragraphId);
+      }
+      const text = block.text;
+      if (!text || text.length === 0) return;
+      text.delete(0, text.length);
+    }, paragraphId);
   });
 
   test('slash menu should hide after click away', async () => {

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -21,59 +21,15 @@ export const SHORT_KEY = IS_MAC ? 'Meta' : 'Control';
  */
 export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
-/**
- * @deprecated Use {@link SHORT_KEY} directly
- */
-async function keyDownCtrlOrMeta(page: Page) {
-  if (IS_MAC) {
-    await page.keyboard.down('Meta');
-  } else {
-    await page.keyboard.down('Control');
-  }
-}
-
-/**
- * @deprecated Use {@link SHORT_KEY} directly
- */
-async function keyUpCtrlOrMeta(page: Page) {
-  if (IS_MAC) {
-    await page.keyboard.up('Meta');
-  } else {
-    await page.keyboard.up('Control');
-  }
-}
-
-/**
- * @deprecated Use {@link MODIFIER_KEY} directly
- */
-async function keyDownOptionMeta(page: Page) {
-  if (IS_MAC) {
-    await page.keyboard.down('Alt');
-  } else {
-    await page.keyboard.down('Shift');
-  }
-}
-
-/**
- * @deprecated Use {@link MODIFIER_KEY} directly
- */
-async function keyUpOptionMeta(page: Page) {
-  if (IS_MAC) {
-    await page.keyboard.up('Alt');
-  } else {
-    await page.keyboard.up('Shift');
-  }
-}
-
-export const withPressKey = async (
+export async function withPressKey(
   page: Page,
   key: string,
   fn: () => Promise<void>
-) => {
+) {
   await page.keyboard.down(key);
   await fn();
   await page.keyboard.up(key);
-};
+}
 
 export async function pressBackspace(page: Page) {
   await page.keyboard.press('Backspace', { delay: 50 });
@@ -114,6 +70,10 @@ export async function pressShiftTab(page: Page) {
 
 export async function pressShiftEnter(page: Page) {
   await page.keyboard.press('Shift+Enter', { delay: 50 });
+}
+
+export async function pressKey(page: Page, key: string) {
+  await page.keyboard.press(key, { delay: 50 });
 }
 
 export async function inlineCode(page: Page) {


### PR DESCRIPTION
This PR adds the same handling to "command + backspace" as "backspace" to support smooth paragraph deletion.
The following video contains a comparison with the notion and obsidian operations.


https://user-images.githubusercontent.com/36295999/212618163-f9e46652-7bec-46a0-b450-d5199ed6214e.mp4


