### PR TITLE
fix: isAtLineEdge with format

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -395,9 +395,8 @@ export function isAtLineEdge(range: Range) {
   }
 
   // TODO find next text node manually after switch to virgo
-  // XXX Insert a "zero width space" in the range and get the rect
-  const BOM = '\ufeff';
-  const tmpNode = document.createTextNode(BOM);
+  // XXX Insert a tmp text node in the range and get the rect
+  const tmpNode = document.createTextNode('.');
   nextRange.insertNode(tmpNode);
   const nextRangeRect = nextRange.getBoundingClientRect();
   tmpNode.remove();

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -372,9 +372,10 @@ export function isAtLineEdge(range: Range) {
     return false;
   }
   const textContent = range.startContainer.textContent;
-  if (!textContent) {
+  if (typeof textContent !== 'string') {
     console.warn(
       'Failed to determine if the caret is at line edge! no textContent in the startContainer',
+      range,
       range.startContainer
     );
     return false;

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -487,10 +487,21 @@ function shiftRange(range: Range): Range | null {
   return nextRange;
 }
 
-// We should determine if the cursor is at the edge of the block, since a cursor at edge may have two cursor points
-// but only one bounding rect.
-// If a cursor is at the edge of a block, its previous cursor rect will not equal to the next one.
-// See https://stackoverflow.com/questions/59767515/incorrect-positioning-of-getboundingclientrect-after-newline-character
+/**
+ * It will return the next range if the cursor is at the edge of the block, otherwise return false.
+ *
+ * We should determine if the cursor is at the edge of the block, since a cursor at edge may have two cursor points
+ * but only one bounding rect.
+ * If a cursor is at the edge of a block, its previous cursor rect will not equal to the next one.
+ *
+ * See the following example:
+ * ```markdown
+ * long text| <- `range.getBoundingClientRect()` will return rect at here
+ * |line wrap <- caret at the start of the second line
+ * ```
+ *
+ * See https://stackoverflow.com/questions/59767515/incorrect-positioning-of-getboundingclientrect-after-newline-character
+ */
 export function isAtLineEdge(range: Range) {
   if (!range.collapsed) {
     console.warn(
@@ -504,7 +515,11 @@ export function isAtLineEdge(range: Range) {
     return false;
   }
   const nextRangeRect = nextRange.getBoundingClientRect();
-  return range.getBoundingClientRect().top !== nextRangeRect.top;
+  const noLineEdge = range.getBoundingClientRect().top === nextRangeRect.top;
+  if (noLineEdge) {
+    return false;
+  }
+  return nextRange;
 }
 
 export function handleKeyUp(model: ExtendedModel, editableContainer: Element) {

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -687,9 +687,18 @@ test('press arrow up in the second line should move caret to the first line', as
     return paragraphId;
   });
 
-  await focusRichText(page);
-  await page.keyboard.press(`${SHORT_KEY}+ArrowLeft`);
+  // await focusRichText(page);
+  const locator = page.locator('.ql-editor').nth(0);
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error("Can't get bounding box");
+  }
+  // Click left bottom corner
+  // Go to the start of the second line
+  await page.mouse.click(box.x + 1, box.y + box.height - 1);
   // await page.keyboard.press('ArrowDown');
+  // await page.keyboard.press(`${SHORT_KEY}+ArrowLeft`);
+
   await page.keyboard.press('ArrowUp');
   await type(page, '0');
   await page.keyboard.press('ArrowUp');

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -28,6 +28,7 @@ import {
   redoByClick,
   pressTab,
   type,
+  SHORT_KEY,
 } from './utils/actions/index.js';
 
 test('init paragraph by page title enter at last', async ({ page }) => {
@@ -662,4 +663,39 @@ test('press left in first paragraph start should not change cursor position', as
   await type(page, 'l');
   await assertRichTexts(page, ['l1']);
   await assertTitle(page, '');
+});
+
+test('press arrow up in the second line should move caret to the first line', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await page.evaluate(() => {
+    const { page } = window;
+    const pageId = page.addBlockByFlavour('affine:page');
+    const frame = page.addBlockByFlavour('affine:frame', {}, pageId);
+    const delta = Array.from({ length: 100 }, (v, i) => {
+      return i % 2 === 0
+        ? { insert: 'i', attributes: { italic: true } }
+        : { insert: 'b', attributes: { bold: true } };
+    });
+    const text = page.Text.fromDelta(page, delta);
+    const paragraphId = page.addBlockByFlavour(
+      'affine:paragraph',
+      { text },
+      frame
+    );
+    return paragraphId;
+  });
+
+  await focusRichText(page);
+  await page.keyboard.press(`${SHORT_KEY}+ArrowLeft`);
+  // await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowUp');
+  await type(page, '0');
+  await page.keyboard.press('ArrowUp');
+  await type(page, '1');
+  await assertTitle(page, '1');
+  await assertRichTexts(page, [
+    '0ibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibibib',
+  ]);
 });

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -678,7 +678,7 @@ test('press arrow up in the second line should move caret to the first line', as
         ? { insert: 'i', attributes: { italic: true } }
         : { insert: 'b', attributes: { bold: true } };
     });
-    const text = page.Text.fromDelta(page, delta);
+    const text = page.Text.fromDelta(delta);
     const paragraphId = page.addBlockByFlavour(
       'affine:paragraph',
       { text },


### PR DESCRIPTION
In `isAtLineEdge`, use the length of the textContent is not accurate,
    since the text may be a part of a text node.

Consider the following case:

```html
    <text>long text
    |<bold>bold</bold> <- when the caret is at the start of bold, it's at the line edge but this function returns false
    </text>
```

And it will break ArrowUp behavior when the caret is at the start of the second line and follow the formatted text.

https://user-images.githubusercontent.com/18554747/216383011-fd868a6c-04b2-4c99-b7e8-a0c8e776cead.mov

