### PR TITLE
fix: reuse comparePoint to decide dragging direction during native selection

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -424,9 +424,11 @@ export function handleNativeRangeDragMove(
   assertExists(startRange);
   const { startContainer, startOffset, endContainer, endOffset } = startRange;
   let currentRange = caretRangeFromPoint(e.raw.clientX, e.raw.clientY);
-  const isForward = !(
-    currentRange?.comparePoint(endContainer, endOffset) === 1
-  );
+  const isDownWard = e.y > e.start.y;
+  const isForward =
+    currentRange?.commonAncestorContainer.nodeType === Node.TEXT_NODE
+      ? !(currentRange?.comparePoint(endContainer, endOffset) === 1)
+      : isDownWard;
   if (isForward) {
     currentRange?.setStart(startContainer, startOffset);
   } else {

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -424,16 +424,20 @@ export function handleNativeRangeDragMove(
   assertExists(startRange);
   const { startContainer, startOffset, endContainer, endOffset } = startRange;
   let currentRange = caretRangeFromPoint(e.raw.clientX, e.raw.clientY);
-  const isDownWard = e.y > e.start.y;
+
+  // See https://github.com/toeverything/blocksuite/pull/783 for direction recognition
+  const isDownward = e.y > e.start.y;
   const isForward =
     currentRange?.commonAncestorContainer.nodeType === Node.TEXT_NODE
       ? !(currentRange?.comparePoint(endContainer, endOffset) === 1)
-      : isDownWard;
+      : isDownward;
+
   if (isForward) {
     currentRange?.setStart(startContainer, startOffset);
   } else {
     currentRange?.setEnd(endContainer, endOffset);
   }
+
   if (currentRange) {
     currentRange = fixCurrentRangeToText(
       e.raw.clientX,

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -21,11 +21,7 @@ import type {
   SelectionInfo,
   SelectionPosition,
 } from './types.js';
-import {
-  BLOCK_ID_ATTR,
-  MOVE_DETECT_THRESHOLD,
-  SCROLL_THRESHOLD,
-} from './consts.js';
+import { BLOCK_ID_ATTR, SCROLL_THRESHOLD } from './consts.js';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
 
 // /[\p{Alphabetic}\p{Mark}\p{Decimal_Number}\p{Connector_Punctuation}\p{Join_Control}]/u
@@ -425,12 +421,12 @@ export function handleNativeRangeDragMove(
   startRange: Range | null,
   e: SelectionEvent
 ) {
-  const isDownward = e.y > e.start.y + MOVE_DETECT_THRESHOLD;
-  const isRightward = e.x > e.start.x;
-  const isForward = isDownward || (e.y === e.start.y && isRightward);
   assertExists(startRange);
   const { startContainer, startOffset, endContainer, endOffset } = startRange;
   let currentRange = caretRangeFromPoint(e.raw.clientX, e.raw.clientY);
+  const isForward = !(
+    currentRange?.comparePoint(endContainer, endOffset) === 1
+  );
   if (isForward) {
     currentRange?.setStart(startContainer, startOffset);
   } else {


### PR DESCRIPTION
Fixes #697 

The problem of `comparePoint()` is when the cursor is not in the text area, its behavior is not stable. But when the cursor is in the text area, it seems very ideal

https://user-images.githubusercontent.com/20554850/213331852-fbb3f174-f49f-424b-97e0-9aef442c524a.mov

https://user-images.githubusercontent.com/20554850/213332527-944909b6-b8e0-4838-8427-c39e33cc9270.mov

