### PR TITLE
refactor: use keyboard event key instead of keyCode

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -39,20 +39,22 @@ interface BindingContext {
   event: KeyboardEvent;
 }
 
-type KeyboardBindings = Record<
-  string,
-  {
-    key: string | number;
-    handler: KeyboardBindingHandler;
-    prefix?: RegExp;
-    suffix?: RegExp;
-    shortKey?: boolean;
-    shiftKey?: boolean;
-    altKey?: boolean;
-    metaKey?: boolean;
-    ctrlKey?: boolean;
-  }
->;
+type KeyboardBinding = {
+  /**
+   * See https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+   */
+  key: number | string | string[];
+  handler: KeyboardBindingHandler;
+  prefix?: RegExp;
+  suffix?: RegExp;
+  shortKey?: boolean | null;
+  shiftKey?: boolean | null;
+  altKey?: boolean | null;
+  metaKey?: boolean | null;
+  ctrlKey?: boolean | null;
+};
+
+type KeyboardBindings = Record<string, KeyboardBinding>;
 
 interface KeyboardEventThis {
   quill: Quill;
@@ -231,7 +233,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     // See https://quilljs.com/docs/modules/keyboard/#configuration
     // The defaultOptions can found at https://github.com/quilljs/quill/blob/6159f6480482dde0530920dc41033ebc6611a9e7/modules/keyboard.ts#L334-L607
     'code exit': {
-      key: 'enter',
+      key: 'Enter',
       // override default quill behavior
       handler: () => ALLOW_DEFAULT,
     },
@@ -252,17 +254,17 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     },
 
     enterMarkdownMatch: {
-      key: 'enter',
+      key: 'Enter',
       handler: enterMarkdownMatch,
     },
     hardEnter: {
-      key: 'enter',
+      key: 'Enter',
       handler() {
         return hardEnter(this.quill);
       },
     },
     softEnter: {
-      key: 'enter',
+      key: 'Enter',
       shiftKey: true,
       handler() {
         return onSoftEnter(this.quill);
@@ -270,18 +272,18 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     },
     // shortKey+enter
     insertLineAfter: {
-      key: 'enter',
+      key: 'Enter',
       shortKey: true,
       handler() {
         return hardEnter(this.quill, true);
       },
     },
     tab: {
-      key: 'tab',
+      key: 'Tab',
       handler: onIndent,
     },
     shiftTab: {
-      key: 'tab',
+      key: 'Tab',
       shiftKey: true,
       handler: onUnindent,
     },
@@ -292,22 +294,16 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     // https://github.com/quilljs/quill/blob/v1.3.7/modules/keyboard.js#L249-L282
     'list autofill': {
       key: ' ',
-      shiftKey: false,
-      prefix: /^(\d+\.|-|\*|\[ ?\]|\[x\]|(#){1,6}|(-){3}|(\*){3}|>)$/,
-      handler: onSpace,
-    },
-    'list autofill shift': {
-      key: ' ',
-      shiftKey: true,
+      shiftKey: null,
       prefix: /^(\d+\.|-|\*|\[ ?\]|\[x\]|(#){1,6}|(-){3}|(\*){3}|>)$/,
       handler: onSpace,
     },
     backspace: {
-      key: 'backspace',
+      key: 'Backspace',
       handler: onBackspace,
     },
     up: {
-      key: 'up',
+      key: 'ArrowUp',
       shiftKey: false,
       handler(
         this: KeyboardEventThis,
@@ -318,7 +314,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
       },
     },
     down: {
-      key: 'down',
+      key: 'ArrowDown',
       shiftKey: false,
       handler(
         this: KeyboardEventThis,
@@ -329,19 +325,18 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
       },
     },
     left: {
-      key: 'left',
+      key: 'ArrowLeft',
       shiftKey: false,
       handler: onKeyLeft,
     },
     right: {
-      key: 'right',
+      key: 'ArrowRight',
       shiftKey: false,
       handler: onKeyRight,
     },
 
     slash: {
-      // Slash '/'
-      key: 191,
+      key: '/',
       // prefix non digit or empty string
       // see https://stackoverflow.com/questions/19127384/what-is-a-regex-to-match-only-an-empty-string
       // prefix: /[^\d]$|^(?![\s\S])/,

--- a/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
@@ -142,19 +142,22 @@ const SHORTKEY = /Mac/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
 
 // See https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/modules/keyboard.ts#L757-L774
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function normalize(binding: unknown): any {
+function normalize(binding: any): any {
   if (typeof binding === 'string' || typeof binding === 'number') {
     binding = { key: binding };
   } else if (typeof binding === 'object') {
     binding = { ...binding };
+
+    // Patch https://github.com/quilljs/quill/blob/0148738cb22d52808f35873adb620ca56b1ae061/modules/history.js#L20-L25
+    if (['Z', 'Y'].includes(binding.key)) {
+      binding.key = binding.key.toLowerCase();
+    }
+    // End patch
   } else {
     return null;
   }
-  // @ts-expect-error
   if (binding.shortKey) {
-    // @ts-expect-error
     binding[SHORTKEY] = binding.shortKey;
-    // @ts-expect-error
     delete binding.shortKey;
   }
   return binding;

--- a/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
@@ -4,10 +4,52 @@ import Quill from 'quill';
 const Keyboard = Quill.import('modules/keyboard');
 const TextBlot = Quill.import('blots/text');
 
-// Patch keyboard event to context for quill 1.3.7
-// See https://github.com/quilljs/quill/commit/90269c7af9fc03e46be257490b2b0aec85d9ecc7
-// Reference to https://github.com/quilljs/quill/blob/develop/modules/keyboard.ts
 export class KeyboardWithEvent extends Keyboard {
+  // Use `KeyboardEvent.key` instead of `KeyboardEvent.keyCode`
+  // See https://github.com/quilljs/quill/issues/1975
+  // See https://github.com/quilljs/quill/pull/1438
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static match(evt: KeyboardEvent, binding: any) {
+    if (
+      (['altKey', 'ctrlKey', 'metaKey', 'shiftKey'] as const).some(key => {
+        return !!binding[key] !== evt[key] && binding[key] !== null;
+      })
+    ) {
+      return false;
+    }
+    return binding.key === evt.key || binding.key === evt.which;
+  }
+
+  // See https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/modules/keyboard.ts
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addBinding(keyBinding: any, context: any, handler: any) {
+    const binding = normalize(keyBinding);
+    if (binding == null) {
+      console.warn('Attempted to add invalid keyboard binding', binding);
+      return;
+    }
+    if (typeof context === 'function') {
+      context = { handler: context };
+    }
+    if (typeof handler === 'function') {
+      handler = { handler };
+    }
+    const keys = Array.isArray(binding.key) ? binding.key : [binding.key];
+    keys.forEach((key: unknown) => {
+      const singleBinding = {
+        ...binding,
+        key,
+        ...context,
+        ...handler,
+      };
+      this.bindings[singleBinding.key] = this.bindings[singleBinding.key] || [];
+      this.bindings[singleBinding.key].push(singleBinding);
+    });
+  }
+
+  // Patch: add keyboard event to context for quill 1.3.7
+  // See https://github.com/quilljs/quill/commit/90269c7af9fc03e46be257490b2b0aec85d9ecc7
+  // Reference to https://github.com/quilljs/quill/blob/develop/modules/keyboard.ts
   listen() {
     this.quill.root.addEventListener('keydown', (evt: KeyboardEvent) => {
       if (evt.defaultPrevented || evt.isComposing) return;
@@ -15,7 +57,7 @@ export class KeyboardWithEvent extends Keyboard {
         this.bindings[evt.which] || []
       );
       const matches = bindings.filter((binding: unknown) =>
-        Keyboard.match(evt, binding)
+        KeyboardWithEvent.match(evt, binding)
       );
       if (matches.length === 0) return;
       // @ts-expect-error
@@ -94,4 +136,26 @@ export class KeyboardWithEvent extends Keyboard {
       }
     });
   }
+}
+
+const SHORTKEY = /Mac/i.test(navigator.platform) ? 'metaKey' : 'ctrlKey';
+
+// See https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/modules/keyboard.ts#L757-L774
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalize(binding: unknown): any {
+  if (typeof binding === 'string' || typeof binding === 'number') {
+    binding = { key: binding };
+  } else if (typeof binding === 'object') {
+    binding = { ...binding };
+  } else {
+    return null;
+  }
+  // @ts-expect-error
+  if (binding.shortKey) {
+    // @ts-expect-error
+    binding[SHORTKEY] = binding.shortKey;
+    // @ts-expect-error
+    delete binding.shortKey;
+  }
+  return binding;
 }

--- a/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/quill-keyboard.ts
@@ -1,3 +1,5 @@
+// This file should be sync with quill keyboard module between v1.3.7 and v2
+// PLEASE DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU ARE DOING
 import { isEqual } from '@blocksuite/global/utils';
 import Quill from 'quill';
 
@@ -20,6 +22,8 @@ export class KeyboardWithEvent extends Keyboard {
     return binding.key === evt.key || binding.key === evt.which;
   }
 
+  // Remove the legacy `normalize` function,
+  // Avoid the binding key to be normalized to keyCode
   // See https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/modules/keyboard.ts
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   addBinding(keyBinding: any, context: any, handler: any) {
@@ -148,6 +152,7 @@ function normalize(binding: any): any {
   } else if (typeof binding === 'object') {
     binding = { ...binding };
 
+    // XXX It will break keyboard bindings for 'Z' and 'Y'
     // Patch https://github.com/quilljs/quill/blob/0148738cb22d52808f35873adb620ca56b1ae061/modules/history.js#L20-L25
     if (['Z', 'Y'].includes(binding.key)) {
       binding.key = binding.key.toLowerCase();


### PR DESCRIPTION
Upstream of https://github.com/toeverything/blocksuite/pull/630

Workaround for https://github.com/quilljs/quill/issues/1975 in quill v1.3.7

