### PR TITLE
fix: update slash menu

### DIFF
--- a/packages/blocks/src/components/link-popover/link-popover.ts
+++ b/packages/blocks/src/components/link-popover/link-popover.ts
@@ -21,8 +21,6 @@ const MAIL_REGEX =
   /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
 
 // For more detail see https://stackoverflow.com/questions/8667070/javascript-regular-expression-to-validate-url
-
-// For more detail see https://stackoverflow.com/questions/8667070/javascript-regular-expression-to-validate-url
 const URL_REGEX = new RegExp(
   '^' +
     // protocol identifier (optional)

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -59,21 +59,22 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
   },
   {
     name: 'Style',
-    items: formatConfig.map(({ name, icon, id }, idx) => ({
-      name,
-      icon,
-      divider: idx === 0,
-      action: ({ model }) => {
-        if (!model.text) {
-          return;
-        }
-        const len = model.text.length;
-        // TODO check if the format is already applied and remove it
-        model.text.format(0, len, {
-          [id]: true,
-        });
-      },
-    })),
+    items: formatConfig
+      .filter(i => !['Link', 'Code'].includes(i.name))
+      .map(({ name, icon, id }, idx) => ({
+        name,
+        icon,
+        divider: idx === 0,
+        action: ({ model }) => {
+          if (!model.text) {
+            return;
+          }
+          const len = model.text.length;
+          model.text.format(0, len, {
+            [id]: true,
+          });
+        },
+      })),
   },
   {
     name: 'List',

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -1,6 +1,7 @@
 import {
   CopyIcon,
   DeleteIcon,
+  DividerIcon,
   DuplicateIcon,
   NowIcon,
   paragraphConfig,
@@ -45,17 +46,32 @@ function insertContent(model: BaseBlockModel, text: string) {
   quill.setSelection(index + text.length, 0);
 }
 
+const dividerItem: SlashItem = {
+  name: 'Divider',
+  icon: DividerIcon,
+  action({ page, model }) {
+    const parent = page.getParent(model);
+    if (!parent) {
+      return;
+    }
+    const index = parent.children.indexOf(model);
+    page.addBlockByFlavour('affine:divider', {}, parent, index + 1);
+  },
+};
+
 export const menuGroups: { name: string; items: SlashItem[] }[] = [
   {
     name: 'Text',
-    // TODO append divider convertToDivider
-    items: paragraphConfig
-      .filter(i => i.flavour !== 'affine:list')
-      .map(({ name, icon, flavour, type }) => ({
-        name,
-        icon,
-        action: ({ model }) => updateBlockType([model], flavour, type),
-      })),
+    items: [
+      ...paragraphConfig
+        .filter(i => i.flavour !== 'affine:list')
+        .map<SlashItem>(({ name, icon, flavour, type }) => ({
+          name,
+          icon,
+          action: ({ model }) => updateBlockType([model], flavour, type),
+        })),
+      dividerItem,
+    ],
   },
   {
     name: 'Style',

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -54,6 +54,12 @@ export class SlashMenu extends LitElement {
     this._disposableGroup.add(
       Signal.disposableListener(window, 'mousedown', this._clickAwayListener)
     );
+    this._disposableGroup.add(
+      Signal.disposableListener(window, 'keydown', this._keyDownListener, {
+        // Workaround: Use capture to prevent the event from triggering the hotkey bindings action
+        capture: true,
+      })
+    );
 
     const richText = getRichTextByModel(this.model);
     if (!richText) {
@@ -154,14 +160,14 @@ export class SlashMenu extends LitElement {
           (this._activeItemIndex - 1 + configLen) % configLen;
         this._queryItemEle(
           this._filterItems[this._activeItemIndex]
-        )?.scrollIntoView(false);
+        )?.scrollIntoView();
         break;
       }
       case 'ArrowDown': {
         this._activeItemIndex = (this._activeItemIndex + 1) % configLen;
         this._queryItemEle(
           this._filterItems[this._activeItemIndex]
-        )?.scrollIntoView(false);
+        )?.scrollIntoView();
         break;
       }
       case 'ArrowRight':

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -55,9 +55,6 @@ export class SlashMenu extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._disposableGroup.add(
-      Signal.disposableListener(window, 'keydown', this._escapeListener)
-    );
-    this._disposableGroup.add(
       Signal.disposableListener(window, 'mousedown', this._clickAwayListener)
     );
     this._disposableGroup.add(
@@ -109,11 +106,16 @@ export class SlashMenu extends LitElement {
    * The slash menu will be closed in the following keyboard cases:
    * - Press the space key
    * - Press the backspace key and the search string is empty
-   * - Press the escape key (handled by {@link _escapeListener})
+   * - Press the escape key
    * - When the search item is empty, the slash menu will be hidden temporarily,
    *   and if the following key is not the backspace key, the slash menu will be closed
    */
   private _keyDownListener = (e: KeyboardEvent) => {
+    if (e.key === '/') {
+      // Can not stopPropagation here,
+      // otherwise the rich text will not be able to trigger a new the slash menu
+      return;
+    }
     // This listener be bind to the window and the rich text element
     // So we need to ensure that the event is triggered once.
     // We also need to prevent the event from triggering the keyboard bindings action
@@ -128,7 +130,7 @@ export class SlashMenu extends LitElement {
       this._hide = false;
       return;
     }
-    if (e.key === ' ') {
+    if (e.key === ' ' || e.key === 'Escape') {
       this.abortController.abort();
       return;
     }
@@ -215,17 +217,6 @@ export class SlashMenu extends LitElement {
     }
     // prevent arrow key from moving cursor
     e.preventDefault();
-  };
-
-  /**
-   * Handle press esc
-   */
-  private _escapeListener = (e: KeyboardEvent) => {
-    if (e.key !== 'Escape') {
-      return;
-    }
-    this.abortController.abort();
-    window.removeEventListener('keyup', this._escapeListener);
   };
 
   private _getGroupIndexByItem(item: SlashItem) {

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -141,6 +141,9 @@ export class SlashMenu extends LitElement {
     const configLen = this._filterItems.length;
     switch (e.key) {
       case 'Enter': {
+        if (e.isComposing) {
+          return;
+        }
         this._handleItemClick(this._activeItemIndex);
         break;
       }

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -276,10 +276,13 @@ export class SlashMenu extends LitElement {
     ) {
       return;
     }
+    // Need to remove the search string
+    // We must to do clean the slash string before we do the action
+    // Otherwise, the action may change the model and cause the slash string to be changed
+    this.abortController.abort(this._searchString);
+
     const { action } = this._filterItems[index];
     action({ page: this.model.page, model: this.model });
-    // Need to remove the search string
-    this.abortController.abort(this._searchString);
   }
 
   private _handleClickCategory(group: { name: string; items: SlashItem[] }) {

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -174,9 +174,13 @@ export class SlashMenu extends LitElement {
         )?.scrollIntoView();
         break;
       }
-      case 'ArrowRight':
       case 'ArrowLeft':
-        this.abortController.abort();
+        this._activeItemIndex = -1;
+        return;
+      case 'ArrowRight':
+        if (this._activeItemIndex < 0) {
+          this._activeItemIndex = 0;
+        }
         return;
       default:
         throw new Error(`Unknown key: ${e.key}`);
@@ -197,6 +201,9 @@ export class SlashMenu extends LitElement {
   };
 
   private _handleItemClick(index: number) {
+    if (index < 0 || index >= this._filterItems.length) {
+      return;
+    }
     // Need to remove the search string
     this.abortController.abort(this._searchString);
     const { action } = this._filterItems[index];

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -108,6 +108,10 @@ export class SlashMenu extends LitElement {
    *   and if the following key is not the backspace key, the slash menu will be closed
    */
   private _keyDownListener = (e: KeyboardEvent) => {
+    // This listener be bind to the window and the rich text element
+    // So we need to ensure that the event is triggered once.
+    // We also need to prevent the event from triggering the keyboard bindings action
+    e.stopPropagation();
     if (this._hide) {
       if (e.key !== 'Backspace') {
         this.abortController.abort();
@@ -179,8 +183,6 @@ export class SlashMenu extends LitElement {
     }
     // prevent arrow key from moving cursor
     e.preventDefault();
-    // prevent the event from triggering the keyboard bindings action
-    e.stopPropagation();
   };
 
   /**

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -320,6 +320,7 @@ function getTextDelta(model: BaseBlockModel) {
   return model.text.toDelta();
 }
 
+// TODO merge with copy-cut-manager
 export async function copyBlock(model: BaseBlockModel) {
   const copyType = 'blocksuite/x-c+w';
   const delta = getTextDelta(model);
@@ -336,6 +337,7 @@ export async function copyBlock(model: BaseBlockModel) {
   };
   const copySuccess = performNativeCopy([
     { mimeType: copyType, data: JSON.stringify(copyData) },
+    { mimeType: 'text/plain', data: model.text?.toString() || '' },
   ]);
   return copySuccess;
 }

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -114,8 +114,8 @@ test.describe('slash menu should show and hide correctly', () => {
       throw new Error("slashMenu doesn't exist");
     }
     const { x, y } = box;
-    assertAlmostEqual(x, 122, 5);
-    assertAlmostEqual(y, 180, 5);
+    assertAlmostEqual(x, 122, 6);
+    assertAlmostEqual(y, 180, 6);
   });
 
   test('left arrow should active left panel', async () => {
@@ -142,7 +142,7 @@ test('should slash menu search and keyboard works', async ({ page }) => {
   await type(page, '/');
   await expect(slashMenu).toBeVisible();
   // Update the snapshot if you add new slash commands
-  await expect(slashItems).toHaveCount(25);
+  await expect(slashItems).toHaveCount(24);
   await type(page, 'todo');
   await expect(slashItems).toHaveCount(1);
   await expect(slashItems).toHaveText(['To-do List']);
@@ -170,11 +170,11 @@ test('should slash menu search and keyboard works', async ({ page }) => {
   await expect(slashItems.nth(1)).toHaveAttribute('hover', '');
 
   // search should reset the active item
-  await type(page, 'code');
+  await type(page, 'co');
   await expect(slashItems).toHaveCount(2);
-  await expect(slashItems).toHaveText(['Code Block', 'Code']);
+  await expect(slashItems).toHaveText(['Code Block', 'Copy']);
   await expect(slashItems.first()).toHaveAttribute('hover', '');
-  await type(page, 'b');
+  await type(page, 'p');
   await expect(slashItems).toHaveCount(1);
   // assert backspace works
   await page.keyboard.press('Backspace');

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -108,26 +108,27 @@ test.describe('slash menu should show and hide correctly', () => {
     await assertRichTexts(page, ['/']);
   });
 
-  test('left arrow should close the slash menu', async () => {
-    await page.keyboard.press('ArrowLeft');
-    await expect(slashMenu).not.toBeVisible();
-    await assertRichTexts(page, ['/']);
-  });
-
-  test('right arrow should close the slash menu', async () => {
-    await page.keyboard.press('ArrowRight');
-    await expect(slashMenu).not.toBeVisible();
-    await assertRichTexts(page, ['/']);
-  });
-
   test('should slash menu position correct', async () => {
     const box = await slashMenu.boundingBox();
     if (!box) {
       throw new Error("slashMenu doesn't exist");
     }
     const { x, y } = box;
-    assertAlmostEqual(x, 122, 10);
-    assertAlmostEqual(y, 180, 10);
+    assertAlmostEqual(x, 122, 5);
+    assertAlmostEqual(y, 180, 5);
+  });
+
+  test('left arrow should active left panel', async () => {
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowRight');
+    await expect(slashMenu).toBeVisible();
+
+    const slashItems = slashMenu.locator('format-bar-button');
+    const activatedItem = slashItems.nth(-3);
+    await expect(activatedItem).toHaveText(['Copy']);
+    await expect(activatedItem).toHaveAttribute('hover', '');
+    await assertRichTexts(page, ['/']);
   });
 });
 


### PR DESCRIPTION
Fix #1123 #1125 

- Add divider to slash menu
- Support uses ArrowLeft to select the category
- Filter Code/Link from slash menu
- Use disposable group