### PR TITLE
test: add BROWSER env config to local environment

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run playwright tests
         env:
-          TEST_PLAYWRIGHT_BROWSER_NAME: ${{ matrix.browsers }}
+          BROWSER: ${{ matrix.browsers }}
         run: pnpm test -- --forbid-only
 
       - name: Upload test results

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -67,3 +67,15 @@ pnpm test:headed
 ```
 
 In headed mode, `await page.pause()` can be used in test cases to suspend the test runner. Note that the usage of the [Playwright VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright) is also highly recommended.
+
+To test browser compatibility, the `BROWSER` environment variable can be used:
+
+```sh
+# supports `firefox|webkit|chromium`
+BROWSER=firefox pnpm test
+
+# passing playwright params with the -- syntax
+BROWSER=webkit pnpm test -- --debug
+```
+
+To investigate flaky tests, we can mark a test case as `test.only`, then perform `npx playwright test --repeat-each=10` to reproduce the problem by repeated execution. It's also very helpful to run `pnpm test -- --debug` with `await page.pause()` added before certain asserters.

--- a/packages/store/playwright.config.ts
+++ b/packages/store/playwright.config.ts
@@ -9,8 +9,7 @@ const config: PlaywrightTestConfig = {
   workers: 1,
   use: {
     browserName:
-      (process.env
-        .TEST_PLAYWRIGHT_BROWSER_NAME as PlaywrightWorkerOptions['browserName']) ??
+      (process.env.BROWSER as PlaywrightWorkerOptions['browserName']) ??
       'chromium',
     viewport: { width: 900, height: 600 },
     actionTimeout: 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,8 +15,7 @@ const config: PlaywrightTestConfig = {
   },
   use: {
     browserName:
-      (process.env
-        .TEST_PLAYWRIGHT_BROWSER_NAME as PlaywrightWorkerOptions['browserName']) ??
+      (process.env.BROWSER as PlaywrightWorkerOptions['browserName']) ??
       'chromium',
     viewport: { width: 900, height: 600 },
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer


### PR DESCRIPTION
This PR brings the `BROWSER` config to non-CI environment, with documentation helping new contributors deal with compatibility issues.

/cc @fi3ework 