### PR TITLE
perf: add yDoc binsize benchmark to ci

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -143,6 +143,8 @@ jobs:
   #         fail_ci_if_error: true
 
   benchmark:
+    permissions:
+      pull-requests: write
     name: Benchmark
     runs-on: ubuntu-latest
     needs:
@@ -179,6 +181,9 @@ jobs:
       - name: Report on the pull_request
         uses: thollander/actions-comment-pull-request@v2
         with:
+          mode: recreate
           message: |
-            ### yDoc Bin Benchmark\n- yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}\n- yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
+            ### yDoc Bin Benchmark
+            - yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}
+            - yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
           comment_tag: benchmark

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -61,86 +61,86 @@ jobs:
           name: playground-artifact
           path: ./packages/playground/dist
 
-  # e2e-test:
-  #   name: Playground E2E test
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build-playground
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: pnpm/action-setup@v2
-  #       with:
-  #         version: 7.9.5
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version-file: '.nvmrc'
-  #         cache: 'pnpm'
+  e2e-test:
+    name: Playground E2E test
+    runs-on: ubuntu-latest
+    needs:
+      - build-playground
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7.9.5
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
-  #     - name: Install dependencies
-  #       run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: playground-artifact
-  #         path: ./packages/playground/dist
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: playground-artifact
+          path: ./packages/playground/dist
 
-  #     - name: Install playwright browsers
-  #       run: npx playwright install chromium
+      - name: Install playwright browsers
+        run: npx playwright install chromium
 
-  #     - name: Run playwright tests
-  #       run: pnpm test -- --forbid-only
-  #       env:
-  #         COVERAGE: true
+      - name: Run playwright tests
+        run: pnpm test -- --forbid-only
+        env:
+          COVERAGE: true
 
-  #     - name: Collect code coverage report
-  #       run: pnpm exec nyc report -t .nyc_output --reporter=lcov
+      - name: Collect code coverage report
+        run: pnpm exec nyc report -t .nyc_output --reporter=lcov
 
-  #     - name: Upload e2e test coverage results
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         files: ./.coverage/lcov.info
-  #         flags: e2etest
-  #         name: blocksuite
-  #         fail_ci_if_error: true
+      - name: Upload e2e test coverage results
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./.coverage/lcov.info
+          flags: e2etest
+          name: blocksuite
+          fail_ci_if_error: true
 
-  #     - name: Upload test results
-  #       if: ${{ failure() }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: test-results-main
-  #         path: ./test-results
-  #         if-no-files-found: ignore
+      - name: Upload test results
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-main
+          path: ./test-results
+          if-no-files-found: ignore
 
-  # unit-test:
-  #   name: Unit test
-  #   runs-on: ubuntu-latest
+  unit-test:
+    name: Unit test
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: pnpm/action-setup@v2
-  #       with:
-  #         version: 7.9.5
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version-file: '.nvmrc'
-  #         cache: 'pnpm'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7.9.5
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
 
-  #     - name: Install dependencies
-  #       run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-  #     - name: Run unit tests
-  #       run: pnpm test:unit:coverage
+      - name: Run unit tests
+        run: pnpm test:unit:coverage
 
-  #     - name: Upload unit test coverage results
-  #       uses: codecov/codecov-action@v3
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         files: ./.coverage/global/lcov.info,./.coverage/store/lcov.info
-  #         flags: unittest
-  #         name: blocksuite
-  #         fail_ci_if_error: true
+      - name: Upload unit test coverage results
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./.coverage/global/lcov.info,./.coverage/store/lcov.info
+          flags: unittest
+          name: blocksuite
+          fail_ci_if_error: true
 
   benchmark:
     permissions: write-all

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -145,6 +145,8 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    needs:
+      - build-playground
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -143,8 +143,7 @@ jobs:
   #         fail_ci_if_error: true
 
   benchmark:
-    permissions:
-      pull-requests: write
+    permissions: write-all
     name: Benchmark
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -182,9 +182,9 @@ jobs:
         with:
           mode: recreate
           message: |
-            | yDoc Bin Size Benchmark |  |
+            | yDoc Bin Size Benchmark | Bytes |
             | --- | --- |
-            | yDoc BIN Size | ${{ steps.bin-size-report.outputs.BIN_SIZE }} |
-            | yDoc JSON Size | ${{ steps.bin-size-report.outputs.JSON_SIZE }} |
-            | Bin / JSON ratio | ${{ steps.bin-size-report.outputs.RATIO }} |
+            | BIN Size | ${{ steps.bin-size-report.outputs.BIN_SIZE }} |
+            | JSON Size | ${{ steps.bin-size-report.outputs.JSON_SIZE }} |
+            | Bin / JSON ratio | ${{ steps.bin-size-report.outputs.RATIO }}% |
           comment_tag: benchmark

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -148,6 +148,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-playground
+    env:
+      CPU_BENCHMARK: true
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -182,7 +182,9 @@ jobs:
         with:
           mode: recreate
           message: |
