### PR TITLE
refactor: add `text` prop in schema

### DIFF
--- a/packages/blocks/src/code-block/code-model.ts
+++ b/packages/blocks/src/code-block/code-model.ts
@@ -3,7 +3,8 @@ import { literal } from 'lit/static-html.js';
 
 export const CodeBlockModelSchema = defineBlockSchema(
   'affine:code',
-  () => ({
+  internal => ({
+    text: internal.Text(),
     language: 'JavaScript',
   }),
   {

--- a/packages/blocks/src/list-block/list-model.ts
+++ b/packages/blocks/src/list-block/list-model.ts
@@ -3,8 +3,9 @@ import { literal } from 'lit/static-html.js';
 
 export const ListBlockModelSchema = defineBlockSchema(
   'affine:list',
-  () => ({
+  internal => ({
     type: 'bulleted' as ListType,
+    text: internal.Text(),
     checked: false,
   }),
   {

--- a/packages/blocks/src/paragraph-block/paragraph-model.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-model.ts
@@ -3,8 +3,9 @@ import { literal } from 'lit/static-html.js';
 
 export const ParagraphBlockModelSchema = defineBlockSchema(
   'affine:paragraph',
-  () => ({
+  internal => ({
     type: 'text' as ParagraphType,
+    text: internal.Text(),
   }),
   {
     version: 1,

--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -7,7 +7,7 @@ import {
   SelectionUtils,
 } from '@blocksuite/blocks';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
-import type { BaseBlockModel } from '@blocksuite/store';
+import { BaseBlockModel, Text } from '@blocksuite/store';
 import type { DeltaOperation } from 'quill';
 
 import type { EditorContainer } from '../../components/index.js';
@@ -384,9 +384,14 @@ export class PasteManager {
       };
       const id = this._editor.page.addBlock(blockProps, parent, index + i);
       const model = this._editor.page.getBlockById(id);
-      if (model && !matchFlavours(model, ['affine:embed', 'affine:divider'])) {
+
+      const flavour = model?.flavour;
+      const initialProps =
+        flavour && this._editor.page.getInitialPropsMapByFlavour(flavour);
+      if (initialProps && initialProps.text instanceof Text) {
         block.text && model?.text?.applyDelta(block.text);
       }
+
       addBlockIds.push(id);
       model && this._addBlocks(block.children, model, 0, addBlockIds);
     }

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -2,7 +2,7 @@ import { Signal } from '@blocksuite/global/utils';
 import type * as Y from 'yjs';
 import { z } from 'zod';
 
-import type { Text } from './text-adapter.js';
+import { Text } from './text-adapter.js';
 import type { Page } from './workspace/index.js';
 
 const FlavourSchema = z.string();
@@ -11,14 +11,32 @@ const TagSchema = z.object({
   r: z.symbol(),
 });
 
+export interface InternalPrimitives {
+  Text: (input?: Y.Text | string) => Text;
+}
+
+export const internalPrimitives: InternalPrimitives = Object.freeze({
+  Text: (input: Y.Text | string = '') => new Text(input),
+});
+
 export const BlockSchema = z.object({
   version: z.number(),
   model: z.object({
     flavour: FlavourSchema,
     tag: TagSchema,
-    props: z.function().returns(z.record(z.any())),
+    props: z
+      .function()
+      .args(z.custom<InternalPrimitives>())
+      .returns(z.record(z.any())),
   }),
 });
+
+export type PropsSetter<Props extends Record<string, unknown>> = (
+  props: Props
+) => Partial<Props>;
+export type PropsGetter<Props extends Record<string, unknown>> = (
+  internalPrimitives: InternalPrimitives
+) => Props;
 
 // ported from lit
 interface StaticValue {
@@ -29,7 +47,7 @@ interface StaticValue {
 export type SchemaToModel<
   Schema extends {
     model: {
-      props: () => Record<string, unknown>;
+      props: PropsGetter<Record<string, unknown>>;
       flavour: string;
     };
   }
@@ -47,19 +65,19 @@ export function defineBlockSchema<
   }>
 >(
   flavour: Flavour,
-  props: () => Props,
+  props: (internalPrimitives: InternalPrimitives) => Props,
   metadata: Metadata
 ): {
   version: number;
   model: {
-    props: () => Props;
+    props: PropsGetter<Props>;
     flavour: Flavour;
   } & Metadata;
 };
 
 export function defineBlockSchema(
   flavour: string,
-  props: () => Record<string, unknown>,
+  props: (internalPrimitives: InternalPrimitives) => Record<string, unknown>,
   metadata: {
     version: number;
     tag: StaticValue;

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -1,8 +1,9 @@
 import { isPrimitive, matchFlavours, SYS_KEYS } from '@blocksuite/global/utils';
 import { fromBase64, toBase64 } from 'lib0/buffer.js';
 import * as Y from 'yjs';
+import type { z } from 'zod';
 
-import type { BaseBlockModel } from '../base.js';
+import { BaseBlockModel, BlockSchema, internalPrimitives } from '../base.js';
 import { Text } from '../text-adapter.js';
 import type { Workspace } from '../workspace/index.js';
 import type {
@@ -42,18 +43,18 @@ export function initInternalProps(yBlock: YBlock, props: Partial<BlockProps>) {
 }
 
 export function syncBlockProps(
-  // schema: z.infer<typeof BlockSchema>,
+  schema: z.infer<typeof BlockSchema>,
   defaultProps: Record<string, unknown>,
   yBlock: YBlock,
   props: Partial<BlockProps>,
   ignoredKeys: Set<string>
 ) {
-  Object.keys(props).forEach(key => {
+  const propSchema = schema.model.props(internalPrimitives);
+  Object.entries(props).forEach(([key, value]) => {
     if (SYS_KEYS.has(key) || ignoredKeys.has(key)) return;
-    const value = props[key];
 
-    // TODO use schema
-    if (key === 'text' && value instanceof Text) {
+    const isText = propSchema[key] instanceof Text;
+    if (isText) {
       yBlock.set(`prop:${key}`, value.yText);
       return;
     }
@@ -73,7 +74,9 @@ export function syncBlockProps(
   // set default value
   Object.entries(defaultProps).forEach(([key, value]) => {
     if (!yBlock.has(`prop:${key}`)) {
-      if (Array.isArray(value)) {
+      if (value instanceof Text) {
+        yBlock.set(`prop:${key}`, new Y.Text());
+      } else if (Array.isArray(value)) {
         yBlock.set(`prop:${key}`, Y.Array.from(value));
       } else {
         yBlock.set(`prop:${key}`, value);

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -1,12 +1,12 @@
 import type { BlockTag, TagSchema } from '@blocksuite/global/database';
 import { debug } from '@blocksuite/global/debug';
-import { assertExists, matchFlavours, Signal } from '@blocksuite/global/utils';
+import { assertExists, Signal } from '@blocksuite/global/utils';
 import { uuidv4 } from 'lib0/random.js';
 import type { Quill } from 'quill';
 import * as Y from 'yjs';
 
 import type { AwarenessStore } from '../awareness.js';
-import { BaseBlockModel } from '../base.js';
+import { BaseBlockModel, internalPrimitives } from '../base.js';
 import { Space, StackItem } from '../space.js';
 import { RichTextAdapter, Text } from '../text-adapter.js';
 import type { IdGenerator } from '../utils/id-generator.js';
@@ -317,6 +317,14 @@ export class Page extends Space<PageData> {
     return parent.children.slice(index + 1);
   }
 
+  getSchemaByFlavour(flavour: string) {
+    return this.workspace.flavourSchemaMap.get(flavour);
+  }
+
+  getInitialPropsMapByFlavour(flavour: string) {
+    return this.workspace.flavourInitialPropsMap.get(flavour);
+  }
+
   @debug('CRUD')
   public addBlocksByFlavour<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -388,7 +396,15 @@ export class Page extends Space<PageData> {
       initInternalProps(yBlock, clonedProps);
       const defaultProps = this.workspace.flavourInitialPropsMap.get(flavour);
       assertExists(defaultProps);
-      syncBlockProps(defaultProps, yBlock, clonedProps, this._ignoredKeys);
+      const schema = this.getSchemaByFlavour(flavour);
+      assertExists(schema);
+      syncBlockProps(
+        schema,
+        defaultProps,
+        yBlock,
+        clonedProps,
+        this._ignoredKeys
+      );
 
       if (typeof parent === 'string') {
         parent = this._blockMap.get(parent);
@@ -492,7 +508,9 @@ export class Page extends Space<PageData> {
         model.flavour
       );
       assertExists(defaultProps);
-      syncBlockProps(defaultProps, yBlock, props, this._ignoredKeys);
+      const schema = this.workspace.flavourSchemaMap.get(model.flavour);
+      assertExists(schema);
+      syncBlockProps(schema, defaultProps, yBlock, props, this._ignoredKeys);
     });
   }
 
@@ -721,7 +739,7 @@ export class Page extends Space<PageData> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     blockModel.flavour = schema.model.flavour as any;
     blockModel.tag = schema.model.tag;
-    const modelProps = schema.model.props();
+    const modelProps = schema.model.props(internalPrimitives);
     Object.entries(modelProps).forEach(([key, value]) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (blockModel as any)[key] = props[key] ?? value;
@@ -744,20 +762,17 @@ export class Page extends Space<PageData> {
     }
     this._blockMap.set(props.id, model);
 
-    if (
-      // TODO use schema
-      matchFlavours(model, [
-        'affine:paragraph',
-        'affine:list',
-        'affine:code',
-      ]) &&
-      !yBlock.get('prop:text')
-    ) {
-      this.transact(() => yBlock.set('prop:text', new Y.Text()));
-    }
+    const initialProps = this.workspace.flavourInitialPropsMap.get(
+      model.flavour
+    );
+    assertExists(initialProps);
+    Object.entries(initialProps).forEach(([key, value]) => {
+      if (value instanceof Text) {
+        const yText = yBlock.get(`prop:${key}`) as Y.Text;
+        Object.assign(model, { [key]: new Text(yText) });
+      }
+    });
 
-    const yText = yBlock.get('prop:text') as Y.Text;
-    model.text = new Text(yText);
     if (model.flavour === 'affine:page') {
       model.tags = yBlock.get('meta:tags') as Y.Map<Y.Map<unknown>>;
       model.tagSchema = yBlock.get('meta:tagSchema') as Y.Map<unknown>;

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -3,7 +3,7 @@ import * as Y from 'yjs';
 import type { z } from 'zod';
 
 import { AwarenessStore, BlobUploadState } from '../awareness.js';
-import { BlockSchema } from '../base.js';
+import { BlockSchema, internalPrimitives } from '../base.js';
 import {
   BlobOptionsGetter,
   BlobStorage,
@@ -326,7 +326,7 @@ export class Workspace {
       this.flavourSchemaMap.set(schema.model.flavour, schema);
       this.flavourInitialPropsMap.set(
         schema.model.flavour,
-        schema.model.props()
+        schema.model.props(internalPrimitives)
       );
     });
     return this;


### PR DESCRIPTION
Add `text` prop in schema to avoid hardcode validation for `prop:text`.
We can use that to decide whether a block has text content now.

This PR is based on https://github.com/toeverything/blocksuite/pull/945 by @Himself65 ❤️ .