### PR TITLE
fix: extra characters when paste

### DIFF
--- a/packages/store/src/text-adapter.ts
+++ b/packages/store/src/text-adapter.ts
@@ -184,6 +184,9 @@ export class Text {
    * @deprecated Use {@link insert} or {@link applyDelta} instead.
    */
   insertList(insertTexts: DeltaOperation[], index: number) {
+    if (!insertTexts.length) {
+      return;
+    }
     this._transact(() => {
       for (let i = insertTexts.length - 1; i >= 0; i--) {
         this._yText.insert(


### PR DESCRIPTION
The `insertList` alway marks `_yText` as `{ split: true }` even if not any update.

https://user-images.githubusercontent.com/18554747/219933347-f5b67471-f462-4c67-a3e5-0a7dba90b64c.mov

