### PR TITLE
fix: focus temp element during copy

### DIFF
--- a/packages/editor/src/managers/clipboard/copy-cut-manager.ts
+++ b/packages/editor/src/managers/clipboard/copy-cut-manager.ts
@@ -225,6 +225,10 @@ export class CopyCutManager {
     const curRange = getCurrentRange();
 
     let success = false;
+    /**
+     * temp element is used to receive copy event dispatched by document.execCommand('copy'); In this way, we can
+     * get the clipboardData binding with system memory.
+     */
     const tempElem = document.createElement('textarea');
     document.body.appendChild(tempElem);
     // https://w3c.github.io/clipboard-apis/#to-fire-a-clipboard-event:~:text=Let%20target%20be,node%20has%20focus.

--- a/packages/editor/src/managers/clipboard/copy-cut-manager.ts
+++ b/packages/editor/src/managers/clipboard/copy-cut-manager.ts
@@ -22,15 +22,14 @@ export class CopyCutManager {
     this._editor = editor;
   }
 
-  /* FIXME
-          private get _selection() {
-            const page =
-              document.querySelector<DefaultPageBlockComponent>('default-page-block');
-            if (!page) throw new Error('No page block');
-            return page.selection;
-          }
-          */
-
+  /** FIXME
+   * private get _selection() {
+   *       const page =
+   *         document.querySelector<DefaultPageBlockComponent>('default-page-block');
+   *       if (!page) throw new Error('No page block');
+   *       return page.selection;
+   *     }
+   */
   public handleCopy = async (e: ClipboardEvent) => {
     const clips = await this._getClipItems();
     if (!clips.length) {
@@ -228,7 +227,8 @@ export class CopyCutManager {
     let success = false;
     const tempElem = document.createElement('textarea');
     document.body.appendChild(tempElem);
-
+    // https://w3c.github.io/clipboard-apis/#to-fire-a-clipboard-event:~:text=Let%20target%20be,node%20has%20focus.
+    tempElem.select();
     const listener = function (e: ClipboardEvent) {
       const clipboardData = e.clipboardData;
       if (clipboardData) {


### PR DESCRIPTION
Need to use `select()` to focus on the temp element, so that the copy event can fire on it, trigging corresponding event handler

Upstream PR: #1153