### PR TITLE
fix: add font family for blockHub & fix menu padding

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -42,6 +42,9 @@ export class BlockHub extends NonShadowLitElement {
   @query('.block-hub-icons-container')
   private _blockHubIconsContainer!: HTMLElement;
 
+  @query('.block-hub-menu-container')
+  private _blockHubMenuContainer!: HTMLElement;
+
   private _onDropCallback: (e: DragEvent, lastModelState: EditingState) => void;
   private _getBlockEditingStateByPosition: DragHandleGetModelStateCallback | null =
     null;
@@ -143,6 +146,7 @@ export class BlockHub extends NonShadowLitElement {
 
     .block-hub-menu-container {
       display: flex;
+      font-family: var(--affine-font-family);
       flex-flow: column;
       justify-content: center;
       align-items: center;
@@ -334,11 +338,14 @@ export class BlockHub extends NonShadowLitElement {
       clearTimeout(this._timer);
     }
     if (!this._expanded) {
+      // when the _blockHubMenuContainer is unexpanded, should cancel the vertical padding making it a square
+      this._blockHubMenuContainer.style.padding = '0px 4px';
       this._timer = window.setTimeout(() => {
         this._blockHubIconsContainer.style.height = '0px';
       }, this._delay);
     } else {
       this._blockHubIconsContainer.style.height = 'unset';
+      this._blockHubMenuContainer.style.padding = '4px';
     }
   };
 


### PR DESCRIPTION
1. Assign font-family for blockHub
2. fix menu padding
Before:
<img width="2056" alt="image" src="https://user-images.githubusercontent.com/20554850/213352275-26b7b072-869e-442e-a21d-ea878a981c6c.png">

After:
<img width="2056" alt="Snipaste_2023-01-19_12-00-51" src="https://user-images.githubusercontent.com/20554850/213352178-5fe48d42-31c7-418e-b456-60d235500a81.png">


Known issues: blockHub should adapt dark mode