### PR TITLE
ci: add build command & OS dependencies options

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -42,9 +42,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      
+      - name: Build Playground
+        run: pnpm run build:playground
 
       - name: Install playwright browsers
-        run: npx playwright install ${{ matrix.browsers }}
+        run: npx playwright install --with-deps ${{ matrix.browsers }}
 
       - name: Run playwright tests
         env:


### PR DESCRIPTION
In broswer-compatibilty workflow all tests failed because of not running build command and playwright use vite preview in CI.

And ubuntu webkit environment seems need to add —install-deps options to install OS dep.

But still a lot of test failed.