### PR TITLE
fix: remove event listener with options

### DIFF
--- a/packages/global/src/utils/signal.ts
+++ b/packages/global/src/utils/signal.ts
@@ -28,7 +28,11 @@ export class Signal<T = void> implements Disposable {
     (element as HTMLElement).addEventListener(eventName, handler, eventOptions);
     signal._disposables.push({
       dispose: () => {
-        (element as HTMLElement).removeEventListener(eventName, handler);
+        (element as HTMLElement).removeEventListener(
+          eventName,
+          handler,
+          eventOptions
+        );
       },
     });
     return signal;


### PR DESCRIPTION
> Warning: If a listener is registered twice, one with the capture flag set and one without, you must remove each one separately. Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.

See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener