### PR TITLE
fix: add event to quill keyboard context

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "hotkeys-js@3.10.1": "patches/hotkeys-js@3.10.1.patch"
+      "hotkeys-js@3.10.1": "patches/hotkeys-js@3.10.1.patch",
+      "quill@1.3.7": "patches/quill@1.3.7.patch"
     }
   }
 }

--- a/patches/quill@1.3.7.patch
+++ b/patches/quill@1.3.7.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/quill.js b/dist/quill.js
+index 811b3d080aa2c3b6bfee42a981c95bbe838872c0..1867e13f49de7c006b885f8eb85262bbe8d11963 100644
+--- a/dist/quill.js
++++ b/dist/quill.js
+@@ -4591,7 +4591,9 @@ var Keyboard = function (_Module) {
+           format: _this2.quill.getFormat(range),
+           offset: offset,
+           prefix: prefixText,
+-          suffix: suffixText
++          suffix: suffixText,
++          // https://github.com/quilljs/quill/commit/90269c7af9fc03e46be257490b2b0aec85d9ecc7
++          event: evt,
+         };
+         var prevented = bindings.some(function (binding) {
+           if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ patchedDependencies:
   hotkeys-js@3.10.1:
     hash: otx73r74oyscqvo3amwccrzngy
     path: patches/hotkeys-js@3.10.1.patch
+  quill@1.3.7:
+    hash: p7fvhlmnj5slwuih2pe6pk5gyy
+    path: patches/quill@1.3.7.patch
 
 importers:
 
@@ -95,7 +98,7 @@ importers:
       highlight.js: 11.7.0
       hotkeys-js: 3.10.1_otx73r74oyscqvo3amwccrzngy
       lit: 2.6.1
-      quill: 1.3.7
+      quill: 1.3.7_p7fvhlmnj5slwuih2pe6pk5gyy
       quill-cursors: 4.0.0
       zod: 3.20.2
     devDependencies:
@@ -5959,7 +5962,7 @@ packages:
       fast-diff: 1.1.2
     dev: false
 
-  /quill/1.3.7:
+  /quill/1.3.7_p7fvhlmnj5slwuih2pe6pk5gyy:
     resolution: {integrity: sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==}
     dependencies:
       clone: 2.1.2
@@ -5969,6 +5972,7 @@ packages:
       parchment: 1.1.4
       quill-delta: 3.6.3
     dev: false
+    patched: true
 
   /randombytes/2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}


### PR DESCRIPTION
In quill 1.3.7, keyboard bindings cannot get the event, this has led to us having to handle the event on quill and hotkey at the same time. Using `event.stopPropagation()` in quill bindings to skip the hotkey handler will reduce the mental overhead of development

See also https://github.com/quilljs/quill/commit/90269c7af9fc03e46be257490b2b0aec85d9ecc7