### PR TITLE
fix(blocks): missing target when mouse fall into between two blocks and Y axis wrongly calculated

### DIFF
--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -107,8 +107,8 @@ export class BlockHub extends NonShadowLitElement {
     e: DragEvent,
     lastModelState: EditingState
   ) => Promise<void>;
-  private _currentPageX = 0;
-  private _currentPageY = 0;
+  private _currentClientX = 0;
+  private _currentClientY = 0;
   private _indicator!: DragIndicator;
   private _indicatorHTMLTemplate!: TemplateResult<1>;
   private _lastModelState: EditingState | null = null;
@@ -675,19 +675,19 @@ export class BlockHub extends NonShadowLitElement {
 
   private _onMouseDown = (e: MouseEvent) => {
     if (isFirefox) {
-      this._currentPageX = e.pageX;
-      this._currentPageY = e.pageY;
+      this._currentClientX = e.clientX;
+      this._currentClientY = e.clientY;
     }
 
     this._refreshCursor(e);
   };
 
   private _refreshCursor = (e: MouseEvent) => {
-    let x = e.pageX;
-    let y = e.pageY;
+    let x = e.clientX;
+    let y = e.clientY;
     if (isFirefox) {
-      x = this._currentPageX;
-      y = this._currentPageY;
+      x = this._currentClientX;
+      y = this._currentClientY;
     }
     const blocks = this.getAllowedBlocks();
     const modelState = getBlockEditingStateByPosition(blocks, x, y, {
@@ -699,13 +699,13 @@ export class BlockHub extends NonShadowLitElement {
   };
 
   private _onDrag = (e: DragEvent) => {
-    let x = e.pageX;
-    let y = e.pageY;
+    let x = e.clientX;
+    let y = e.clientY;
     if (isFirefox) {
       // In Firefox, `pageX` and `pageY` are always set to 0.
       // Refs: https://stackoverflow.com/questions/13110349/pagex-and-pagey-are-always-set-to-0-in-firefox-during-the-ondrag-event.
-      x = this._currentPageX;
-      y = this._currentPageY;
+      x = this._currentClientX;
+      y = this._currentClientY;
     }
 
     const modelState = this._cursor
@@ -743,8 +743,8 @@ export class BlockHub extends NonShadowLitElement {
     if (!isFirefox) {
       throw new Error('FireFox only');
     }
-    this._currentPageX = e.pageX;
-    this._currentPageY = e.pageY;
+    this._currentClientX = e.clientX;
+    this._currentClientY = e.clientY;
   };
 
   private _onDragEnd = (e: DragEvent) => {

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -844,8 +844,8 @@ export class DefaultSelectionManager {
     this.state.refreshBlockRectCache();
     const hoverEditingState = getBlockEditingStateByPosition(
       this._allowSelectedBlocks,
-      e.raw.pageX,
-      e.raw.pageY
+      e.raw.clientX,
+      e.raw.clientY
     );
     if ((e.raw.target as HTMLElement).closest('.embed-editing-state')) return;
 

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -136,12 +136,22 @@ function binarySearchBlockEditingState(
     containerLeft = firstBlock.blockRect.left;
   }
 
+  let inside = false;
   while (start <= end) {
     const mid = start + Math.floor((end - start) / 2);
     const { block, blockRect, detectRect, hoverDom } = getBlockAndRect(
       blocks,
       mid
     );
+
+    // if the detectRect is not in the view port, it's definitely not the block we want
+    if (detectRect.top > window.innerHeight) {
+      end = mid - 1;
+      continue;
+    } else if (detectRect.bottom < 0) {
+      start = mid + 1;
+      continue;
+    }
 
     // code block use async loading
     if (block.flavour === 'affine:code' && !hoverDom) {
@@ -185,7 +195,7 @@ function binarySearchBlockEditingState(
       }
     }
 
-    const inside = y >= detectRect.top && y <= detectRect.bottom;
+    !inside && (inside = y >= detectRect.top && y <= detectRect.bottom);
 
     if (inside) {
       assertExists(blockRect);
@@ -241,6 +251,31 @@ function binarySearchBlockEditingState(
       end = mid - 1;
     } else if (detectRect.bottom < y) {
       start = mid + 1;
+    }
+
+    // if search failed, it may be caused by the mouse fall between two blocks
+    if (start > end) {
+      let targetIndex = -1;
+      // now start = end + 1, eg: [0, 1, ..., end start ..., blocks.length - 1]
+      if (start === blocks.length) {
+        targetIndex = end;
+      } else if (end === -1) {
+        targetIndex = start;
+      } else {
+        const { detectRect: prevDetectRect } = getBlockAndRect(blocks, end);
+        const { detectRect: nextDetectRect } = getBlockAndRect(blocks, start);
+        if (
+          Math.abs(prevDetectRect.bottom - y) < Math.abs(y - nextDetectRect.top)
+        ) {
+          // nearer to prevDetectRect
+          targetIndex = end;
+        } else {
+          // nearer to nextDetectRect
+          targetIndex = start;
+        }
+      }
+      inside = true;
+      start = end = targetIndex;
     }
   }
 

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -265,7 +265,9 @@ function binarySearchBlockEditingState(
         const { detectRect: prevDetectRect } = getBlockAndRect(blocks, end);
         const { detectRect: nextDetectRect } = getBlockAndRect(blocks, start);
         if (
-          Math.abs(prevDetectRect.bottom - y) < Math.abs(y - nextDetectRect.top)
+          y <
+          prevDetectRect.bottom +
+            (nextDetectRect.top - prevDetectRect.bottom) / 2
         ) {
           // nearer to prevDetectRect
           targetIndex = end;


### PR DESCRIPTION
## Y axis
The  `top` value of Rect calculated by `Element.getBoundingClientRect()`  is neither the same as `PageY` nor `ClientY` in `MouseEvent`.  [It represent the distance from the element top to the top of viewport](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect#scrolling), when the element is upside of the viewport, it's negative, and When the element is downside of the viewport, it's bigger than `window.innerHeight`.

**But when the Element is in the viewPort, the `top` can be compared with `clientY`**. This PR used this point, to first filter only the blocks in the viewPort. Then we can always use `clientY` in `MouseEvent` when comparing.

##  When mouse falls into between two blocks

Currently our binary search uses `y >= detectRect.top && y <= detectRect.bottom` to decide current cursor falls into a block. When mouse fall into between two blocks, the search fails. We think returning the nearest block to the cursor maybe better. This is achieved by the fact the when the search fails, the [`start` and `end`](https://github.com/toeverything/blocksuite/blob/b9719d40ed4572c5621f2d40b4c4e7c75717dc78/packages/blocks/src/page-block/default/utils.ts#L149) is already the indexes of two closest candidate blocks. By comparing the distances between the mouse and two blocks we can get the result.

## Before

https://user-images.githubusercontent.com/20554850/222664255-6ecd9653-1ed1-4b17-911b-caf4d6085bbb.mov


https://user-images.githubusercontent.com/20554850/222664265-bec04651-f09e-42de-a76d-267d00a30bf0.mov



## After

https://user-images.githubusercontent.com/20554850/222666123-32f78214-ae0b-4a53-b046-bfbd6b31be6a.mov




