### PR TITLE
fix: handle None selection in format quick bar

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -104,7 +104,7 @@ export const showFormatQuickBar = async ({
 
   const selectionChangeHandler = () => {
     const selection = document.getSelection();
-    if (!selection || selection.type === 'Caret') {
+    if (!selection || selection.type === 'Caret' || selection.type === 'None') {
       abortController.abort();
       return;
     }


### PR DESCRIPTION
### Update
Just realized that it's part of the error mentioned in #749
~~I will try to fix both errors in this PR. Draft first~~ 😄 

The selection is so complex that I have to move it to another PR.

---

closes #829 

In Edgeless mode, blurring the frame will cause the selection type to be `None`.
This PR handled the case.

Another way is to only allow showing the quick bar when the selection type is `Range`.
Let me know if you want it to be this way.
```js
if(selection?.type !== 'Range') {
```