### PR TITLE
fix: block hub card list hover state & hovertip style

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -392,7 +392,12 @@ export class BlockHub extends NonShadowLitElement {
           affine-type="text"
         >
           ${RectIcon}
-          <tool-tip inert role="tooltip" tip-position="left" style="top: 5px"
+          <tool-tip
+            inert
+            role="tooltip"
+            tip-position="left"
+            style="top: 5px"
+            ?hidden=${!this._showToolTip}
             >Drag to Insert blank line
           </tool-tip>
         </div>

--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -52,6 +52,9 @@ export class BlockHub extends NonShadowLitElement {
   @query('.block-hub-menu-container')
   private _blockHubMenuContainer!: HTMLElement;
 
+  @query('[role="menu-entry"]')
+  private _blockHubMenuEntry!: HTMLElement;
+
   private _onDropCallback: (e: DragEvent, lastModelState: EditingState) => void;
   private _getBlockEditingStateByPosition: DragHandleGetModelStateCallback | null =
     null;
@@ -285,6 +288,10 @@ export class BlockHub extends NonShadowLitElement {
     for (const blockHubMenu of this._blockHubMenus) {
       blockHubMenu.addEventListener('mouseover', this._onBlockHubMenuMouseOver);
     }
+    this._blockHubMenuEntry.addEventListener(
+      'mouseover',
+      this._onBlockHubEntryMouseOver
+    );
 
     document.addEventListener('click', this._onClick);
     this._blockHubButton.addEventListener('click', this._onBlockHubButtonClick);
@@ -324,6 +331,10 @@ export class BlockHub extends NonShadowLitElement {
           this._onBlockHubMenuMouseOver
         );
       }
+      this._blockHubMenuEntry.addEventListener(
+        'mouseover',
+        this._onBlockHubEntryMouseOver
+      );
       document.removeEventListener('click', this._onClick);
       this._blockHubButton.removeEventListener(
         'click',
@@ -583,6 +594,11 @@ export class BlockHub extends NonShadowLitElement {
     assertExists(cardType);
     this._isCardListVisible = true;
     this._cardVisibleType = cardType;
+    this.requestUpdate();
+  };
+
+  private _onBlockHubEntryMouseOver = () => {
+    this._isCardListVisible = false;
     this.requestUpdate();
   };
 


### PR DESCRIPTION
1. Make card list disappear when hovering on close button

https://user-images.githubusercontent.com/20554850/215694186-bac5ce5e-7b9f-46be-ae11-4c9cd362bf6f.mov

2.  Make hover tips disappear when after starting dragging from blank line button

https://user-images.githubusercontent.com/20554850/215694590-80796b3e-b50e-4531-90a0-4a05d2bfcdaf.mov