-            ### yDoc Bin Benchmark
-            - yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}
-            - yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
+            | yDoc Bin Size Benchmark |  |
+            | --- | --- |
+            | yDoc BIN Size | ${{ steps.bin-size-report.outputs.BIN_SIZE }} |
+            | yDoc JSON Size | ${{ steps.bin-size-report.outputs.JSON_SIZE }} |
+            | Bin / JSON ratio | ${{ steps.bin-size-report.outputs.RATIO }} |
           comment_tag: benchmark

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -61,11 +61,90 @@ jobs:
           name: playground-artifact
           path: ./packages/playground/dist
 
-  e2e-test:
-    name: Playground E2E test
+  # e2e-test:
+  #   name: Playground E2E test
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - build-playground
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: pnpm/action-setup@v2
+  #       with:
+  #         version: 7.9.5
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version-file: '.nvmrc'
+  #         cache: 'pnpm'
+
+  #     - name: Install dependencies
+  #       run: pnpm install --frozen-lockfile
+
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: playground-artifact
+  #         path: ./packages/playground/dist
+
+  #     - name: Install playwright browsers
+  #       run: npx playwright install chromium
+
+  #     - name: Run playwright tests
+  #       run: pnpm test -- --forbid-only
+  #       env:
+  #         COVERAGE: true
+
+  #     - name: Collect code coverage report
+  #       run: pnpm exec nyc report -t .nyc_output --reporter=lcov
+
+  #     - name: Upload e2e test coverage results
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
+  #         files: ./.coverage/lcov.info
+  #         flags: e2etest
+  #         name: blocksuite
+  #         fail_ci_if_error: true
+
+  #     - name: Upload test results
+  #       if: ${{ failure() }}
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: test-results-main
+  #         path: ./test-results
+  #         if-no-files-found: ignore
+
+  # unit-test:
+  #   name: Unit test
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: pnpm/action-setup@v2
+  #       with:
+  #         version: 7.9.5
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version-file: '.nvmrc'
+  #         cache: 'pnpm'
+
+  #     - name: Install dependencies
+  #       run: pnpm install --frozen-lockfile
+
+  #     - name: Run unit tests
+  #       run: pnpm test:unit:coverage
+
+  #     - name: Upload unit test coverage results
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
+  #         files: ./.coverage/global/lcov.info,./.coverage/store/lcov.info
+  #         flags: unittest
+  #         name: blocksuite
+  #         fail_ci_if_error: true
+
+  benchmark:
+    name: Benchmark
     runs-on: ubuntu-latest
-    needs:
-      - build-playground
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
@@ -88,56 +167,18 @@ jobs:
       - name: Install playwright browsers
         run: npx playwright install chromium
 
-      - name: Run playwright tests
-        run: pnpm test -- --forbid-only
-        env:
-          COVERAGE: true
+      - name: Run Benchmark (yDoc bin size)
+        run: pnpm benchmark
 
-      - name: Collect code coverage report
-        run: pnpm exec nyc report -t .nyc_output --reporter=lcov
+      - name: Read size benchmark
+        id: bin-size-report
+        run: cat bench-mark-size.out >> $GITHUB_OUTPUT
 
-      - name: Upload e2e test coverage results
-        uses: codecov/codecov-action@v3
+      - name: Report on the pull_request
+        uses: thollander/actions-comment-pull-request@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./.coverage/lcov.info
-          flags: e2etest
-          name: blocksuite
-          fail_ci_if_error: true
-
-      - name: Upload test results
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results-main
-          path: ./test-results
-          if-no-files-found: ignore
-
-  unit-test:
-    name: Unit test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 7.9.5
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run unit tests
-        run: pnpm test:unit:coverage
-
-      - name: Upload unit test coverage results
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./.coverage/global/lcov.info,./.coverage/store/lcov.info
-          flags: unittest
-          name: blocksuite
-          fail_ci_if_error: true
+          message: |
+            ### yDoc Bin Benchmark
+            - yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}
+            - yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
+          comment_tag: benchmark

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -180,7 +180,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            ### yDoc Bin Benchmark
-            - yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}
-            - yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
+            ### yDoc Bin Benchmark\n- yDoc BIN Size: ${{ steps.bin-size-report.outputs.BIN_SIZE }}\n- yDoc JSON Size: ${{ steps.bin-size-report.outputs.JSON_SIZE }}
           comment_tag: benchmark

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ next-env.d.ts
 
 # Cache
 .eslintcache
+
+/tmp

