### PR TITLE
refactor(blocks): disable custom gesture handler on `HTMLInputElement`

### DIFF
--- a/packages/blocks/src/__internal__/utils/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture.ts
@@ -82,6 +82,17 @@ function toSelectionEvent(
   return selectionEvent;
 }
 
+function shouldFilterMouseEvent(event: Event): boolean {
+  const target = event.target;
+  if (!target || !(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.tagName === 'INPUT') {
+    return true;
+  }
+  return false;
+}
+
 export function initMouseEventHandlers(
   container: HTMLElement,
   onContainerDragStart: (e: SelectionEvent) => void,
@@ -107,6 +118,7 @@ export function initMouseEventHandlers(
     );
 
   const mouseDownHandler = (e: MouseEvent) => {
+    if (shouldFilterMouseEvent(e)) return;
     if (!isTitleElement(e.target) && !isDatabaseInput(e.target)) {
       e.preventDefault();
     }
@@ -124,6 +136,7 @@ export function initMouseEventHandlers(
   };
 
   const mouseMoveHandler = (e: MouseEvent) => {
+    if (shouldFilterMouseEvent(e)) return;
     if (!isTitleElement(e.target) && !isDatabaseInput(e.target)) {
       e.preventDefault();
     }
@@ -213,12 +226,17 @@ export function initMouseEventHandlers(
   };
 
   const dblClickHandler = (e: MouseEvent) => {
+    if (shouldFilterMouseEvent(e)) return;
     onContainerDblClick(
       toSelectionEvent(e, getBoundingClientRect, startX, startY)
     );
   };
 
-  const selectionChangeHandler = debounce(e => {
+  const selectionChangeHandler = debounce<
+    Event[],
+    (this: unknown, ...args: Event[]) => void
+  >(e => {
+    if (shouldFilterMouseEvent(e)) return;
     if (isDragging) {
       return;
     }

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -3,7 +3,7 @@ import type { KeyHandler } from 'hotkeys-js';
 import { isCaptionElement, isInsideRichText, isTitleElement } from './query.js';
 
 hotkeys.filter = (event: KeyboardEvent) => {
-  if (shouldFilter(event)) {
+  if (shouldFilterHotKey(event)) {
     return false;
   }
   return true;
@@ -17,7 +17,7 @@ function isUndoRedo(event: KeyboardEvent) {
   return false;
 }
 
-function shouldFilter(event: KeyboardEvent) {
+function shouldFilterHotKey(event: KeyboardEvent) {
   const target = event.target;
   // Not sure if this is the right thing to do
   if (!target) {

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -215,7 +215,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
   }
 
   private _onClick() {
-    this.showLangList = 'visible';
+    this.showLangList = this.showLangList === 'visible' ? 'hidden' : 'visible';
   }
 
   render() {


### PR DESCRIPTION
1. disabled the mouse handlers in `HTMLInputElement`, (It seems ok for the moment
, as we don't deal with complex mouse events in input tag). This can make mouse event in language select input and image caption correct

https://user-images.githubusercontent.com/20554850/215765803-56e88869-f98a-4889-9529-36ce07a9282a.mov

2. a bug fix, now can close language select list when clicking lang button