### PR TITLE
ci: correct browser name

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -10,9 +10,10 @@ jobs:
     name: Playground E2E test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        browsers: [firefox, safari]
+        browsers: [firefox, webkit]
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## why

fix the wrong target name which made https://github.com/toeverything/blocksuite/actions/runs/3972260634/jobs/6809980658 fail.

```ts
type BrowserName = 'chromium' | 'firefox' | 'webkit';
```
---

And also add `fail-fast: false` to see all matrix results as some jobs will constantly fail at the moment.