--- a/benchmark/benchmark-cpu.tsx
+++ b/benchmark/benchmark-cpu.tsx
@@ -2,7 +2,7 @@ import { forceGC, previewURL, startBrowser } from './common';
 import { computeResultsCPU } from './timeline';
 
 export async function runCPUBenchmark() {
-  const browser = await startBrowser({ headless: false });
+  const browser = await startBrowser({ headless: true });
   const page = await browser.newPage();
   const client = await page.context().newCDPSession(page);
 

--- a/benchmark/benchmark-cpu.tsx
+++ b/benchmark/benchmark-cpu.tsx
@@ -1,0 +1,52 @@
+import { forceGC, previewURL, startBrowser } from './common';
+import { computeResultsCPU } from './timeline';
+
+export async function runCPUBenchmark() {
+  const browser = await startBrowser({ headless: false });
+  const page = await browser.newPage();
+  const client = await page.context().newCDPSession(page);
+
+  const tmpTraceFile = './tmp/trace.json';
+
+  const durations: number[] = [];
+
+  for (let i = 0; i < 10; i++) {
+    console.log('CPU benchmark run ' + i);
+    await client.send('Emulation.setCPUThrottlingRate', { rate: 16 });
+    await forceGC(page);
+    const categories = [
+      'blink.user_timing',
+      'devtools.timeline',
+      'disabled-by-default-devtools.timeline',
+    ];
+    await browser.startTracing(page, {
+      path: tmpTraceFile,
+      screenshots: false,
+      categories: categories,
+    });
+    await page.goto(previewURL + '?init=preset');
+    const pageTitle = page.locator(
+      '.affine-default-page-block-title >> text="Welcome to BlockSuite playground"'
+    );
+    await pageTitle.isVisible();
+    await browser.stopTracing();
+    const duration = await computeResultsCPU(tmpTraceFile);
+    durations.push(duration);
+  }
+
+  const sum = durations.reduce((a, b) => a + b, 0);
+  durations.sort((a, b) => a - b);
+  const avg = sum / durations.length || 0;
+  const max = Math.max(...durations);
+  const min = Math.min(...durations);
+  const median = durations[Math.floor(durations.length / 2)];
+
+  console.log('CPU benchmark result:', {
+    avg,
+    max,
+    min,
+    median,
+  });
+
+  await browser.close();
+}

--- a/benchmark/benchmark-ydoc-bin-size.tsx
+++ b/benchmark/benchmark-ydoc-bin-size.tsx
@@ -1,0 +1,35 @@
+import { previewURL, startBrowser } from './common';
+
+export async function runYDocBenchmark() {
+  const browser = await startBrowser({ headless: false });
+  const page = await browser.newPage();
+
+  await page.goto(previewURL + '?init=preset');
+  const pageTitle = page.locator(
+    '.affine-default-page-block-title >> text="Welcome to BlockSuite playground"'
+  );
+  await pageTitle.isVisible();
+
+  const info = await page.evaluate(() => {
+    // @ts-ignore
+    const Y = window.Y;
+    // @ts-ignore
+    const workspace = window.workspace;
+    const binary: Uint8Array = Y.encodeStateAsUpdate(workspace.doc);
+
+    // size of the binary is
+    const binSize = binary.length;
+
+    const yDocSerialized = workspace.serializeYDoc();
+    const json = JSON.stringify(yDocSerialized);
+
+    // size of the json is
+    const jsonSize = new TextEncoder().encode(json).length;
+
+    return { binSize, jsonSize };
+  });
+
+  await browser.close();
+
+  return info;
+}

--- a/benchmark/benchmark-ydoc-bin-size.tsx
+++ b/benchmark/benchmark-ydoc-bin-size.tsx
@@ -1,7 +1,7 @@
 import { previewURL, startBrowser } from './common';
 
 export async function runYDocBenchmark() {
-  const browser = await startBrowser({ headless: false });
+  const browser = await startBrowser({ headless: true });
   const page = await browser.newPage();
 
   await page.goto(previewURL + '?init=preset');

--- a/benchmark/common.ts
+++ b/benchmark/common.ts
@@ -1,4 +1,4 @@
-import { Browser, chromium, Page } from 'playwright';
+import { Browser, chromium, Page } from '@playwright/test';
 
 export const previewURL = `http://127.0.0.1:4173/`;
 

--- a/benchmark/common.ts
+++ b/benchmark/common.ts
@@ -1,0 +1,21 @@
+import { Browser, chromium, Page } from 'playwright';
+
+export const previewURL = `http://127.0.0.1:4173/`;
+
+export async function forceGC(page: Page) {
+  for (let i = 0; i < 7; i++) {
+    await page.evaluate('window.gc()');
+  }
+}
+
+export async function startBrowser(options: {
+  headless?: boolean;
+}): Promise<Browser> {
+  const args = ['--window-size=1000,800', '--js-flags=--expose-gc'];
+  if (options.headless) args.push('--headless=chrome');
+  const browser = await chromium.launch({
+    args,
+    headless: options.headless,
+  });
+  return browser;
+}

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -6,7 +6,7 @@ import { runYDocBenchmark as runYDocBinarySizeBenchmark } from './benchmark-ydoc
 
 const previewURL = `http://127.0.0.1:4173/`;
 
-const startPlaygroundPreview = (timeout = 10000) => {
+const startPlaygroundPreview = (timeout = 30000) => {
   console.log('starting playground preview ...');
   const child = spawn('pnpm', ['preview:playground'], {});
   let started = false;
@@ -20,7 +20,7 @@ const startPlaygroundPreview = (timeout = 10000) => {
     // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
     child.stdout?.on('data', data => {
       const output = data.toString();
-      // console.log(output);
+      console.log(output);
       if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
         reject('Failed to start playground preview');
         child.kill();

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -20,11 +20,11 @@ const startPlaygroundPreview = (timeout = 30000) => {
     // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
     child.stdout?.on('data', data => {
       const output = data.toString();
-      console.log('stdout: data', output);
+      console.log('stdout: data', output, output.indexOf('Local:'));
       if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
         reject('Failed to start playground preview');
         child.kill();
-      } else if (output.includes('Local:')) {
+      } else if (output.indexOf('Local:') > -1) {
         started = true;
         resolve(child);
         console.log('playground preview started');
@@ -63,6 +63,7 @@ async function main() {
     );
   } catch (err) {
     console.error(err);
+    process.exit(1);
   }
   process.exit();
 }

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -20,19 +20,19 @@ const startPlaygroundPreview = (timeout = 30000) => {
     // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
     child.stdout?.on('data', data => {
       const output = data.toString();
-      console.log(output);
+      console.log('stdout: data', output);
       if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
         reject('Failed to start playground preview');
         child.kill();
       } else if (output.includes(previewURL)) {
-        resolve(child);
         started = true;
+        resolve(child);
         console.log('playground preview started');
       }
     });
 
     child.stderr?.on('data', data => {
-      console.error(data.toString());
+      console.error('stderr: data', data.toString());
     });
 
     child.on('close', () => {

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -1,0 +1,70 @@
+import { ChildProcess, spawn } from 'child_process';
+import fsp from 'fs/promises';
+
+import { runCPUBenchmark } from './benchmark-cpu';
+import { runYDocBenchmark as runYDocBinarySizeBenchmark } from './benchmark-ydoc-bin-size';
+
+const previewURL = `http://127.0.0.1:4173/`;
+
+const startPlaygroundPreview = (timeout = 10000) => {
+  console.log('starting playground preview ...');
+  const child = spawn('pnpm', ['preview:playground'], {});
+  let started = false;
+  return new Promise<ChildProcess>((resolve, reject) => {
+    setTimeout(() => {
+      if (!started) {
+        reject('Start playground preview timeout');
+      }
+    }, timeout);
+
+    // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
+    child.stdout?.on('data', data => {
+      const output = data.toString();
+      // console.log(output);
+      if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
+        reject('Failed to start playground preview');
+        child.kill();
+      } else if (output.includes(previewURL)) {
+        resolve(child);
+        started = true;
+        console.log('playground preview started');
+      }
+    });
+
+    child.stderr?.on('data', data => {
+      console.error(data.toString());
+    });
+
+    child.on('close', () => {
+      console.log('playground preview exited');
+    });
+
+    process.on('exit', function () {
+      console.log('killing child process ...');
+      child.kill();
+    });
+  });
+};
+
+async function main() {
+  try {
+    await startPlaygroundPreview();
+
+    if (process.env.CPU_BENCHMARK) {
+      await runCPUBenchmark();
+    }
+
+    const info = await runYDocBinarySizeBenchmark();
+    const ratio = ((info.binSize / info.jsonSize) * 100).toFixed(1);
+    console.log(`YDoc binary size is ${ratio}% about the JSON size`);
+    await fsp.writeFile(
+      'bench-mark-size.out',
+      `BIN_SIZE=${info.binSize}\nJSON_SIZE=${info.jsonSize}\nRATIO=${ratio}`
+    );
+  } catch (err) {
+    console.error(err);
+  }
+  process.exit();
+}
+
+main();

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -24,7 +24,7 @@ const startPlaygroundPreview = (timeout = 30000) => {
       if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
         reject('Failed to start playground preview');
         child.kill();
-      } else if (output.includes(previewURL)) {
+      } else if (output.includes('Local:')) {
         started = true;
         resolve(child);
         console.log('playground preview started');

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -14,7 +14,7 @@ const startPlaygroundPreview = () => {
       // todo: check if the service is really up
       console.log('playground preview started');
       resolve(child);
-    }, 1000);
+    }, 6000);
     // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
     child.stdout?.on('data', data => {
       console.error('stderr: data', data.toString());

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -6,29 +6,18 @@ import { runYDocBenchmark as runYDocBinarySizeBenchmark } from './benchmark-ydoc
 
 const previewURL = `http://127.0.0.1:4173/`;
 
-const startPlaygroundPreview = (timeout = 30000) => {
+const startPlaygroundPreview = () => {
   console.log('starting playground preview ...');
   const child = spawn('pnpm', ['preview:playground'], {});
-  let started = false;
   return new Promise<ChildProcess>((resolve, reject) => {
     setTimeout(() => {
-      if (!started) {
-        reject('Start playground preview timeout');
-      }
-    }, timeout);
-
+      // todo: check if the service is really up
+      console.log('playground preview started');
+      resolve(child);
+    }, 1000);
     // wait until child output "http://127.0.0.1:4173/", which means the preview is ready
     child.stdout?.on('data', data => {
-      const output = data.toString();
-      console.log('stdout: data', output, output.indexOf('Local:'));
-      if (output.includes('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')) {
-        reject('Failed to start playground preview');
-        child.kill();
-      } else if (output.indexOf('Local:') > -1) {
-        started = true;
-        resolve(child);
-        console.log('playground preview started');
-      }
+      console.error('stderr: data', data.toString());
     });
 
     child.stderr?.on('data', data => {

--- a/benchmark/timeline.ts
+++ b/benchmark/timeline.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { readFile } from 'fs/promises';
 
 interface Timingresult {
@@ -6,7 +7,7 @@ interface Timingresult {
   dur: number;
   end: number;
   mem?: number;
-  evt?: any;
+  evt?: unknown;
 }
 
 export function extractRelevantEvents(entries: any[]) {

--- a/benchmark/timeline.ts
+++ b/benchmark/timeline.ts
@@ -81,11 +81,11 @@ async function fetchEventsFromPerformanceLog(
   fileName: string
 ): Promise<Timingresult[]> {
   let timingResults: Timingresult[] = [];
-  const entries = [];
+  let entries = [];
   do {
     const contents = await readFile(fileName, { encoding: 'utf8' });
     const json = JSON.parse(contents);
-    const entries = json['traceEvents'];
+    entries = json['traceEvents'];
     const filteredEvents = extractRelevantEvents(entries);
     timingResults = timingResults.concat(filteredEvents);
   } while (entries.length > 0);

--- a/benchmark/timeline.ts
+++ b/benchmark/timeline.ts
@@ -1,0 +1,120 @@
+import { readFile } from 'fs/promises';
+
+interface Timingresult {
+  type: string;
+  ts: number;
+  dur: number;
+  end: number;
+  mem?: number;
+  evt?: any;
+}
+
+export function extractRelevantEvents(entries: any[]) {
+  const filteredEvents: Timingresult[] = [];
+
+  entries.forEach(x => {
+    const e = x;
+    if (e.name === 'EventDispatch') {
+      if (e.args.data.type === 'click') {
+        filteredEvents.push({
+          type: 'click',
+          ts: +e.ts,
+          dur: +e.dur,
+          end: +e.ts + e.dur,
+        });
+      }
+    } else if (e.name === 'CompositeLayers' && e.ph === 'X') {
+      filteredEvents.push({
+        type: 'compositelayers',
+        ts: +e.ts,
+        dur: +e.dur,
+        end: +e.ts + e.dur,
+        evt: JSON.stringify(e),
+      });
+    } else if (e.name === 'Layout' && e.ph === 'X') {
+      filteredEvents.push({
+        type: 'layout',
+        ts: +e.ts,
+        dur: +e.dur,
+        end: +e.ts + e.dur,
+        evt: JSON.stringify(e),
+      });
+    } else if (e.name === 'Paint' && e.ph === 'X') {
+      filteredEvents.push({
+        type: 'paint',
+        ts: +e.ts,
+        dur: +e.dur,
+        end: +e.ts + e.dur,
+        evt: JSON.stringify(e),
+      });
+    } else if (e.name === 'FireAnimationFrame' && e.ph === 'X') {
+      filteredEvents.push({
+        type: 'fireAnimationFrame',
+        ts: +e.ts,
+        dur: +e.dur,
+        end: +e.ts + e.dur,
+        evt: JSON.stringify(e),
+      });
+    } else if (e.name === 'UpdateLayoutTree' && e.ph === 'X') {
+      filteredEvents.push({
+        type: 'updateLayoutTree',
+        ts: +e.ts,
+        dur: +e.dur,
+        end: +e.ts + e.dur,
+        evt: JSON.stringify(e),
+      });
+    } else if (e.name === 'RequestAnimationFrame') {
+      filteredEvents.push({
+        type: 'requestAnimationFrame',
+        ts: +e.ts,
+        dur: 0,
+        end: +e.ts,
+        evt: JSON.stringify(e),
+      });
+    }
+  });
+  return filteredEvents;
+}
+
+async function fetchEventsFromPerformanceLog(
+  fileName: string
+): Promise<Timingresult[]> {
+  let timingResults: Timingresult[] = [];
+  const entries = [];
+  do {
+    const contents = await readFile(fileName, { encoding: 'utf8' });
+    const json = JSON.parse(contents);
+    const entries = json['traceEvents'];
+    const filteredEvents = extractRelevantEvents(entries);
+    timingResults = timingResults.concat(filteredEvents);
+  } while (entries.length > 0);
+  return timingResults;
+}
+
+function type_eq(requiredType: string) {
+  return (e: Timingresult) => e.type === requiredType;
+}
+
+export async function computeResultsCPU(fileName: string): Promise<number> {
+  const perfLogEvents = await fetchEventsFromPerformanceLog(fileName);
+  const eventsDuringBenchmark = perfLogEvents.sort(
+    (a, b) => (a.end ?? 0) - (b.end ?? 0)
+  );
+
+  const layouts = eventsDuringBenchmark.filter(type_eq('layout'));
+  const paints = eventsDuringBenchmark.filter(type_eq('paint'));
+
+  const lastPaint = paints[paints.length - 1];
+  const firstLayout = layouts[0];
+
+  // last paint to first layout
+  const duration = (lastPaint.end - firstLayout.ts) / 1000.0;
+
+  const fafs = eventsDuringBenchmark.filter(type_eq('fireAnimationFrame'));
+
+  // console.log('faf', fafs.length);
+  // console.log('paint', paints.length);
+  // console.log('layout', layouts.length);
+
+  return duration;
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "build:playground": "pnpm --filter @blocksuite/playground build",
     "clean": "./scripts/clean.sh",
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "benchmark": "tsx ./benchmark/runner.ts"
   },
   "lint-staged": {
     "*": "prettier --write --cache --ignore-unknown",
@@ -46,9 +47,9 @@
   "author": "toeverything",
   "license": "MPL-2.0",
   "devDependencies": {
+    "@blocksuite/blocks": "workspace:*",
     "@blocksuite/global": "workspace:*",
     "@blocksuite/store": "workspace:*",
-    "@blocksuite/blocks": "workspace:*",
     "@blocksuite/virgo": "workspace:*",
     "@commitlint/cli": "^17.4.3",
     "@commitlint/config-conventional": "^17.4.3",
@@ -75,8 +76,10 @@
     "micromatch": "^4.0.5",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
+    "playwright": "^1.31.1",
     "prettier": "^2.8.4",
     "pretty-format": "^29.4.2",
+    "tsx": "^3.12.3",
     "typescript": "^4.9.5",
     "vite": "^4.1.1",
     "vite-plugin-istanbul": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "micromatch": "^4.0.5",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
-    "playwright": "^1.31.1",
     "prettier": "^2.8.4",
     "pretty-format": "^29.4.2",
     "tsx": "^3.12.3",

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -164,4 +164,8 @@ export class Store {
     }
     return yDocToJSXNode(json['space:page0'], id);
   }
+
+  serializeYDoc() {
+    return serializeYDoc(this.doc) as unknown as SerializedStore;
+  }
 }

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -418,4 +418,8 @@ export class Workspace {
   exportJSX(id = '0') {
     return this._store.exportJSX(id);
   }
+
+  serializeYDoc() {
+    return this._store.serializeYDoc();
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,6 @@ importers:
       micromatch: ^4.0.5
       npm-run-all: ^4.1.5
       nyc: ^15.1.0
-      playwright: ^1.31.1
       prettier: ^2.8.4
       pretty-format: ^29.4.2
       tsx: ^3.12.3
@@ -77,7 +76,6 @@ importers:
       micromatch: 4.0.5
       npm-run-all: 4.1.5
       nyc: 15.1.0
-      playwright: 1.31.1
       prettier: 2.8.4
       pretty-format: 29.4.2
       tsx: 3.12.3
@@ -6134,21 +6132,6 @@ packages:
     resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
-
-  /playwright-core/1.31.1:
-    resolution: {integrity: sha512-JTyX4kV3/LXsvpHkLzL2I36aCdml4zeE35x+G5aPc4bkLsiRiQshU5lWeVpHFAuC8xAcbI6FDcw/8z3q2xtJSQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
-  /playwright/1.31.1:
-    resolution: {integrity: sha512-zKJabsIA2rvOwJ12lGTqWv4HVJzlfw2JtUvO4hAr7J8UXQZ1qEPpX20E1vcz/9fotnTkwgqp3CVdIBwptBN3Fg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      playwright-core: 1.31.1
     dev: true
 
   /postcss/8.4.14:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,10 @@ importers:
       micromatch: ^4.0.5
       npm-run-all: ^4.1.5
       nyc: ^15.1.0
+      playwright: ^1.31.1
       prettier: ^2.8.4
       pretty-format: ^29.4.2
+      tsx: ^3.12.3
       typescript: ^4.9.5
       vite: ^4.1.1
       vite-plugin-istanbul: ^4.0.0
@@ -75,8 +77,10 @@ importers:
       micromatch: 4.0.5
       npm-run-all: 4.1.5
       nyc: 15.1.0
+      playwright: 1.31.1
       prettier: 2.8.4
       pretty-format: 29.4.2
+      tsx: 3.12.3
       typescript: 4.9.5
       vite: 4.1.1_@types+node@18.13.0
       vite-plugin-istanbul: 4.0.0_vite@4.1.1
@@ -852,8 +856,38 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /@esbuild-kit/cjs-loader/2.4.2:
+    resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
+    dev: true
+
+  /@esbuild-kit/core-utils/3.1.0:
+    resolution: {integrity: sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==}
+    dependencies:
+      esbuild: 0.17.10
+      source-map-support: 0.5.21
+    dev: true
+
+  /@esbuild-kit/esm-loader/2.5.5:
+    resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
+    dev: true
+
   /@esbuild/android-arm/0.16.17:
     resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm/0.17.10:
+    resolution: {integrity: sha512-7YEBfZ5lSem9Tqpsz+tjbdsEshlO9j/REJrfv4DXgKTt1+/MHqGwbtlyxQuaSlMeUZLxUKBaX8wdzlTfHkmnLw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -870,8 +904,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm64/0.17.10:
+    resolution: {integrity: sha512-ht1P9CmvrPF5yKDtyC+z43RczVs4rrHpRqrmIuoSvSdn44Fs1n6DGlpZKdK6rM83pFLbVaSUwle8IN+TPmkv7g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64/0.16.17:
     resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64/0.17.10:
+    resolution: {integrity: sha512-CYzrm+hTiY5QICji64aJ/xKdN70IK8XZ6iiyq0tZkd3tfnwwSWTYH1t3m6zyaaBxkuj40kxgMyj1km/NqdjQZA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -888,8 +940,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64/0.17.10:
+    resolution: {integrity: sha512-3HaGIowI+nMZlopqyW6+jxYr01KvNaLB5znXfbyyjuo4lE0VZfvFGcguIJapQeQMS4cX/NEispwOekJt3gr5Dg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64/0.16.17:
     resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64/0.17.10:
+    resolution: {integrity: sha512-J4MJzGchuCRG5n+B4EHpAMoJmBeAE1L3wGYDIN5oWNqX0tEr7VKOzw0ymSwpoeSpdCa030lagGUfnfhS7OvzrQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -906,8 +976,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64/0.17.10:
+    resolution: {integrity: sha512-ZkX40Z7qCbugeK4U5/gbzna/UQkM9d9LNV+Fro8r7HA7sRof5Rwxc46SsqeMvB5ZaR0b1/ITQ/8Y1NmV2F0fXQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64/0.16.17:
     resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64/0.17.10:
+    resolution: {integrity: sha512-0m0YX1IWSLG9hWh7tZa3kdAugFbZFFx9XrvfpaCMMvrswSTvUZypp0NFKriUurHpBA3xsHVE9Qb/0u2Bbi/otg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -924,8 +1012,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm/0.17.10:
+    resolution: {integrity: sha512-whRdrrl0X+9D6o5f0sTZtDM9s86Xt4wk1bf7ltx6iQqrIIOH+sre1yjpcCdrVXntQPCNw/G+XqsD4HuxeS+2QA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64/0.16.17:
     resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64/0.17.10:
+    resolution: {integrity: sha512-g1EZJR1/c+MmCgVwpdZdKi4QAJ8DCLP5uTgLWSAVd9wlqk9GMscaNMEViG3aE1wS+cNMzXXgdWiW/VX4J+5nTA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -942,8 +1048,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32/0.17.10:
+    resolution: {integrity: sha512-1vKYCjfv/bEwxngHERp7huYfJ4jJzldfxyfaF7hc3216xiDA62xbXJfRlradiMhGZbdNLj2WA1YwYFzs9IWNPw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64/0.16.17:
     resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.17.10:
+    resolution: {integrity: sha512-mvwAr75q3Fgc/qz3K6sya3gBmJIYZCgcJ0s7XshpoqIAIBszzfXsqhpRrRdVFAyV1G9VUjj7VopL2HnAS8aHFA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -960,8 +1084,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el/0.17.10:
+    resolution: {integrity: sha512-XilKPgM2u1zR1YuvCsFQWl9Fc35BqSqktooumOY2zj7CSn5czJn279j9TE1JEqSqz88izJo7yE4x3LSf7oxHzg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64/0.16.17:
     resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64/0.17.10:
+    resolution: {integrity: sha512-kM4Rmh9l670SwjlGkIe7pYWezk8uxKHX4Lnn5jBZYBNlWpKMBCVfpAgAJqp5doLobhzF3l64VZVrmGeZ8+uKmQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -978,8 +1120,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64/0.17.10:
+    resolution: {integrity: sha512-r1m9ZMNJBtOvYYGQVXKy+WvWd0BPvSxMsVq8Hp4GzdMBQvfZRvRr5TtX/1RdN6Va8JMVQGpxqde3O+e8+khNJQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x/0.16.17:
     resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x/0.17.10:
+    resolution: {integrity: sha512-LsY7QvOLPw9WRJ+fU5pNB3qrSfA00u32ND5JVDrn/xG5hIQo3kvTxSlWFRP0NJ0+n6HmhPGG0Q4jtQsb6PFoyg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -996,8 +1156,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64/0.17.10:
+    resolution: {integrity: sha512-zJUfJLebCYzBdIz/Z9vqwFjIA7iSlLCFvVi7glMgnu2MK7XYigwsonXshy9wP9S7szF+nmwrelNaP3WGanstEg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64/0.16.17:
     resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64/0.17.10:
+    resolution: {integrity: sha512-lOMkailn4Ok9Vbp/q7uJfgicpDTbZFlXlnKT2DqC8uBijmm5oGtXAJy2ZZVo5hX7IOVXikV9LpCMj2U8cTguWA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -1014,8 +1192,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64/0.17.10:
+    resolution: {integrity: sha512-/VE0Kx6y7eekqZ+ZLU4AjMlB80ov9tEz4H067Y0STwnGOYL8CsNg4J+cCmBznk1tMpxMoUOf0AbWlb1d2Pkbig==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64/0.16.17:
     resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64/0.17.10:
+    resolution: {integrity: sha512-ERNO0838OUm8HfUjjsEs71cLjLMu/xt6bhOlxcJ0/1MG3hNqCmbWaS+w/8nFLa0DDjbwZQuGKVtCUJliLmbVgg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1032,6 +1228,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64/0.17.10:
+    resolution: {integrity: sha512-fXv+L+Bw2AeK+XJHwDAQ9m3NRlNemG6Z6ijLwJAAVdu4cyoFbBWbEtyZzDeL+rpG2lWI51cXeMt70HA8g2MqIg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32/0.16.17:
     resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
     engines: {node: '>=12'}
@@ -1041,8 +1246,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32/0.17.10:
+    resolution: {integrity: sha512-3s+HADrOdCdGOi5lnh5DMQEzgbsFsd4w57L/eLKKjMnN0CN4AIEP0DCP3F3N14xnxh3ruNc32A0Na9zYe1Z/AQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64/0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.10:
+    resolution: {integrity: sha512-oP+zFUjYNaMNmjTwlFtWep85hvwUu19cZklB3QsBOcZSs6y7hmH4LNCJ7075bsqzYaNvZFXJlAVaQ2ApITDXtw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3671,6 +3894,36 @@ packages:
       '@esbuild/win32-x64': 0.16.17
     dev: true
 
+  /esbuild/0.17.10:
+    resolution: {integrity: sha512-n7V3v29IuZy5qgxx25TKJrEm0FHghAlS6QweUcyIgh/U0zYmQcvogWROitrTyZId1mHSkuhhuyEXtI9OXioq7A==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.10
+      '@esbuild/android-arm64': 0.17.10
+      '@esbuild/android-x64': 0.17.10
+      '@esbuild/darwin-arm64': 0.17.10
+      '@esbuild/darwin-x64': 0.17.10
+      '@esbuild/freebsd-arm64': 0.17.10
+      '@esbuild/freebsd-x64': 0.17.10
+      '@esbuild/linux-arm': 0.17.10
+      '@esbuild/linux-arm64': 0.17.10
+      '@esbuild/linux-ia32': 0.17.10
+      '@esbuild/linux-loong64': 0.17.10
+      '@esbuild/linux-mips64el': 0.17.10
+      '@esbuild/linux-ppc64': 0.17.10
+      '@esbuild/linux-riscv64': 0.17.10
+      '@esbuild/linux-s390x': 0.17.10
+      '@esbuild/linux-x64': 0.17.10
+      '@esbuild/netbsd-x64': 0.17.10
+      '@esbuild/openbsd-x64': 0.17.10
+      '@esbuild/sunos-x64': 0.17.10
+      '@esbuild/win32-arm64': 0.17.10
+      '@esbuild/win32-ia32': 0.17.10
+      '@esbuild/win32-x64': 0.17.10
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -4253,6 +4506,10 @@ packages:
 
   /get-tsconfig/4.2.0:
     resolution: {integrity: sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==}
+    dev: true
+
+  /get-tsconfig/4.4.0:
+    resolution: {integrity: sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==}
     dev: true
 
   /git-raw-commits/2.0.11:
@@ -5879,6 +6136,21 @@ packages:
     hasBin: true
     dev: true
 
+  /playwright-core/1.31.1:
+    resolution: {integrity: sha512-JTyX4kV3/LXsvpHkLzL2I36aCdml4zeE35x+G5aPc4bkLsiRiQshU5lWeVpHFAuC8xAcbI6FDcw/8z3q2xtJSQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
+  /playwright/1.31.1:
+    resolution: {integrity: sha512-zKJabsIA2rvOwJ12lGTqWv4HVJzlfw2JtUvO4hAr7J8UXQZ1qEPpX20E1vcz/9fotnTkwgqp3CVdIBwptBN3Fg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.31.1
+    dev: true
+
   /postcss/8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6734,6 +7006,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
+    dev: true
+
+  /tsx/3.12.3:
+    resolution: {integrity: sha512-Wc5BFH1xccYTXaQob+lEcimkcb/Pq+0en2s+ruiX0VEIC80nV7/0s7XRahx8NnsoCnpCVUPz8wrqVSPi760LkA==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.4.2
+      '@esbuild-kit/core-utils': 3.1.0
+      '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /turndown/7.1.1:


### PR DESCRIPTION
fix https://github.com/toeverything/blocksuite/issues/1176
Add basic benchmark to blocksuite.

There are two tests in this PR
- calculating the rendering duration,
- the ratio between yDoc binary and the JSON serialized output

On benchmark job finished, it shall report something like this in [the PR comment](https://github.com/pengx17/blocksuite/pull/1#issuecomment-1448593311):
<img width="395" alt="image" src="https://user-images.githubusercontent.com/584378/221933390-fb19b07f-39b2-4c6e-ab8d-308ee5d7ed38.png">

However it seems this repo does not grant write permissions to github actions so commenting on PR will always fail right now.
