### PR TITLE
fix: format bar should follow selection convert

### DIFF
--- a/packages/blocks/src/__internal__/utils/block-range.ts
+++ b/packages/blocks/src/__internal__/utils/block-range.ts
@@ -157,6 +157,7 @@ export function restoreSelection(blockRange: BlockRange) {
     // In the edgeless mode
     return;
   }
+  defaultPageBlock.selection.state.type = 'block';
   defaultPageBlock.selection.refreshSelectedBlocksRectsByModels(
     blockRange.models
   );

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -21,7 +21,6 @@ import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import { getRichTextByModel } from '../../__internal__/utils/index.js';
 import { formatConfig } from '../../page-block/utils/const.js';
 import {
-  DragDirection,
   getCurrentCombinedFormat,
   updateBlockType,
 } from '../../page-block/utils/index.js';
@@ -48,10 +47,6 @@ export class FormatQuickBar extends LitElement {
   // Sometimes the quick bar need to update position
   @property()
   positionUpdated = new Signal();
-
-  // for update position
-  @property()
-  direction!: DragDirection;
 
   @state()
   models: BaseBlockModel[] = [];

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -5,7 +5,6 @@ import { Page, Signal } from '@blocksuite/store';
 
 import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import { getDefaultPageBlock } from '../../__internal__/utils/query.js';
-import { getCurrentNativeRange } from '../../__internal__/utils/selection.js';
 import { throttle } from '../../__internal__/utils/std.js';
 import {
   calcPositionPointByRange,
@@ -24,12 +23,13 @@ export const showFormatQuickBar = async ({
   abortController = new AbortController(),
 }: {
   page: Page;
-  anchorEl?:
-    | {
-        getBoundingClientRect: () => DOMRect;
-        // contextElement?: Element;
-      }
-    | Range;
+  anchorEl: {
+    getBoundingClientRect: () => {
+      x: number;
+      y: number;
+    };
+    // contextElement?: Element;
+  };
   direction?: DragDirection;
   container?: HTMLElement;
   abortController?: AbortController;
@@ -46,7 +46,6 @@ export const showFormatQuickBar = async ({
   formatQuickBar.abortController = abortController;
   const positionUpdatedSignal = new Signal();
   formatQuickBar.positionUpdated = positionUpdatedSignal;
-  formatQuickBar.direction = direction;
 
   formatQuickBarInstance = formatQuickBar;
   abortController.signal.addEventListener('abort', () => {
@@ -57,22 +56,10 @@ export const showFormatQuickBar = async ({
 
   // Once performance problems occur, it can be mitigated increasing throttle limit
   const updatePos = throttle(() => {
-    const positioningEl = anchorEl ?? getCurrentNativeRange();
-    const dir = formatQuickBar.direction;
-
     const positioningPoint =
-      positioningEl instanceof Range
-        ? calcPositionPointByRange(positioningEl, dir)
-        : (() => {
-            const rect = positioningEl.getBoundingClientRect();
-            const x = dir.includes('center')
-              ? rect.left + rect.width / 2
-              : dir.includes('left')
-              ? rect.left
-              : rect.right;
-            const y = dir.includes('bottom') ? rect.bottom : rect.top;
-            return { x, y };
-          })();
+      anchorEl instanceof Range
+        ? calcPositionPointByRange(anchorEl, direction)
+        : anchorEl.getBoundingClientRect();
 
     // TODO maybe use the editor container as the boundary rect to avoid the format bar being covered by other elements
     const boundaryRect = document.body.getBoundingClientRect();
@@ -80,7 +67,7 @@ export const showFormatQuickBar = async ({
       formatQuickBar.formatQuickBarElement.getBoundingClientRect();
     // Add offset to avoid the quick bar being covered by the window border
     const gapY = 5;
-    const isBottom = dir.includes('bottom');
+    const isBottom = direction.includes('bottom');
     const safeCoordinate = calcSafeCoordinate({
       positioningPoint,
       objRect: formatBarRect,

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -1015,12 +1015,10 @@ export class DefaultSelectionManager {
   }
 
   refreshSelectedBlocksRectsByModels(models: BaseBlockModel[]) {
-    requestAnimationFrame(() => {
-      this.state.selectedBlocks = models
-        .map(model => getBlockElementByModel(model))
-        .filter((block): block is BlockComponentElement => block !== null);
-      this.refreshSelectedBlocksRects();
-    });
+    this.state.selectedBlocks = models
+      .map(model => getBlockElementByModel(model))
+      .filter((block): block is BlockComponentElement => block !== null);
+    this.refreshSelectedBlocksRects();
   }
 
   refreshEmbedRects(hoverEditingState: EmbedEditingState | null = null) {

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../__internal__/index.js';
 import { showFormatQuickBar } from '../../../components/format-quick-bar/index.js';
 import {
+  calcCurrentSelectionPosition,
   getNativeSelectionMouseDragInfo,
   repairContextMenuRange,
 } from '../../utils/position.js';
@@ -264,7 +265,15 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
         // If nothing is selected, then we should not show the format bar
         return;
       }
-      showFormatQuickBar({ page: this._page, direction });
+      showFormatQuickBar({
+        page: this._page,
+        direction,
+        anchorEl: {
+          getBoundingClientRect: () => {
+            return calcCurrentSelectionPosition(direction);
+          },
+        },
+      });
     } else if (this.blockSelectionState.type === 'single') {
       if (!this._frameSelectionState) {
         this._page.captureSync();

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -241,7 +241,9 @@ function handleTab(page: Page, selection: DefaultSelectionManager) {
         getModelByElement(block)
       );
       handleMultiBlockIndent(page, models);
-      selection.refreshSelectedBlocksRectsByModels(models);
+      requestAnimationFrame(() => {
+        selection.refreshSelectedBlocksRectsByModels(models);
+      });
       break;
     }
   }
@@ -294,6 +296,7 @@ export function bindHotkeys(
       return;
     }
     // TODO fix native selection enter
+
     return;
   });
 

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -42,6 +42,7 @@ function getFormatBar(page: Page) {
   const textBtn = formatQuickBar.getByTestId('affine:paragraph/text');
   const h1Btn = formatQuickBar.getByTestId('affine:paragraph/h1');
   const bulletedBtn = formatQuickBar.getByTestId('affine:list/bulleted');
+  const codeBlockBtn = formatQuickBar.getByTestId('affine:code/');
 
   return {
     formatQuickBar,
@@ -57,6 +58,7 @@ function getFormatBar(page: Page) {
     textBtn,
     h1Btn,
     bulletedBtn,
+    codeBlockBtn,
   };
 }
 
@@ -936,4 +938,29 @@ test('should format quick bar with block selection works when update block type'
   await expect(blockSelections).toHaveCount(3);
   await page.mouse.click(0, 0);
   await expect(formatBarController.formatQuickBar).not.toBeVisible();
+});
+
+test('should format quick bar show after convert to code block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page, { enable_block_selection_format_bar: true });
+  const { frameId } = await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  const formatBarController = getFormatBar(page);
+  await dragBetweenIndices(page, [2, 3], [0, 0]);
+  await expect(formatBarController.formatQuickBar).toBeVisible();
+  await formatBarController.openParagraphMenu();
+  await formatBarController.codeBlockBtn.click();
+  await expect(formatBarController.formatQuickBar).toBeVisible();
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:frame>
+  <affine:code
+    prop:language="JavaScript"
+    prop:text="123\n456\n789"
+  />
+</affine:frame>`,
+    frameId
+  );
 });


### PR DESCRIPTION
When selection convert from native range to block selection, the format bar should not throw error