### PR TITLE
fix: embed component lifecycle warning

### DIFF
--- a/packages/blocks/src/embed-block/embed-block.ts
+++ b/packages/blocks/src/embed-block/embed-block.ts
@@ -47,10 +47,15 @@ export class EmbedBlockComponent extends NonShadowLitElement {
   _caption!: string;
 
   firstUpdated() {
-    this._caption = this.model?.caption ?? '';
-    if (this._caption) {
-      this._input.classList.add('caption-show');
-    }
+    requestAnimationFrame(() => {
+      this._caption = this.model?.caption ?? '';
+
+      if (this._caption.length > 0) {
+        // Caption input should be toggled manually.
+        // Otherwise it will be lost if the caption is deleted into empty state.
+        this._input.classList.add('caption-show');
+      }
+    });
 
     // The embed block can not be focused,
     // so the active element will be the last activated element.

--- a/packages/blocks/src/embed-block/image/image-block.ts
+++ b/packages/blocks/src/embed-block/image/image-block.ts
@@ -106,20 +106,19 @@ export class ImageBlockComponent extends NonShadowLitElement {
     }
   `;
 
+  @property({ hasChanged: () => true })
   model!: EmbedBlockModel;
 
   @property()
   host!: BlockHost;
 
   @query('.resizable-img')
-  _resizeImg!: HTMLElement;
+  private _resizeImg!: HTMLElement;
 
   @state()
-  _source!: string;
+  private _source!: string;
 
-  // This is the initial width before event resize is applied
-
-  override async firstUpdated() {
+  async firstUpdated() {
     this.model.propsUpdated.on(() => this.requestUpdate());
     this.model.childrenUpdated.on(() => this.requestUpdate());
     // exclude padding and border width


### PR DESCRIPTION
Fixes #285 

Console warning message:


> reactive-element.ts:76 Element **affine-embed** scheduled an update (generally because a property was set) after an update completed, causing a new update to be scheduled. This is inefficient and should be avoided unless the next update can only be scheduled as a side effect of the previous update. See https://lit.dev/msg/change-in-update for more information.


/cc @DiamondThree 
