### PR TITLE
ci: add browser compatibility cron job test

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -1,0 +1,41 @@
+name: Browser compatibility (Firefox and Safari)
+
+on:
+  schedule:
+    # At the end of every day
+    - cron: '0 0 * * *'
+
+jobs:
+  main-test:
+    name: Playground E2E test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        browsers: [firefox, safari]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7.9.5
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install playwright browsers
+        run: npx playwright install ${{ matrix.browsers }}
+
+      - name: Run playwright tests
+        run: TEST_PLAYWRIGHT_BROWSER_NAME=${{ matrix.browsers }} pnpm test -- --forbid-only
+
+      - name: Upload test results
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-main
+          path: ./test-results
+          if-no-files-found: ignore

--- a/packages/store/playwright.config.ts
+++ b/packages/store/playwright.config.ts
@@ -1,11 +1,17 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
+import type {
+  PlaywrightTestConfig,
+  PlaywrightWorkerOptions,
+} from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   testDir: 'src/',
   testIgnore: ['**.unit.spec.ts'],
   workers: 1,
   use: {
-    browserName: 'chromium',
+    browserName:
+      (process.env
+        .TEST_PLAYWRIGHT_BROWSER_NAME as PlaywrightWorkerOptions['browserName']) ??
+      'chromium',
     viewport: { width: 900, height: 600 },
     actionTimeout: 1000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 /// <reference types="node" />
-import type { PlaywrightTestConfig } from '@playwright/test';
+import type {
+  PlaywrightTestConfig,
+  PlaywrightWorkerOptions,
+} from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
@@ -11,7 +14,10 @@ const config: PlaywrightTestConfig = {
     reuseExistingServer: !process.env.CI,
   },
   use: {
-    browserName: 'chromium',
+    browserName:
+      (process.env
+        .TEST_PLAYWRIGHT_BROWSER_NAME as PlaywrightWorkerOptions['browserName']) ??
+      'chromium',
     viewport: { width: 900, height: 600 },
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
     // You can open traces locally(`npx playwright show-trace trace.zip`)


### PR DESCRIPTION
## why
The first step for #335 .
The naming is a bit ugly somehow. The prefix `TEST_` is to avoid collision with playwright's official environment naming convention(in the future). Any good naming ideas are welcomed.

<img width="561" alt="image" src="https://user-images.githubusercontent.com/12322740/213531808-ff6866f1-a739-4f54-a728-9ae167c3f494.png">
