### PR TITLE
feat: case-insensitive matching in code block language shortcut

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
+++ b/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
@@ -3,7 +3,7 @@ import { assertExists, matchFlavours } from '@blocksuite/global/utils';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import type { Quill, RangeStatic } from 'quill';
 
-import { getCodeLaguage } from '../../code-block/utils/code-laguages.js';
+import { getCodeLanguage } from '../../code-block/utils/code-laguages.js';
 import {
   convertToDivider,
   convertToList,
@@ -272,7 +272,7 @@ const matches: Match[] = [
       page.deleteBlock(model);
       page.addBlockByFlavour(
         'affine:code',
-        { language: getCodeLaguage(match?.[1] || '') || 'JavaScript' },
+        { language: getCodeLanguage(match?.[1] || '') || 'JavaScript' },
         parent,
         index
       );

--- a/packages/blocks/src/code-block/utils/code-laguages.ts
+++ b/packages/blocks/src/code-block/utils/code-laguages.ts
@@ -224,14 +224,14 @@ const laguagesWithShortName: Record<string, string> = {
   yml: 'yaml',
 };
 
-export const getCodeLaguage = (shortName: string) => {
-  const language = codeLaguages.find(codeLaguage => {
-    return codeLaguage.toLowerCase() === shortName.toLowerCase();
+export const getCodeLanguage = (languageName: string) => {
+  const language = codeLaguages.find(codeLanguage => {
+    return codeLanguage.toLowerCase() === languageName.toLowerCase();
   });
 
   if (language) {
     return language;
   }
 
-  return laguagesWithShortName[shortName];
+  return laguagesWithShortName[languageName];
 };

--- a/packages/blocks/src/code-block/utils/code-laguages.ts
+++ b/packages/blocks/src/code-block/utils/code-laguages.ts
@@ -87,6 +87,7 @@ export const codeLaguages = [
   'haxe',
   'hsp',
   'http',
+  'html',
   'hy',
   'inform7',
   'ini',
@@ -224,5 +225,13 @@ const laguagesWithShortName: Record<string, string> = {
 };
 
 export const getCodeLaguage = (shortName: string) => {
+  const language = codeLaguages.find(codeLaguage => {
+    return codeLaguage.toLowerCase() === shortName.toLowerCase();
+  });
+
+  if (language) {
+    return language;
+  }
+
   return laguagesWithShortName[shortName];
 };


### PR DESCRIPTION
Optimize the behavior of creating code block in BlockSuite with markdown shortcut.

The problem:

 😱 
```markdown
|'''typescript | -> JavaScript
|'''TypeScript| -> JavaScript
|'''java | -> JavaScript
|'''html | -> JavaScript
|'''cpp | -> JavaScript
```
