### PR TITLE
test: make test pass in local

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -56,7 +56,7 @@ When you contribute new features and bug fixes, the test cases are encouraged an
 
 We use [Playwright](https://playwright.dev/) for E2E test, and [vitest](https://vitest.dev/) for unit test.
 
-To test locally, please make sure browser binaries are already installed via `npx playwright install` and Vite playground is started with `pnpm dev`. Then there are multi commands to choose from:
+To test locally, please make sure browser binaries are already installed via `npx playwright install`. Then there are multi commands to choose from:
 
 ```sh
 # run tests in headless mode in another terminal window

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,10 +4,15 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
   fullyParallel: true,
+  timeout: process.env.CI ? 50_000 : 30_000,
+  webServer: {
+    command: 'pnpm dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
   use: {
     browserName: 'chromium',
     viewport: { width: 900, height: 600 },
-    actionTimeout: 3 * 1000,
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
     // You can open traces locally(`npx playwright show-trace trace.zip`)
     // or in your browser on [Playwright Trace Viewer](https://trace.playwright.dev/).
@@ -24,10 +29,6 @@ const config: PlaywrightTestConfig = {
 };
 
 if (process.env.CI) {
-  config.webServer = {
-    command: 'pnpm dev',
-    port: 5173,
-  };
   config.retries = 2;
   // config.workers = 2;
 }


### PR DESCRIPTION
## why
I found that I can't make the `pnpm test` pass following the `BUILDING.md` tutorial, even on a clean Codespaces on GitHub. 🫠 Guessing some details are missing in the documentation so I tweak the playwright config file. And now, I can pass the `pnpm test` on my mac.

why remove `actionTimeout`?
I found when running on my mac (6 core, 12 workers), playwright will be failed on `actionTimeout` timeout. I think maybe too many workers are running concurrently so it stuck.