### PR TITLE
refactor: `Signal.fromEvent` -> `Singal.disposableListener`

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -386,7 +386,7 @@ export class BlockHub extends NonShadowLitElement {
           blockHubMenu.removeEventListener('mouseup', this._onBlankMenuMouseUp);
         }
       }
-      this._blockHubMenuEntry.addEventListener(
+      this._blockHubMenuEntry.removeEventListener(
         'mouseover',
         this._onBlockHubEntryMouseOver
       );

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -93,7 +93,7 @@ export class EditorContainer extends NonShadowLitElement {
 
     // Question: Why do we prevent this?
     this._disposables.add(
-      Signal.fromEvent(window, 'keydown').on(e => {
+      Signal.disposableListener(window, 'keydown', e => {
         if (e.altKey && e.metaKey && e.code === 'KeyC') {
           e.preventDefault();
         }
@@ -125,13 +125,19 @@ export class EditorContainer extends NonShadowLitElement {
 
     // connect mouse mode event changes
     this._disposables.add(
-      Signal.fromEvent(window, 'affine.switch-mouse-mode').on(({ detail }) => {
-        this.mouseMode = detail;
-      })
+      Signal.disposableListener(
+        window,
+        'affine.switch-mouse-mode',
+        ({ detail }) => {
+          this.mouseMode = detail;
+        }
+      )
     );
 
     this._disposables.add(
-      Signal.fromEvent(window, 'affine:switch-edgeless-display-mode').on(
+      Signal.disposableListener(
+        window,
+        'affine:switch-edgeless-display-mode',
         ({ detail }) => {
           this.showGrid = detail;
         }

--- a/packages/global/src/utils/signal.ts
+++ b/packages/global/src/utils/signal.ts
@@ -6,6 +6,7 @@ export class Signal<T = void> implements Disposable {
   private _emitting = false;
   private _callbacks: ((v: T) => unknown)[] = [];
   private _disposables: Disposable[] = [];
+
   static fromEvent<N extends keyof WindowEventMap>(
     element: Window,
     eventName: N,
@@ -36,6 +37,35 @@ export class Signal<T = void> implements Disposable {
       },
     });
     return signal;
+  }
+
+  /**
+   * This is method will return a disposable that will remove the listener
+   */
+  static disposableListener<N extends keyof WindowEventMap>(
+    element: Window,
+    eventName: N,
+    handler: (e: WindowEventMap[N]) => void,
+    options?: boolean | AddEventListenerOptions
+  ): Disposable;
+  static disposableListener<N extends keyof HTMLElementEventMap>(
+    element: HTMLElement,
+    eventName: N,
+    handler: (e: HTMLElementEventMap[N]) => void,
+    eventOptions?: boolean | AddEventListenerOptions
+  ): Disposable;
+  static disposableListener(
+    element: HTMLElement | Window,
+    eventName: string,
+    handler: (e: Event) => void,
+    eventOptions?: boolean | AddEventListenerOptions
+  ): Disposable {
+    element.addEventListener(eventName, handler, eventOptions);
+    return {
+      dispose: () => {
+        element.removeEventListener(eventName, handler, eventOptions);
+      },
+    };
   }
 
   filter(testFun: (v: T) => boolean): Signal<T> {

--- a/packages/global/src/utils/signal.ts
+++ b/packages/global/src/utils/signal.ts
@@ -7,38 +7,6 @@ export class Signal<T = void> implements Disposable {
   private _callbacks: ((v: T) => unknown)[] = [];
   private _disposables: Disposable[] = [];
 
-  static fromEvent<N extends keyof WindowEventMap>(
-    element: Window,
-    eventName: N,
-    options?: boolean | AddEventListenerOptions
-  ): Signal<WindowEventMap[N]>;
-  static fromEvent<N extends keyof HTMLElementEventMap>(
-    element: HTMLElement,
-    eventName: N,
-    eventOptions?: boolean | AddEventListenerOptions
-  ): Signal<HTMLElementEventMap[N]>;
-  static fromEvent<N extends keyof HTMLElementEventMap>(
-    element: HTMLElement | Window,
-    eventName: N,
-    eventOptions?: boolean | AddEventListenerOptions
-  ): Signal<HTMLElementEventMap[N]> {
-    const signal = new Signal<HTMLElementEventMap[N]>();
-    const handler = (ev: HTMLElementEventMap[N]) => {
-      signal.emit(ev);
-    };
-    (element as HTMLElement).addEventListener(eventName, handler, eventOptions);
-    signal._disposables.push({
-      dispose: () => {
-        (element as HTMLElement).removeEventListener(
-          eventName,
-          handler,
-          eventOptions
-        );
-      },
-    });
-    return signal;
-  }
-
   /**
    * This is method will return a disposable that will remove the listener
    */


### PR DESCRIPTION
- Add `Signal.disposableListener`
- Remove incorrect `Signal.fromEvent` usage
ref https://github.com/toeverything/blocksuite/pull/1025#issuecomment-1418852914