### PR TITLE
refactor: use disposable style event listener in blockHub

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -136,7 +136,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
     .affine-code-block-container .ql-syntax {
       width: 620px;
       margin: 0;
-      overflow: scroll;
+      overflow-x: scroll;
       /*scrollbar-color: #fff0 #fff0;*/
     }
 

--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -8,7 +8,12 @@ import {
   RectIcon,
   TextIconLarge,
 } from '@blocksuite/global/config';
-import { assertExists, isFirefox, Signal } from '@blocksuite/global/utils';
+import {
+  assertExists,
+  DisposableGroup,
+  isFirefox,
+  Signal,
+} from '@blocksuite/global/utils';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { css, html, TemplateResult } from 'lit';
 import {
@@ -105,8 +110,10 @@ export class BlockHub extends NonShadowLitElement {
   private _cursor: number | null = 0;
   private _timer: number | null = null;
   private _delay = 200;
-  private readonly enable_database: boolean;
+  private readonly _enable_database: boolean;
+  private _mouseRoot: HTMLElement;
   private _topDistance = 24;
+  private _disposables: DisposableGroup = new DisposableGroup();
 
   static styles = css`
     affine-block-hub {
@@ -296,11 +303,13 @@ export class BlockHub extends NonShadowLitElement {
   `;
 
   constructor(options: {
+    mouseRoot: HTMLElement;
     enable_database: boolean;
     onDropCallback: (e: DragEvent, lastModelState: EditingState) => void;
   }) {
     super();
-    this.enable_database = options.enable_database;
+    this._mouseRoot = options.mouseRoot;
+    this._enable_database = options.enable_database;
     this.getAllowedBlocks = () => {
       console.warn('you may forget to set `getAllowedBlocks`');
       return [];
@@ -310,96 +319,108 @@ export class BlockHub extends NonShadowLitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener('dragstart', this._onDragStart);
-    this.addEventListener('drag', this._onDrag);
-    this.addEventListener('dragend', this._onDragEnd);
+    const disposables = this._disposables;
+    disposables.add(
+      Signal.disposableListener(this, 'dragstart', this._onDragStart)
+    );
+    disposables.add(Signal.disposableListener(this, 'drag', this._onDrag));
+    disposables.add(
+      Signal.disposableListener(this, 'dragend', this._onDragEnd)
+    );
 
-    document.addEventListener('dragover', this._onDragOver);
-    document.addEventListener('drop', this._onDrop);
+    disposables.add(
+      Signal.disposableListener(this._mouseRoot, 'dragover', this._onDragOver)
+    );
+    disposables.add(
+      Signal.disposableListener(this._mouseRoot, 'drop', this._onDrop)
+    );
     isFirefox &&
-      document.addEventListener('dragover', this._onDragOverDocument);
-    this.addEventListener('mousedown', this._onMouseDown);
+      disposables.add(
+        Signal.disposableListener(
+          this._mouseRoot,
+          'dragover',
+          this._onDragOverDocument
+        )
+      );
+    disposables.add(
+      Signal.disposableListener(this, 'mousedown', this._onMouseDown)
+    );
     this._onResize();
   }
 
   protected firstUpdated() {
+    const disposables = this._disposables;
     this._blockHubCards.forEach(card => {
-      card.addEventListener('mousedown', this._onCardMouseDown);
-      card.addEventListener('mouseup', this._onCardMouseUp);
+      disposables.add(
+        Signal.disposableListener(card, 'mousedown', this._onCardMouseDown)
+      );
+      disposables.add(
+        Signal.disposableListener(card, 'mouseup', this._onCardMouseUp)
+      );
     });
     for (const blockHubMenu of this._blockHubMenus) {
-      blockHubMenu.addEventListener('mouseover', this._onBlockHubMenuMouseOver);
+      disposables.add(
+        Signal.disposableListener(
+          blockHubMenu,
+          'mouseover',
+          this._onBlockHubMenuMouseOver
+        )
+      );
       if (blockHubMenu.getAttribute('type') === 'blank') {
-        blockHubMenu.addEventListener('mousedown', this._onBlankMenuMouseDown);
-        blockHubMenu.addEventListener('mouseup', this._onBlankMenuMouseUp);
+        disposables.add(
+          Signal.disposableListener(
+            blockHubMenu,
+            'mousedown',
+            this._onBlankMenuMouseDown
+          )
+        );
+        disposables.add(
+          Signal.disposableListener(
+            blockHubMenu,
+            'mouseup',
+            this._onBlankMenuMouseUp
+          )
+        );
       }
     }
-    this._blockHubMenuEntry.addEventListener(
-      'mouseover',
-      this._onBlockHubEntryMouseOver
+    disposables.add(
+      Signal.disposableListener(
+        this._blockHubMenuEntry,
+        'mouseover',
+        this._onBlockHubEntryMouseOver
+      )
     );
-
-    document.addEventListener('click', this._onClick);
-    this._blockHubButton.addEventListener('click', this._onBlockHubButtonClick);
+    disposables.add(
+      Signal.disposableListener(document, 'click', this._onClick)
+    );
+    disposables.add(
+      Signal.disposableListener(
+        this._blockHubButton,
+        'click',
+        this._onBlockHubButtonClick
+      )
+    );
+    disposables.add(
+      Signal.disposableListener(
+        this._blockHubIconsContainer,
+        'transitionstart',
+        this._onTransitionStart
+      )
+    );
+    disposables.add(
+      Signal.disposableListener(window, 'resize', this._onResize)
+    );
     this._indicator = <DragIndicator>(
       document.querySelector('affine-drag-indicator')
     );
     if (!this._indicator) {
       this._indicatorHTMLTemplate = html` <affine-drag-indicator></affine-drag-indicator>`;
     }
-    this._blockHubIconsContainer.addEventListener(
-      'transitionstart',
-      this._onTransitionStart
-    );
-    window.addEventListener('resize', this._onResize);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener('dragstart', this._onDragStart);
-    this.removeEventListener('drag', this._onDrag);
-    this.removeEventListener('dragend', this._onDragEnd);
-
-    // FIXME: do not listen on the document
-    document.removeEventListener('dragover', this._onDragOver);
-    document.removeEventListener('drop', this._onDrop);
-    isFirefox &&
-      document.removeEventListener('dragover', this._onDragOverDocument);
-    this.removeEventListener('mousedown', this._onMouseDown);
-    window.removeEventListener('resize', this._onResize);
-
-    if (this.hasUpdated) {
-      this._blockHubCards.forEach(card => {
-        card.removeEventListener('mousedown', this._onCardMouseDown);
-        card.removeEventListener('mouseup', this._onCardMouseUp);
-      });
-      for (const blockHubMenu of this._blockHubMenus) {
-        blockHubMenu.removeEventListener(
-          'mouseover',
-          this._onBlockHubMenuMouseOver
-        );
-        if (blockHubMenu.getAttribute('type') === 'blank') {
-          blockHubMenu.removeEventListener(
-            'mousedown',
-            this._onBlankMenuMouseDown
-          );
-          blockHubMenu.removeEventListener('mouseup', this._onBlankMenuMouseUp);
-        }
-      }
-      this._blockHubMenuEntry.removeEventListener(
-        'mouseover',
-        this._onBlockHubEntryMouseOver
-      );
-      document.removeEventListener('click', this._onClick);
-      this._blockHubButton.removeEventListener(
-        'click',
-        this._onBlockHubButtonClick
-      );
-      this._blockHubIconsContainer.removeEventListener(
-        'transitionstart',
-        this._onTransitionStart
-      );
-    }
+    this._disposables.dispose();
   }
 
   /**
@@ -434,7 +455,7 @@ export class BlockHub extends NonShadowLitElement {
   }
 
   private _blockHubMenuTemplate = () => {
-    const menuNum = this.enable_database ? 4 : 3;
+    const menuNum = this._enable_database ? 4 : 3;
     const height = menuNum * 44 + 10;
     return html`
       <div
@@ -477,7 +498,7 @@ export class BlockHub extends NonShadowLitElement {
           ${this._blockHubCardTemplate(BLOCKHUB_LIST_ITEMS, 'list', 'List')}
           ${BulletedListIconLarge}
         </div>
-        ${this.enable_database
+        ${this._enable_database
           ? html`
               <div
                 class="block-hub-icon-container has-tool-tip"

--- a/packages/editor/src/utils/editor.ts
+++ b/packages/editor/src/utils/editor.ts
@@ -14,6 +14,7 @@ export const createBlockHub: (
   page: Page
 ) => BlockHub = (editor: EditorContainer, page: Page) => {
   const blockHub = new BlockHub({
+    mouseRoot: editor,
     enable_database: !!page.awarenessStore.getFlag('enable_database'),
     onDropCallback: (e, end) => {
       const dataTransfer = e.dataTransfer;

--- a/packages/global/src/utils/signal.ts
+++ b/packages/global/src/utils/signal.ts
@@ -16,7 +16,7 @@ export class Signal<T = void> implements Disposable {
     handler: (e: WindowEventMap[N]) => void,
     options?: boolean | AddEventListenerOptions
   ): Disposable;
-  static disposableListener<N extends keyof HTMLElementEventMap>(
+  static disposableListener<N extends keyof DocumentEventMap>(
     element: Document,
     eventName: N,
     handler: (e: DocumentEventMap[N]) => void,

--- a/packages/global/src/utils/signal.ts
+++ b/packages/global/src/utils/signal.ts
@@ -17,13 +17,19 @@ export class Signal<T = void> implements Disposable {
     options?: boolean | AddEventListenerOptions
   ): Disposable;
   static disposableListener<N extends keyof HTMLElementEventMap>(
+    element: Document,
+    eventName: N,
+    handler: (e: DocumentEventMap[N]) => void,
+    eventOptions?: boolean | AddEventListenerOptions
+  ): Disposable;
+  static disposableListener<N extends keyof HTMLElementEventMap>(
     element: HTMLElement,
     eventName: N,
     handler: (e: HTMLElementEventMap[N]) => void,
     eventOptions?: boolean | AddEventListenerOptions
   ): Disposable;
   static disposableListener(
-    element: HTMLElement | Window,
+    element: HTMLElement | Window | Document,
     eventName: string,
     handler: (e: Event) => void,
     eventOptions?: boolean | AddEventListenerOptions


### PR DESCRIPTION
1. Use `Signal.disposableListener`. Upstream PR: #1114
2. Use `EditorContainer` as `mouseRoot` in place of `document`, on which to listen `dragover`, `drop` event