### PR TITLE
fix: sub selected blocks should not be drawn when pressing tab key

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -52,3 +52,4 @@ Example:
 - zqran, @zqran, 2023/02/17
 - shengxinjing, @shengxinjing, 2023/02/20
 - qinluhe, @qinluhe, 2023/02/21
+- PerfectPan, @PerfectPan, 2023/02/22

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -258,8 +258,8 @@ function handleTab(page: Page, selection: DefaultSelectionManager) {
           return;
         }
         selection.state.type = 'block';
-        selection.state.refreshBlockRectCache();
-        selection.setSelectedBlocks(selectBlocks);
+        selection.state.selectedBlocks = selectBlocks;
+        selection.refreshSelectedBlocksRects();
       });
       selection.clear();
       break;


### PR DESCRIPTION

https://user-images.githubusercontent.com/24316656/220421819-ac69eacb-1807-4d46-ac10-903658e4c0e4.mp4

try to fix the above problem, the subtree's blocks are also drawn rects, which is a wrong behavior.

