### PR TITLE
refactor: clean usage for cross-env

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -47,7 +47,9 @@ jobs:
         run: npx playwright install ${{ matrix.browsers }}
 
       - name: Run playwright tests
-        run: TEST_PLAYWRIGHT_BROWSER_NAME=${{ matrix.browsers }} pnpm test -- --forbid-only
+        env:
+          TEST_PLAYWRIGHT_BROWSER_NAME: ${{ matrix.browsers }}
+        run: pnpm test -- --forbid-only
 
       - name: Upload test results
         if: ${{ failure() }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
-    "serve": "cross-env PORT=4444 node node_modules/y-webrtc/bin/server.js",
+    "serve": "PORT=4444 node node_modules/y-webrtc/bin/server.js",
     "build": "tsc",
     "test:unit": "vitest --run",
     "test:unit:ui": "vitest --ui",
@@ -29,7 +29,6 @@
     "y-webrtc": "^10.2.4"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3",
     "lit": "^2.6.1",
     "yjs": "^13.5.44"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,6 @@ importers:
       '@blocksuite/global': workspace:*
       '@types/flexsearch': ^0.7.3
       buffer: ^6.0.3
-      cross-env: ^7.0.3
       flexsearch: 0.7.21
       idb-keyval: ^6.2.0
       ky: ^0.33.2
@@ -259,7 +258,6 @@ importers:
       y-protocols: 1.0.5
       y-webrtc: 10.2.4
     devDependencies:
-      cross-env: 7.0.3
       lit: 2.6.1
       yjs: 13.5.44
 
@@ -3261,14 +3259,6 @@ packages:
 
   /create-require/1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: true
-
-  /cross-env/7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
-    dependencies:
-      cross-spawn: 7.0.3
     dev: true
 
   /cross-spawn/5.1.0:


### PR DESCRIPTION
## why

1. use pnpm's shell-emulator to replace usage of `cross-env` for Windows. https://pnpm.io/cli/run#shell-emulator
2. add missing process env for CI by using `environment` property.