### PR TITLE
fix: browser compatibility issues

### DIFF
--- a/packages/global/src/debug.ts
+++ b/packages/global/src/debug.ts
@@ -21,8 +21,12 @@ export const debugLog = function (
   const stackInfo = removeStackHeader(error.stack).split('\n');
   const upperStackInfo = stackInfo.slice(1).join('\n');
   const message = stackInfo[callerIdx].trim();
-  const method = /(?<=at\s)(\S*)(?=\s)/.exec(message)?.[0] ?? message;
-  const subsystem = /(?<=\/packages\/)[a-z]+/.exec(message)?.[0] ?? 'unknown';
+  // For example, the message is:
+  // at handleBlockEndEnter (http://localhost:5173/@fs/Users/username/blocksuite/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts?t=1674485091790:41:44)
+  // method will match `handleBlockEndEnter`
+  // subsystem will match `blocks`
+  const method = /at\s(\S*)(?=\s)/.exec(message)?.[1] ?? message;
+  const subsystem = /\/packages\/([a-z]+)/.exec(message)?.[1] ?? 'unknown';
   console.log(
     `[packages/${color.blue(subsystem)}] ${color.magenta(
       method

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -23,8 +23,6 @@ function shamefullyIgnoreConsoleMessage(message: ConsoleMessage): boolean {
     'Failed to load resource: the server responded with a status of 404 (Not Found)',
     // embed.spec.ts
     'Error while getting blob HTTPError: Request failed with status code 404 Not Found',
-    // embed.spec.ts
-    'Element affine-embed scheduled an update (generally because a property was set) after an update completed',
     // clipboard.spec.ts
     "TypeError: Cannot read properties of null (reading 'model')",
     // basic.spec.ts › should readonly mode not be able to modify text

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -29,6 +29,9 @@ function shamefullyIgnoreConsoleMessage(message: ConsoleMessage): boolean {
     "TypeError: Cannot read properties of null (reading 'model')",
     // basic.spec.ts › should readonly mode not be able to modify text
     'cannot modify data in readonly mode',
+    // Firefox warn on quill
+    // See https://github.com/quilljs/quill/issues/2030
+    '[JavaScript Warning: "Use of Mutation Events is deprecated. Use MutationObserver instead."',
   ];
   return ignoredMessages.some(msg => message.text().startsWith(msg));
 }


### PR DESCRIPTION
Fix safari doesn't support lookbehind

breaks in Safari: Invalid regular expression: invalid group specifier name

See https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group

---

Suppress firefox warning

see https://github.com/quilljs/quill/issues/2030