### PR TITLE
feat: support `focusTitle` & skip container in `getNextBlock`

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -204,7 +204,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
   function onKeyRight(this: KeyboardEventThis, range: QuillRange) {
     const textLength = this.quill.getText().length;
     if (range.index + 1 === textLength) {
-      const nextBlock = getNextBlock(model.id);
+      const nextBlock = getNextBlock(model);
       if (!nextBlock) {
         return ALLOW_DEFAULT;
       }

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -5,7 +5,6 @@ import type { Quill } from 'quill';
 import {
   ExtendedModel,
   getRichTextByModel,
-  getContainerByModel,
   getPreviousBlock,
   getNextBlock,
   asyncFocusRichText,
@@ -277,8 +276,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 
     const parent = page.getParent(model);
     if (!parent || matchFlavours(parent, ['affine:frame'])) {
-      const container = getContainerByModel(model);
-      const previousSibling = getPreviousBlock(container, model.id);
+      const previousSibling = getPreviousBlock(model);
       const previousSiblingParent = previousSibling
         ? page.getParent(previousSibling)
         : null;
@@ -367,8 +365,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 
 export function handleKeyUp(model: ExtendedModel, editableContainer: Element) {
   const selection = window.getSelection();
-  const container = getContainerByModel(model);
-  const preNodeModel = getPreviousBlock(container, model.id);
+  const preNodeModel = getPreviousBlock(model);
   if (selection) {
     const range = selection.getRangeAt(0);
     const { height, left, top } = range.getBoundingClientRect();

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -425,7 +425,7 @@ export function handleKeyDown(
     // TODO resolve compatible problem
     const newRange = caretRangeFromPoint(left, bottom + height / 2);
     if (!newRange || !textContainer.contains(newRange.startContainer)) {
-      const nextBlock = getNextBlock(model.id);
+      const nextBlock = getNextBlock(model);
       if (!nextBlock) {
         return ALLOW_DEFAULT;
       }

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -49,7 +49,15 @@ export function getParentBlockById<T extends ElementTagName>(
  *
  * NOTE: this method will skip the `affine:frame` block
  */
-export function getNextBlock(model: BaseBlockModel): BaseBlockModel | null {
+export function getNextBlock(
+  model: BaseBlockModel,
+  map: Record<string, true> = {}
+): BaseBlockModel | null {
+  if (model.id in map) {
+    throw new Error("Can't get next block! There's a loop in the block tree!");
+  }
+  map[model.id] = true;
+
   const page = model.page;
   if (model.children.length) {
     return model.children[0];
@@ -85,7 +93,17 @@ export function getNextBlock(model: BaseBlockModel): BaseBlockModel | null {
  *
  * NOTE: this method will skip the `affine:frame` and `affine:page` block
  */
-export function getPreviousBlock(model: BaseBlockModel): BaseBlockModel | null {
+export function getPreviousBlock(
+  model: BaseBlockModel,
+  map: Record<string, true> = {}
+): BaseBlockModel | null {
+  if (model.id in map) {
+    throw new Error(
+      "Can't get previous block! There's a loop in the block tree!"
+    );
+  }
+  map[model.id] = true;
+
   const page = model.page;
   const parentBlock = page.getParent(model);
   if (!parentBlock) {

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -40,11 +40,11 @@ export function getParentBlockById<T extends ElementTagName>(
  * ```md
  * page
  * - frame
- *  - paragraph <- invoke this method recursively, and the return order is following
+ *  - paragraph <- when invoked here, the traverse order will be following
  *    - child <- 1
  *  - sibling <- 2
- * - frame    <- 2.9 frame will be skipped
- *   - paragraph <- 3
+ * - frame <- 3 (will be skipped)
+ *   - paragraph <- 4
  * ```
  *
  * NOTE: this method will skip the `affine:frame` block
@@ -83,12 +83,12 @@ export function getNextBlock(
  * ```md
  * page
  * - frame
- *   - paragraph <- 4
- * - frame      <- 3.9 frame will be skipped
+ *   - paragraph <- 5
+ * - frame <- 4 (will be skipped)
  *  - paragraph <- 3
  *    - child <- 2
  *      - child <- 1
- *  - paragraph <- invoke this method recursively, and the return order is following
+ *  - paragraph <- when invoked here, the traverse order will be above
  * ```
  *
  * NOTE: this method will skip the `affine:frame` and `affine:page` block

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -287,7 +287,7 @@ export function focusNextBlock(
   } else if (page.lastSelectionPosition) {
     nextPosition = page.lastSelectionPosition;
   }
-  const nextNodeModel = getNextBlock(model.id);
+  const nextNodeModel = getNextBlock(model);
 
   if (nextNodeModel) {
     focusBlockByModel(nextNodeModel, nextPosition);

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -3,7 +3,6 @@ import type { RichText } from '../rich-text/rich-text.js';
 import type { IPoint, SelectionEvent } from './gesture.js';
 import {
   getBlockElementByModel,
-  getContainerByModel,
   getCurrentRange,
   getDefaultPageBlock,
   getElementFromEventTarget,
@@ -261,7 +260,6 @@ export function focusPreviousBlock(
   position?: SelectionPosition
 ) {
   const page = getDefaultPageBlock(model);
-  const container = getContainerByModel(model);
 
   let nextPosition = position;
   if (nextPosition) {
@@ -270,7 +268,7 @@ export function focusPreviousBlock(
     nextPosition = page.lastSelectionPosition;
   }
 
-  const preNodeModel = getPreviousBlock(container, model.id);
+  const preNodeModel = getPreviousBlock(model);
   if (preNodeModel && nextPosition) {
     focusBlockByModel(preNodeModel, nextPosition);
   }

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -218,6 +218,9 @@ export function focusBlockByModel(
   model: BaseBlockModel,
   position: SelectionPosition = 'end'
 ) {
+  if (matchFlavours(model, ['affine:frame', 'affine:page'])) {
+    throw new Error("Can't focus frame or page!");
+  }
   const defaultPageBlock = getDefaultPageBlock(model);
   if (
     matchFlavours(model, [

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -181,6 +181,23 @@ async function setNewTop(y: number, editableContainer: Element) {
   }
 }
 
+/**
+ * As the title is a text area, this function does not yet have support for `SelectionPosition`.
+ */
+export function focusTitle(offset = Infinity) {
+  const titleElement = document.querySelector(
+    '.affine-default-page-block-title'
+  ) as HTMLTextAreaElement | null;
+  if (!titleElement) {
+    throw new Error("Can't find title element");
+  }
+  if (offset > titleElement.value.length) {
+    offset = titleElement.value.length;
+  }
+  titleElement.setSelectionRange(offset, offset);
+  titleElement.focus();
+}
+
 export async function focusRichText(
   editableContainer: Element,
   position: SelectionPosition = 'end'

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -184,17 +184,17 @@ async function setNewTop(y: number, editableContainer: Element) {
 /**
  * As the title is a text area, this function does not yet have support for `SelectionPosition`.
  */
-export function focusTitle(offset = Infinity) {
+export function focusTitle(index = Infinity) {
   const titleElement = document.querySelector(
     '.affine-default-page-block-title'
   ) as HTMLTextAreaElement | null;
   if (!titleElement) {
     throw new Error("Can't find title element");
   }
-  if (offset > titleElement.value.length) {
-    offset = titleElement.value.length;
+  if (index > titleElement.value.length) {
+    index = titleElement.value.length;
   }
-  titleElement.setSelectionRange(offset, offset);
+  titleElement.setSelectionRange(index, index);
   titleElement.focus();
 }
 

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -304,7 +304,7 @@ export class DefaultPageBlockComponent
 
   firstUpdated() {
     autosize(this._title);
-    bindHotkeys(this.page, this.selection, this.signals, this.model);
+    bindHotkeys(this.page, this.selection, this.signals);
 
     hotkey.enableHotkey();
     this.model.propsUpdated.on(() => {

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -4,6 +4,7 @@ import { isAtLineEdge } from '../../__internal__/rich-text/rich-text-operations.
 import {
   asyncFocusRichText,
   focusNextBlock,
+  focusTitle,
   focusPreviousBlock,
   getBlockById,
   getBlockElementByModel,
@@ -18,7 +19,6 @@ import {
   isCaptionElement,
   doesInSamePath,
 } from '../../__internal__/utils/index.js';
-import type { PageBlockModel } from '../page-model.js';
 import {
   bindCommonHotkey,
   handleMultiBlockBackspace,
@@ -401,15 +401,8 @@ export function handleUp(
       !isAtLineEdge(range)
     ) {
       // FIXME: Then it will turn the input into the div
-      if (
-        activePreNodeModel &&
-        matchFlavours(activePreNodeModel, ['affine:frame'])
-      ) {
-        (
-          document.querySelector(
-            '.affine-default-page-block-title'
-          ) as HTMLTextAreaElement
-        ).focus();
+      if (!activePreNodeModel) {
+        focusTitle();
       } else {
         focusPreviousBlock(model, new Point(left, top));
       }
@@ -481,8 +474,7 @@ function isDispatchFromCodeBlock(e: KeyboardEvent) {
 export function bindHotkeys(
   page: Page,
   selection: DefaultSelectionManager,
-  signals: DefaultPageSignals,
-  pageModel: PageBlockModel
+  signals: DefaultPageSignals
 ) {
   const {
     BACKSPACE,

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -403,7 +403,7 @@ export function handleUp(
       if (!activePreNodeModel) {
         focusTitle();
       } else {
-        focusPreviousBlock(activePreNodeModel, new Point(left, top));
+        focusPreviousBlock(model, new Point(left, top));
       }
     }
     return;

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -588,12 +588,6 @@ export function bindHotkeys(
     model && focusPreviousBlock(model, 'end');
   });
   hotkey.addListener(RIGHT, e => {
-    if (
-      e.target instanceof HTMLTextAreaElement &&
-      e.target.classList.contains('affine-default-page-block-title')
-    ) {
-      return;
-    }
     let model: BaseBlockModel | null = null;
     const {
       state: { selectedBlocks, type },

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -400,19 +400,17 @@ export function handleUp(
       (!newRange || !editableContainer.contains(newRange.startContainer)) &&
       !isAtLineEdge(range)
     ) {
-      // FIXME: Then it will turn the input into the div
       if (!activePreNodeModel) {
         focusTitle();
       } else {
-        focusPreviousBlock(model, new Point(left, top));
+        focusPreviousBlock(activePreNodeModel, new Point(left, top));
       }
     }
+    return;
   } else {
     signals.updateSelectedRects.emit([]);
     const { state } = selection;
     const selectedModel = getModelByElement(state.selectedBlocks[0]);
-    const preNodeModel = getPreviousBlock(selectedModel);
-    assertExists(preNodeModel);
     const page = getDefaultPageBlock(selectedModel);
     e.preventDefault();
     focusPreviousBlock(
@@ -443,8 +441,6 @@ export function handleDown(
     signals.updateSelectedRects.emit([]);
     const { state } = selection;
     const selectedModel = getModelByElement(state.selectedBlocks[0]);
-    const preNodeModel = getPreviousBlock(selectedModel);
-    assertExists(preNodeModel);
     const page = getDefaultPageBlock(selectedModel);
     e.preventDefault();
     focusNextBlock(

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -7,7 +7,6 @@ import {
   focusPreviousBlock,
   getBlockById,
   getBlockElementByModel,
-  getContainerByModel,
   getDefaultPageBlock,
   getModelByElement,
   getPreviousBlock,
@@ -390,8 +389,7 @@ export function handleUp(
   const nativeSelection = window.getSelection();
   if (nativeSelection?.anchorNode) {
     const model = getStartModelBySelection();
-    const activeContainer = getContainerByModel(model);
-    const activePreNodeModel = getPreviousBlock(activeContainer, model.id);
+    const activePreNodeModel = getPreviousBlock(model);
     const editableContainer = getBlockElementByModel(model)?.querySelector(
       '.ql-editor'
     ) as HTMLElement;
@@ -420,8 +418,7 @@ export function handleUp(
     signals.updateSelectedRects.emit([]);
     const { state } = selection;
     const selectedModel = getModelByElement(state.selectedBlocks[0]);
-    const container = getContainerByModel(selectedModel);
-    const preNodeModel = getPreviousBlock(container, selectedModel.id);
+    const preNodeModel = getPreviousBlock(selectedModel);
     assertExists(preNodeModel);
     const page = getDefaultPageBlock(selectedModel);
     e.preventDefault();
@@ -453,8 +450,7 @@ export function handleDown(
     signals.updateSelectedRects.emit([]);
     const { state } = selection;
     const selectedModel = getModelByElement(state.selectedBlocks[0]);
-    const container = getContainerByModel(selectedModel);
-    const preNodeModel = getPreviousBlock(container, selectedModel.id);
+    const preNodeModel = getPreviousBlock(selectedModel);
     assertExists(preNodeModel);
     const page = getDefaultPageBlock(selectedModel);
     e.preventDefault();

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -631,7 +631,7 @@ test('after deleting a text row, cursor should jump to the end of previous list 
   await assertSelection(page, 0, 5, 0);
 });
 
-test('press tab in paragarph children', async ({ page }) => {
+test('press tab in paragraph children', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await pressEnter(page);
@@ -646,4 +646,19 @@ test('press tab in paragarph children', async ({ page }) => {
   await page.keyboard.press('ArrowLeft', { delay: 50 });
   await page.keyboard.type('- ');
   await assertRichTexts(page, ['1', '2', '3', '\n']);
+});
+
+test('press left in first paragraph start should not change cursor position', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await page.keyboard.type('1');
+
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.type('l');
+  await assertRichTexts(page, ['l1']);
+  await assertTitle(page, '');
 });

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -793,11 +793,11 @@ test('should add a new line when clicking the bottom of the last non-text block'
   await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
   await assertRichTexts(page, ['123', '456', '789']);
-  await page.keyboard.press('Enter');
+  await pressEnter(page);
 
   // code block
   await page.keyboard.type('```');
-  await page.keyboard.press('Enter');
+  await pressEnter(page);
 
   const locator = page.locator('affine-code');
   await expect(locator).toBeVisible();


### PR DESCRIPTION
- Refactor `getNextBlock` and `getPreviousBlock`
  - Skip `affine:frame`/`affine:page`
  - Sunset `getSiblingsById`/`getNextSiblingById`/`getPreviousSiblingById`
- Add new utility function `focusTitle(offset)`
- Other misc changes

https://user-images.githubusercontent.com/18554747/215123880-295c82db-35db-4a03-a495-3d1a21108dce.mov

