### PR TITLE
feat: add append-flavor slash menu behavior

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -157,11 +157,11 @@ export class FormatQuickBar extends LitElement {
               const { flavour: defaultFlavour, type: defaultType } =
                 paragraphConfig[0];
               if (this.paragraphType === defaultType) return;
-              updateSelectedTextType(defaultFlavour, defaultType, this.page);
+              updateSelectedTextType(defaultFlavour, defaultType);
               this.paragraphType = defaultType;
               return;
             }
-            updateSelectedTextType(flavour, type, this.page);
+            updateSelectedTextType(flavour, type);
             this.paragraphType = type;
             this.positionUpdated.emit();
           }}

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -71,7 +71,7 @@ function onAbort(
   if (typeof e.target.reason !== 'string') {
     throw new Error('Failed to clean slash search text! Unknown abort reason');
   }
-  const searchStr: string = '/' + e.target.reason;
+  const searchStr = '/' + e.target.reason;
   const text = model.text;
   if (!text || text instanceof PrelimText) {
     console.warn(

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -178,7 +178,7 @@ export class SlashMenu extends LitElement {
     this.abortController.abort(this._searchString);
     const { flavour, type } = this._filterItems[index];
 
-    if (this.model.page.awarenessStore.getFlag('enable_boss_flavor_slash')) {
+    if (this.model.page.awarenessStore.getFlag('enable_append_flavor_slash')) {
       // Add new block
       const page = this.model.page;
       const parent = page.getParent(this.model);

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -24,7 +24,7 @@ export function bindCommonHotkey(page: Page) {
       return;
     }
     hotkey.addListener(hotkeyStr, () => {
-      updateSelectedTextType(flavour, type, page);
+      updateSelectedTextType(flavour, type);
     });
   });
 

--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -68,6 +68,7 @@ declare type BlockSuiteFlags = {
   enable_surface: boolean;
   enable_block_hub: boolean;
   enable_slash_menu: boolean;
+  enable_boss_flavor_slash: boolean;
   readonly: Record<string, boolean>;
 };
 

--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -68,7 +68,7 @@ declare type BlockSuiteFlags = {
   enable_surface: boolean;
   enable_block_hub: boolean;
   enable_slash_menu: boolean;
-  enable_boss_flavor_slash: boolean;
+  enable_append_flavor_slash: boolean;
   readonly: Record<string, boolean>;
 };
 

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -1,3 +1,4 @@
+import type { TemplateResult } from 'lit/html.js';
 import {
   BulletedListIcon,
   CodeIcon,
@@ -13,6 +14,18 @@ import {
   TextIcon,
   TodoIcon,
 } from './icons.js';
+
+export type BlockConfig<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ALLProps extends Record<string, any> = BlockSuiteModelProps.ALL,
+  Flavour extends keyof ALLProps & string = keyof ALLProps & string
+> = {
+  flavour: Flavour;
+  type: ALLProps[Flavour]['type'];
+  name: string;
+  hotkey: string | null;
+  icon: TemplateResult<2>;
+};
 
 export const paragraphConfig = [
   {
@@ -106,7 +119,7 @@ export const paragraphConfig = [
   //   name: 'Callout',
   //   icon: CalloutIcon,
   // },
-];
+] satisfies BlockConfig[];
 
 export const BLOCKHUB_TEXT_ITEMS = [
   {

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -127,7 +127,7 @@ export class DebugMenu extends LitElement {
     e.preventDefault();
     this.blockTypeDropdown.hide();
 
-    updateSelectedTextType('affine:list', listType, this.page);
+    updateSelectedTextType('affine:list', listType);
   }
 
   private _addCodeBlock(e: PointerEvent) {
@@ -152,7 +152,7 @@ export class DebugMenu extends LitElement {
     e.preventDefault();
     this.blockTypeDropdown.hide();
 
-    updateSelectedTextType('affine:paragraph', type, this.page);
+    updateSelectedTextType('affine:paragraph', type);
   }
 
   private _switchEditorMode() {

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -27,8 +27,18 @@ export function initFeatureFlags(page: Page) {
   if (params.get('surface') !== null) {
     page.awarenessStore.setFlag('enable_surface', true);
   }
-  if (params.get('slash') !== null) {
-    page.awarenessStore.setFlag('enable_slash_menu', true);
+  const slashFlag = params.get('slash');
+  switch (slashFlag) {
+    case '0':
+      page.awarenessStore.setFlag('enable_slash_menu', false);
+      break;
+    case '1':
+      page.awarenessStore.setFlag('enable_slash_menu', true);
+      page.awarenessStore.setFlag('enable_boss_flavor_slash', true);
+      break;
+    default:
+      page.awarenessStore.setFlag('enable_slash_menu', true);
+      break;
   }
 }
 

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -34,7 +34,7 @@ export function initFeatureFlags(page: Page) {
       break;
     case '1':
       page.awarenessStore.setFlag('enable_slash_menu', true);
-      page.awarenessStore.setFlag('enable_boss_flavor_slash', true);
+      page.awarenessStore.setFlag('enable_append_flavor_slash', true);
       break;
     default:
       page.awarenessStore.setFlag('enable_slash_menu', true);

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -70,6 +70,7 @@ const flagsPreset = {
   enable_block_hub: true,
   enable_surface: false,
   enable_slash_menu: false,
+  enable_boss_flavor_slash: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -70,7 +70,7 @@ const flagsPreset = {
   enable_block_hub: true,
   enable_surface: false,
   enable_slash_menu: false,
-  enable_boss_flavor_slash: false,
+  enable_append_flavor_slash: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 


### PR DESCRIPTION
This PR:

- Enabled the slash menu in the playground by default.
- Adds append-flavor slash flag (with URL param `?slash=1`). In this mode, pressing enter will create a new block.
- Simplifies `updateBlockType`.