### PR TITLE
fix: render `selectedRects` based on viewport scroll

### DIFF
--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -22,7 +22,10 @@ import type {
   EmbedEditingState,
 } from './default-page-block.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
-import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
+import {
+  BLOCK_CHILDREN_CONTAINER_PADDING_LEFT,
+  BLOCK_ID_ATTR,
+} from '@blocksuite/global/config';
 
 export function FrameSelectionRect(rect: DOMRect | null) {
   if (rect === null) return null;
@@ -81,11 +84,13 @@ export function EmbedSelectedRectsContainer(
   `;
 }
 
-export function SelectedRectsContainer(rects: DOMRect[]) {
+export function SelectedRectsContainer(rects: DOMRect[], scrollTop: number) {
   return html`
     <style>
+      .affine-page-selected-rects-container {
+        position: relative;
+      }
       .affine-page-selected-rects-container > div {
-        position: fixed;
         background: var(--affine-selected-color);
         z-index: 1;
         pointer-events: none;
@@ -95,9 +100,10 @@ export function SelectedRectsContainer(rects: DOMRect[]) {
     <div class="affine-page-selected-rects-container">
       ${rects.map(rect => {
         const style = {
+          position: 'absolute',
           display: 'block',
-          left: rect.left + 'px',
-          top: rect.top + 'px',
+          left: BLOCK_CHILDREN_CONTAINER_PADDING_LEFT + 'px',
+          top: scrollTop + rect.top + 'px',
           width: rect.width + 'px',
           height: rect.height + 'px',
         };

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -22,10 +22,8 @@ import type {
   EmbedEditingState,
 } from './default-page-block.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
-import {
-  BLOCK_CHILDREN_CONTAINER_PADDING_LEFT,
-  BLOCK_ID_ATTR,
-} from '@blocksuite/global/config';
+import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
+import { repeat } from 'lit/directives/repeat.js';
 
 export function FrameSelectionRect(rect: DOMRect | null) {
   if (rect === null) return null;
@@ -65,6 +63,7 @@ export function EmbedSelectedRectsContainer(
     <div class="affine-page-selected-embed-rects-container resizable">
       ${rects.map(rect => {
         const style = {
+          position: 'absolute',
           display: 'block',
           left: rect.left + 'px',
           top: rect.top + 'px',
@@ -84,12 +83,15 @@ export function EmbedSelectedRectsContainer(
   `;
 }
 
-export function SelectedRectsContainer(rects: DOMRect[], scrollTop: number) {
+export function SelectedRectsContainer(
+  rects: DOMRect[],
+  scroll: {
+    left: number;
+    top: number;
+  }
+) {
   return html`
     <style>
-      .affine-page-selected-rects-container {
-        position: relative;
-      }
       .affine-page-selected-rects-container > div {
         background: var(--affine-selected-color);
         z-index: 1;
@@ -98,12 +100,12 @@ export function SelectedRectsContainer(rects: DOMRect[], scrollTop: number) {
       }
     </style>
     <div class="affine-page-selected-rects-container">
-      ${rects.map(rect => {
+      ${repeat(rects, rect => {
         const style = {
           position: 'absolute',
           display: 'block',
-          left: BLOCK_CHILDREN_CONTAINER_PADDING_LEFT + 'px',
-          top: scrollTop + rect.top + 'px',
+          left: scroll.left + rect.left + 'px',
+          top: scroll.top + rect.top + 'px',
           width: rect.width + 'px',
           height: rect.height + 'px',
         };

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -509,7 +509,6 @@ export class DefaultPageBlockComponent
       <div class="affine-default-viewport">
         <div class="affine-default-page-block-container">
           ${selectedRectsContainer}
-          ${selectedEmbedContainer}${embedEditingContainer}
           <div class="affine-default-page-block-title-container">
             <textarea
               ?disabled=${this.readonly}

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -76,6 +76,7 @@ export class DefaultPageBlockComponent
 {
   static styles = css`
     .affine-default-viewport {
+      position: relative;
       overflow-x: hidden;
       overflow-y: auto;
       height: 100%;
@@ -181,6 +182,9 @@ export class DefaultPageBlockComponent
 
   @state()
   codeBlockOption!: CodeBlockOption | null;
+
+  @query('.affine-default-viewport')
+  defaultViewportElement!: HTMLDivElement;
 
   signals: DefaultPageSignals = {
     updateFrameSelectionRect: new Signal<DOMRect | null>(),
@@ -397,7 +401,7 @@ export class DefaultPageBlockComponent
   };
 
   private _getViewportScrollOffset() {
-    const container = this.children[0];
+    const container = this.defaultViewportElement;
     return {
       left: container.scrollLeft,
       top: container.scrollTop,
@@ -493,7 +497,7 @@ export class DefaultPageBlockComponent
     const selectionRect = FrameSelectionRect(this.frameSelectionRect);
     const selectedRectsContainer = SelectedRectsContainer(
       this.selectedRects,
-      this.viewportScrollOffset.top
+      this.viewportScrollOffset
     );
     const selectedEmbedContainer = EmbedSelectedRectsContainer(
       this.selectEmbedRects


### PR DESCRIPTION
Will close https://github.com/toeverything/blocksuite/issues/330

FYI: `selectedEmbedContainer` and `embedEditingContainer` have a similar issue, but not addressed in this PR. If this PR merged, then we could implement the fix later.