### PR TITLE
feat(blocks): drag & drop multiple blocks

### DIFF
--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -10,6 +10,15 @@ import { getCurrentRange } from './selection.js';
 
 type ElementTagName = keyof HTMLElementTagNameMap;
 
+export type BlockComponentElement =
+  HTMLElementTagNameMap[keyof HTMLElementTagNameMap] extends infer U
+    ? U extends { model: infer M }
+      ? M extends BaseBlockModel
+        ? U
+        : never
+      : never
+    : never;
+
 interface ContainerBlock {
   model?: BaseBlockModel;
 }
@@ -18,10 +27,14 @@ export function getBlockById<T extends ElementTagName>(
   id: string,
   container: Element = document.body
 ) {
-  return container.querySelector<T>(`[${ATTR}="${id}"]` as T);
+  return container.querySelector<T>(
+    `[${ATTR}="${id}"]` as T
+  ) as BlockComponentElement | null;
 }
 
-export function getBlockByPoint(point: IPoint): Element | null | undefined {
+export function getBlockByPoint(
+  point: IPoint
+): BlockComponentElement | null | undefined {
   return document.elementFromPoint(point.x, point.y)?.closest(`[${ATTR}]`);
 }
 
@@ -32,8 +45,12 @@ export function getParentBlockById<T extends ElementTagName>(
   id: string,
   ele: Element = document.body
 ) {
-  const currentBlock = getBlockById<T>(id, ele);
-  return currentBlock?.parentElement?.closest<T>(`[${ATTR}]` as T) || null;
+  const currentBlock = getBlockById(id, ele);
+  return (
+    (currentBlock?.parentElement?.closest<T>(
+      `[${ATTR}]` as T
+    ) as BlockComponentElement) || null
+  );
 }
 
 /**
@@ -150,7 +167,9 @@ export function getContainerByModel(model: BaseBlockModel) {
   return container;
 }
 
-export function getBlockElementByModel(model: BaseBlockModel) {
+export function getBlockElementByModel(
+  model: BaseBlockModel
+): BlockComponentElement | null {
   assertExists(model.page.root);
   const page = document.querySelector(
     `[${ATTR}="${model.page.root.id}"]`
@@ -158,11 +177,11 @@ export function getBlockElementByModel(model: BaseBlockModel) {
   if (!page) return null;
 
   if (model.id === model.page.root.id) {
-    return page as HTMLElement;
+    return page;
   }
 
   const element = page.querySelector(`[${ATTR}="${model.id}"]`);
-  return element as HTMLElement | null;
+  return element as BlockComponentElement | null;
 }
 
 export function getStartModelBySelection() {
@@ -364,7 +383,9 @@ export function getTextNodeBySelectedBlock(model: BaseBlockModel, offset = 0) {
 }
 
 export function getAllBlocks() {
-  const blocks = Array.from(document.querySelectorAll(`[${ATTR}]`));
+  const blocks: BlockComponentElement[] = Array.from(
+    document.querySelectorAll(`[${ATTR}]`)
+  );
   return blocks.filter(item => {
     return (
       item.tagName !== 'AFFINE-DEFAULT-PAGE' && item.tagName !== 'AFFINE-FRAME'

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -12,6 +12,7 @@ import type { RichText } from '../rich-text/rich-text.js';
 import { asyncFocusRichText } from './common-operations.js';
 import type { IPoint, SelectionEvent } from './gesture.js';
 import {
+  BlockComponentElement,
   getBlockElementByModel,
   getDefaultPageBlock,
   getElementFromEventTarget,
@@ -172,7 +173,9 @@ export function focusBlockByModel(
     if (matchFlavours(model, ['affine:database'])) {
       const elements = model.children
         .map(child => getBlockElementByModel(child))
-        .filter((element): element is HTMLElement => element !== null);
+        .filter(
+          (element): element is BlockComponentElement => element !== null
+        );
       defaultPageBlock.selection.state.selectedBlocks.push(...elements);
     }
     defaultPageBlock.selection.state.type = 'block';

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -942,7 +942,7 @@ export function restoreSelection(blockRange: BlockRange) {
   defaultPageBlock.selection.state.type = 'block';
   defaultPageBlock.selection.state.selectedBlocks = models
     .map(model => getBlockElementByModel(model))
-    .filter(Boolean) as Element[];
+    .filter(Boolean) as BlockComponentElement[];
   defaultPageBlock.selection.refreshSelectedBlocksRects();
   // Try clean native selection
   resetNativeSelection(null);

--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -1,4 +1,3 @@
-import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
 import { assertExists, isFirefox } from '@blocksuite/global/utils';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { css, html, LitElement, svg } from 'lit';
@@ -118,7 +117,7 @@ export class DragHandle extends LitElement {
     container: HTMLElement;
     onDropCallback: (
       e: DragEvent,
-      dragged: EditingState,
+      dragged: BlockComponentElement[],
       lastModelState: EditingState
     ) => void;
     getBlockEditingStateByPosition: DragHandleGetModelStateCallback;
@@ -157,7 +156,7 @@ export class DragHandle extends LitElement {
   @property()
   public onDropCallback: (
     e: DragEvent,
-    startModelState: EditingState,
+    draggingBlockElements: BlockComponentElement[],
     lastModelState: EditingState
   ) => void;
 
@@ -460,9 +459,9 @@ export class DragHandle extends LitElement {
       // may drop to the same block position
       return;
     }
-    assertExists(this._startModelState);
+    assertExists(this._draggingElements);
 
-    this.onDropCallback?.(e, this._startModelState, this._lastModelState);
+    this.onDropCallback?.(e, this._draggingElements, this._lastModelState);
 
     this.hide();
   };

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -410,9 +410,13 @@ export class DefaultPageBlockComponent
           );
         }
 
-        return getAllowSelectedBlocks(this.model).filter(block => {
-          return !draggingBlockIds?.includes(block.id);
-        });
+        if (!draggingBlockIds || draggingBlockIds.length === 1) {
+          return getAllowSelectedBlocks(this.model);
+        } else {
+          return getAllowSelectedBlocks(this.model).filter(block => {
+            return !draggingBlockIds?.includes(block.id);
+          });
+        }
       };
     };
     if (

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -103,8 +103,6 @@ export class DefaultPageBlockComponent
       cursor: default;
 
       min-height: calc(100% - 78px);
-      height: auto;
-      overflow: hidden;
       padding-bottom: 150px;
     }
 

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -395,20 +395,24 @@ export class DefaultPageBlockComponent
   private _initDragHandle = () => {
     const createHandle = () => {
       this.components.dragHandle = createDragHandle(this);
-      this.components.dragHandle.getDropAllowedBlocks = draggingBlock => {
+      this.components.dragHandle.getDropAllowedBlocks = draggingBlockIds => {
         if (
-          draggingBlock &&
+          draggingBlockIds &&
+          draggingBlockIds.length === 1 &&
           Utils.doesInsideBlockByFlavour(
             this.page,
-            draggingBlock,
+            draggingBlockIds[0],
             'affine:database'
           )
         ) {
           return getAllowSelectedBlocks(
-            this.page.getParent(draggingBlock) as BaseBlockModel
+            this.page.getParent(draggingBlockIds[0]) as BaseBlockModel
           );
         }
-        return getAllowSelectedBlocks(this.model);
+
+        return getAllowSelectedBlocks(this.model).filter(block => {
+          return !draggingBlockIds?.includes(block.id);
+        });
       };
     };
     if (

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -10,6 +10,7 @@ import type { Page } from '@blocksuite/store';
 import { BaseBlockModel, DisposableGroup } from '@blocksuite/store';
 
 import {
+  BlockComponentElement,
   getAllBlocks,
   getBlockElementByModel,
   getCurrentRange,
@@ -86,13 +87,13 @@ function contains(bound: DOMRect, a: DOMRect, offset: IPoint) {
 //
 // TODO: checks the parent by `contains` method
 function filterSelectedBlockWithoutSubtree(
-  blockCache: Map<Element, DOMRect>,
+  blockCache: Map<BlockComponentElement, DOMRect>,
   selectionRect: DOMRect,
   offset: IPoint
 ) {
   const entries = Array.from(blockCache.entries());
   const len = entries.length;
-  const results: { block: Element; index: number }[] = [];
+  const results: { block: BlockComponentElement; index: number }[] = [];
 
   // empty
   if (len === 0) return results;
@@ -143,14 +144,14 @@ function filterSelectedBlockWithoutSubtree(
 // Find the current focused block and its substree.
 // The `selectionRect` is a rect of block element.
 function filterSelectedBlockByIndex(
-  blockCache: Map<Element, DOMRect>,
+  blockCache: Map<BlockComponentElement, DOMRect>,
   focusedBlockIndex: number,
   selectionRect: DOMRect,
   offset: IPoint = {
     x: 0,
     y: 0,
   }
-): Element[] {
+): BlockComponentElement[] {
   // SELECT_ALL
   if (focusedBlockIndex === -1) {
     return Array.from(blockCache.keys());
@@ -189,7 +190,7 @@ function filterSelectedBlockByIndex(
 }
 
 // clear subtree in block for drawing rect
-function clearSubtree(selectedBlocks: Element[], left: number) {
+function clearSubtree(selectedBlocks: BlockComponentElement[], left: number) {
   return selectedBlocks.filter((block, index) => {
     if (index === 0) return true;
     const currentLeft = block.getBoundingClientRect().left;
@@ -206,8 +207,11 @@ function clearSubtree(selectedBlocks: Element[], left: number) {
 
 // find blocks and its subtree
 function findBlocksWithSubtree(
-  blockCache: Map<Element, DOMRect>,
-  selectedBlocksWithoutSubtree: { block: Element; index: number }[] = []
+  blockCache: Map<BlockComponentElement, DOMRect>,
+  selectedBlocksWithoutSubtree: {
+    block: BlockComponentElement;
+    index: number;
+  }[] = []
 ) {
   const results = [];
   const len = selectedBlocksWithoutSubtree.length;
@@ -255,7 +259,7 @@ type PageSelectionType = 'native' | 'block' | 'none' | 'embed' | 'database';
 export class PageSelectionState {
   type: PageSelectionType;
   selectedEmbeds: EmbedBlockComponent[] = [];
-  selectedBlocks: Element[] = [];
+  selectedBlocks: BlockComponentElement[] = [];
   // -1: SELECT_ALL
   // >=0: only current focused-block
   focusedBlockIndex = -1;
@@ -265,9 +269,9 @@ export class PageSelectionState {
   private _startPoint: { x: number; y: number } | null = null;
   private _endPoint: { x: number; y: number } | null = null;
   private _richTextCache = new Map<RichText, DOMRect>();
-  private _blockCache = new Map<Element, DOMRect>();
+  private _blockCache = new Map<BlockComponentElement, DOMRect>();
   private _embedCache = new Map<EmbedBlockComponent, DOMRect>();
-  private _activeComponent: HTMLElement | null = null;
+  private _activeComponent: BlockComponentElement | null = null;
 
   constructor(type: PageSelectionType) {
     this.type = type;
@@ -277,7 +281,7 @@ export class PageSelectionState {
     return this._activeComponent;
   }
 
-  set activeComponent(component: HTMLElement | null) {
+  set activeComponent(component: BlockComponentElement | null) {
     this._activeComponent = component;
   }
 
@@ -481,7 +485,7 @@ export class DefaultSelectionManager {
   }
 
   setSelectedBlocks(
-    selectedBlocks: Element[],
+    selectedBlocks: BlockComponentElement[],
     rects?: DOMRect[],
     selectionType?: PageSelectionType
   ) {
@@ -882,7 +886,7 @@ export class DefaultSelectionManager {
   }
 
   selecting(
-    blockCache: Map<Element, DOMRect>,
+    blockCache: Map<BlockComponentElement, DOMRect>,
     selectionRect: DOMRect,
     viewportState: ViewportState
   ) {
@@ -996,7 +1000,7 @@ export class DefaultSelectionManager {
 
   // Click on the prefix icon of list block
   resetSelectedBlockByRect(
-    blockElement: Element,
+    blockElement: BlockComponentElement,
     pageSelectionType: PageSelectionType = 'block'
   ) {
     this.setFocusedBlockIndexByElement(blockElement);

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -464,7 +464,7 @@ export function getAllowSelectedBlocks(
 export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
   return new DragHandle({
     // drag handle should be the same level with editor-container
-    container: defaultPageBlock.mouseRoot.parentElement as HTMLElement,
+    container: defaultPageBlock.mouseRoot as HTMLElement,
     getBlockEditingStateByCursor(
       blocks,
       pageX,

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -508,7 +508,6 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
       defaultPageBlock.signals.updateEmbedEditingState.emit(null);
       defaultPageBlock.signals.updateEmbedRects.emit([]);
 
-      // ??? is there a better way?
       requestAnimationFrame(() => {
         // update selection rects
         defaultPageBlock.selection.setSelectedBlocks(blocks);

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -485,22 +485,35 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
         skipX,
       });
     },
-    onDropCallback(e, start, end): void {
+    onDropCallback(e, blocks, end): void {
       const page = defaultPageBlock.page;
-      const startModel = start.model;
+      const firstDraggingModel = blocks[0].model;
       const rect = end.position;
-      const nextModel = end.model;
-      if (doesInSamePath(page, nextModel, startModel)) {
+      const targetModel = end.model;
+      if (
+        blocks.length === 1 &&
+        doesInSamePath(page, targetModel, firstDraggingModel)
+      ) {
         return;
       }
       page.captureSync();
       const distanceToTop = Math.abs(rect.top - e.y);
       const distanceToBottom = Math.abs(rect.bottom - e.y);
-      page.moveBlock(startModel, nextModel, distanceToTop < distanceToBottom);
+      page.moveBlocks(
+        blocks.map(b => b.model),
+        targetModel,
+        distanceToTop < distanceToBottom
+      );
       defaultPageBlock.signals.updateSelectedRects.emit([]);
       defaultPageBlock.signals.updateFrameSelectionRect.emit(null);
       defaultPageBlock.signals.updateEmbedEditingState.emit(null);
       defaultPageBlock.signals.updateEmbedRects.emit([]);
+
+      // ??? is there a better way?
+      setTimeout(() => {
+        // update selection rects
+        defaultPageBlock.selection.setSelectedBlocks(blocks);
+      });
     },
     setSelectedBlocks(
       selectedBlocks: EditingState | BlockComponentElement[] | null

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -487,12 +487,11 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
     },
     onDropCallback(e, blocks, end): void {
       const page = defaultPageBlock.page;
-      const firstDraggingModel = blocks[0].model;
       const rect = end.position;
       const targetModel = end.model;
       if (
         blocks.length === 1 &&
-        doesInSamePath(page, targetModel, firstDraggingModel)
+        doesInSamePath(page, targetModel, blocks[0].model)
       ) {
         return;
       }
@@ -510,7 +509,7 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
       defaultPageBlock.signals.updateEmbedRects.emit([]);
 
       // ??? is there a better way?
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         // update selection rects
         defaultPageBlock.selection.setSelectedBlocks(blocks);
       });

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -510,7 +510,12 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
 
       requestAnimationFrame(() => {
         // update selection rects
-        defaultPageBlock.selection.setSelectedBlocks(blocks);
+        // block may change its flavour after moved.
+        defaultPageBlock.selection.setSelectedBlocks(
+          blocks
+            .map(b => getBlockById(b.model.id))
+            .filter((b): b is BlockComponentElement => !!b)
+        );
       });
     },
     setSelectedBlocks(

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -8,6 +8,7 @@ import type { BaseBlockModel } from '@blocksuite/store';
 
 import { getService } from '../../__internal__/service.js';
 import {
+  BlockComponentElement,
   doesInSamePath,
   getBlockById,
   getBlockElementByModel,
@@ -28,6 +29,7 @@ export interface EditingState {
   model: BaseBlockModel;
   position: DOMRect;
   index: number;
+  element: BlockComponentElement;
 }
 
 function hasOptionBar(block: BaseBlockModel) {
@@ -196,6 +198,7 @@ function binarySearchBlockEditingState(
                 index: mid,
                 position: result.blockRect,
                 model: result.block,
+                element: result.hoverDom,
               };
             }
           }
@@ -211,6 +214,7 @@ function binarySearchBlockEditingState(
         index: mid,
         position: blockRect,
         model: block,
+        element: hoverDom,
       };
     }
 
@@ -498,14 +502,21 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
       defaultPageBlock.signals.updateEmbedEditingState.emit(null);
       defaultPageBlock.signals.updateEmbedRects.emit([]);
     },
-    setSelectedBlocks(selectedBlocks: EditingState | null): void {
-      if (selectedBlocks) {
+    setSelectedBlocks(
+      selectedBlocks: EditingState | BlockComponentElement[] | null
+    ): void {
+      if (Array.isArray(selectedBlocks)) {
+        defaultPageBlock.selection.setSelectedBlocks(selectedBlocks);
+      } else if (selectedBlocks) {
         const { position, index } = selectedBlocks;
         defaultPageBlock.selection.selectBlocksByIndexAndBounding(
           index,
           position
         );
       }
+    },
+    getSelectedBlocks() {
+      return defaultPageBlock.selection.state.selectedBlocks;
     },
   });
 }

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -11,6 +11,7 @@ import { handleMultiBlockIndent } from '../../__internal__/rich-text/rich-text-o
 import { isAtLineEdge } from '../../__internal__/utils/check-line.js';
 import {
   asyncFocusRichText,
+  BlockComponentElement,
   focusNextBlock,
   focusPreviousBlock,
   focusTitle,
@@ -247,7 +248,7 @@ function handleTab(page: Page, selection: DefaultSelectionManager) {
         // get fresh elements
         selection.state.selectedBlocks = models
           .map(model => getBlockElementByModel(model))
-          .filter(block => block !== null) as Element[];
+          .filter(block => block !== null) as BlockComponentElement[];
         selection.refreshSelectedBlocksRects();
       });
       selection.clear();

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -209,7 +209,9 @@ export class EditorContainer extends NonShadowLitElement {
 
     return html`
       <style>
+        editor-container,
         .affine-editor-container {
+          display: block;
           height: 100%;
           position: relative;
           overflow-y: auto;

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -93,6 +93,9 @@ export class DebugMenu extends NonShadowLitElement {
   @state()
   readonly = false;
 
+  @state()
+  hasOffset = false;
+
   @query('#block-type-dropdown')
   blockTypeDropdown!: SlDropdown;
 
@@ -179,6 +182,10 @@ export class DebugMenu extends NonShadowLitElement {
   private _switchEditorMode() {
     const mode = this.editor.mode === 'page' ? 'edgeless' : 'page';
     this.mode = mode;
+  }
+
+  private _switchOffsetMode() {
+    this.hasOffset = !this.hasOffset;
   }
 
   private _addFrame() {
@@ -289,6 +296,9 @@ export class DebugMenu extends NonShadowLitElement {
       window.dispatchEvent(
         createEvent('affine:switch-edgeless-display-mode', this.showGrid)
       );
+    }
+    if (changedProperties.has('hasOffset')) {
+      document.body.style.margin = this.hasOffset ? '60px 0 0 40px' : '0';
     }
     super.update(changedProperties);
   }
@@ -469,6 +479,16 @@ export class DebugMenu extends NonShadowLitElement {
               @click=${this._switchEditorMode}
             >
               <sl-icon name="phone-flip"></sl-icon>
+            </sl-button>
+          </sl-tooltip>
+
+          <sl-tooltip content="Add container offset" placement="bottom" hoist>
+            <sl-button
+              size="small"
+              content="Add container offset"
+              @click=${this._switchOffsetMode}
+            >
+              <sl-icon name="aspect-ratio"></sl-icon>
             </sl-button>
           </sl-tooltip>
         </div>

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -119,7 +119,7 @@ export function applyYjsUpdateV2(workspace: Workspace, update: string): void {
 
 export function doesInsideBlockByFlavour(
   page: Page,
-  block: BaseBlockModel,
+  block: BaseBlockModel | string,
   flavour: keyof BlockSuiteInternal.BlockModels
 ): boolean {
   const parent = page.getParent(block);

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -462,30 +462,45 @@ export class Page extends Space<PageData> {
   }
 
   @debug('CRUD')
-  moveBlock(model: BaseBlockModel, targetModel: BaseBlockModel, top = true) {
+  moveBlocks(
+    blocks: BaseBlockModel[],
+    targetModel: BaseBlockModel,
+    top = true
+  ) {
     if (this.awarenessStore.isReadonly(this)) {
       console.error('cannot modify data in readonly mode');
       return;
     }
-    const currentParentModel = this.getParent(model);
+
+    const firstBlock = blocks[0];
+    const currentParentModel = this.getParent(firstBlock);
+
+    // the blocks must have the same parent (siblings)
+    if (blocks.some(block => this.getParent(block) !== currentParentModel)) {
+      console.error('the blocks must have the same parent');
+    }
+
     const nextParentModel = this.getParent(targetModel);
     if (currentParentModel === null || nextParentModel === null) {
       throw new Error('cannot find parent model');
     }
+
     this.transact(() => {
       const yParentA = this._yBlocks.get(currentParentModel.id) as YBlock;
       const yChildrenA = yParentA.get('sys:children') as Y.Array<string>;
-      const idx = yChildrenA.toArray().findIndex(id => id === model.id);
-      yChildrenA.delete(idx);
+      const idx = yChildrenA.toArray().findIndex(id => id === firstBlock.id);
+      yChildrenA.delete(idx, blocks.length);
       const yParentB = this._yBlocks.get(nextParentModel.id) as YBlock;
       const yChildrenB = yParentB.get('sys:children') as Y.Array<string>;
       const nextIdx = yChildrenB
         .toArray()
         .findIndex(id => id === targetModel.id);
+
+      const ids = blocks.map(block => block.id);
       if (top) {
-        yChildrenB.insert(nextIdx, [model.id]);
+        yChildrenB.insert(nextIdx, ids);
       } else {
-        yChildrenB.insert(nextIdx + 1, [model.id]);
+        yChildrenB.insert(nextIdx + 1, ids);
       }
     });
     currentParentModel.propsUpdated.emit();

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -244,14 +244,18 @@ export class Page extends Space<PageData> {
     );
   }
 
-  getParentById(rootId: string, target: BaseBlockModel): BaseBlockModel | null {
-    if (rootId === target.id) return null;
+  getParentById(
+    rootId: string,
+    target: BaseBlockModel | string
+  ): BaseBlockModel | null {
+    const targetId = typeof target === 'string' ? target : target.id;
+    if (rootId === targetId) return null;
 
     const root = this._blockMap.get(rootId);
     if (!root) return null;
 
     for (const [childId] of root.childMap) {
-      if (childId === target.id) return root;
+      if (childId === targetId) return root;
 
       const parent = this.getParentById(childId, target);
       if (parent !== null) return parent;
@@ -259,7 +263,7 @@ export class Page extends Space<PageData> {
     return null;
   }
 
-  getParent(block: BaseBlockModel) {
+  getParent(block: BaseBlockModel | string) {
     if (!this.root) return null;
 
     return this.getParentById(this.root.id, block);

--- a/tests/utils/actions/drag.ts
+++ b/tests/utils/actions/drag.ts
@@ -124,10 +124,6 @@ export async function dragHandleFromBlockToBlockBottomById(
   if (!handle) {
     throw new Error();
   }
-  await page.mouse.click(
-    handle.x + handle.width / 2,
-    handle.y + handle.height / 2
-  );
   await page.mouse.move(
     handle.x + handle.width / 2,
     handle.y + handle.height / 2


### PR DESCRIPTION
- [x] fix [dnd continuous blocks to another block](https://github.com/toeverything/blocksuite/issues/1324) (top/bottom). The dropped blocks will be selected after that
- [x] improve types
- [x] tests
- [x] fix handle offset https://github.com/toeverything/blocksuite/issues/1352
- [x] playground offset switch button to test blocksuite editor with offset 

### The handle offset issue
Root cause: the handle was be attached to the parent of `<editor-container />`. However, unless we wrap `<editor-container />` into a relative container without padding, there will be offset issue for handles.
The solution in this pr moves the handle as a child of `<editor-container />` and make `<editor-container />` a relative container. As a result, there are some event issues this time, mainly `mousedown` & `mousemove` events conflicts defined in `initMouseEventHandlers`. Solution here is to stop event propagation in `dragHandle` event handlers accordingly. 

https://user-images.githubusercontent.com/584378/220875092-640c9f75-cc23-46a9-9778-8c53ef116e47.mp4

