### PR TITLE
perf(editor): append quill async

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -166,35 +166,36 @@ export class RichText extends NonShadowLitElement {
   }
 
   firstUpdated() {
-    const { host, model, placeholder, _textContainer } = this;
-    const { page } = host;
-    const keyboardBindings = createKeyboardBindings(page, model);
+    requestAnimationFrame(() => {
+      const { host, model, placeholder, _textContainer } = this;
+      const { page } = host;
+      const keyboardBindings = createKeyboardBindings(page, model);
+      this.quill = new Quill(_textContainer, {
+        modules: Object.assign(
+          {
+            toolbar: false,
+            history: {
+              maxStack: 0,
+              userOnly: true,
+            },
+            keyboard: {
+              bindings: keyboardBindings,
+            },
+          },
+          this.modules
+        ),
+        placeholder,
+      });
 
-    this.quill = new Quill(_textContainer, {
-      modules: Object.assign(
-        {
-          toolbar: false,
-          history: {
-            maxStack: 0,
-            userOnly: true,
-          },
-          keyboard: {
-            bindings: keyboardBindings,
-          },
-        },
-        this.modules
-      ),
-      placeholder,
+      page.attachRichText(model.id, this.quill);
+      this.model.propsUpdated.on(() => this.requestUpdate());
+
+      if (this.modules.syntax && this.quill.getText() === '\n') {
+        this.quill.focus();
+      }
+
+      this._handleInlineBoundaryInput();
     });
-
-    page.attachRichText(model.id, this.quill);
-    this.model.propsUpdated.on(() => this.requestUpdate());
-
-    if (this.modules.syntax && this.quill.getText() === '\n') {
-      this.quill.focus();
-    }
-
-    this._handleInlineBoundaryInput();
   }
 
   connectedCallback() {

--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -6,10 +6,14 @@ import type { Quill } from 'quill';
 import type { ExtendedModel } from './types.js';
 
 // XXX: workaround quill lifecycle issue
-export function asyncFocusRichText(page: Page, id: string) {
+export function asyncFocusRichText(page: Page, id: string, retries = 2) {
   requestAnimationFrame(() => {
     const adapter = page.richTextAdapters.get(id);
-    adapter?.quill.focus();
+    if (adapter) {
+      adapter?.quill.focus();
+    } else if (retries > 0) {
+      asyncFocusRichText(page, id, retries - 1);
+    }
   });
 }
 


### PR DESCRIPTION
The heavy example takes around 5 seconds to load because when `rich-text` is appended to DOM it will also create an Quill instance, which will cause the page to reflow because Quill will access blocking apis like `document.getSelection()`. If there are a lot of rich-text elements being added at once, it will cause the page to freeze for a few seconds.

The proposed fix is to move quill instance instance appending to `requestAnimationFrame`.

The profile charts before & after:

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/584378/221768473-453c9a4f-309e-4411-a05e-d3650dc9500e.png">

<img width="1636" alt="image" src="https://user-images.githubusercontent.com/584378/221767794-c8d0a20e-b8b6-498e-b181-b0c58ba0db42.png">
