### PR TITLE
ci: run tests in parallel

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,8 +64,6 @@ jobs:
   e2e-test:
     name: Playground E2E test (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
-    needs:
-      - build-playground
     strategy:
       matrix:
         shard: [1, 2, 3, 4]
@@ -81,12 +79,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: playground-artifact
-          path: ./packages/playground/dist
 
       - name: Install playwright browsers
         run: npx playwright install chromium

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -62,10 +62,13 @@ jobs:
           path: ./packages/playground/dist
 
   e2e-test:
-    name: Playground E2E test
+    name: Playground E2E test (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
     needs:
       - build-playground
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
@@ -89,7 +92,7 @@ jobs:
         run: npx playwright install chromium
 
       - name: Run playwright tests
-        run: pnpm test -- --forbid-only
+        run: pnpm test -- --forbid-only --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           COVERAGE: true
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -65,6 +65,7 @@ jobs:
     name: Playground E2E test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -62,7 +62,7 @@ jobs:
           path: ./packages/playground/dist
 
   e2e-test:
-    name: Playground E2E test (${{ matrix.shard }}/${{ strategy.job-total }})
+    name: Playground E2E test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -104,7 +104,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.shard }}/${{ strategy.job-total }}
+          name: test-results-main
           path: ./test-results
           if-no-files-found: ignore
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-main
+          name: test-results-${{ matrix.shard }}/${{ strategy.job-total }}
           path: ./test-results
           if-no-files-found: ignore
 

--- a/packages/global/src/utils.ts
+++ b/packages/global/src/utils.ts
@@ -117,4 +117,5 @@ export async function sleep(ms: number): Promise<void> {
 }
 
 export const getDefaultPlaygroundURL = (isE2E: boolean): URL =>
-  new URL(`http://localhost:${isE2E ? 4173 : 5173}/`);
+  new URL(`http://localhost:5173/`);
+// new URL(`http://localhost:${isE2E ? 4173 : 5173}/`);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,8 +9,10 @@ const config: PlaywrightTestConfig = {
   fullyParallel: true,
   timeout: process.env.CI ? 50_000 : 30_000,
   webServer: {
-    command: process.env.CI ? 'pnpm preview' : 'pnpm dev',
-    port: process.env.CI ? 4173 : 5173,
+    command: 'pnpm dev',
+    port: 5173,
+    // command: process.env.CI ? 'pnpm preview' : 'pnpm dev',
+    // port: process.env.CI ? 4173 : 5173,
     reuseExistingServer: !process.env.CI,
     env: {
       COVERAGE: process.env.COVERAGE ?? '',


### PR DESCRIPTION
Make testing fast again

<img width="734" alt="Screenshot 2023-03-04 at 2 00 25 AM" src="https://user-images.githubusercontent.com/18554747/222794023-92e5370a-6b4e-4c2a-aa14-a418749fcb43.png">

Code coverage is normal

<img width="996" alt="Screenshot 2023-03-04 at 1 55 44 AM" src="https://user-images.githubusercontent.com/18554747/222793137-41487382-c2b8-4ef9-a176-f2c5df29639f.png">


> `<job_id>.strategy.fail-fast` is set to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to true.

References

https://timdeschryver.dev/blog/using-playwright-test-shards-in-combination-with-a-job-matrix-to-improve-your-ci-speed#github-workflow-caching