### PR TITLE
fix: fix cors fetch in chrome

### DIFF
--- a/packages/editor/src/managers/clipboard/content-parser/parse-html.ts
+++ b/packages/editor/src/managers/clipboard/content-parser/parse-html.ts
@@ -452,7 +452,12 @@ export class HtmlParser {
       const imgUrl = (element as HTMLImageElement).src;
       let resp;
       try {
-        resp = await fetch(imgUrl, { mode: 'cors' });
+        resp = await fetch(imgUrl, {
+          mode: 'cors',
+          headers: {
+            Origin: window.location.origin,
+          },
+        });
       } catch (error) {
         console.error(error);
         return result;


### PR DESCRIPTION
chrome's fetch not include Origin header by default