### PR TITLE
refactor(store): `model.state` -> `model.props`

### DIFF
--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -15,7 +15,7 @@ export const BlockSchema = z.object({
   model: z.object({
     flavour: FlavourSchema,
     tag: TagSchema,
-    state: z.function().returns(z.record(z.any())),
+    props: z.function().returns(z.record(z.any())),
   }),
 });
 
@@ -28,37 +28,37 @@ interface StaticValue {
 export type SchemaToModel<
   Schema extends {
     model: {
-      state: () => Record<string, unknown>;
+      props: () => Record<string, unknown>;
       flavour: string;
     };
   }
 > = BaseBlockModel &
-  ReturnType<Schema['model']['state']> & {
+  ReturnType<Schema['model']['props']> & {
     flavour: Schema['model']['flavour'];
   };
 
 export function defineBlockSchema<
   Flavour extends string,
-  State extends Record<string, unknown>,
+  Props extends Record<string, unknown>,
   Metadata extends Readonly<{
     version: number;
     tag: StaticValue;
   }>
 >(
   flavour: Flavour,
-  state: () => State,
+  props: () => Props,
   metadata: Metadata
 ): {
   version: number;
   model: {
-    state: () => State;
+    props: () => Props;
     flavour: Flavour;
   } & Metadata;
 };
 
 export function defineBlockSchema(
   flavour: string,
-  state: () => Record<string, unknown>,
+  props: () => Record<string, unknown>,
   metadata: {
     version: number;
     tag: StaticValue;
@@ -69,7 +69,7 @@ export function defineBlockSchema(
     model: {
       flavour,
       tag: metadata.tag,
-      state,
+      props,
     },
   } satisfies z.infer<typeof BlockSchema>;
   BlockSchema.parse(schema);

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -42,7 +42,7 @@ export function initInternalProps(yBlock: YBlock, props: Partial<BlockProps>) {
 
 export function syncBlockProps(
   // schema: z.infer<typeof BlockSchema>,
-  defaultState: Record<string, unknown>,
+  defaultProps: Record<string, unknown>,
   yBlock: YBlock,
   props: Partial<BlockProps>,
   ignoredKeys: Set<string>
@@ -67,7 +67,7 @@ export function syncBlockProps(
   });
 
   // set default value
-  Object.entries(defaultState).forEach(([key, value]) => {
+  Object.entries(defaultProps).forEach(([key, value]) => {
     if (!yBlock.has(`prop:${key}`)) {
       if (Array.isArray(value)) {
         yBlock.set(`prop:${key}`, Y.Array.from(value));

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -344,9 +344,9 @@ export class Page extends Space<PageData> {
 
       assertValidChildren(this._yBlocks, clonedProps);
       initInternalProps(yBlock, clonedProps);
-      const defaultState = this.workspace.flavourInitialStateMap.get(flavour);
-      assertExists(defaultState);
-      syncBlockProps(defaultState, yBlock, clonedProps, this._ignoredKeys);
+      const defaultProps = this.workspace.flavourInitialPropsMap.get(flavour);
+      assertExists(defaultProps);
+      syncBlockProps(defaultProps, yBlock, clonedProps, this._ignoredKeys);
       trySyncTextProp(this._splitSet, yBlock, clonedProps.text);
 
       if (typeof parent === 'string') {
@@ -450,11 +450,11 @@ export class Page extends Space<PageData> {
         yBlock.set('sys:children', yChildren);
       }
 
-      const defaultState = this.workspace.flavourInitialStateMap.get(
+      const defaultProps = this.workspace.flavourInitialPropsMap.get(
         model.flavour
       );
-      assertExists(defaultState);
-      syncBlockProps(defaultState, yBlock, props, this._ignoredKeys);
+      assertExists(defaultProps);
+      syncBlockProps(defaultProps, yBlock, props, this._ignoredKeys);
     });
   }
 
@@ -676,8 +676,8 @@ export class Page extends Space<PageData> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     blockModel.flavour = schema.model.flavour as any;
     blockModel.tag = schema.model.tag;
-    const state = schema.model.state();
-    Object.entries(state).forEach(([key, value]) => {
+    const modelProps = schema.model.props();
+    Object.entries(modelProps).forEach(([key, value]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (blockModel as any)[key] = props[key] ?? value;
     });

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -235,7 +235,7 @@ export class Workspace {
   };
 
   flavourSchemaMap = new Map<string, z.infer<typeof BlockSchema>>();
-  flavourInitialStateMap = new Map<string, Record<string, unknown>>();
+  flavourInitialPropsMap = new Map<string, Record<string, unknown>>();
 
   constructor(options: StoreOptions) {
     this._store = new Store(options);
@@ -289,9 +289,9 @@ export class Workspace {
     blockSchema.forEach(schema => {
       BlockSchema.parse(schema);
       this.flavourSchemaMap.set(schema.model.flavour, schema);
-      this.flavourInitialStateMap.set(
+      this.flavourInitialPropsMap.set(
         schema.model.flavour,
-        schema.model.state()
+        schema.model.props()
       );
     });
     return this;


### PR DESCRIPTION
In #859 we removed the class-based model, calling the new model instances "state"s. Compared to `props`, This introduces a new concept in BlockSuite:

``` ts
// Here the { title: 'hello' } is *props* in our API definition
page.updateBlock(pageModel, { title: 'hello' })

pageModel // model state
```

We were hoping to replace "props" with "state", making the concepts in our system more consistent. However, after some quick experiments, I found it hard to rename "props" since we have already used it in YBlock fields (.e.g., `"prop:title"`).

So the other option is to rename the `State` concept with `Props`, ensuring they are essentially the same thing.

/cc @Himself65 