### PR TITLE
refactor: move drag indicator to a global singleton pattern

### DIFF
--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -131,6 +131,12 @@ export class DragHandle extends LitElement {
     this._indicator = <DragIndicator>(
       document.querySelector('affine-drag-indicator')
     );
+    if (!this._indicator) {
+      this._indicator = <DragIndicator>(
+        document.createElement('affine-drag-indicator')
+      );
+      document.body.appendChild(this._indicator);
+    }
   }
 
   public show(startModelState: EditingState) {

--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -128,6 +128,9 @@ export class DragHandle extends LitElement {
   protected firstUpdated() {
     this.setAttribute('draggable', 'true');
     this.style.display = 'none';
+    this._indicator = <DragIndicator>(
+      document.querySelector('affine-drag-indicator')
+    );
   }
 
   public show(startModelState: EditingState) {
@@ -158,10 +161,6 @@ export class DragHandle extends LitElement {
     );
     document.body.addEventListener('wheel', this._onWheel);
     window.addEventListener('resize', this._onResize);
-    this._indicator = <DragIndicator>(
-      document.createElement('affine-drag-indicator')
-    );
-    document.body.appendChild(this._indicator);
     this.addEventListener('mousedown', this._onMouseDown);
     isFirefox &&
       document.addEventListener('dragover', this._onDragOverDocument);
@@ -173,7 +172,8 @@ export class DragHandle extends LitElement {
 
   public disconnectedCallback() {
     super.disconnectedCallback();
-    this._indicator.remove();
+    this._indicator.cursorPosition = null;
+    this._indicator.targetRect = null;
     window.removeEventListener('resize', this._onResize);
     document.body.removeEventListener('wheel', this._onWheel);
     document.body.removeEventListener(

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -385,7 +385,6 @@ export class DefaultPageBlockComponent
           </div>
           ${childrenContainer}
         </div>
-        <affine-drag-indicator></affine-drag-indicator>
         ${selectedRectsContainer} ${selectionRect}
         ${selectedEmbedContainer}${embedEditingContainer}
         ${codeBlockOptionContainer}

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -385,6 +385,7 @@ export class DefaultPageBlockComponent
           </div>
           ${childrenContainer}
         </div>
+        <affine-drag-indicator></affine-drag-indicator>
         ${selectedRectsContainer} ${selectionRect}
         ${selectedEmbedContainer}${embedEditingContainer}
         ${codeBlockOptionContainer}


### PR DESCRIPTION
Now drag indicator lifecycle is created and and removed in Drag handler, as we have may have more drag scenarios using drag indicator, as blockHub so far, and there will be only one dragging at a time. So how about making it globally exists, and after a component finished using it, hide it rather than removing it. In this way any components with dragging behavior can share one indicator