### PR TITLE
refactor: reorganize range structure

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
+++ b/packages/blocks/src/__internal__/rich-text/bracket-complete.ts
@@ -1,7 +1,7 @@
 import { ALLOW_DEFAULT, PREVENT_DEFAULT } from '@blocksuite/global/config';
 import type { BaseBlockModel } from '@blocksuite/store';
 
-import { getCurrentRange, resetNativeSelection } from '../index.js';
+import { getCurrentNativeRange, resetNativeSelection } from '../index.js';
 import type { KeyboardBindings } from './keyboard.js';
 
 type BracketPair = {
@@ -100,7 +100,7 @@ export function createBracketAutoCompleteBindings(
         model.text.insert(pair.left, range.index);
         model.text.insert(pair.right, range.index + range.length + 1);
 
-        const curRange = getCurrentRange();
+        const curRange = getCurrentNativeRange();
         // move cursor to the end of the inserted text
         curRange.setStart(curRange.startContainer, curRange.startOffset + 1);
         resetNativeSelection(curRange);

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -5,7 +5,7 @@ import type { Quill, RangeStatic } from 'quill';
 
 import { showSlashMenu } from '../../components/slash-menu/index.js';
 import {
-  getCurrentRange,
+  getCurrentNativeRange,
   getNextBlock,
   isCollapsedAtBlockStart,
   isMultiBlockRange,
@@ -219,15 +219,15 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     return tryMatchSpaceHotkey(page, model, quill, prefix, range);
   }
 
-  function onBackspace(this: KeyboardEventThis) {
+  function onBackspace(e: KeyboardEvent, quill: Quill) {
     // To workaround uncontrolled behavior when deleting character at block start,
     // in this case backspace should be handled in quill.
-    if (isCollapsedAtBlockStart(this.quill)) {
+    if (isCollapsedAtBlockStart(quill)) {
       // window.requestAnimationFrame(() => {
       handleLineStartBackspace(page, model);
       // });
       return PREVENT_DEFAULT;
-    } else if (isMultiBlockRange(getCurrentRange())) {
+    } else if (isMultiBlockRange(getCurrentNativeRange())) {
       // return PREVENT_DEFAULT;
       noop();
     }
@@ -307,7 +307,13 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     },
     backspace: {
       key: 'Backspace',
-      handler: onBackspace,
+      handler(
+        this: KeyboardEventThis,
+        range: QuillRange,
+        context: BindingContext
+      ) {
+        return onBackspace(context.event, this.quill);
+      },
     },
     up: {
       key: 'ArrowUp',
@@ -367,7 +373,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
         //   return ALLOW_DEFAULT;
         // }
         requestAnimationFrame(() => {
-          const curRange = getCurrentRange();
+          const curRange = getCurrentNativeRange();
           showSlashMenu({ model, range: curRange });
         });
         return ALLOW_DEFAULT;

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -8,8 +8,6 @@ import {
   getCurrentNativeRange,
   getNextBlock,
   isCollapsedAtBlockStart,
-  isMultiBlockRange,
-  noop,
 } from '../utils/index.js';
 import { createBracketAutoCompleteBindings } from './bracket-complete.js';
 import { markdownConvert, tryMatchSpaceHotkey } from './markdown-convert.js';
@@ -220,16 +218,10 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
   }
 
   function onBackspace(e: KeyboardEvent, quill: Quill) {
-    // To workaround uncontrolled behavior when deleting character at block start,
-    // in this case backspace should be handled in quill.
     if (isCollapsedAtBlockStart(quill)) {
-      // window.requestAnimationFrame(() => {
       handleLineStartBackspace(page, model);
-      // });
+      e.stopPropagation();
       return PREVENT_DEFAULT;
-    } else if (isMultiBlockRange(getCurrentNativeRange())) {
-      // return PREVENT_DEFAULT;
-      noop();
     }
     return ALLOW_DEFAULT;
   }

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -11,7 +11,7 @@ import {
   ExtendedModel,
   focusBlockByModel,
   focusTitle,
-  getCurrentRange,
+  getCurrentNativeRange,
   getModelByElement,
   getPreviousBlock,
   getRichTextByModel,
@@ -402,7 +402,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 }
 
 export function handleKeyUp(event: KeyboardEvent, editableContainer: Element) {
-  const range = getCurrentRange();
+  const range = getCurrentNativeRange();
   if (!range.collapsed) {
     // If the range is not collapsed,
     // we assume that the caret is at the start of the range.
@@ -424,7 +424,7 @@ export function handleKeyDown(
   event: KeyboardEvent,
   editableContainer: HTMLElement
 ) {
-  const range = getCurrentRange();
+  const range = getCurrentNativeRange();
   if (!range.collapsed) {
     // If the range is not collapsed,
     // we assume that the caret is at the end of the range.

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -65,8 +65,14 @@ export function getCurrentBlockRange(page: Page): BlockRange | null {
 }
 
 export function blockRangeToNativeRange(blockRange: BlockRange) {
+  const models = blockRange.models.filter(model => model.text);
+  if (!models.length) {
+    // BlockRange may be selected embeds, and it don't have text
+    // so we can't convert it to native range
+    return null;
+  }
   const [startNode, startOffset] = getTextNodeBySelectedBlock(
-    blockRange.models[0],
+    models[0],
     blockRange.startOffset
   );
   if (!startNode) {
@@ -75,7 +81,7 @@ export function blockRangeToNativeRange(blockRange: BlockRange) {
     );
   }
   const [endNode, endOffset] = getTextNodeBySelectedBlock(
-    blockRange.models[blockRange.models.length - 1],
+    models[models.length - 1],
     blockRange.endOffset
   );
   if (!startNode) {
@@ -93,6 +99,8 @@ export function nativeRangeToBlockRange(range: Range): BlockRange | null {
   // TODO check range is in page
   const models = getModelsByRange(range);
   if (!models.length) {
+    // NativeRange may be outside of the editor
+    // so we can't convert it to block range
     return null;
   }
   const startOffset = getQuillIndexByNativeSelection(
@@ -172,7 +180,7 @@ export function restoreSelection(blockRange: BlockRange) {
 
 type ExperimentBlockRange = {
   type: 'Native' | 'Block';
-  range: Range;
+  range: Range | null;
   models: BaseBlockModel[];
   startModel: BaseBlockModel;
   endModel: BaseBlockModel;

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -59,7 +59,6 @@ export function getCurrentBlockRange(page: Page): BlockRange | null {
   // check exist native selection
   if (hasNativeSelection()) {
     const range = getCurrentNativeRange();
-    // TODO check range is in page
     return nativeRangeToBlockRange(range);
   }
   return null;
@@ -90,8 +89,12 @@ export function blockRangeToNativeRange(blockRange: BlockRange) {
   return range;
 }
 
-export function nativeRangeToBlockRange(range: Range): BlockRange {
+export function nativeRangeToBlockRange(range: Range): BlockRange | null {
+  // TODO check range is in page
   const models = getModelsByRange(range);
+  if (!models.length) {
+    return null;
+  }
   const startOffset = getQuillIndexByNativeSelection(
     range.startContainer,
     range.startOffset
@@ -182,7 +185,7 @@ type ExperimentBlockRange = {
 
 export const experimentCreateBlockRange = (
   rangeOrBlockRange: Range | BlockRange
-): ExperimentBlockRange => {
+): ExperimentBlockRange | null => {
   let cacheRange: Range | null =
     rangeOrBlockRange instanceof Range ? rangeOrBlockRange : null;
   const blockRange =
@@ -190,6 +193,9 @@ export const experimentCreateBlockRange = (
       ? nativeRangeToBlockRange(rangeOrBlockRange)
       : rangeOrBlockRange;
 
+  if (!blockRange) {
+    return null;
+  }
   if (!blockRange.models.length) {
     throw new Error('Block range must have at least one model.');
   }

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -1,6 +1,7 @@
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import {
+  BlockComponentElement,
   getBlockElementByModel,
   getDefaultPageBlock,
   getModelByElement,
@@ -55,6 +56,7 @@ export function getCurrentBlockRange(page: Page): BlockRange | null {
     if (pageBlock.selection) {
       const selectedBlocks = pageBlock.selection.state.selectedBlocks;
       const selectedEmbeds = pageBlock.selection.state.selectedEmbeds;
+      // Fix order may be wrong
       const models = [...selectedBlocks, ...selectedEmbeds]
         .map(element => getModelByElement(element))
         .filter(Boolean);
@@ -183,7 +185,7 @@ export function restoreSelection(blockRange: BlockRange) {
   defaultPageBlock.selection.state.type = 'block';
   defaultPageBlock.selection.state.selectedBlocks = models
     .map(model => getBlockElementByModel(model))
-    .filter(Boolean) as Element[];
+    .filter(Boolean) as BlockComponentElement[];
   defaultPageBlock.selection.refreshSelectedBlocksRects();
   // Try clean native selection
   resetNativeSelection(null);

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -168,7 +168,7 @@ export function restoreSelection(blockRange: BlockRange) {
   defaultPageBlock.selection.refreshSelectedBlocksRects();
   // Try clean native selection
   resetNativeSelection(null);
-  (document.activeElement as HTMLTextAreaElement).blur();
+  (document.activeElement as HTMLElement).blur();
 }
 
 // The following section is experimental code.

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -1,0 +1,188 @@
+import type { BaseBlockModel, Page } from '@blocksuite/store';
+
+import {
+  getBlockElementByModel,
+  getDefaultPageBlock,
+  getModelByElement,
+  getModelsByRange,
+  getQuillIndexByNativeSelection,
+  getTextNodeBySelectedBlock,
+} from './query.js';
+import {
+  getCurrentNativeRange,
+  hasNativeSelection,
+  resetNativeSelection,
+} from './selection.js';
+
+/**
+ * Use {@link getCurrentBlockRange} to get current block range.
+ *
+ * You can use {@link nativeRangeToBlockRange} and {@link blockRangeToNativeRange} convert between native range and block range.
+ */
+export type BlockRange = {
+  /**
+   * @deprecated Use models instead
+   */
+  startModel: BaseBlockModel;
+  /**
+   * @deprecated Use models instead
+   */
+  endModel: BaseBlockModel;
+  /**
+   * Models between startModel and endModel, not including startModel and endModel
+   * @deprecated Use models instead
+   */
+  betweenModels: BaseBlockModel[];
+
+  /**
+   * 'Native' for native selection, 'Block' for block selection
+   */
+  type: 'Native' | 'Block';
+  /**
+   * Promise the length of models is greater than 0
+   */
+  // models: BaseBlockModel[];
+  startOffset: number;
+  endOffset: number;
+  // collapsed is true when models.length === 1 && startOffset === endOffset
+  // collapsed: true;
+};
+
+export function getCurrentBlockRange(page: Page): BlockRange | null {
+  // check exist block selection
+  if (page.root) {
+    const pageBlock = getDefaultPageBlock(page.root);
+    if (pageBlock.selection) {
+      const selectedBlock = pageBlock.selection.state.selectedBlocks;
+      const models = selectedBlock.map(element => getModelByElement(element));
+      // .filter(model => model.text);
+      if (models.length) {
+        return {
+          type: 'Block',
+          startModel: models[0],
+          startOffset: 0,
+          endModel: models[models.length - 1],
+          endOffset: models[models.length - 1].text?.length ?? 0,
+          betweenModels: models.slice(1, models.length - 1),
+        };
+      }
+    }
+  }
+  // check exist native selection
+  if (hasNativeSelection()) {
+    const range = getCurrentNativeRange();
+    // TODO check range is in page
+    return nativeRangeToBlockRange(range);
+  }
+  return null;
+}
+
+export function blockRangeToNativeRange(blockRange: BlockRange) {
+  const [startNode, startOffset] = getTextNodeBySelectedBlock(
+    blockRange.startModel,
+    blockRange.startOffset
+  );
+  if (!startNode) {
+    throw new Error(
+      'Failed to convert block range to native range. Start node is null.'
+    );
+  }
+  const [endNode, endOffset] = getTextNodeBySelectedBlock(
+    blockRange.endModel,
+    blockRange.endOffset
+  );
+  if (!startNode) {
+    throw new Error(
+      'Failed to convert block range to native range. End node is null.'
+    );
+  }
+  const range = new Range();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  return range;
+}
+
+export function nativeRangeToBlockRange(range: Range): BlockRange {
+  const models = getModelsByRange(range);
+  const startOffset = getQuillIndexByNativeSelection(
+    range.startContainer,
+    range.startOffset
+  );
+  const endOffset = getQuillIndexByNativeSelection(
+    range.endContainer,
+    range.endOffset
+  );
+  return {
+    type: 'Native',
+    startModel: models[0],
+    startOffset,
+    endModel: models[models.length - 1],
+    endOffset,
+    betweenModels: models.slice(1, -1),
+  };
+}
+
+/**
+ * Sometimes, the block in the block range is updated, we need to update the block range manually.
+ *
+ * Note: it will mutate the `blockRange` object.
+ */
+export function updateBlockRange(
+  blockRange: BlockRange,
+  oldModel: BaseBlockModel,
+  newModel: BaseBlockModel
+) {
+  if (blockRange.startModel === oldModel) {
+    blockRange.startModel = newModel;
+  }
+  if (blockRange.endModel === oldModel) {
+    blockRange.endModel = newModel;
+  }
+  blockRange.betweenModels = blockRange.betweenModels.map(model =>
+    model === oldModel ? newModel : model
+  );
+  return blockRange;
+}
+
+/**
+ * Restore the block selection.
+ * See also {@link resetNativeSelection}
+ */
+export function restoreSelection(blockRange: BlockRange) {
+  if (blockRange.type === 'Native') {
+    const range = blockRangeToNativeRange(blockRange);
+    resetNativeSelection(range);
+
+    // Try clean block selection
+    const defaultPageBlock = getDefaultPageBlock(blockRange.startModel);
+    if (!defaultPageBlock.selection) {
+      // In the edgeless mode
+      return;
+    }
+    defaultPageBlock.selection.state.clearBlock();
+    return;
+  }
+  const defaultPageBlock = getDefaultPageBlock(blockRange.startModel);
+  if (!defaultPageBlock.selection) {
+    // In the edgeless mode
+    return;
+  }
+  const models =
+    blockRange.startModel === blockRange.endModel
+      ? [blockRange.startModel]
+      : [
+          blockRange.startModel,
+          ...blockRange.betweenModels,
+          blockRange.endModel,
+        ];
+  defaultPageBlock.selection.clear();
+  // get fresh elements
+  defaultPageBlock.selection.state.type = 'block';
+  defaultPageBlock.selection.state.selectedBlocks = models
+    .map(model => getBlockElementByModel(model))
+    .filter(Boolean) as Element[];
+  defaultPageBlock.selection.refreshSelectedBlocksRects();
+  // Try clean native selection
+  resetNativeSelection(null);
+  (document.activeElement as HTMLTextAreaElement).blur();
+}

--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -53,9 +53,11 @@ export function getCurrentBlockRange(page: Page): BlockRange | null {
   if (page.root) {
     const pageBlock = getDefaultPageBlock(page.root);
     if (pageBlock.selection) {
-      const selectedBlock = pageBlock.selection.state.selectedBlocks;
-      const models = selectedBlock.map(element => getModelByElement(element));
-      // .filter(model => model.text);
+      const selectedBlocks = pageBlock.selection.state.selectedBlocks;
+      const selectedEmbeds = pageBlock.selection.state.selectedEmbeds;
+      const models = [...selectedBlocks, ...selectedEmbeds]
+        .map(element => getModelByElement(element))
+        .filter(Boolean);
       if (models.length) {
         return {
           type: 'Block',
@@ -160,6 +162,7 @@ export function restoreSelection(blockRange: BlockRange) {
       return;
     }
     defaultPageBlock.selection.state.clearBlock();
+    defaultPageBlock.selection.state.type = 'native';
     return;
   }
   const defaultPageBlock = getDefaultPageBlock(blockRange.startModel);

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -368,8 +368,18 @@ export function getTextNodeBySelectedBlock(model: BaseBlockModel, offset = 0) {
     throw new Error("Failed to get block's text!");
   }
   if (offset > text.length) {
-    // FIXME
-    console.error('Offset is out of range! model: ', model, offset);
+    offset = text.length;
+    // FIXME enable strict check
+    // console.error(
+    //   'Offset is out of range! model: ',
+    //   model,
+    //   'offset: ',
+    //   offset,
+    //   'text: ',
+    //   text.toString(),
+    //   'text.length: ',
+    //   text.length
+    // );
   }
   const blockElement = getBlockById(model.id);
   if (!blockElement) {

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -6,7 +6,7 @@ import type { LeafBlot } from 'parchment';
 import type { DefaultPageBlockComponent } from '../../index.js';
 import type { RichText } from '../rich-text/rich-text.js';
 import type { IPoint } from './gesture.js';
-import { getCurrentRange } from './selection.js';
+import { getCurrentNativeRange } from './selection.js';
 
 type ElementTagName = keyof HTMLElementTagNameMap;
 
@@ -185,7 +185,7 @@ export function getBlockElementByModel(
 }
 
 export function getStartModelBySelection() {
-  const range = getCurrentRange();
+  const range = getCurrentNativeRange();
   const startContainer =
     range.startContainer instanceof Text
       ? (range.startContainer.parentElement as HTMLElement)

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -192,6 +192,7 @@ export function getStartModelBySelection() {
       : (range.startContainer as HTMLElement);
 
   const startComponent = startContainer.closest(`[${ATTR}]`) as ContainerBlock;
+  // TODO Fix this, this cast is not safe
   const startModel = startComponent.model as BaseBlockModel;
   return startModel;
 }
@@ -368,7 +369,7 @@ export function getTextNodeBySelectedBlock(model: BaseBlockModel, offset = 0) {
   }
   if (offset > text.length) {
     // FIXME
-    // console.error('Offset is out of range! model: ', model, offset);
+    console.error('Offset is out of range! model: ', model, offset);
   }
   const blockElement = getBlockById(model.id);
   if (!blockElement) {

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -802,7 +802,13 @@ export function isEmbed(e: SelectionEvent) {
 }
 
 export function isDatabase(e: SelectionEvent) {
-  if ((e.raw.target as HTMLElement).className.startsWith('affine-database')) {
+  const target = e.raw.target;
+  if (!(target instanceof HTMLElement)) {
+    // When user click on the list indicator,
+    // the target is not an `HTMLElement`, instead `SVGElement`.
+    return false;
+  }
+  if (target.className.startsWith('affine-database')) {
     return true;
   }
   return false;

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -44,23 +44,6 @@ export interface CommonBlockElement extends HTMLElement {
  */
 export type DomSelectionType = 'Caret' | 'Range' | 'None';
 
-export type BlockRange = {
-  /**
-   * 'Native' for native selection, 'Block' for block selection
-   */
-  type: 'Native' | 'Block';
-  startModel: BaseBlockModel;
-  endModel: BaseBlockModel;
-  startOffset: number;
-  endOffset: number;
-  /**
-   * Models between startModel and endModel, not including startModel and endModel
-   */
-  betweenModels: BaseBlockModel[];
-  // collapsed is true when startModel === endModel && startOffset === endOffset
-  // collapsed: true;
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ExtendedModel = BaseBlockModel & Record<string, any>;
 

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -103,18 +103,20 @@ export class IconButton extends LitElement {
       );
     }
 
+    let width = this.width;
+    let height = this.height;
     if (this.size) {
-      this.width = this.size;
-      this.height = this.size;
+      width = this.size;
+      height = this.size;
     }
 
     this.style.setProperty(
       '--button-width',
-      typeof this.width === 'string' ? this.width : `${this.width}px`
+      typeof width === 'string' ? width : `${width}px`
     );
     this.style.setProperty(
       '--button-height',
-      typeof this.height === 'string' ? this.height : `${this.height}px`
+      typeof height === 'string' ? height : `${height}px`
     );
   }
 

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -17,10 +17,8 @@ import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import {
-  getCurrentBlockRange,
-  getRichTextByModel,
-} from '../../__internal__/utils/index.js';
+import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
+import { getRichTextByModel } from '../../__internal__/utils/index.js';
 import { formatConfig } from '../../page-block/utils/const.js';
 import {
   DragDirection,

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -80,7 +80,11 @@ export class FormatQuickBar extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.models = this._getCurrentModels();
+    const blockRange = getCurrentBlockRange(this.page);
+    if (!blockRange) {
+      throw new Error("Can't get current block range");
+    }
+    this.models = blockRange.models;
     const startModel = this.models[0];
     this.paragraphType = `${startModel.flavour}/${startModel.type}`;
     this.format = getCurrentCombinedFormat(this.page);
@@ -124,22 +128,6 @@ export class FormatQuickBar extends LitElement {
   override disconnectedCallback() {
     super.disconnectedCallback();
     this._disposableGroup.dispose();
-  }
-
-  private _getCurrentModels() {
-    const blockRange = getCurrentBlockRange(this.page);
-    if (!blockRange) {
-      throw new Error("Can't get current block range");
-    }
-    const models =
-      blockRange.startModel === blockRange.endModel
-        ? [blockRange.startModel]
-        : [
-            blockRange.startModel,
-            ...blockRange.betweenModels,
-            blockRange.endModel,
-          ];
-    return models;
   }
 
   private _onHover() {

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -127,8 +127,8 @@ export const showFormatQuickBar = async ({
     }
     // If the selection is collapsed, abort the format quick bar
     if (
-      blockRange.type &&
-      blockRange.startModel === blockRange.endModel &&
+      blockRange.type === 'Native' &&
+      blockRange.models.length === 1 &&
       blockRange.startOffset === blockRange.endOffset
     ) {
       abortController.abort();

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -3,12 +3,10 @@ import './format-bar-node.js';
 
 import { Page, Signal } from '@blocksuite/store';
 
-import {
-  getCurrentBlockRange,
-  getCurrentRange,
-  getDefaultPageBlock,
-  throttle,
-} from '../../__internal__/utils/index.js';
+import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
+import { getDefaultPageBlock } from '../../__internal__/utils/query.js';
+import { getCurrentNativeRange } from '../../__internal__/utils/selection.js';
+import { throttle } from '../../__internal__/utils/std.js';
 import {
   calcPositionPointByRange,
   calcSafeCoordinate,
@@ -59,7 +57,7 @@ export const showFormatQuickBar = async ({
 
   // Once performance problems occur, it can be mitigated increasing throttle limit
   const updatePos = throttle(() => {
-    const positioningEl = anchorEl ?? getCurrentRange();
+    const positioningEl = anchorEl ?? getCurrentNativeRange();
     const dir = formatQuickBar.direction;
 
     const positioningPoint =

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -16,7 +16,7 @@ import { Page, Text } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
 import {
-  getCurrentRange,
+  getCurrentNativeRange,
   getRichTextByModel,
   resetNativeSelection,
   uploadImageFromLocal,
@@ -185,7 +185,7 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
         icon: CopyIcon,
         divider: true,
         action: async ({ model }) => {
-          const curRange = getCurrentRange();
+          const curRange = getCurrentNativeRange();
           await copyBlock(model);
           resetNativeSelection(curRange);
           toast('Copied to clipboard');

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -16,6 +16,7 @@ import './database-block/index.js';
 export * from './__internal__/rich-text/rich-text-operations.js';
 export { getServiceOrRegister } from './__internal__/service.js';
 export type { BaseService } from './__internal__/service/index.js';
+export * from './__internal__/utils/block-range.js';
 export * from './__internal__/utils/common-operations.js';
 export * from './__internal__/utils/filesys.js';
 export * from './__internal__/utils/lit.js';

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -17,7 +17,7 @@ import {
   asyncFocusRichText,
   BlockChildrenContainer,
   type BlockHost,
-  getCurrentRange,
+  getCurrentNativeRange,
   getRichTextByModel,
   hotkey,
   isMultiBlockRange,
@@ -378,7 +378,7 @@ export class DefaultPageBlockComponent
       (e.key.length === 1 || e.key === 'Enter') &&
       window.getSelection()?.type === 'Range'
     ) {
-      const range = getCurrentRange();
+      const range = getCurrentNativeRange();
       if (isMultiBlockRange(range)) {
         deleteModelsByRange(this.page);
       }

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -1121,9 +1121,7 @@ export class DefaultSelectionManager {
       const userRange: UserRange = {
         startOffset: blockRange.startOffset,
         endOffset: blockRange.endOffset,
-        startBlockId: blockRange.startModel.id,
-        endBlockId: blockRange.endModel.id,
-        betweenBlockIds: blockRange.betweenModels.map(m => m.id),
+        blockIds: blockRange.models.map(m => m.id),
       };
       page.awarenessStore.setLocalRange(page, userRange);
     }

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -13,8 +13,7 @@ import {
   BlockComponentElement,
   getAllBlocks,
   getBlockElementByModel,
-  getCurrentBlockRange,
-  getCurrentRange,
+  getCurrentNativeRange,
   getDefaultPageBlock,
   getModelByElement,
   handleNativeRangeClick,
@@ -31,6 +30,7 @@ import {
   SelectionEvent,
 } from '../../__internal__/index.js';
 import type { RichText } from '../../__internal__/rich-text/rich-text.js';
+import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import { showFormatQuickBar } from '../../components/format-quick-bar/index.js';
 import type {
   EmbedBlockComponent,
@@ -828,7 +828,7 @@ export class DefaultSelectionManager {
       return;
     }
 
-    const range = getCurrentRange(selection);
+    const range = getCurrentNativeRange(selection);
     if (range.collapsed) {
       return;
     }

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -13,7 +13,7 @@ import {
   doesInSamePath,
   getBlockById,
   getBlockElementByModel,
-  getCurrentRange,
+  getCurrentNativeRange,
   getRichTextByModel,
   OpenBlockInfo,
   resetNativeSelection,
@@ -428,7 +428,7 @@ export function copyCode(codeBlockOption: CodeBlockOption) {
   quill.setSelection(0, quill.getLength());
   document.body.dispatchEvent(new ClipboardEvent('copy', { bubbles: true }));
 
-  const range = getCurrentRange();
+  const range = getCurrentNativeRange();
   range.setStart(richText, 0);
   range.setEnd(richText, 0);
   resetNativeSelection(range);

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -2,13 +2,13 @@ import type { SurfaceElement } from '@blocksuite/phasor';
 import type { Disposable, Page, UserRange } from '@blocksuite/store';
 
 import {
-  getCurrentBlockRange,
   initMouseEventHandlers,
   MouseMode,
   noop,
   SelectionEvent,
   TopLevelBlockModel,
 } from '../../__internal__/index.js';
+import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import type { EdgelessPageBlockComponent } from './edgeless-page-block.js';
 import { DefaultModeController } from './mode-controllers/default-mode.js';
 import type { MouseModeController } from './mode-controllers/index.js';
@@ -285,9 +285,7 @@ export class EdgelessSelectionManager {
       const userRange: UserRange = {
         startOffset: blockRange.startOffset,
         endOffset: blockRange.endOffset,
-        startBlockId: blockRange.startModel.id,
-        endBlockId: blockRange.endModel.id,
-        betweenBlockIds: blockRange.betweenModels.map(m => m.id),
+        blockIds: blockRange.models.map(m => m.id),
       };
       page.awarenessStore.setLocalRange(page, userRange);
     }

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -56,15 +56,7 @@ export function bindCommonHotkey(page: Page) {
       if (!blockRange) {
         return;
       }
-      const models =
-        blockRange.startModel === blockRange.endModel
-          ? [blockRange.startModel]
-          : [
-              blockRange.startModel,
-              ...blockRange.betweenModels,
-              blockRange.endModel,
-            ];
-      updateBlockType(models, flavour, type);
+      updateBlockType(blockRange.models, flavour, type);
     });
   });
 
@@ -300,9 +292,9 @@ export function bindHotkeys(
     if (blockRange.type === 'Block') {
       e.stopPropagation();
       e.preventDefault();
-      const model = blockRange.endModel;
-      const parentModel = page.getParent(model);
-      const index = parentModel?.children.indexOf(model);
+      const endModel = blockRange.models[blockRange.models.length - 1];
+      const parentModel = page.getParent(endModel);
+      const index = parentModel?.children.indexOf(endModel);
       assertExists(index);
       assertExists(parentModel);
       const id = page.addBlockByFlavour(
@@ -329,16 +321,8 @@ export function bindHotkeys(
       return;
     }
 
-    const models =
-      blockRange.startModel === blockRange.endModel
-        ? [blockRange.startModel]
-        : [
-            blockRange.startModel,
-            ...blockRange.betweenModels,
-            blockRange.endModel,
-          ];
     // delete blocks
-    handleBlockSelectionBatchDelete(page, models);
+    handleBlockSelectionBatchDelete(page, blockRange.models);
     selection.clear();
     e.preventDefault();
     return;

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -150,11 +150,9 @@ export function updateBlockType(
     requestAnimationFrame(() =>
       restoreSelection({
         type: 'Block',
-        startModel: model,
-        endModel: model,
         startOffset: 0,
         endOffset: model.text?.length ?? 0,
-        betweenModels: [],
+        models: [model],
       })
     );
     return [model];
@@ -238,8 +236,8 @@ function mergeFormat(formatArr: TextAttributes[]): TextAttributes {
 }
 
 export function getCombinedFormat(blockRange: BlockRange): TextAttributes {
-  if (blockRange.startModel === blockRange.endModel) {
-    const richText = getRichTextByModel(blockRange.startModel);
+  if (blockRange.models.length === 1) {
+    const richText = getRichTextByModel(blockRange.models[0]);
     assertExists(richText);
     const { quill } = richText;
     const format = quill.getFormat(
@@ -251,12 +249,13 @@ export function getCombinedFormat(blockRange: BlockRange): TextAttributes {
   const formatArr = [];
   // Start block
   // Skip code block or empty block
+  const startModel = blockRange.models[0];
   if (
-    !matchFlavours(blockRange.startModel, ['affine:code']) &&
-    blockRange.startModel.text &&
-    blockRange.startModel.text.length
+    !matchFlavours(startModel, ['affine:code']) &&
+    startModel.text &&
+    startModel.text.length
   ) {
-    const startRichText = getRichTextByModel(blockRange.startModel);
+    const startRichText = getRichTextByModel(startModel);
     assertExists(startRichText);
     const startFormat = startRichText.quill.getFormat(
       blockRange.startOffset,
@@ -265,18 +264,20 @@ export function getCombinedFormat(blockRange: BlockRange): TextAttributes {
     formatArr.push(startFormat);
   }
   // End block
+  const endModel = blockRange.models[blockRange.models.length - 1];
   if (
-    !matchFlavours(blockRange.endModel, ['affine:code']) &&
-    blockRange.endModel.text &&
-    blockRange.endModel.text.length
+    !matchFlavours(endModel, ['affine:code']) &&
+    endModel.text &&
+    endModel.text.length
   ) {
-    const endRichText = getRichTextByModel(blockRange.endModel);
+    const endRichText = getRichTextByModel(endModel);
     assertExists(endRichText);
     const endFormat = endRichText.quill.getFormat(0, blockRange.endOffset);
     formatArr.push(endFormat);
   }
   // Between blocks
-  blockRange.betweenModels
+  blockRange.models
+    .slice(1, -1)
     .filter(model => !matchFlavours(model, ['affine:code']))
     .filter(model => model.text && model.text.length)
     .forEach(model => {
@@ -301,17 +302,18 @@ export function getCurrentCombinedFormat(page: Page): TextAttributes {
 }
 
 function formatBlockRange(blockRange: BlockRange, key: keyof TextAttributes) {
-  const { startModel, startOffset, endModel, endOffset, betweenModels } =
-    blockRange;
+  const { startOffset, endOffset } = blockRange;
+  const startModel = blockRange.models[0];
+  const endModel = blockRange.models[blockRange.models.length - 1];
   // edge case 1: collapsed range
-  if (startModel === endModel && startOffset === endOffset) {
+  if (blockRange.models.length === 1 && startOffset === endOffset) {
     // Collapsed range
     return;
   }
   const format = getCombinedFormat(blockRange);
 
   // edge case 2: same model
-  if (startModel === endModel) {
+  if (blockRange.models.length === 1) {
     if (matchFlavours(startModel, ['affine:code'])) return;
     startModel.text?.format(startOffset, endOffset - startOffset, {
       [key]: !format[key],
@@ -330,7 +332,8 @@ function formatBlockRange(blockRange: BlockRange, key: keyof TextAttributes) {
     endModel.text?.format(0, endOffset, { [key]: !format[key] });
   }
   // format between models
-  betweenModels
+  blockRange.models
+    .slice(1, -1)
     .filter(model => !matchFlavours(model, ['affine:code']))
     .forEach(model => {
       model.text?.format(0, model.text.length, { [key]: !format[key] });

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -8,10 +8,15 @@ import type { TextAttributes } from '@blocksuite/virgo';
 
 import {
   almostEqual,
-  BlockRange,
   ExtendedModel,
   TopLevelBlockModel,
 } from '../../__internal__/index.js';
+import {
+  BlockRange,
+  getCurrentBlockRange,
+  restoreSelection,
+  updateBlockRange,
+} from '../../__internal__/utils/block-range.js';
 import { asyncFocusRichText } from '../../__internal__/utils/common-operations.js';
 import {
   getBlockElementByModel,
@@ -22,20 +27,23 @@ import {
   getRichTextByModel,
 } from '../../__internal__/utils/query.js';
 import {
-  getCurrentBlockRange,
-  getCurrentRange,
+  getCurrentNativeRange,
   hasNativeSelection,
   isCollapsedNativeSelection,
   isMultiBlockRange,
   resetNativeSelection,
-  restoreSelection,
-  updateBlockRange,
 } from '../../__internal__/utils/selection.js';
 import type { BlockSchema } from '../../models.js';
 import type { DefaultSelectionManager } from '../default/selection-manager.js';
 import { DEFAULT_SPACING } from '../edgeless/utils.js';
 
-export function deleteModelsByRange(page: Page, range = getCurrentRange()) {
+/**
+ * TODO Use BlockRange
+ */
+export function deleteModelsByRange(
+  page: Page,
+  range = getCurrentNativeRange()
+) {
   const models = getModelsByRange(range);
 
   const first = models[0];
@@ -112,15 +120,6 @@ function mergeToCodeBlocks(page: Page, models: BaseBlockModel[]) {
     index
   );
   return id;
-}
-
-export async function updateSelectedTextType(
-  flavour: keyof BlockSchema,
-  type?: string
-) {
-  const range = getCurrentRange();
-  const modelsInRange = getModelsByRange(range);
-  updateBlockType(modelsInRange, flavour, type);
 }
 
 export function updateBlockType(
@@ -357,7 +356,7 @@ export function handleSelectAll(selection: DefaultSelectionManager) {
     selection.state.selectedBlocks.length === 0 &&
     currentSelection?.focusNode?.nodeName === '#text'
   ) {
-    const currentRange = getCurrentRange();
+    const currentRange = getCurrentNativeRange();
     const rangeRect = currentRange.getBoundingClientRect();
     selection.selectBlocksByRect(rangeRect);
   } else {

--- a/packages/blocks/src/page-block/utils/position.ts
+++ b/packages/blocks/src/page-block/utils/position.ts
@@ -2,7 +2,7 @@ import { caretRangeFromPoint } from '@blocksuite/global/utils';
 
 import {
   clamp,
-  getCurrentRange,
+  getCurrentNativeRange,
   isMultiLineRange,
   resetNativeSelection,
   SelectionEvent,
@@ -53,7 +53,7 @@ export function getDragDirection(e: SelectionEvent): DragDirection {
   const endY = e.y;
   // selection direction
   const isForwards = endX > startX;
-  const range = getCurrentRange();
+  const range = getCurrentNativeRange();
   const selectedOneLine = !isMultiLineRange(range);
 
   if (isForwards) {
@@ -84,7 +84,7 @@ export function getDragDirection(e: SelectionEvent): DragDirection {
  * ```
  */
 export function getNativeSelectionMouseDragInfo(e: SelectionEvent) {
-  const curRange = getCurrentRange();
+  const curRange = getCurrentNativeRange();
   const direction = getDragDirection(e);
 
   const isSelectedNothing =

--- a/packages/editor/src/managers/clipboard/copy-cut-manager.ts
+++ b/packages/editor/src/managers/clipboard/copy-cut-manager.ts
@@ -221,7 +221,9 @@ export class CopyCutManager {
   // TODO: Optimization
   // TODO: is not compatible with safari
   private _copyToClipboardFromPc(clips: ClipboardItem[]): boolean {
-    const curRange = SelectionUtils.getCurrentRange();
+    const savedRange = SelectionUtils.hasNativeSelection()
+      ? SelectionUtils.getCurrentNativeRange()
+      : null;
 
     let success = false;
     /**
@@ -251,7 +253,7 @@ export class CopyCutManager {
     } finally {
       tempElem.removeEventListener('copy', listener);
       document.body.removeChild(tempElem);
-      SelectionUtils.resetNativeSelection(curRange);
+      savedRange && SelectionUtils.resetNativeSelection(savedRange);
     }
     return success;
   }

--- a/packages/editor/src/managers/clipboard/utils.ts
+++ b/packages/editor/src/managers/clipboard/utils.ts
@@ -39,6 +39,9 @@ function getLastSelectBlock(blocks: SelectedBlock[]): SelectedBlock | null {
   return getLastSelectBlock(last.children);
 }
 
+/**
+ * @deprecated Use `getCurrentBlockRange` instead,
+ */
 export function getSelectInfo(page: Page): SelectionInfo {
   if (!page.root) {
     return {
@@ -60,7 +63,7 @@ export function getSelectInfo(page: Page): SelectionInfo {
     selectedModels = selectedBlocks.map(block => getModelByElement(block));
   } else if (nativeSelection && nativeSelection.type !== 'None') {
     type = nativeSelection.type as DomSelectionType;
-    selectedModels = getModelsByRange(SelectionUtils.getCurrentRange());
+    selectedModels = getModelsByRange(SelectionUtils.getCurrentNativeRange());
   }
   if (type !== 'None') {
     selectedBlocks = getSelectedBlock(selectedModels);

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -153,15 +153,7 @@ export class DebugMenu extends NonShadowLitElement {
     if (!blockRange) {
       return;
     }
-    const models =
-      blockRange.startModel === blockRange.endModel
-        ? [blockRange.startModel]
-        : [
-            blockRange.startModel,
-            ...blockRange.betweenModels,
-            blockRange.endModel,
-          ];
-    updateBlockType(models, 'affine:list', listType);
+    updateBlockType(blockRange.models, 'affine:list', listType);
   }
 
   private _addCodeBlock(e: PointerEvent) {
@@ -172,7 +164,7 @@ export class DebugMenu extends NonShadowLitElement {
     if (!blockRange) {
       throw new Error("Can't add code block without a selection");
     }
-    const startModel = blockRange.startModel;
+    const startModel = blockRange.models[0];
     const parent = this.page.getParent(startModel);
     const index = parent?.children.indexOf(startModel);
     const blockProps = {
@@ -193,15 +185,7 @@ export class DebugMenu extends NonShadowLitElement {
     if (!blockRange) {
       return;
     }
-    const models =
-      blockRange.startModel === blockRange.endModel
-        ? [blockRange.startModel]
-        : [
-            blockRange.startModel,
-            ...blockRange.betweenModels,
-            blockRange.endModel,
-          ];
-    updateBlockType(models, 'affine:paragraph', type);
+    updateBlockType(blockRange.models, 'affine:paragraph', type);
   }
 
   private _switchEditorMode() {

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -15,12 +15,11 @@ import '@shoelace-style/shoelace/dist/components/color-picker/color-picker.js';
 import {
   createEvent,
   type FrameBlockModel,
-  getModelsByRange,
+  getCurrentBlockRange,
   MouseMode,
   NonShadowLitElement,
-  SelectionUtils,
   ShapeMouseMode,
-  updateSelectedTextType,
+  updateBlockType,
 } from '@blocksuite/blocks';
 import type { EditorContainer } from '@blocksuite/editor';
 import {
@@ -150,16 +149,30 @@ export class DebugMenu extends NonShadowLitElement {
   ) {
     e.preventDefault();
     this.blockTypeDropdown.hide();
-
-    updateSelectedTextType('affine:list', listType);
+    const blockRange = getCurrentBlockRange(this.page);
+    if (!blockRange) {
+      return;
+    }
+    const models =
+      blockRange.startModel === blockRange.endModel
+        ? [blockRange.startModel]
+        : [
+            blockRange.startModel,
+            ...blockRange.betweenModels,
+            blockRange.endModel,
+          ];
+    updateBlockType(models, 'affine:list', listType);
   }
 
   private _addCodeBlock(e: PointerEvent) {
     e.preventDefault();
     this.blockTypeDropdown.hide();
 
-    const range = SelectionUtils.getCurrentRange();
-    const startModel = getModelsByRange(range)[0];
+    const blockRange = getCurrentBlockRange(this.page);
+    if (!blockRange) {
+      throw new Error("Can't add code block without a selection");
+    }
+    const startModel = blockRange.startModel;
     const parent = this.page.getParent(startModel);
     const index = parent?.children.indexOf(startModel);
     const blockProps = {
@@ -176,7 +189,19 @@ export class DebugMenu extends NonShadowLitElement {
     e.preventDefault();
     this.blockTypeDropdown.hide();
 
-    updateSelectedTextType('affine:paragraph', type);
+    const blockRange = getCurrentBlockRange(this.page);
+    if (!blockRange) {
+      return;
+    }
+    const models =
+      blockRange.startModel === blockRange.endModel
+        ? [blockRange.startModel]
+        : [
+            blockRange.startModel,
+            ...blockRange.betweenModels,
+            blockRange.endModel,
+          ];
+    updateBlockType(models, 'affine:paragraph', type);
   }
 
   private _switchEditorMode() {

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -9,9 +9,7 @@ import { uuidv4 } from './utils/id-generator.js';
 export interface UserRange {
   startOffset: number;
   endOffset: number;
-  startBlockId: string;
-  endBlockId: string;
-  betweenBlockIds: string[];
+  blockIds: string[];
 }
 
 export interface UserInfo {

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -15,7 +15,6 @@ import {
   pressEnter,
   redoByKeyboard,
   selectAllByKeyboard,
-  SHORT_KEY,
   type,
   undoByKeyboard,
 } from './utils/actions/index.js';
@@ -554,23 +553,6 @@ test('code block option can appear and disappear during mousemove', async ({
   await expect(locator).toBeVisible();
   await page.mouse.move(optionPosition.right + 10, optionPosition.y);
   await expect(locator).toBeHidden();
-});
-
-test('should ctrl+enter works in code block', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyCodeBlockState(page);
-  await focusRichText(page);
-
-  await type(page, 'const a = 10;');
-  await assertRichTexts(page, ['const a = 10;\n']);
-  await page.keyboard.press('ArrowLeft');
-  await page.keyboard.press(`${SHORT_KEY}+Enter`);
-  // TODO fix this
-  // actual
-  await assertRichTexts(page, ['const a = 10\n;\n']);
-  test.fail();
-  // but expected
-  await assertRichTexts(page, ['const a = 10;\n\n']);
 });
 
 test('should tab works in code block', async ({ page }) => {

--- a/tests/knwon_issues.spec.ts
+++ b/tests/knwon_issues.spec.ts
@@ -3,9 +3,26 @@ import './utils/declare-test-window.js';
 import {
   enterPlaygroundRoom,
   focusRichText,
-  initEmptyParagraphState,
-  pressEnter,
+  initEmptyCodeBlockState,
+  SHORT_KEY,
   type,
 } from './utils/actions/index.js';
-import { assertRichTexts, assertStoreMatchJSX } from './utils/asserts.js';
+import { assertRichTexts } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
+
+test('should ctrl+enter works in code block', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyCodeBlockState(page);
+  await focusRichText(page);
+
+  await type(page, 'const a = 10;');
+  await assertRichTexts(page, ['const a = 10;\n']);
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.press(`${SHORT_KEY}+Enter`);
+  // TODO fix this
+  // actual
+  await assertRichTexts(page, ['const a = 10\n;\n']);
+  test.fail();
+  // but expected
+  await assertRichTexts(page, ['const a = 10;\n\n']);
+});

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -521,7 +521,7 @@ async function clickListIcon(page: Page, i = 0) {
   await locator.click();
 }
 
-test('click the list icon to select', async ({ page }) => {
+test('click the list icon can select and copy', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await initThreeLists(page);
@@ -534,16 +534,21 @@ test('click the list icon to select', async ({ page }) => {
   await copyByKeyboard(page);
   await pasteByKeyboard(page);
   await assertRichTexts(page, ['123', '123', '456', '789', '456', '789']);
-  await clickListIcon(page, 4);
+});
+
+test('click the list icon can select and delete', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeLists(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+
+  await clickListIcon(page, 0);
   await page.keyboard.press('Backspace', { delay: 50 });
-  await assertRichTexts(page, ['123', '123', '456', '789', '\n']);
-  // FIXME
-  // This should be ['123', '123', '456', '789'] but there is another bug affecting it
-  await clickListIcon(page, 1);
+  await assertRichTexts(page, ['\n', '456', '789']);
+
+  await clickListIcon(page, 0);
   await page.keyboard.press('Backspace', { delay: 50 });
-  await assertRichTexts(page, ['123', '\n', '456', '789']);
-  // FIXME
-  // This should be ['123','456','789'] but there is another bug affecting it
+  await assertRichTexts(page, ['\n']);
 });
 
 test('drag to select tagged text, and copy', async ({ page }) => {

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -545,10 +545,6 @@ test('click the list icon can select and delete', async ({ page }) => {
   await clickListIcon(page, 0);
   await page.keyboard.press('Backspace', { delay: 50 });
   await assertRichTexts(page, ['\n', '456', '789']);
-
-  await clickListIcon(page, 0);
-  await page.keyboard.press('Backspace', { delay: 50 });
-  await assertRichTexts(page, ['\n']);
 });
 
 test('drag to select tagged text, and copy', async ({ page }) => {
@@ -2116,23 +2112,13 @@ test('undo should clear block selection', async ({ page }) => {
   );
 
   await redoByKeyboard(page);
-  let selectedBlocks = await page.evaluate(() => {
-    const selectedBlocks = document.querySelectorAll(
-      '.affine-page-selected-rects-container > *'
-    );
-    return Array.from(selectedBlocks).length === 1;
-  });
-  expect(selectedBlocks).toBe(true);
+  const selectedBlocks = page.locator(
+    '.affine-page-selected-rects-container > *'
+  );
+  await expect(selectedBlocks).toHaveCount(1);
 
   await undoByKeyboard(page);
-
-  selectedBlocks = await page.evaluate(() => {
-    const selectedBlocks = document.querySelectorAll(
-      '.affine-page-selected-rects-container > *'
-    );
-    return Array.from(selectedBlocks).length === 0;
-  });
-  expect(selectedBlocks).toBe(true);
+  await expect(selectedBlocks).toHaveCount(0);
 });
 
 test('should not draw rect for sub selected blocks when entering tab key', async ({


### PR DESCRIPTION
- Rename `getCurrentRange` to `getCurrentNativeRange`
- Simpify `BlockRange`
```ts
export type BlockRange = {
  /**
   * 'Native' for native selection, 'Block' for block selection
   */
  type: 'Native' | 'Block';
  /**
   * Promise the length of models is greater than 0
   */
  models: BaseBlockModel[];
  startOffset: number;
  endOffset: number;
};
```