### PR TITLE
feat: tweak slash menu show behavior

### DIFF
--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -199,6 +199,7 @@ export class SlashMenu extends LitElement {
     this.abortController.abort(this._searchString);
     const { flavour, type } = this._filterItems[index];
 
+    // @deprecated
     // WARNING: This flag is a simple prototype implementation, just for proof of product.
     if (this.model.page.awarenessStore.getFlag('enable_append_flavor_slash')) {
       // Add new block
@@ -233,6 +234,8 @@ export class SlashMenu extends LitElement {
       asyncFocusRichText(page, id);
       return;
     }
+    // End of deprecated
+
     updateSelectedTextType(flavour, type);
   }
 

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -82,20 +82,7 @@ export class SlashMenu extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     window.addEventListener('keydown', this._escapeListener);
-
-    // Handle click outside
-    const clickAwayListener = (e: MouseEvent) => {
-      // if (e.target === this) {
-      //   return;
-      // }
-      if (!this._hide) {
-        return;
-      }
-      // If the slash menu is hidden, click anywhere will close the slash menu
-      this.abortController.abort();
-      window.removeEventListener('mousedown', clickAwayListener);
-    };
-    window.addEventListener('mousedown', clickAwayListener);
+    window.addEventListener('mousedown', this._clickAwayListener);
 
     const richText = getRichTextByModel(this.model);
     if (!richText) {
@@ -105,11 +92,12 @@ export class SlashMenu extends LitElement {
       );
       return;
     }
+    this._richText = richText;
     richText.addEventListener('keydown', this._keyDownListener, {
       // Workaround: Use capture to prevent the event from triggering the keyboard bindings action
       capture: true,
     });
-    this._richText = richText;
+    richText.addEventListener('focusout', this._clickAwayListener);
   }
 
   override disconnectedCallback() {
@@ -118,7 +106,20 @@ export class SlashMenu extends LitElement {
     this._richText?.removeEventListener('keydown', this._keyDownListener, {
       capture: true,
     });
+    this._richText?.removeEventListener('focusout', this._clickAwayListener);
   }
+
+  // Handle click outside
+  private _clickAwayListener = (e: Event) => {
+    // if (e.target === this) {
+    //   return;
+    // }
+    if (!this._hide) {
+      return;
+    }
+    // If the slash menu is hidden, click anywhere will close the slash menu
+    this.abortController.abort();
+  };
 
   /**
    * Handle arrow key

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -83,6 +83,20 @@ export class SlashMenu extends LitElement {
     super.connectedCallback();
     window.addEventListener('keydown', this._escapeListener);
 
+    // Handle click outside
+    const clickAwayListener = (e: MouseEvent) => {
+      // if (e.target === this) {
+      //   return;
+      // }
+      if (!this._hide) {
+        return;
+      }
+      // If the slash menu is hidden, click anywhere will close the slash menu
+      this.abortController.abort();
+      window.removeEventListener('mousedown', clickAwayListener);
+    };
+    window.addEventListener('mousedown', clickAwayListener);
+
     const richText = getRichTextByModel(this.model);
     if (!richText) {
       console.warn(

--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -69,6 +69,9 @@ declare type BlockSuiteFlags = {
   enable_surface: boolean;
   enable_block_hub: boolean;
   enable_slash_menu: boolean;
+  /**
+   * @deprecated Will be removed after slash menu is stable
+   */
   enable_append_flavor_slash: boolean;
   readonly: Record<string, boolean>;
 };

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -81,6 +81,14 @@ test.describe('slash menu should show and hide correctly', () => {
     await page.keyboard.type('_');
     await expect(slashMenu).not.toBeVisible();
     await assertRichTexts(page, ['/_']);
+
+    // And pressing backspace immediately should reappear the slash menu
+    await page.keyboard.press('Backspace');
+    await expect(slashMenu).toBeVisible();
+
+    await page.keyboard.type('__');
+    await page.keyboard.press('Backspace');
+    await expect(slashMenu).not.toBeVisible();
   });
 
   test('pressing the slash key again should close the old slash menu and open new one', async () => {


### PR DESCRIPTION
When the search item is empty, the slash menu will be hidden temporarily, and if the following key is the backspace key, the slash menu will be reopen