### PR TITLE
fix: add version to cancel workflow

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: styfle/cancel-workflow-action
+      - uses: styfle/cancel-workflow-action@0.11.0
         with:
           workflow_id: 46388772, 34612818
           access_token: ${{ github.token }}


### PR DESCRIPTION
> Error: .github#L1
> the `uses' attribute must be a path, a Docker image, or owner/repo@ref

Related to https://github.com/styfle/cancel-workflow-action/pull/184

But I still think that using the native [concurrency](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/) property to cancel workflows is enough

Ref https://github.com/toeverything/blocksuite/pull/962#issuecomment-1414732803