### PR TITLE
fix: cannot locate insert position through dragging from block hub when page has very many blocks

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -683,6 +683,24 @@ export class BlockHub extends NonShadowLitElement {
       this._currentPageX = e.pageX;
       this._currentPageY = e.pageY;
     }
+
+    this._refreshCursor(e);
+  };
+
+  private _refreshCursor = (e: MouseEvent) => {
+    let x = e.pageX;
+    let y = e.pageY;
+    if (isFirefox) {
+      x = this._currentPageX;
+      y = this._currentPageY;
+    }
+    const blocks = this.getAllowedBlocks();
+    const modelState = getBlockEditingStateByPosition(blocks, x, y, {
+      skipX: true,
+    });
+    modelState
+      ? (this._cursor = modelState.index)
+      : (this._cursor = blocks.length - 1);
   };
 
   private _onDrag = (e: DragEvent) => {


### PR DESCRIPTION
# Before

https://user-images.githubusercontent.com/20554850/219600665-4fae13b1-5828-4561-b305-f1d9ff3a43d4.mov

# After

https://user-images.githubusercontent.com/20554850/219600680-ac7a1095-32b1-4529-9c78-89ed4450b771.mov


