### PR TITLE
fix: disable shortcut "h" to shown/hidden dat.gui css debug menu

### DIFF
--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -249,7 +249,7 @@ export class DebugMenu extends NonShadowLitElement {
       this.canUndo = this.page.canUndo;
       this.canRedo = this.page.canRedo;
     });
-    this._styleMenu = new GUI();
+    this._styleMenu = new GUI({ hideable: false });
     this._styleMenu.width = 350;
     const style = document.documentElement.style;
     const sizeFolder = this._styleMenu.addFolder('Size');


### PR DESCRIPTION
close: #1227

reference: https://github.com/dataarts/dat.gui/blob/master/API.md#:~:text=If%20true%2C%20GUI,keypress.