### PR TITLE
fix: should render nothing when no page model

### DIFF
--- a/packages/blocks/src/__internal__/utils/components.ts
+++ b/packages/blocks/src/__internal__/utils/components.ts
@@ -84,6 +84,11 @@ export function BlockChildrenContainer(
   host: BlockHost,
   onLoaded: () => void
 ) {
+  if (!model) {
+    throw new Error(
+      "Failed to render block's children container! model not found"
+    );
+  }
   const paddingLeft = matchFlavours(model, [
     'affine:page',
     'affine:frame',

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -167,6 +167,9 @@ export class EditorContainer extends NonShadowLitElement {
 
   public async createBlockHub() {
     await this.updateComplete;
+    if (!this.page.root) {
+      await new Promise(res => this.page.signals.rootAdded.once(res));
+    }
     return createBlockHub(this, this.page);
   }
 
@@ -177,13 +180,13 @@ export class EditorContainer extends NonShadowLitElement {
   }
 
   render() {
-    if (!this.model) return null;
+    if (!this.model || !this.pageBlockModel) return null;
 
     const pageContainer = html`
       <affine-default-page
         .mouseRoot=${this as HTMLElement}
         .page=${this.page}
-        .model=${this.pageBlockModel as PageBlockModel}
+        .model=${this.pageBlockModel}
         .readonly=${this.readonly}
       ></affine-default-page>
     `;
@@ -192,7 +195,7 @@ export class EditorContainer extends NonShadowLitElement {
       <affine-edgeless-page
         .mouseRoot=${this as HTMLElement}
         .page=${this.page}
-        .pageModel=${this.pageBlockModel as PageBlockModel}
+        .pageModel=${this.pageBlockModel}
         .surfaceModel=${this.surfaceBlockModel as SurfaceBlockModel}
         .mouseMode=${this.mouseMode}
         .readonly=${this.readonly}

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -29,11 +29,8 @@ export const empty: InitFn = (workspace: Workspace) => {
       const frameId = page.addBlockByFlavour('affine:frame', {}, pageBlockId);
       // Add paragraph block inside frame block
       page.addBlockByFlavour('affine:paragraph', {}, frameId);
-
-      requestAnimationFrame(() => {
-        page.resetHistory();
-        resolve(pageId);
-      });
+      page.resetHistory();
+      resolve(pageId);
     });
 
     workspace.createPage('page0');
@@ -113,10 +110,8 @@ export const preset: InitFn = (workspace: Workspace) => {
       // Import preset markdown content inside frame block
       await window.editor.clipboard.importMarkdown(presetMarkdown, frameId);
 
-      requestAnimationFrame(() => {
-        page.resetHistory();
-        resolve(pageId);
-      });
+      page.resetHistory();
+      resolve(pageId);
     });
 
     workspace.createPage('page0');
@@ -222,10 +217,8 @@ export const database: InitFn = (workspace: Workspace) => {
       // Add a paragraph after database
       page.addBlockByFlavour('affine:paragraph', {}, frameId);
 
-      requestAnimationFrame(() => {
-        page.resetHistory();
-        resolve(pageId);
-      });
+      page.resetHistory();
+      resolve(pageId);
     });
 
     workspace.createPage('page0');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -68,9 +68,9 @@ async function initEmptyEditor(
 
       document.body.appendChild(editor);
       document.body.appendChild(debugMenu);
-      const blockHub = await editor.createBlockHub();
-      document.body.appendChild(blockHub);
-
+      editor.createBlockHub().then(blockHub => {
+        document.body.appendChild(blockHub);
+      });
       window.debugMenu = debugMenu;
       window.editor = editor;
       window.page = page;


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/1225


When creating an editor without adding a page block immediately, the `affine-default-page` component may not receive a model, which is unexpected.