### PR TITLE
feat: typed `matchFlavours` utility function

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "@blocksuite/global": "workspace:*",
+    "@blocksuite/store": "workspace:*",
+    "@blocksuite/blocks": "workspace:*",
     "@blocksuite/virgo": "workspace:*",
     "@commitlint/cli": "^17.4.3",
     "@commitlint/config-conventional": "^17.4.3",

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -77,8 +77,8 @@ function isAtBlockEnd(quill: Quill) {
 // 2. In the middle and start of block, press Enter will insert a \n to break the line
 // TODO this should be configurable per-block
 function isSoftEnterable(model: BaseBlockModel) {
-  if (matchFlavours(model, ['affine:code'])) return true;
-  if (matchFlavours(model, ['affine:paragraph'])) {
+  if (matchFlavours(model, ['affine:code'] as const)) return true;
+  if (matchFlavours(model, ['affine:paragraph'] as const)) {
     return model.type === 'quote';
   }
   return false;
@@ -111,14 +111,15 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
     const parent = page.getParent(model);
     const isLastChild = parent?.lastChild() === model;
     const isEmptyList =
-      matchFlavours(model, ['affine:list']) && model.text?.length === 0;
+      matchFlavours(model, ['affine:list'] as const) &&
+      model.text?.length === 0;
     const selection = quill.getSelection();
     assertExists(selection);
 
     if (
       isEmptyList &&
       parent &&
-      matchFlavours(parent, ['affine:frame']) &&
+      matchFlavours(parent, ['affine:frame'] as const) &&
       model.children.length === 0
     ) {
       handleLineStartBackspace(page, model);
@@ -169,7 +170,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
   }
 
   function onTab(this: KeyboardEventThis) {
-    if (matchFlavours(model, ['affine:code'])) {
+    if (matchFlavours(model, ['affine:code'] as const)) {
       return ALLOW_DEFAULT;
     }
     const index = this.quill.getSelection()?.index;
@@ -178,7 +179,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
   }
 
   function onShiftTab(this: KeyboardEventThis) {
-    if (matchFlavours(model, ['affine:code'])) {
+    if (matchFlavours(model, ['affine:code'] as const)) {
       return ALLOW_DEFAULT;
     }
     const index = this.quill.getSelection()?.index;
@@ -358,7 +359,7 @@ export function createKeyboardBindings(page: Page, model: BaseBlockModel) {
         }
         // End of feature flag
 
-        if (matchFlavours(model, ['affine:code'])) {
+        if (matchFlavours(model, ['affine:code'] as const)) {
           return ALLOW_DEFAULT;
         }
         // if (context.format['code'] === true) {

--- a/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
+++ b/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
@@ -385,7 +385,7 @@ export function tryMatchSpaceHotkey(
   if (offset > prefix.length) {
     return ALLOW_DEFAULT;
   }
-  if (matchFlavours(model, ['affine:code'])) {
+  if (matchFlavours(model, ['affine:code'] as const)) {
     return ALLOW_DEFAULT;
   }
   let isConverted = false;

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -34,7 +34,7 @@ export function handleBlockEndEnter(page: Page, model: ExtendedModel) {
   // make adding text block by enter a standalone operation
   page.captureSync();
 
-  const shouldInheritFlavour = matchFlavours(model, ['affine:list']);
+  const shouldInheritFlavour = matchFlavours(model, ['affine:list'] as const);
   const blockProps = shouldInheritFlavour
     ? {
         flavour: model.flavour,
@@ -83,7 +83,10 @@ export function handleBlockSplit(
 
   let newParent = parent;
   let newBlockIndex = newParent.children.indexOf(model) + 1;
-  if (matchFlavours(model, ['affine:list']) && model.children.length > 0) {
+  if (
+    matchFlavours(model, ['affine:list'] as const) &&
+    model.children.length > 0
+  ) {
     newParent = model;
     newBlockIndex = 0;
   }
@@ -228,7 +231,7 @@ export function handleUnindent(
   capture = true
 ) {
   const parent = page.getParent(model);
-  if (!parent || matchFlavours(parent, ['affine:frame'])) {
+  if (!parent || matchFlavours(parent, ['affine:frame'] as const)) {
     // Topmost, do nothing
     return;
   }
@@ -274,7 +277,7 @@ export function handleUnindent(
 export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
   // When deleting at line start of a code block,
   // select the code block itself
-  if (matchFlavours(model, ['affine:code'])) {
+  if (matchFlavours(model, ['affine:code'] as const)) {
     focusBlockByModel(model);
     return;
   }
@@ -285,7 +288,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 
   // When deleting at line start of a list block,
   // switch it to normal paragraph block.
-  if (matchFlavours(model, ['affine:list'])) {
+  if (matchFlavours(model, ['affine:list'] as const)) {
     const parent = page.getParent(model);
     if (!parent) return;
 
@@ -309,7 +312,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 
   // When deleting at line start of a paragraph block,
   // firstly switch it to normal text, then delete this empty block.
-  if (matchFlavours(model, ['affine:paragraph'])) {
+  if (matchFlavours(model, ['affine:paragraph'] as const)) {
     if (model.type !== 'text') {
       // Try to switch to normal text
       page.captureSync();
@@ -318,14 +321,14 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
     }
 
     const parent = page.getParent(model);
-    if (!parent || matchFlavours(parent, ['affine:frame'])) {
+    if (!parent || matchFlavours(parent, ['affine:frame'] as const)) {
       const previousSibling = getPreviousBlock(model);
       const previousSiblingParent = previousSibling
         ? page.getParent(previousSibling)
         : null;
       if (
         previousSiblingParent &&
-        matchFlavours(previousSiblingParent, ['affine:database'])
+        matchFlavours(previousSiblingParent, ['affine:database'] as const)
       ) {
         window.requestAnimationFrame(() => {
           focusBlockByModel(previousSiblingParent, 'end');
@@ -337,7 +340,10 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
         });
       } else if (
         previousSibling &&
-        matchFlavours(previousSibling, ['affine:paragraph', 'affine:list'])
+        matchFlavours(previousSibling, [
+          'affine:paragraph',
+          'affine:list',
+        ] as const)
       ) {
         page.captureSync();
         const preTextLength = previousSibling.text?.length || 0;
@@ -353,7 +359,7 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
           'affine:embed',
           'affine:divider',
           'affine:code',
-        ])
+        ] as const)
       ) {
         window.requestAnimationFrame(() => {
           focusBlockByModel(previousSibling);

--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -49,10 +49,13 @@ export function convertToList(
   prefix: string,
   otherProperties?: Record<string, unknown>
 ): boolean {
-  if (matchFlavours(model, ['affine:list']) && model['type'] === listType) {
+  if (
+    matchFlavours(model, ['affine:list'] as const) &&
+    model['type'] === listType
+  ) {
     return false;
   }
-  if (matchFlavours(model, ['affine:paragraph'])) {
+  if (matchFlavours(model, ['affine:paragraph'] as const)) {
     const parent = page.getParent(model);
     if (!parent) return false;
 
@@ -73,7 +76,7 @@ export function convertToList(
     const id = page.addBlock(blockProps, parent, index);
     asyncFocusRichText(page, id);
   } else if (
-    matchFlavours(model, ['affine:list']) &&
+    matchFlavours(model, ['affine:list'] as const) &&
     model['type'] !== listType
   ) {
     model.text?.insert(' ', prefix.length);
@@ -94,7 +97,7 @@ export function convertToParagraph(
   if (matchFlavours(model, ['affine:paragraph']) && model['type'] === type) {
     return false;
   }
-  if (!matchFlavours(model, ['affine:paragraph'])) {
+  if (!matchFlavours(model, ['affine:paragraph'] as const)) {
     const parent = page.getParent(model);
     if (!parent) return false;
 
@@ -114,7 +117,7 @@ export function convertToParagraph(
     const id = page.addBlock(blockProps, parent, index);
     asyncFocusRichText(page, id);
   } else if (
-    matchFlavours(model, ['affine:paragraph']) &&
+    matchFlavours(model, ['affine:paragraph'] as const) &&
     model['type'] !== type
   ) {
     model.text?.insert(' ', prefix.length);
@@ -131,10 +134,13 @@ export function convertToDivider(
   model: ExtendedModel,
   prefix: string
 ): boolean {
-  if (matchFlavours(model, ['affine:divider']) || model.type === 'quote') {
+  if (
+    matchFlavours(model, ['affine:divider'] as const) ||
+    model.type === 'quote'
+  ) {
     return false;
   }
-  if (!matchFlavours(model, ['affine:divider'])) {
+  if (!matchFlavours(model, ['affine:divider'] as const)) {
     const parent = page.getParent(model);
     if (!parent) return false;
 

--- a/packages/blocks/src/__internal__/utils/components.ts
+++ b/packages/blocks/src/__internal__/utils/components.ts
@@ -84,7 +84,10 @@ export function BlockChildrenContainer(
   host: BlockHost,
   onLoaded: () => void
 ) {
-  const paddingLeft = matchFlavours(model, ['affine:page', 'affine:frame'])
+  const paddingLeft = matchFlavours(model, [
+    'affine:page',
+    'affine:frame',
+  ] as const)
     ? 0
     : BLOCK_CHILDREN_CONTAINER_PADDING_LEFT;
 

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -86,7 +86,7 @@ export function getNextBlock(
     const nextSibling = page.getNextSibling(currentBlock);
     if (nextSibling) {
       // Assert nextSibling is not possible to be `affine:page`
-      if (matchFlavours(nextSibling, ['affine:frame'])) {
+      if (matchFlavours(nextSibling, ['affine:frame'] as const)) {
         return getNextBlock(nextSibling);
       }
       return nextSibling;
@@ -130,7 +130,7 @@ export function getPreviousBlock(
   }
   const previousBlock = page.getPreviousSibling(model);
   if (!previousBlock) {
-    if (matchFlavours(parentBlock, ['affine:frame', 'affine:page'])) {
+    if (matchFlavours(parentBlock, ['affine:frame', 'affine:page'] as const)) {
       return getPreviousBlock(parentBlock);
     }
     return parentBlock;
@@ -226,7 +226,7 @@ export function getModelsByRange(range: Range): BaseBlockModel[] {
       const block = ele as ContainerBlock;
       assertExists(block.model);
       const blockElement = getBlockElementByModel(block.model);
-      const mainElement = matchFlavours(block.model, ['affine:page'])
+      const mainElement = matchFlavours(block.model, ['affine:page'] as const)
         ? blockElement?.querySelector(
             '.affine-default-page-block-title-container'
           )

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -144,7 +144,7 @@ export function focusBlockByModel(
   model: BaseBlockModel,
   position: SelectionPosition = 'end'
 ) {
-  if (matchFlavours(model, ['affine:frame', 'affine:page'])) {
+  if (matchFlavours(model, ['affine:frame', 'affine:page'] as const)) {
     throw new Error("Can't focus frame or page!");
   }
   const defaultPageBlock = getDefaultPageBlock(model);
@@ -155,7 +155,7 @@ export function focusBlockByModel(
       'affine:divider',
       'affine:code',
       'affine:database',
-    ])
+    ] as const)
   ) {
     if (!defaultPageBlock.selection) {
       // TODO fix this
@@ -168,7 +168,7 @@ export function focusBlockByModel(
     const element = getBlockElementByModel(model);
     assertExists(element);
     defaultPageBlock.selection.state.selectedBlocks.push(element);
-    if (matchFlavours(model, ['affine:database'])) {
+    if (matchFlavours(model, ['affine:database'] as const)) {
       const elements = model.children
         .map(child => getBlockElementByModel(child))
         .filter(
@@ -470,7 +470,7 @@ function handleClickRetargeting(page: Page, e: SelectionEvent) {
   const shouldRetarget = matchFlavours(parentModel, [
     'affine:frame',
     'affine:page',
-  ]);
+  ] as const);
   if (!shouldRetarget) return;
 
   const { clientX, clientY } = e.raw;

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -11,7 +11,7 @@ export function supportsChildren(model: BaseBlockModel): boolean {
     return false;
   }
   if (
-    matchFlavours(model, ['affine:paragraph']) &&
+    matchFlavours(model, ['affine:paragraph'] as const) &&
     ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'quote'].includes(model.type ?? '')
   ) {
     return false;

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -765,7 +765,10 @@ export class DefaultSelectionManager {
 
     if (
       clickBlockInfo &&
-      matchFlavours(clickBlockInfo.model, ['affine:embed', 'affine:divider'])
+      matchFlavours(clickBlockInfo.model, [
+        'affine:embed',
+        'affine:divider',
+      ] as const)
     ) {
       window.getSelection()?.removeAllRanges();
 

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -170,7 +170,7 @@ function binarySearchBlockEditingState(
         options
       );
       return result;
-    } else if (matchFlavours(block, ['affine:database'])) {
+    } else if (matchFlavours(block, ['affine:database'] as const)) {
       // double check when current block is database block
       const result = binarySearchBlockEditingState(
         blocks,

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -151,7 +151,7 @@ export function handleDown(
   if (hasNativeSelection()) {
     // TODO fix event trigger out of editor
     const model = getStartModelBySelection();
-    if (matchFlavours(model, ['affine:code'])) {
+    if (matchFlavours(model, ['affine:code'] as const)) {
       return;
     }
     const range = getCurrentNativeRange();

--- a/packages/editor/src/managers/clipboard/copy-cut-manager.ts
+++ b/packages/editor/src/managers/clipboard/copy-cut-manager.ts
@@ -102,7 +102,7 @@ export class CopyCutManager {
 
     let { flavour, type } = model;
     let delta: DeltaOperation[] = [];
-    if (matchFlavours(model, ['affine:page'])) {
+    if (matchFlavours(model, ['affine:page'] as const)) {
       flavour = 'affine:paragraph';
       type = 'text';
       const service = await getServiceOrRegister(model.flavour);
@@ -117,7 +117,7 @@ export class CopyCutManager {
           insert: text,
         },
       ];
-    } else if (matchFlavours(model, ['affine:embed'])) {
+    } else if (matchFlavours(model, ['affine:embed'] as const)) {
       flavour = 'affine:embed';
       type = 'image';
       const service = await getServiceOrRegister(model.flavour);

--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -191,7 +191,7 @@ export class PasteManager {
       let parent = selectedBlock;
       let index = 0;
       if (selectedBlock) {
-        if (matchFlavours(selectedBlock, ['affine:page'])) {
+        if (matchFlavours(selectedBlock, ['affine:page'] as const)) {
           if (matchFlavours(selectedBlock.children[0], ['affine:frame'])) {
             parent = selectedBlock.children[0];
           } else {
@@ -248,7 +248,7 @@ export class PasteManager {
           // instead of appending a new image block, if this paragraph is empty.
           if (
             lastBlockModel &&
-            matchFlavours(lastBlockModel, ['affine:paragraph']) &&
+            matchFlavours(lastBlockModel, ['affine:paragraph'] as const) &&
             lastBlockModel?.text?.length === 0 &&
             lastBlockModel?.children.length === 0
           ) {
@@ -263,7 +263,7 @@ export class PasteManager {
             insertLen > 0 &&
             parent &&
             lastBlockModel &&
-            matchFlavours(lastBlockModel, ['affine:paragraph']) &&
+            matchFlavours(lastBlockModel, ['affine:paragraph'] as const) &&
             lastBlockModel?.text?.length === 0 &&
             lastBlockModel?.children.length === 0
           ) {
@@ -334,7 +334,7 @@ export class PasteManager {
       let parent = selectedBlock;
       let index = 0;
       if (selectedBlock) {
-        if (matchFlavours(selectedBlock, ['affine:page'])) {
+        if (matchFlavours(selectedBlock, ['affine:page'] as const)) {
           if (matchFlavours(selectedBlock.children[0], ['affine:frame'])) {
             parent = selectedBlock.children[0];
           } else {

--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -88,31 +88,6 @@ declare namespace BlockSuiteInternal {
     // TODO use schema
     text?: Text;
   }
-
-  import type {
-    // Model
-    CodeBlockModel,
-    DatabaseBlockModel,
-    DividerBlockModel,
-    EmbedBlockModel,
-    FrameBlockModel,
-    ListBlockModel,
-    PageBlockModel,
-    ParagraphBlockModel,
-    SurfaceBlockModel,
-  } from '@blocksuite/blocks/models';
-
-  export type BlockModels = {
-    'affine:paragraph': ParagraphBlockModel;
-    'affine:page': PageBlockModel;
-    'affine:list': ListBlockModel;
-    'affine:frame': FrameBlockModel;
-    'affine:code': CodeBlockModel;
-    'affine:divider': DividerBlockModel;
-    'affine:embed': EmbedBlockModel;
-    'affine:surface': SurfaceBlockModel;
-    'affine:database': DatabaseBlockModel;
-  };
 }
 
 declare type EmbedType = 'image' | 'video' | 'audio' | 'file';

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./index.d.ts",
     "./database": "./src/database.ts",
+    "./types": "./src/types.ts",
     "./utils": "./src/utils.ts",
     "./debug": "./src/debug.ts",
     "./config": "./src/config/index.ts",

--- a/packages/global/src/types.ts
+++ b/packages/global/src/types.ts
@@ -1,0 +1,24 @@
+import type {
+  // Model
+  CodeBlockModel,
+  DatabaseBlockModel,
+  DividerBlockModel,
+  EmbedBlockModel,
+  FrameBlockModel,
+  ListBlockModel,
+  PageBlockModel,
+  ParagraphBlockModel,
+  SurfaceBlockModel,
+} from '@blocksuite/blocks/models';
+
+export type BlockModels = {
+  'affine:paragraph': ParagraphBlockModel;
+  'affine:page': PageBlockModel;
+  'affine:list': ListBlockModel;
+  'affine:frame': FrameBlockModel;
+  'affine:code': CodeBlockModel;
+  'affine:divider': DividerBlockModel;
+  'affine:embed': EmbedBlockModel;
+  'affine:surface': SurfaceBlockModel;
+  'affine:database': DatabaseBlockModel;
+};

--- a/packages/global/src/utils.ts
+++ b/packages/global/src/utils.ts
@@ -1,3 +1,7 @@
+import type { BaseBlockModel } from '@blocksuite/store';
+
+import type { BlockModels } from './types.js';
+
 export type { Disposable } from './utils/disposable.js';
 export { DisposableGroup, flattenDisposable } from './utils/disposable.js';
 export { Signal } from './utils/signal.js';
@@ -23,17 +27,27 @@ export function assertFlavours(model: { flavour: string }, allowed: string[]) {
   }
 }
 
-export function matchFlavours<
-  Key extends keyof BlockSuiteInternal.BlockModels &
-    string = keyof BlockSuiteInternal.BlockModels & string
->(
-  model: { flavour: Key },
-  expected: readonly Key[]
-): boolean /* model is BlockModels[Key] */ {
-  return expected.includes(model.flavour as Key);
-}
+type BlockModelKey = keyof BlockModels;
+type Flavours<T> = T extends BlockModelKey[] ? BlockModels[T[number]] : never;
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
-export const nonTextBlock: (keyof BlockSuiteInternal.BlockModels)[] = [
+export function matchFlavours<Key extends Readonly<Array<string>>>(
+  model: BaseBlockModel,
+  expected: Key
+): model is Flavours<Writeable<Key>> {
+  return expected.includes(model.flavour);
+}
+// export function matchFlavours<
+//   Key extends keyof BlockModels &
+//     string = keyof BlockModels & string
+// >(
+//   model: { flavour: Key },
+//   expected: readonly Key[]
+// ): model is BlockModels[Key] {
+//   return expected.includes(model.flavour as Key);
+// }
+
+export const nonTextBlock: (keyof BlockModels)[] = [
   'affine:database',
   'affine:divider',
   'affine:embed',
@@ -41,11 +55,10 @@ export const nonTextBlock: (keyof BlockSuiteInternal.BlockModels)[] = [
 ];
 
 export const isNonTextBlock = <
-  Key extends keyof BlockSuiteInternal.BlockModels &
-    string = keyof BlockSuiteInternal.BlockModels & string
->(model: {
-  flavour: Key;
-}) => matchFlavours(model, nonTextBlock);
+  Key extends keyof BlockModels & string = keyof BlockModels & string
+>(
+  model: BaseBlockModel
+) => matchFlavours(model, nonTextBlock);
 
 type Allowed =
   | void

--- a/packages/playground/examples/virgo/test-page.ts
+++ b/packages/playground/examples/virgo/test-page.ts
@@ -70,7 +70,7 @@ export class RichText extends LitElement {
   }
 
   render() {
-    return html`<style>
+    return html` <style>
         .rich-text-container {
           width: 100%;
           height: 100%;

--- a/packages/playground/examples/virgo/test-page.ts
+++ b/packages/playground/examples/virgo/test-page.ts
@@ -70,7 +70,7 @@ export class RichText extends LitElement {
   }
 
   render() {
-    return html` <style>
+    return html`<style>
         .rich-text-container {
           width: 100%;
           height: 100%;

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -1,3 +1,4 @@
+import type { BlockModels } from '@blocksuite/global/types';
 import { Signal } from '@blocksuite/global/utils';
 import type * as Y from 'yjs';
 import { z } from 'zod';
@@ -99,7 +100,7 @@ export class BaseBlockModel<Props = unknown>
   implements BlockSuiteInternal.IBaseBlockProps
 {
   static version: number;
-  flavour!: keyof BlockSuiteInternal.BlockModels & string;
+  flavour!: keyof BlockModels & string;
   tag!: StaticValue;
   id: string;
 

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import type { BlockModels } from '@blocksuite/global/types';
 import { isPrimitive, matchFlavours, SYS_KEYS } from '@blocksuite/global/utils';
 import { fromBase64, toBase64 } from 'lib0/buffer.js';
 import * as Y from 'yjs';
@@ -120,7 +121,7 @@ export function applyYjsUpdateV2(workspace: Workspace, update: string): void {
 export function doesInsideBlockByFlavour(
   page: Page,
   block: BaseBlockModel | string,
-  flavour: keyof BlockSuiteInternal.BlockModels
+  flavour: keyof BlockModels
 ): boolean {
   const parent = page.getParent(block);
   if (parent === null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,9 @@ importers:
 
   .:
     specifiers:
+      '@blocksuite/blocks': workspace:*
       '@blocksuite/global': workspace:*
+      '@blocksuite/store': workspace:*
       '@blocksuite/virgo': workspace:*
       '@commitlint/cli': ^17.4.3
       '@commitlint/config-conventional': ^17.4.3
@@ -44,7 +46,9 @@ importers:
       vite-plugin-web-components-hmr: ^0.1.3
       vitest: ^0.28.5
     devDependencies:
+      '@blocksuite/blocks': link:packages/blocks
       '@blocksuite/global': link:packages/global
+      '@blocksuite/store': link:packages/store
       '@blocksuite/virgo': link:packages/virgo
       '@commitlint/cli': 17.4.3
       '@commitlint/config-conventional': 17.4.3


### PR DESCRIPTION
Before:

```ts
// we have a model here
declare const model: BaseBlockModel;
if (matchFlavours(mode, ['affine:page']) {
  model.title // 💥  Error! The type of model is still BaseBlockModel. 
}
```

After:

```ts
if (matchFlavours(model, ['affine:page'] as const) {
  //                        ^ trade off here, we have to use `as const` to generate the tuple
  model.title // 🚀 Works! The type of model is PageBlockModel
}

// What will happen for multiple flavours?
if (matchFlavours(model, ['affine:code', 'affine:paragraph'] as const) {
  model // 🔮 CodeBlockModel | ParagraphModel
}
```