### PR TITLE
fix: text overflow when font-family fallback fails until "Hiragino Sans GB"

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -213,6 +213,7 @@ export class BlockHub extends NonShadowLitElement {
       font-size: var(--affine-font-sm);
       line-height: var(--affine-line-height);
       color: var(--affine-secondary-text-color);
+      white-space: pre;
     }
 
     .card-container:hover.grabbing {


### PR DESCRIPTION
close https://github.com/toeverything/blocksuite/issues/1298