### PR TITLE
ci: add params for cron job

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: pnpm/action-setup@v2
         with:


### PR DESCRIPTION
## why
no `inputs` for cron type job, use the default value.