### PR TITLE
perf: reduce rich text re-render

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -89,7 +89,7 @@ export class RichText extends NonShadowLitElement {
 
   quill!: QuillType;
 
-  @property({ hasChanged: () => true })
+  @property()
   host!: BlockHost;
 
   @property()
@@ -222,9 +222,11 @@ export class RichText extends NonShadowLitElement {
   }
 
   render() {
-    return html`<div class="affine-rich-text quill-container ql-container">
-      <slot></slot>
-    </div>`;
+    return html`
+      <div class="affine-rich-text quill-container ql-container">
+        <slot></slot>
+      </div>
+    `;
   }
 }
 


### PR DESCRIPTION
Related to #1258

Mouse move before (using http://localhost:5173/?init=preset):

<img width="400" src="https://user-images.githubusercontent.com/7312949/222673733-68dcb775-8479-4826-96b6-f6a088f3a7b1.jpg">

Mouse move after:

<img width="400" src="https://user-images.githubusercontent.com/7312949/222673807-c5f14513-32dd-4abc-b7d3-ddc9d7174af5.jpg">