### PR TITLE
fix: keydown position in line edge and empty line

### DIFF
--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -715,3 +715,31 @@ test('press arrow up in the second line should move caret to the first line', as
     '2',
   ]);
 });
+
+test('press arrow down in indent line should  not move caret to the start of line', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await page.evaluate(() => {
+    const { page } = window;
+    const pageId = page.addBlockByFlavour('affine:page');
+    const frame = page.addBlockByFlavour('affine:frame', {}, pageId);
+    const p1 = page.addBlockByFlavour('affine:paragraph', {}, frame);
+    const p2 = page.addBlockByFlavour('affine:paragraph', {}, p1);
+    page.addBlockByFlavour('affine:paragraph', {}, p2);
+    page.addBlockByFlavour(
+      'affine:paragraph',
+      {
+        text: new page.Text('0'),
+      },
+      frame
+    );
+  });
+
+  // Focus the empty child paragraph
+  await focusRichText(page, 2);
+  await page.keyboard.press('ArrowDown');
+  // Now the caret should be at the end of the last paragraph
+  await type(page, '1');
+  await assertRichTexts(page, ['\n', '\n', '\n', '01']);
+});

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -716,7 +716,7 @@ test('press arrow up in the second line should move caret to the first line', as
   ]);
 });
 
-test('press arrow down in indent line should  not move caret to the start of line', async ({
+test('press arrow down in indent line should not move caret to the start of line', async ({
   page,
 }) => {
   await enterPlaygroundRoom(page);
@@ -742,4 +742,16 @@ test('press arrow down in indent line should  not move caret to the start of lin
   // Now the caret should be at the end of the last paragraph
   await type(page, '1');
   await assertRichTexts(page, ['\n', '\n', '\n', '01']);
+
+  await focusRichText(page, 2);
+  // Insert a new long text to wrap the line
+  await page.keyboard.insertText('0'.repeat(100));
+
+  await focusRichText(page, 1);
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+
+  await page.keyboard.press('ArrowDown');
+  await type(page, '2');
+  await assertRichTexts(page, ['\n', '\n', '0'.repeat(100), '012']);
 });


### PR DESCRIPTION
Pressing ArrowDown at empty will always focus on the start of the line, it's unexpected when there's a multi-level indent. And it also happens at the end of multiple line blocks.

https://user-images.githubusercontent.com/18554747/216912135-51fe4cd5-e02f-4b10-9307-496b2e11f7f5.mov


