### PR TITLE
refactor(phasor): `SurfaceContainer` -> `SurfaceManager`

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -35,7 +35,7 @@ import { NonShadowLitElement } from '../../__internal__/utils/lit.js';
 import { getService } from '../../__internal__/service.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
-import { SurfaceContainer } from '@blocksuite/phasor';
+import { SurfaceManager } from '@blocksuite/phasor';
 
 export interface EdgelessContainer extends HTMLElement {
   readonly page: Page;
@@ -115,7 +115,7 @@ export class EdgelessPageBlockComponent
     shapeUpdated: new Signal(),
   };
 
-  surface!: SurfaceContainer;
+  surface!: SurfaceManager;
 
   viewport = new ViewportState();
 
@@ -178,11 +178,11 @@ export class EdgelessPageBlockComponent
   }
 
   // Should be called in requestAnimationFrame,
-  // so as to avoid DOM mutation in SurfaceContainer constructor
+  // so as to avoid DOM mutation in SurfaceManager constructor
   private _initSurface() {
     const { page } = this;
     const yContainer = page.ySurfaceContainer;
-    this.surface = new SurfaceContainer(this._canvas, yContainer);
+    this.surface = new SurfaceManager(this._canvas, yContainer);
     this._syncSurfaceViewport();
   }
 

--- a/packages/blocks/src/surface-block/surface-model.ts
+++ b/packages/blocks/src/surface-block/surface-model.ts
@@ -5,6 +5,4 @@ export class SurfaceBlockModel extends BaseBlockModel {
   static version = 1;
   flavour = 'affine:surface' as const;
   tag = literal`affine-surface`;
-
-  paths: string[] = [];
 }

--- a/packages/phasor/src/surface.ts
+++ b/packages/phasor/src/surface.ts
@@ -12,7 +12,7 @@ import { Renderer } from './renderer.js';
 import { assertExists } from '@blocksuite/global/utils';
 import { nanoid } from 'nanoid';
 
-export class SurfaceContainer {
+export class SurfaceManager {
   readonly renderer: Renderer;
   private _yElements: Y.Map<Y.Map<unknown>>;
   private _elements = new Map<string, Element>();

--- a/packages/playground/examples/canvas/main.ts
+++ b/packages/playground/examples/canvas/main.ts
@@ -1,6 +1,6 @@
 import { Workspace } from '@blocksuite/store';
 import {
-  SurfaceContainer,
+  SurfaceManager,
   bindWheelEvents,
   Bound,
   // initMockData,
@@ -12,19 +12,19 @@ function main() {
   const doc = new Y.Doc();
   const canvas = document.querySelector('canvas') as HTMLCanvasElement;
   const yContainer = doc.getMap('container');
-  const container = new SurfaceContainer(canvas, yContainer);
+  const surface = new SurfaceManager(canvas, yContainer);
 
-  bindWheelEvents(container.renderer, canvas);
+  bindWheelEvents(surface.renderer, canvas);
 
-  container.addDebugElement(new Bound(0, 0, 100, 100), 'red');
+  surface.addDebugElement(new Bound(0, 0, 100, 100), 'red');
 
-  container.addDebugElement(new Bound(50, 50, 100, 100), 'black');
+  surface.addDebugElement(new Bound(50, 50, 100, 100), 'black');
 
   // Uncomment to batch load mock data
   // initMockData(container.renderer, 100, 1000, 1000);
 
   // @ts-ignore
-  window.container = container;
+  window.surface = surface;
 }
 
 main();


### PR DESCRIPTION
This avoids the conflict between the `surface` entity and the `ySurfaceContainer` that holds the elements.

We don't do

``` ts
const container = new SurfaceContainer();
```

Instead, we do

``` ts
const surface = new SurfaceManager();
```
