### PR TITLE
refactor: eliminate redundant code block button inheritance

### DIFF
--- a/packages/blocks/src/code-block/components/button.ts
+++ b/packages/blocks/src/code-block/components/button.ts
@@ -1,11 +1,11 @@
-import { css, html } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { IconButton } from '../../components/button.js';
 
 // TODO reuse existing button component
 @customElement('code-block-button')
-export class CodeBlockButton extends IconButton {
+export class CodeBlockButton extends LitElement {
   static styles = css`
     ${IconButton.styles}
     :host {


### PR DESCRIPTION
With help of @pengx17, we came to a conclusion that
- `CodeBlockButton` doesn't need Inheriting `IconButton`, as it only uses `IconButton`'s static property `styles`.
- This PR also fixes the apparent delay when clicking the code block button (which is used to show code language selector) in the local dev env when hmr is enabled.

### Before:
![image](https://user-images.githubusercontent.com/20554850/221328768-4fb0622e-5172-4ed0-8d42-20efff157465.png)
![image](https://user-images.githubusercontent.com/20554850/221328773-737e1d8b-c1c1-40f9-bc50-dbd47889c18f.png)

### After:
<img width="2560" alt="image" src="https://user-images.githubusercontent.com/20554850/221329060-7b549f52-c61e-4531-936b-66889774e50c.png">

