### PR TITLE
fix: should get rect of first child element in safari

### DIFF
--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -4,6 +4,7 @@ import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '@blocksuite/global/config
 import {
   assertExists,
   caretRangeFromPoint,
+  isSafari,
   matchFlavours,
 } from '@blocksuite/global/utils';
 import type { Page } from '@blocksuite/store';
@@ -43,6 +44,7 @@ import { EmbedResizeManager } from './embed-resize-manager.js';
 import {
   getAllowSelectedBlocks,
   getBlockEditingStateByPosition,
+  getBoundingClientRectCompatibleWithSafari,
 } from './utils.js';
 
 function calcDepth(left: number, containerLeft: number) {
@@ -182,7 +184,7 @@ function filterSelectedBlockByIndex(
 function clearSubtree(selectedBlocks: Element[], left: number) {
   return selectedBlocks.filter((block, index) => {
     if (index === 0) return true;
-    const currentLeft = block.getBoundingClientRect().left;
+    const currentLeft = getBoundingClientRectCompatibleWithSafari(block).left;
     if (currentLeft > left) {
       return false;
     } else if (currentLeft < left) {
@@ -298,7 +300,7 @@ export class PageSelectionState {
     this._blockCache.clear();
     const allBlocks = getAllBlocks();
     for (const block of allBlocks) {
-      const rect = block.getBoundingClientRect();
+      const rect = getBoundingClientRectCompatibleWithSafari(block);
       this._blockCache.set(block, rect);
     }
   }
@@ -420,7 +422,7 @@ export class DefaultSelectionManager {
 
     const calculatedRects = [] as DOMRect[];
     for (const block of selectedBlocks) {
-      calculatedRects.push(block.getBoundingClientRect());
+      calculatedRects.push(getBoundingClientRectCompatibleWithSafari(block));
     }
 
     const newSelectionType = this._computeSelectionType(
@@ -831,7 +833,7 @@ export class DefaultSelectionManager {
   getBlockWithIndexByElement(blockElement: Element) {
     const entries = Array.from(this.state.blockCache.entries());
     const len = entries.length;
-    const boundRect = blockElement.getBoundingClientRect();
+    const boundRect = getBoundingClientRectCompatibleWithSafari(blockElement);
     const top = boundRect.top;
 
     if (!boundRect) return null;

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -4,7 +4,6 @@ import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '@blocksuite/global/config
 import {
   assertExists,
   caretRangeFromPoint,
-  isSafari,
   matchFlavours,
 } from '@blocksuite/global/utils';
 import type { Page } from '@blocksuite/store';

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -3,7 +3,11 @@ import {
   BLOCK_ID_ATTR,
   BLOCK_SERVICE_LOADING_ATTR,
 } from '@blocksuite/global/config';
-import { assertExists, matchFlavours } from '@blocksuite/global/utils';
+import {
+  assertExists,
+  isSafari,
+  matchFlavours,
+} from '@blocksuite/global/utils';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { PrelimText } from '@blocksuite/store';
 
@@ -235,13 +239,12 @@ function getBlockAndRect(blocks: BaseBlockModel[], mid: number) {
   let blockRect: DOMRect | null = null;
   let detectRect: DOMRect | null = null;
   if (hasOptionBar(block)) {
-    blockRect = getBlockWithOptionBarRect(
-      hoverDom,
-      block
-    ).getBoundingClientRect();
+    blockRect = getBoundingClientRectCompatibleWithSafari(
+      getBlockWithOptionBarRect(hoverDom, block)
+    );
     detectRect = getDetectRect(block, blockRect);
   } else {
-    blockRect = hoverDom.getBoundingClientRect() as DOMRect;
+    blockRect = getBoundingClientRectCompatibleWithSafari(hoverDom) as DOMRect;
     if (block.flavour === 'affine:database') {
       // in a database block, `.affine-database-block-title` which is its own editing area
       detectRect = hoverDom
@@ -507,3 +510,9 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
     },
   });
 }
+
+// See https://github.com/toeverything/blocksuite/issues/902
+export const getBoundingClientRectCompatibleWithSafari = isSafari
+  ? (block: Element): DOMRect =>
+      (block.firstElementChild || block).getBoundingClientRect()
+  : (block: Element): DOMRect => block.getBoundingClientRect();

--- a/packages/global/src/utils.ts
+++ b/packages/global/src/utils.ts
@@ -1,7 +1,12 @@
 export type { Disposable } from './utils/disposable.js';
 export { DisposableGroup, flattenDisposable } from './utils/disposable.js';
 export { Signal } from './utils/signal.js';
-export { caretRangeFromPoint, isFirefox, isWeb } from './utils/web.js';
+export {
+  caretRangeFromPoint,
+  isFirefox,
+  isSafari,
+  isWeb,
+} from './utils/web.js';
 export const SYS_KEYS = new Set(['id', 'flavour', 'children']);
 
 // https://stackoverflow.com/questions/31538010/test-if-a-variable-is-a-primitive-rather-than-an-object

--- a/packages/global/src/utils/web.ts
+++ b/packages/global/src/utils/web.ts
@@ -1,6 +1,10 @@
 export const isWeb = typeof window !== 'undefined';
 export const isFirefox =
   isWeb && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+export const isSafari =
+  isWeb &&
+  !isFirefox &&
+  navigator.userAgent.toLowerCase().indexOf('safari') > -1;
 
 declare global {
   interface Document {


### PR DESCRIPTION
Related: #902 