### PR TITLE
refactor: `Signal` -> `Slot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pnpm i \
 
 And here is a minimal collaboration-ready editor showing how these underlying BlockSuite packages are composed together:
 
-> 🚧 Here we will work with the concepts of `Workspace`, `Page`, `Block` and `Signal`. These are the primitives for building a block-based collaborative application. We are preparing a comprehensive documentation about their usage!
+> 🚧 Here we will work with the concepts of `Workspace`, `Page`, `Block` and `Slot`. These are the primitives for building a block-based collaborative application. We are preparing a comprehensive documentation about their usage!
 
 ```ts
 import '@blocksuite/blocks';
@@ -117,8 +117,8 @@ import { EditorContainer } from '@blocksuite/editor';
  * In these cases, this function should not be called.
  */
 function createInitialPage(workspace: Workspace) {
-  // Events are being emitted using signals.
-  workspace.signals.pageAdded.once(pageId => {
+  // Events are being emitted using slots.
+  workspace.slots.pageAdded.once(pageId => {
     const page = workspace.getPage(pageId) as Page;
 
     // Block types are defined and registered in BlockSchema.
@@ -127,13 +127,13 @@ function createInitialPage(workspace: Workspace) {
     page.addBlock({ flavour: 'affine:paragraph' }, frameId);
   });
 
-  // Create a new page. This will trigger the signal above.
+  // Create a new page. This will trigger the slot above.
   workspace.createPage('page0');
 }
 
 // Subscribe for page update and create editor on page added.
 function initEditorOnPageAdded(workspace: Workspace) {
-  workspace.signals.pageAdded.once(pageId => {
+  workspace.slots.pageAdded.once(pageId => {
     const page = workspace.getPage(pageId) as Page;
     const editor = new EditorContainer();
     editor.page = page;

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -165,7 +165,7 @@ export function focusBlockByModel(
     }
     defaultPageBlock.selection.state.clear();
     const rect = getBlockElementByModel(model)?.getBoundingClientRect();
-    rect && defaultPageBlock.signals.updateSelectedRects.emit([rect]);
+    rect && defaultPageBlock.slots.updateSelectedRects.emit([rect]);
     const element = getBlockElementByModel(model);
     assertExists(element);
     defaultPageBlock.selection.state.selectedBlocks.push(element);

--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -14,7 +14,7 @@ import {
   assertExists,
   DisposableGroup,
   isFirefox,
-  Signal,
+  Slot,
 } from '@blocksuite/global/utils';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { css, html, TemplateResult } from 'lit';
@@ -56,10 +56,10 @@ export class BlockHub extends NonShadowLitElement {
   public getAllowedBlocks: () => BaseBlockModel[];
 
   @property()
-  updateSelectedRectsSignal: Signal<DOMRect[]> | null = null;
+  updateSelectedRectsSlot: Slot<DOMRect[]> | null = null;
 
   @property()
-  blockHubStatusUpdated: Signal<boolean> = new Signal<boolean>();
+  blockHubStatusUpdated: Slot<boolean> = new Slot<boolean>();
 
   @property()
   bottom = 70;
@@ -355,29 +355,27 @@ export class BlockHub extends NonShadowLitElement {
     super.connectedCallback();
     const disposables = this._disposables;
     disposables.add(
-      Signal.disposableListener(this, 'dragstart', this._onDragStart)
+      Slot.disposableListener(this, 'dragstart', this._onDragStart)
     );
-    disposables.add(Signal.disposableListener(this, 'drag', this._onDrag));
-    disposables.add(
-      Signal.disposableListener(this, 'dragend', this._onDragEnd)
-    );
+    disposables.add(Slot.disposableListener(this, 'drag', this._onDrag));
+    disposables.add(Slot.disposableListener(this, 'dragend', this._onDragEnd));
 
     disposables.add(
-      Signal.disposableListener(this._mouseRoot, 'dragover', this._onDragOver)
+      Slot.disposableListener(this._mouseRoot, 'dragover', this._onDragOver)
     );
     disposables.add(
-      Signal.disposableListener(this._mouseRoot, 'drop', this._onDrop)
+      Slot.disposableListener(this._mouseRoot, 'drop', this._onDrop)
     );
     isFirefox &&
       disposables.add(
-        Signal.disposableListener(
+        Slot.disposableListener(
           this._mouseRoot,
           'dragover',
           this._onDragOverDocument
         )
       );
     disposables.add(
-      Signal.disposableListener(this, 'mousedown', this._onMouseDown)
+      Slot.disposableListener(this, 'mousedown', this._onMouseDown)
     );
     this._onResize();
   }
@@ -386,15 +384,15 @@ export class BlockHub extends NonShadowLitElement {
     const disposables = this._disposables;
     this._blockHubCards.forEach(card => {
       disposables.add(
-        Signal.disposableListener(card, 'mousedown', this._onCardMouseDown)
+        Slot.disposableListener(card, 'mousedown', this._onCardMouseDown)
       );
       disposables.add(
-        Signal.disposableListener(card, 'mouseup', this._onCardMouseUp)
+        Slot.disposableListener(card, 'mouseup', this._onCardMouseUp)
       );
     });
     for (const blockHubMenu of this._blockHubMenus) {
       disposables.add(
-        Signal.disposableListener(
+        Slot.disposableListener(
           blockHubMenu,
           'mouseover',
           this._onBlockHubMenuMouseOver
@@ -402,14 +400,14 @@ export class BlockHub extends NonShadowLitElement {
       );
       if (blockHubMenu.getAttribute('type') === 'blank') {
         disposables.add(
-          Signal.disposableListener(
+          Slot.disposableListener(
             blockHubMenu,
             'mousedown',
             this._onBlankMenuMouseDown
           )
         );
         disposables.add(
-          Signal.disposableListener(
+          Slot.disposableListener(
             blockHubMenu,
             'mouseup',
             this._onBlankMenuMouseUp
@@ -418,32 +416,28 @@ export class BlockHub extends NonShadowLitElement {
       }
     }
     disposables.add(
-      Signal.disposableListener(
+      Slot.disposableListener(
         this._blockHubMenuEntry,
         'mouseover',
         this._onBlockHubEntryMouseOver
       )
     );
+    disposables.add(Slot.disposableListener(document, 'click', this._onClick));
     disposables.add(
-      Signal.disposableListener(document, 'click', this._onClick)
-    );
-    disposables.add(
-      Signal.disposableListener(
+      Slot.disposableListener(
         this._blockHubButton,
         'click',
         this._onBlockHubButtonClick
       )
     );
     disposables.add(
-      Signal.disposableListener(
+      Slot.disposableListener(
         this._blockHubIconsContainer,
         'transitionstart',
         this._onTransitionStart
       )
     );
-    disposables.add(
-      Signal.disposableListener(window, 'resize', this._onResize)
-    );
+    disposables.add(Slot.disposableListener(window, 'resize', this._onResize));
     this._indicator = <DragIndicator>(
       document.querySelector('affine-drag-indicator')
     );
@@ -670,7 +664,7 @@ export class BlockHub extends NonShadowLitElement {
       data.type = affineType;
     }
     event.dataTransfer.setData('affine/block-hub', JSON.stringify(data));
-    this.updateSelectedRectsSignal && this.updateSelectedRectsSignal.emit([]);
+    this.updateSelectedRectsSlot && this.updateSelectedRectsSlot.emit([]);
   };
 
   private _onMouseDown = (e: MouseEvent) => {

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -6,12 +6,7 @@ import {
   CopyIcon,
   paragraphConfig,
 } from '@blocksuite/global/config';
-import {
-  BaseBlockModel,
-  DisposableGroup,
-  Page,
-  Signal,
-} from '@blocksuite/store';
+import { BaseBlockModel, DisposableGroup, Page, Slot } from '@blocksuite/store';
 import type { TextAttributes } from '@blocksuite/virgo';
 import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -46,7 +41,7 @@ export class FormatQuickBar extends LitElement {
 
   // Sometimes the quick bar need to update position
   @property()
-  positionUpdated = new Signal();
+  positionUpdated = new Slot();
 
   @property()
   models: BaseBlockModel[] = [];

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -1,7 +1,7 @@
 import './button.js';
 import './format-bar-node.js';
 
-import { matchFlavours, Page, Signal } from '@blocksuite/store';
+import { matchFlavours, Page, Slot } from '@blocksuite/store';
 
 import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import { getDefaultPageBlock } from '../../__internal__/utils/query.js';
@@ -60,8 +60,8 @@ export const showFormatQuickBar = async ({
   formatQuickBar.page = page;
   formatQuickBar.models = blockRange.models;
   formatQuickBar.abortController = abortController;
-  const positionUpdatedSignal = new Signal();
-  formatQuickBar.positionUpdated = positionUpdatedSignal;
+  const positionUpdatedSlot = new Slot();
+  formatQuickBar.positionUpdated = positionUpdatedSlot;
 
   formatQuickBarInstance = formatQuickBar;
   abortController.signal.addEventListener('abort', () => {
@@ -107,7 +107,7 @@ export const showFormatQuickBar = async ({
     // Note: in edgeless mode, the scroll container is not exist!
     scrollContainer.addEventListener('scroll', updatePos, { passive: true });
   }
-  positionUpdatedSignal.on(updatePos);
+  positionUpdatedSlot.on(updatePos);
   window.addEventListener('resize', updatePos, { passive: true });
 
   // Mount
@@ -158,7 +158,7 @@ export const showFormatQuickBar = async ({
     document.removeEventListener('mouseup', mouseDownHandler);
     document.removeEventListener('selectionchange', selectionChangeHandler);
     window.removeEventListener('popstate', popstateHandler);
-    positionUpdatedSignal.dispose();
+    positionUpdatedSlot.dispose();
   });
   return formatQuickBar;
 };

--- a/packages/blocks/src/components/link-popover/link-popover.ts
+++ b/packages/blocks/src/components/link-popover/link-popover.ts
@@ -336,7 +336,6 @@ export class LinkPopover extends LitElement {
   }
 }
 
-// TODO use signal to control the popover
 declare global {
   interface HTMLElementTagNameMap {
     'edit-link-panel': LinkPopover;

--- a/packages/blocks/src/components/remote-selection/remote-selection.ts
+++ b/packages/blocks/src/components/remote-selection/remote-selection.ts
@@ -82,7 +82,7 @@ export class RemoteSelection extends LitElement {
 
   protected firstUpdated() {
     assertExists(this.page);
-    this.page.awarenessStore.signals.update.subscribe(
+    this.page.awarenessStore.slots.update.subscribe(
       msg => msg,
       msg => {
         if (!msg || !msg.state?.rangeMap) {

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -1,5 +1,5 @@
 import type { BaseBlockModel } from '@blocksuite/store';
-import { DisposableGroup, Signal } from '@blocksuite/store';
+import { DisposableGroup, Slot } from '@blocksuite/store';
 import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -55,16 +55,16 @@ export class SlashMenu extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._disposableGroup.add(
-      Signal.disposableListener(window, 'mousedown', this._clickAwayListener)
+      Slot.disposableListener(window, 'mousedown', this._clickAwayListener)
     );
     this._disposableGroup.add(
-      Signal.disposableListener(window, 'keydown', this._keyDownListener, {
+      Slot.disposableListener(window, 'keydown', this._keyDownListener, {
         // Workaround: Use capture to prevent the event from triggering the hotkey bindings action
         capture: true,
       })
     );
     this._disposableGroup.add(
-      Signal.disposableListener(this, 'mousedown', e => {
+      Slot.disposableListener(this, 'mousedown', e => {
         // Prevent input from losing focus
         e.preventDefault();
       })
@@ -79,13 +79,13 @@ export class SlashMenu extends LitElement {
       return;
     }
     this._disposableGroup.add(
-      Signal.disposableListener(richText, 'keydown', this._keyDownListener, {
+      Slot.disposableListener(richText, 'keydown', this._keyDownListener, {
         // Workaround: Use capture to prevent the event from triggering the keyboard bindings action
         capture: true,
       })
     );
     this._disposableGroup.add(
-      Signal.disposableListener(richText, 'focusout', this._clickAwayListener)
+      Slot.disposableListener(richText, 'focusout', this._clickAwayListener)
     );
   }
 

--- a/packages/blocks/src/embed-block/image/image-block.ts
+++ b/packages/blocks/src/embed-block/image/image-block.ts
@@ -151,36 +151,35 @@ export class ImageBlockComponent extends NonShadowLitElement {
       const isBlobUploadingOnInit =
         this.model.page.awarenessStore.isBlobUploading(this.model.sourceId);
 
-      const disposeSignal = this.model.page.awarenessStore.signals.update.on(
-        () => {
-          const isBlobUploading =
-            this.model.page.awarenessStore.isBlobUploading(this.model.sourceId);
+      const disposeSlot = this.model.page.awarenessStore.slots.update.on(() => {
+        const isBlobUploading = this.model.page.awarenessStore.isBlobUploading(
+          this.model.sourceId
+        );
 
-          /**
-           * case:
-           * clientA send image, but network latency is high,
-           * clientB got ydoc, but doesn't get awareness,
-           * clientC has a good network, and send awareness because of cursor changed,
-           * clientB receives awareness change from clientC,
-           * this listener will be called,
-           * but clientB doesn't get uploading state from clientA.
-           */
-          if (
-            isBlobUploadingOnInit === isBlobUploading &&
-            isBlobUploading === false
-          ) {
-            return;
-          }
-
-          if (!isBlobUploading) {
-            clearTimeout(timer);
-            resolve();
-          }
+        /**
+         * case:
+         * clientA send image, but network latency is high,
+         * clientB got ydoc, but doesn't get awareness,
+         * clientC has a good network, and send awareness because of cursor changed,
+         * clientB receives awareness change from clientC,
+         * this listener will be called,
+         * but clientB doesn't get uploading state from clientA.
+         */
+        if (
+          isBlobUploadingOnInit === isBlobUploading &&
+          isBlobUploading === false
+        ) {
+          return;
         }
-      );
+
+        if (!isBlobUploading) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
 
       this._imageReady.dispose = () => {
-        disposeSignal.dispose();
+        disposeSlot.dispose();
         clearTimeout(timer);
         resolve();
       };

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -12,7 +12,7 @@ import { toolTipStyle } from '../../components/tooltip/tooltip.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
 import type {
   CodeBlockOption,
-  DefaultPageSignals,
+  DefaultPageSlots,
   EmbedEditingState,
   ViewportState,
 } from './default-page-block.js';
@@ -116,7 +116,7 @@ export function SelectedRectsContainer(
 
 export function EmbedEditingContainer(
   embedEditingState: EmbedEditingState | null,
-  signals: DefaultPageSignals,
+  slots: DefaultPageSlots,
   viewportState: ViewportState
 ) {
   if (!embedEditingState) return null;
@@ -149,7 +149,7 @@ export function EmbedEditingContainer(
           width="100%"
           @click=${() => {
             focusCaption(model);
-            signals.updateEmbedRects.emit([]);
+            slots.updateEmbedRects.emit([]);
           }}
         >
           ${CaptionIcon}
@@ -186,7 +186,7 @@ export function EmbedEditingContainer(
           width="100%"
           @click="${() => {
             model.page.deleteBlock(model);
-            signals.updateEmbedRects.emit([]);
+            slots.updateEmbedRects.emit([]);
           }}"
         >
           ${DeleteIcon}

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -2,12 +2,7 @@
 import { BLOCK_ID_ATTR, SCROLL_THRESHOLD } from '@blocksuite/global/config';
 import { assertExists } from '@blocksuite/global/utils';
 import { Utils } from '@blocksuite/store';
-import {
-  BaseBlockModel,
-  DisposableGroup,
-  Page,
-  Signal,
-} from '@blocksuite/store';
+import { BaseBlockModel, DisposableGroup, Page, Slot } from '@blocksuite/store';
 import { VEditor, ZERO_WIDTH_SPACE } from '@blocksuite/virgo';
 import { css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -61,13 +56,13 @@ export interface ViewportState {
 
 export type CodeBlockOption = EmbedEditingState;
 
-export interface DefaultPageSignals {
-  updateFrameSelectionRect: Signal<DOMRect | null>;
-  updateSelectedRects: Signal<DOMRect[]>;
-  updateEmbedRects: Signal<DOMRect[]>;
-  updateEmbedEditingState: Signal<EmbedEditingState | null>;
-  updateCodeBlockOption: Signal<CodeBlockOption | null>;
-  nativeSelection: Signal<boolean>;
+export interface DefaultPageSlots {
+  updateFrameSelectionRect: Slot<DOMRect | null>;
+  updateSelectedRects: Slot<DOMRect[]>;
+  updateEmbedRects: Slot<DOMRect[]>;
+  updateEmbedEditingState: Slot<EmbedEditingState | null>;
+  updateCodeBlockOption: Slot<CodeBlockOption | null>;
+  nativeSelection: Slot<boolean>;
 }
 
 @customElement('affine-default-page')
@@ -183,13 +178,13 @@ export class DefaultPageBlockComponent
   @query('.affine-default-viewport')
   defaultViewportElement!: HTMLDivElement;
 
-  signals: DefaultPageSignals = {
-    updateFrameSelectionRect: new Signal<DOMRect | null>(),
-    updateSelectedRects: new Signal<DOMRect[]>(),
-    updateEmbedRects: new Signal<DOMRect[]>(),
-    updateEmbedEditingState: new Signal<EmbedEditingState | null>(),
-    updateCodeBlockOption: new Signal<CodeBlockOption | null>(),
-    nativeSelection: new Signal<boolean>(),
+  slots: DefaultPageSlots = {
+    updateFrameSelectionRect: new Slot<DOMRect | null>(),
+    updateSelectedRects: new Slot<DOMRect[]>(),
+    updateEmbedRects: new Slot<DOMRect[]>(),
+    updateEmbedEditingState: new Slot<EmbedEditingState | null>(),
+    updateCodeBlockOption: new Slot<CodeBlockOption | null>(),
+    nativeSelection: new Slot<boolean>(),
   };
 
   public isCompositionStart = false;
@@ -357,7 +352,7 @@ export class DefaultPageBlockComponent
       this.selection = new DefaultSelectionManager({
         page: this.page,
         mouseRoot: this.mouseRoot,
-        signals: this.signals,
+        slots: this.slots,
         container: this,
         threshold: SCROLL_THRESHOLD / 2, // 50
       });
@@ -430,7 +425,7 @@ export class DefaultPageBlockComponent
       createHandle();
     }
     this._disposables.add(
-      this.page.awarenessStore.signals.update.subscribe(
+      this.page.awarenessStore.slots.update.subscribe(
         msg => msg.state?.flags.enable_drag_handle,
         enable => {
           if (enable) {
@@ -466,35 +461,35 @@ export class DefaultPageBlockComponent
   }
 
   firstUpdated() {
-    bindHotkeys(this.page, this.selection, this.signals);
+    bindHotkeys(this.page, this.selection, this.slots);
 
     hotkey.enableHotkey();
 
-    this.signals.updateFrameSelectionRect.on(rect => {
+    this.slots.updateFrameSelectionRect.on(rect => {
       this._frameSelectionRect = rect;
       this.requestUpdate();
     });
-    this.signals.updateSelectedRects.on(rects => {
+    this.slots.updateSelectedRects.on(rects => {
       this._selectedRects = rects;
       this.requestUpdate();
     });
-    this.signals.updateEmbedRects.on(rects => {
+    this.slots.updateEmbedRects.on(rects => {
       this._selectedEmbedRects = rects;
       if (rects.length === 0) {
         this._embedEditingState = null;
       }
       this.requestUpdate();
     });
-    this.signals.updateEmbedEditingState.on(embedEditingState => {
+    this.slots.updateEmbedEditingState.on(embedEditingState => {
       this._embedEditingState = embedEditingState;
       this.requestUpdate();
     });
-    this.signals.updateCodeBlockOption.on(codeBlockOption => {
+    this.slots.updateCodeBlockOption.on(codeBlockOption => {
       this.codeBlockOption = codeBlockOption;
       this.requestUpdate();
     });
 
-    this.signals.nativeSelection.on(bind => {
+    this.slots.nativeSelection.on(bind => {
       if (bind) {
         window.addEventListener('keydown', this._handleNativeKeydown);
       } else {
@@ -577,7 +572,7 @@ export class DefaultPageBlockComponent
     );
     const embedEditingContainer = EmbedEditingContainer(
       readonly ? null : this._embedEditingState,
-      this.signals,
+      this.slots,
       this.viewportState
     );
     const codeBlockOptionContainer = CodeBlockOptionContainer(

--- a/packages/blocks/src/page-block/default/embed-resize-manager.ts
+++ b/packages/blocks/src/page-block/default/embed-resize-manager.ts
@@ -1,12 +1,12 @@
 import { assertExists } from '@blocksuite/global/utils';
 
 import { getModelByElement, IPoint, SelectionEvent } from '../../std.js';
-import type { DefaultPageSignals } from '../index.js';
+import type { DefaultPageSlots } from '../index.js';
 import type { PageSelectionState } from './selection-manager.js';
 
 export class EmbedResizeManager {
   state: PageSelectionState;
-  signals: DefaultPageSignals;
+  slots: DefaultPageSlots;
   private _originPosition: IPoint = { x: 0, y: 0 };
   private _dropContainer: HTMLElement | null = null;
   private _dropContainerSize: { w: number; h: number; left: number } = {
@@ -16,9 +16,9 @@ export class EmbedResizeManager {
   };
   private _dragMoveTarget = 'right';
 
-  constructor(state: PageSelectionState, signals: DefaultPageSignals) {
+  constructor(state: PageSelectionState, slots: DefaultPageSlots) {
     this.state = state;
-    this.signals = signals;
+    this.slots = slots;
   }
 
   onStart(e: SelectionEvent) {
@@ -60,7 +60,7 @@ export class EmbedResizeManager {
 
       height = width * (this._dropContainerSize.h / this._dropContainerSize.w);
       if (this._dropContainer) {
-        this.signals.updateEmbedRects.emit([
+        this.slots.updateEmbedRects.emit([
           new DOMRect(
             left,
             this._dropContainer.getBoundingClientRect().top,

--- a/packages/blocks/src/page-block/default/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager.ts
@@ -42,7 +42,7 @@ import {
 } from '../utils/position.js';
 import type {
   DefaultPageBlockComponent,
-  DefaultPageSignals,
+  DefaultPageSlots,
   EmbedEditingState,
   ViewportState,
 } from './default-page-block.js';
@@ -443,30 +443,30 @@ export class DefaultSelectionManager {
   private readonly _mouseRoot: HTMLElement;
   private readonly _container: DefaultPageBlockComponent;
   private readonly _disposables = new DisposableGroup();
-  private readonly _signals: DefaultPageSignals;
+  private readonly _slots: DefaultPageSlots;
   private readonly _embedResizeManager: EmbedResizeManager;
   private readonly _threshold: number; // distance to the upper and lower boundaries of the viewport
 
   constructor({
     page,
     mouseRoot,
-    signals,
+    slots,
     container,
     threshold,
   }: {
     page: Page;
     mouseRoot: HTMLElement;
-    signals: DefaultPageSignals;
+    slots: DefaultPageSlots;
     container: DefaultPageBlockComponent;
     threshold: number;
   }) {
     this.page = page;
-    this._signals = signals;
+    this._slots = slots;
     this._mouseRoot = mouseRoot;
     this._container = container;
     this._threshold = threshold;
 
-    this._embedResizeManager = new EmbedResizeManager(this.state, signals);
+    this._embedResizeManager = new EmbedResizeManager(this.state, slots);
     this._disposables.add(
       initMouseEventHandlers(
         this._mouseRoot,
@@ -535,7 +535,7 @@ export class DefaultSelectionManager {
     this.state.type = selectionType ?? this.state.type;
 
     if (rects) {
-      this._signals.updateSelectedRects.emit(rects);
+      this._slots.updateSelectedRects.emit(rects);
       return;
     }
 
@@ -549,7 +549,7 @@ export class DefaultSelectionManager {
       selectionType
     );
     this.state.type = newSelectionType;
-    this._signals.updateSelectedRects.emit(calculatedRects);
+    this._slots.updateSelectedRects.emit(calculatedRects);
   }
 
   private _onBlockSelectionDragStart(e: SelectionEvent) {
@@ -621,14 +621,14 @@ export class DefaultSelectionManager {
   private _onBlockSelectionDragEnd(_: SelectionEvent) {
     this.state.type = 'block';
     this.state.clearBlockSelectionRect();
-    this._signals.updateFrameSelectionRect.emit(null);
+    this._slots.updateFrameSelectionRect.emit(null);
     // do not clear selected rects here
   }
 
   private _onNativeSelectionDragStart(e: SelectionEvent) {
     this.state.resetStartRange(e);
     this.state.type = 'native';
-    this._signals.nativeSelection.emit(false);
+    this._slots.nativeSelection.emit(false);
   }
 
   private _onNativeSelectionDragMove(e: SelectionEvent) {
@@ -637,7 +637,7 @@ export class DefaultSelectionManager {
   }
 
   private _onNativeSelectionDragEnd(_: SelectionEvent) {
-    this._signals.nativeSelection.emit(true);
+    this._slots.nativeSelection.emit(true);
   }
 
   private _onContainerDragStart = (e: SelectionEvent) => {
@@ -796,11 +796,11 @@ export class DefaultSelectionManager {
         this.state.selectedEmbeds.push(
           this.state.activeComponent as EmbedBlockComponent
         );
-        this._signals.updateEmbedRects.emit([clickBlockInfo.position]);
+        this._slots.updateEmbedRects.emit([clickBlockInfo.position]);
       } else {
         this.state.type = 'block';
         this.state.selectedBlocks.push(this.state.activeComponent);
-        this._signals.updateSelectedRects.emit([clickBlockInfo.position]);
+        this._slots.updateSelectedRects.emit([clickBlockInfo.position]);
       }
       return;
     }
@@ -862,13 +862,13 @@ export class DefaultSelectionManager {
       } else {
         hoverEditingState.position.x = hoverEditingState.position.right + 10;
       }
-      this._signals.updateEmbedEditingState.emit(hoverEditingState);
+      this._slots.updateEmbedEditingState.emit(hoverEditingState);
     } else if (hoverEditingState?.model.flavour === 'affine:code') {
       hoverEditingState.position.x = hoverEditingState.position.right + 12;
-      this._signals.updateCodeBlockOption.emit(hoverEditingState);
+      this._slots.updateCodeBlockOption.emit(hoverEditingState);
     } else {
-      this._signals.updateEmbedEditingState.emit(null);
-      this._signals.updateCodeBlockOption.emit(null);
+      this._slots.updateEmbedEditingState.emit(null);
+      this._slots.updateCodeBlockOption.emit(null);
     }
   };
 
@@ -932,26 +932,26 @@ export class DefaultSelectionManager {
 
   // clear selection: `block`, `embed`, `native`
   clear() {
-    const { state, _signals } = this;
+    const { state, _slots } = this;
     const { type } = state;
     if (type === 'block') {
       state.clearBlock();
-      _signals.updateSelectedRects.emit([]);
-      _signals.updateFrameSelectionRect.emit(null);
+      _slots.updateSelectedRects.emit([]);
+      _slots.updateFrameSelectionRect.emit(null);
     } else if (type === 'embed') {
       state.clearEmbed();
-      _signals.updateEmbedRects.emit([]);
-      _signals.updateEmbedEditingState.emit(null);
+      _slots.updateEmbedRects.emit([]);
+      _slots.updateEmbedEditingState.emit(null);
     } else if (type === 'native') {
       state.clearNative();
     }
   }
 
   dispose() {
-    this._signals.updateSelectedRects.dispose();
-    this._signals.updateFrameSelectionRect.dispose();
-    this._signals.updateEmbedEditingState.dispose();
-    this._signals.updateEmbedRects.dispose();
+    this._slots.updateSelectedRects.dispose();
+    this._slots.updateFrameSelectionRect.dispose();
+    this._slots.updateEmbedEditingState.dispose();
+    this._slots.updateEmbedRects.dispose();
     this._disposables.dispose();
   }
 
@@ -963,7 +963,7 @@ export class DefaultSelectionManager {
       this.state.focusedBlockIndex = -1;
     }
     const selectionRect = createSelectionRect(endPoint, startPoint);
-    this._signals.updateFrameSelectionRect.emit(selectionRect);
+    this._slots.updateFrameSelectionRect.emit(selectionRect);
     return selectionRect;
   }
 
@@ -1011,7 +1011,7 @@ export class DefaultSelectionManager {
     } else {
       this.state.setStartPoint(null);
       this.state.setEndPoint(null);
-      this._signals.updateFrameSelectionRect.emit(null);
+      this._slots.updateFrameSelectionRect.emit(null);
       this.refreshSelectedBlocksRects();
     }
   }
@@ -1030,10 +1030,10 @@ export class DefaultSelectionManager {
       const rects = clearSubtree(selectedBlocks, firstBlock).map(
         block => blockCache.get(block) as DOMRect
       );
-      this._signals.updateSelectedRects.emit(rects);
+      this._slots.updateSelectedRects.emit(rects);
     } else {
       // only current focused-block
-      this._signals.updateSelectedRects.emit([
+      this._slots.updateSelectedRects.emit([
         blockCache.get(firstBlock) as DOMRect,
       ]);
     }
@@ -1061,7 +1061,7 @@ export class DefaultSelectionManager {
           }
         }
 
-        this._signals.updateEmbedRects.emit([rect]);
+        this._slots.updateEmbedRects.emit([rect]);
       }
     }
   }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -5,7 +5,7 @@ import './view-control-bar.js';
 import { BLOCK_ID_ATTR, HOTKEYS } from '@blocksuite/global/config';
 import { deserializeXYWH } from '@blocksuite/phasor';
 import { SurfaceManager } from '@blocksuite/phasor';
-import { DisposableGroup, Page, Signal } from '@blocksuite/store';
+import { DisposableGroup, Page, Slot } from '@blocksuite/store';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -47,11 +47,11 @@ export interface EdgelessContainer extends HTMLElement {
   readonly viewport: ViewportState;
   readonly mouseRoot: HTMLElement;
   readonly surface: SurfaceManager;
-  readonly signals: {
-    hoverUpdated: Signal;
-    viewportUpdated: Signal;
-    updateSelection: Signal<EdgelessSelectionState>;
-    surfaceUpdated: Signal;
+  readonly slots: {
+    hoverUpdated: Slot;
+    viewportUpdated: Slot;
+    updateSelection: Slot<EdgelessSelectionState>;
+    surfaceUpdated: Slot;
   };
 }
 
@@ -119,12 +119,12 @@ export class EdgelessPageBlockComponent
   @query('.affine-surface-canvas')
   private _canvas!: HTMLCanvasElement;
 
-  signals = {
-    viewportUpdated: new Signal(),
-    updateSelection: new Signal<EdgelessSelectionState>(),
-    hoverUpdated: new Signal(),
-    surfaceUpdated: new Signal(),
-    mouseModeUpdated: new Signal<MouseMode>(),
+  slots = {
+    viewportUpdated: new Slot(),
+    updateSelection: new Slot<EdgelessSelectionState>(),
+    hoverUpdated: new Slot(),
+    surfaceUpdated: new Slot(),
+    mouseModeUpdated: new Slot<MouseMode>(),
   };
 
   surface!: SurfaceManager;
@@ -156,24 +156,12 @@ export class EdgelessPageBlockComponent
 
   private _handleBackspace = (e: KeyboardEvent) => {
     if (this._selection.blockSelectionState.type === 'single') {
-      // const selectedBlock = this._selection.blockSelectionState.selected;
-      // if (selectedBlock.flavour === 'affine:shape') {
-      //   this.page.captureSync();
-      //   this.page.deleteBlock(selectedBlock);
-      //   // TODO: cleanup state instead of create a instance
-      //   this._selection = new EdgelessSelectionManager(this);
-      //   this.signals.updateSelection.emit({
-      //     type: 'none',
-      //   });
-      // } else {
-      //   handleMultiBlockBackspace(this.page, e);
-      // }
       const { selected } = this._selection.blockSelectionState;
 
       if (this.surface.hasElement(selected.id)) {
         this.surface.removeElement(selected.id);
         this._selection.currentController.clearSelection();
-        this.signals.updateSelection.emit(this._selection.blockSelectionState);
+        this.slots.updateSelection.emit(this._selection.blockSelectionState);
         return;
       }
       handleMultiBlockBackspace(this.page, e);
@@ -251,7 +239,7 @@ export class EdgelessPageBlockComponent
       this.page.awarenessStore.getFlag('enable_edgeless_toolbar') ?? false;
 
     this._disposables.add(
-      this.page.awarenessStore.signals.update.subscribe(
+      this.page.awarenessStore.slots.update.subscribe(
         msg => msg.state?.flags.enable_edgeless_toolbar,
         enable => {
           this._toolbarEnabled = enable ?? false;
@@ -280,7 +268,7 @@ export class EdgelessPageBlockComponent
       frame.propsUpdated.on(() => this._selection.syncSelectionRect());
     });
 
-    this.signals.viewportUpdated.on(() => {
+    this.slots.viewportUpdated.on(() => {
       this.style.setProperty('--affine-zoom', `${this.viewport.zoom}`);
 
       this._syncSurfaceViewport();
@@ -288,12 +276,12 @@ export class EdgelessPageBlockComponent
       this._selection.syncSelectionRect();
       this.requestUpdate();
     });
-    this.signals.hoverUpdated.on(() => this.requestUpdate());
-    this.signals.updateSelection.on(() => this.requestUpdate());
-    this.signals.surfaceUpdated.on(() => this.requestUpdate());
-    this.signals.mouseModeUpdated.on(mouseMode => (this.mouseMode = mouseMode));
+    this.slots.hoverUpdated.on(() => this.requestUpdate());
+    this.slots.updateSelection.on(() => this.requestUpdate());
+    this.slots.surfaceUpdated.on(() => this.requestUpdate());
+    this.slots.mouseModeUpdated.on(mouseMode => (this.mouseMode = mouseMode));
 
-    const historyDisposable = this.page.signals.historyUpdated.on(() => {
+    const historyDisposable = this.page.slots.historyUpdated.on(() => {
       this._clearSelection();
       this.requestUpdate();
     });
@@ -322,11 +310,11 @@ export class EdgelessPageBlockComponent
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    this.signals.updateSelection.dispose();
-    this.signals.viewportUpdated.dispose();
-    this.signals.hoverUpdated.dispose();
-    this.signals.surfaceUpdated.dispose();
-    this.signals.mouseModeUpdated.dispose();
+    this.slots.updateSelection.dispose();
+    this.slots.viewportUpdated.dispose();
+    this.slots.hoverUpdated.dispose();
+    this.slots.surfaceUpdated.dispose();
+    this.slots.mouseModeUpdated.dispose();
     this._disposables.dispose();
     this._selection.dispose();
     this.surface.dispose();

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
@@ -60,7 +60,7 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
     this._draggingPathPoints = points;
     this._draggingLeftTopPoint = [modelX, modelY];
 
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerDragMove(e: SelectionEvent) {
@@ -104,7 +104,7 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
       this._draggingPathPoints
     );
 
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerDragEnd(e: SelectionEvent) {
@@ -112,7 +112,7 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
     this._draggingPathPoints = null;
     this._draggingLeftTopPoint = null;
     this._page.captureSync();
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerMouseMove(e: SelectionEvent) {

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -79,7 +79,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
       selected,
       rect: getSelectionBoxBound(this._edgeless.viewport, xywh),
     };
-    this._edgeless.signals.updateSelection.emit(this._blockSelectionState);
+    this._edgeless.slots.updateSelection.emit(this._blockSelectionState);
   }
 
   private _handleClickOnSelected(selected: Selectable, e: SelectionEvent) {
@@ -147,7 +147,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
       this._handleClickOnSelected(selected, e);
     } else {
       this._setNoneSelectionState();
-      this._edgeless.signals.updateSelection.emit(this.blockSelectionState);
+      this._edgeless.slots.updateSelection.emit(this.blockSelectionState);
       resetNativeSelection(null);
     }
   }
@@ -177,7 +177,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
         end: new DOMPoint(e.x, e.y),
       };
 
-      this._edgeless.signals.updateSelection.emit(this.blockSelectionState);
+      this._edgeless.slots.updateSelection.emit(this.blockSelectionState);
       resetNativeSelection(null);
     }
 
@@ -265,7 +265,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
     const blocks = pick(this._blocks, modelX, modelY);
 
     this._updateHoverState(shape ?? blocks);
-    this._edgeless.signals.hoverUpdated.emit();
+    this._edgeless.slots.hoverUpdated.emit();
   }
 
   onContainerMouseOut(_: SelectionEvent) {
@@ -280,7 +280,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
       const xywh = getXYWH(selected);
       const rect = getSelectionBoxBound(this._edgeless.viewport, xywh);
       this.blockSelectionState.rect = rect;
-      this._edgeless.signals.updateSelection.emit(this.blockSelectionState);
+      this._edgeless.slots.updateSelection.emit(this.blockSelectionState);
     }
 
     this._updateHoverState(this._hoverState?.content || null);

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
@@ -42,7 +42,7 @@ export class PanModeController extends MouseModeController<PanMouseMode> {
 
     this._edgeless.viewport.applyDeltaCenter(deltaX, deltaY);
 
-    this._edgeless.signals.viewportUpdated.emit();
+    this._edgeless.slots.viewportUpdated.emit();
   }
 
   onContainerDragEnd() {

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -54,7 +54,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
       start: new DOMPoint(e.x, e.y),
       end: new DOMPoint(e.x, e.y),
     };
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerDragMove(e: SelectionEvent) {
@@ -78,14 +78,14 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     const bound = new Bound(x, y, w, h);
     const id = this._draggingElementId;
     this._surface.setElementBound(id, bound);
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerDragEnd(e: SelectionEvent) {
     this._draggingElementId = null;
     this._draggingArea = null;
     this._page.captureSync();
-    this._edgeless.signals.surfaceUpdated.emit();
+    this._edgeless.slots.surfaceUpdated.emit();
   }
 
   onContainerMouseMove(e: SelectionEvent) {

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -211,7 +211,7 @@ export class EdgelessSelectionManager {
       noop,
       this._onSelectionChangeWithoutDebounce
     );
-    this._selectionUpdateCallback = this._container.signals.updateSelection.on(
+    this._selectionUpdateCallback = this._container.slots.updateSelection.on(
       state => {
         if (this._prevSelectedShapeId) {
           /*

--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
@@ -121,7 +121,7 @@ export class EdgelessBrushMenu extends LitElement {
     if (this.mouseMode.type !== 'brush') return;
 
     const { lineWidth } = this.mouseMode;
-    this.edgeless.signals.mouseModeUpdated.emit({
+    this.edgeless.slots.mouseModeUpdated.emit({
       type: 'brush',
       color,
       lineWidth,
@@ -132,7 +132,7 @@ export class EdgelessBrushMenu extends LitElement {
     if (this.mouseMode.type !== 'brush') return;
 
     const { color } = this.mouseMode;
-    this.edgeless.signals.mouseModeUpdated.emit({
+    this.edgeless.slots.mouseModeUpdated.emit({
       type: 'brush',
       color,
       lineWidth,

--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
@@ -69,7 +69,7 @@ export class EdgelessBrushToolButton extends LitElement {
   private _trySetBrushMode() {
     if (this.mouseMode.type === 'brush') return;
 
-    this.edgeless.signals.mouseModeUpdated.emit({
+    this.edgeless.slots.mouseModeUpdated.emit({
       type: 'brush',
       lineWidth: 4,
       color: '#010101',

--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -56,7 +56,7 @@ export class EdgelessToolbar extends LitElement {
   edgeless!: EdgelessPageBlockComponent;
 
   private _setMouseMode(mouseMode: MouseMode) {
-    this.edgeless?.signals.mouseModeUpdated.emit(mouseMode);
+    this.edgeless?.slots.mouseModeUpdated.emit(mouseMode);
   }
 
   render() {

--- a/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-menu.ts
@@ -44,7 +44,7 @@ export class EdgelessShapeMenu extends LitElement {
               @tool.click=${() => {
                 if (disabled) return;
 
-                this.edgeless.signals.mouseModeUpdated.emit({
+                this.edgeless.slots.mouseModeUpdated.emit({
                   type: 'shape',
                   shape: name,
                   color: '#000000',

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -65,7 +65,7 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
       const dx = e.deltaX / viewport.zoom;
       const dy = e.deltaY / viewport.zoom;
       viewport.applyDeltaCenter(dx, dy);
-      container.signals.viewportUpdated.emit();
+      container.slots.viewportUpdated.emit();
     }
     // zoom
     else {
@@ -89,7 +89,7 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
       const newCenterY = baseY + offsetY * (prevZoom / newZoom);
       viewport.setCenter(newCenterX, newCenterY);
 
-      container.signals.viewportUpdated.emit();
+      container.slots.viewportUpdated.emit();
     }
   };
 

--- a/packages/blocks/src/page-block/edgeless/view-control-bar.ts
+++ b/packages/blocks/src/page-block/edgeless/view-control-bar.ts
@@ -61,7 +61,7 @@ export class EdgelessViewControlBar extends LitElement {
 
   private _setZoom(zoom: number) {
     this.edgeless.viewport.setZoom(zoom);
-    this.edgeless.signals.viewportUpdated.emit();
+    this.edgeless.slots.viewportUpdated.emit();
   }
 
   private _zoomToFit() {
@@ -86,7 +86,7 @@ export class EdgelessViewControlBar extends LitElement {
     const cy = bound.y + bound.h / 2;
     this.edgeless.viewport.setZoom(zoom);
     this.edgeless.viewport.setCenter(cx, cy);
-    this.edgeless.signals.viewportUpdated.emit();
+    this.edgeless.slots.viewportUpdated.emit();
   }
 
   render() {

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -26,7 +26,7 @@ import {
   getRichTextByModel,
   Point,
 } from '../../__internal__/utils/index.js';
-import type { DefaultPageSignals } from '../default/default-page-block.js';
+import type { DefaultPageSlots } from '../default/default-page-block.js';
 import type { DefaultSelectionManager } from '../default/selection-manager.js';
 import { handleSelectAll } from '../utils/index.js';
 import { formatConfig } from './const.js';
@@ -279,7 +279,7 @@ function handleTab(
 export function bindHotkeys(
   page: Page,
   selection: DefaultSelectionManager,
-  signals: DefaultPageSignals
+  slots: DefaultPageSlots
 ) {
   const {
     BACKSPACE,

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -5,7 +5,7 @@ import {
   PageBlockModel,
 } from '@blocksuite/blocks';
 import { NonShadowLitElement, SurfaceBlockModel } from '@blocksuite/blocks';
-import { Page, Signal } from '@blocksuite/store';
+import { Page, Slot } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -77,7 +77,7 @@ export class EditorContainer extends NonShadowLitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._disposables.add(
-      this.page.awarenessStore.signals.update.subscribe(
+      this.page.awarenessStore.slots.update.subscribe(
         msg => msg.state?.flags.readonly[this.page.prefixedId],
         rd => {
           if (typeof rd === 'boolean' && rd !== this.readonly) {
@@ -92,7 +92,7 @@ export class EditorContainer extends NonShadowLitElement {
 
     // Question: Why do we prevent this?
     this._disposables.add(
-      Signal.disposableListener(window, 'keydown', e => {
+      Slot.disposableListener(window, 'keydown', e => {
         if (e.altKey && e.metaKey && e.code === 'KeyC') {
           e.preventDefault();
         }
@@ -124,7 +124,7 @@ export class EditorContainer extends NonShadowLitElement {
 
     // connect mouse mode event changes
     this._disposables.add(
-      Signal.disposableListener(
+      Slot.disposableListener(
         window,
         'affine.switch-mouse-mode',
         ({ detail }) => {
@@ -134,7 +134,7 @@ export class EditorContainer extends NonShadowLitElement {
     );
 
     this._disposables.add(
-      Signal.disposableListener(
+      Slot.disposableListener(
         window,
         'affine:switch-edgeless-display-mode',
         ({ detail }) => {
@@ -145,12 +145,12 @@ export class EditorContainer extends NonShadowLitElement {
 
     // subscribe store
     this._disposables.add(
-      this.page.signals.rootAdded.on(() => {
+      this.page.slots.rootAdded.on(() => {
         this.requestUpdate();
       })
     );
     this._disposables.add(
-      this.page.signals.blockUpdated.on(async ({ type, id }) => {
+      this.page.slots.blockUpdated.on(async ({ type, id }) => {
         const block = this.page.getBlockById(id);
 
         if (!block) return;
@@ -168,7 +168,7 @@ export class EditorContainer extends NonShadowLitElement {
   public async createBlockHub() {
     await this.updateComplete;
     if (!this.page.root) {
-      await new Promise(res => this.page.signals.rootAdded.once(res));
+      await new Promise(res => this.page.slots.rootAdded.once(res));
     }
     return createBlockHub(this, this.page);
   }

--- a/packages/editor/src/components/simple-affine-editor.ts
+++ b/packages/editor/src/components/simple-affine-editor.ts
@@ -32,7 +32,7 @@ export class SimpleAffineEditor extends NonShadowLitElement {
   // Subscribe for page update and create editor after page loaded.
   private _subscribePage() {
     const { workspace } = this;
-    workspace.signals.pageAdded.once(pageId => {
+    workspace.slots.pageAdded.once(pageId => {
       const page = workspace.getPage(pageId) as Page;
       this.page = page;
 

--- a/packages/editor/src/managers/clipboard/content-parser/index.ts
+++ b/packages/editor/src/managers/clipboard/content-parser/index.ts
@@ -1,7 +1,7 @@
 import type { BaseService, PageBlockModel } from '@blocksuite/blocks';
 import type { OpenBlockInfo } from '@blocksuite/blocks';
 import { getServiceOrRegister } from '@blocksuite/blocks';
-import { BaseBlockModel, Signal } from '@blocksuite/store';
+import { BaseBlockModel, Slot } from '@blocksuite/store';
 import { marked } from 'marked';
 
 import type { EditorContainer, SelectedBlock } from '../../../index.js';
@@ -13,8 +13,8 @@ type ParseHtml2BlockFunc = (...args: any[]) => Promise<OpenBlockInfo[] | null>;
 
 export class ContentParser {
   private _editor: EditorContainer;
-  readonly signals = {
-    beforeHtml2Block: new Signal<Element>(),
+  readonly slots = {
+    beforeHtml2Block: new Slot<Element>(),
   };
   private _parsers: Record<string, ParseHtml2BlockFunc> = {};
   private _htmlParser: HtmlParser;
@@ -75,7 +75,7 @@ export class ContentParser {
     const htmlEl = document.createElement('html');
     htmlEl.innerHTML = html;
     htmlEl.querySelector('head')?.remove();
-    this.signals.beforeHtml2Block.emit(htmlEl);
+    this.slots.beforeHtml2Block.emit(htmlEl);
     return this._convertHtml2Blocks(htmlEl);
   }
 

--- a/packages/editor/src/managers/clipboard/event-dispatcher.ts
+++ b/packages/editor/src/managers/clipboard/event-dispatcher.ts
@@ -1,14 +1,14 @@
 import { isInsideRichText } from '@blocksuite/blocks/std';
-import { Signal } from '@blocksuite/store';
+import { Slot } from '@blocksuite/store';
 
 import { checkEditorElementActive } from '../../utils/editor.js';
 import { ClipboardAction } from './types.js';
 
 export class ClipboardEventDispatcher {
-  readonly signals = {
-    [ClipboardAction.copy]: new Signal<ClipboardEvent>(),
-    [ClipboardAction.cut]: new Signal<ClipboardEvent>(),
-    [ClipboardAction.paste]: new Signal<ClipboardEvent>(),
+  readonly slots = {
+    [ClipboardAction.copy]: new Slot<ClipboardEvent>(),
+    [ClipboardAction.cut]: new Slot<ClipboardEvent>(),
+    [ClipboardAction.paste]: new Slot<ClipboardEvent>(),
   };
 
   constructor(clipboardTarget: HTMLElement) {
@@ -64,27 +64,27 @@ export class ClipboardEventDispatcher {
   private _onCopy = (e: ClipboardEvent) => {
     if (!this._isValidClipboardEvent(e)) return;
 
-    this.signals.copy.emit(e);
+    this.slots.copy.emit(e);
   };
 
   private _onCut = (e: ClipboardEvent) => {
     if (!this._isValidClipboardEvent(e)) return;
 
-    this.signals.cut.emit(e);
+    this.slots.cut.emit(e);
   };
 
   private _onPaste = (e: ClipboardEvent) => {
     if (!this._isValidClipboardEvent(e)) return;
 
     if (ClipboardEventDispatcher.editorElementActive()) {
-      this.signals.paste.emit(e);
+      this.slots.paste.emit(e);
     }
   };
 
   dispose(clipboardTarget: HTMLElement) {
-    this.signals.copy.dispose();
-    this.signals.cut.dispose();
-    this.signals.paste.dispose();
+    this.slots.copy.dispose();
+    this.slots.cut.dispose();
+    this.slots.paste.dispose();
     this.disposeClipboardTargetEvent(clipboardTarget);
   }
 }

--- a/packages/editor/src/managers/clipboard/index.ts
+++ b/packages/editor/src/managers/clipboard/index.ts
@@ -22,9 +22,9 @@ export class ClipboardManager {
       this._clipboardTarget
     );
 
-    this._clipboardEventDispatcher.signals.copy.on(this._copy.handleCopy);
-    this._clipboardEventDispatcher.signals.cut.on(this._copy.handleCut);
-    this._clipboardEventDispatcher.signals.paste.on(this._paste.handlePaste);
+    this._clipboardEventDispatcher.slots.copy.on(this._copy.handleCopy);
+    this._clipboardEventDispatcher.slots.cut.on(this._copy.handleCut);
+    this._clipboardEventDispatcher.slots.paste.on(this._paste.handlePaste);
   }
 
   set clipboardTarget(clipboardTarget: HTMLElement) {

--- a/packages/editor/src/utils/editor.ts
+++ b/packages/editor/src/utils/editor.ts
@@ -54,8 +54,8 @@ export const createBlockHub: (
   if (editor.mode === 'page') {
     const defaultPageBlock = editor.querySelector('affine-default-page');
     assertExists(defaultPageBlock);
-    blockHub.updateSelectedRectsSignal =
-      defaultPageBlock.signals.updateSelectedRects;
+    blockHub.updateSelectedRectsSlot =
+      defaultPageBlock.slots.updateSelectedRects;
     blockHub.getAllowedBlocks = () =>
       getAllowSelectedBlocks(defaultPageBlock.model);
   } else {

--- a/packages/global/src/utils.ts
+++ b/packages/global/src/utils.ts
@@ -4,7 +4,7 @@ import type { BlockModels } from './types.js';
 
 export type { Disposable } from './utils/disposable.js';
 export { DisposableGroup, flattenDisposable } from './utils/disposable.js';
-export { Signal } from './utils/signal.js';
+export { Slot } from './utils/slot.js';
 export { caretRangeFromPoint, isFirefox, isWeb } from './utils/web.js';
 export const SYS_KEYS = new Set(['id', 'flavour', 'children']);
 

--- a/packages/global/src/utils/slot.ts
+++ b/packages/global/src/utils/slot.ts
@@ -2,7 +2,7 @@ import { Disposable, flattenDisposable } from './disposable.js';
 
 // borrowed from blocky-editor
 // https://github.com/vincentdchan/blocky-editor
-export class Signal<T = void> implements Disposable {
+export class Slot<T = void> implements Disposable {
   private _emitting = false;
   private _callbacks: ((v: T) => unknown)[] = [];
   private _disposables: Disposable[] = [];
@@ -42,8 +42,8 @@ export class Signal<T = void> implements Disposable {
     };
   }
 
-  filter(testFun: (v: T) => boolean): Signal<T> {
-    const result = new Signal<T>();
+  filter(testFun: (v: T) => boolean): Slot<T> {
+    const result = new Slot<T>();
     // if result is disposed, dispose this too
     result._disposables.push({ dispose: () => this.dispose() });
 
@@ -146,7 +146,7 @@ export class Signal<T = void> implements Disposable {
     this._emitting = prevEmitting;
   }
 
-  pipe(that: Signal<T>): Signal<T> {
+  pipe(that: Slot<T>): Slot<T> {
     this._callbacks.push(v => that.emit(v));
     return this;
   }
@@ -156,7 +156,7 @@ export class Signal<T = void> implements Disposable {
     this._callbacks.length = 0;
   }
 
-  toDispose(disposables: Disposable[]): Signal<T> {
+  toDispose(disposables: Disposable[]): Slot<T> {
     disposables.push(this);
     return this;
   }

--- a/packages/global/tests/slot.unit.ts
+++ b/packages/global/tests/slot.unit.ts
@@ -1,44 +1,44 @@
-import { Signal } from '@blocksuite/global/utils';
+import { Slot } from '@blocksuite/global/utils';
 import { describe, expect, test, vi } from 'vitest';
-describe('signal', () => {
+describe('slot', () => {
   test('init', () => {
-    const signal = new Signal();
-    expect(signal).is.toBeDefined();
+    const slot = new Slot();
+    expect(slot).is.toBeDefined();
   });
 
   test('emit', () => {
-    const signal = new Signal<void>();
+    const slot = new Slot<void>();
     const callback = vi.fn();
-    signal.on(callback);
-    signal.emit();
+    slot.on(callback);
+    slot.emit();
     expect(callback).toBeCalled();
   });
 
   test('emit with value', () => {
-    const signal = new Signal<number>();
+    const slot = new Slot<number>();
     const callback = vi.fn(v => expect(v).toBe(5));
-    signal.on(callback);
-    signal.emit(5);
+    slot.on(callback);
+    slot.emit(5);
     expect(callback).toBeCalled();
   });
 
   test('listen once', () => {
-    const signal = new Signal<number>();
+    const slot = new Slot<number>();
     const callback = vi.fn(v => expect(v).toBe(5));
-    signal.once(callback);
-    signal.emit(5);
-    signal.emit(6);
+    slot.once(callback);
+    slot.emit(5);
+    slot.emit(6);
     expect(callback).toBeCalledTimes(1);
   });
 
   test('listen once with dispose', () => {
-    const signal = new Signal<void>();
+    const slot = new Slot<void>();
     const callback = vi.fn(() => {
       throw new Error('');
     });
-    const disposable = signal.once(callback);
+    const disposable = slot.once(callback);
     disposable.dispose();
-    signal.emit();
+    slot.emit();
     expect(callback).toBeCalledTimes(0);
   });
 
@@ -47,10 +47,10 @@ describe('signal', () => {
       name: string;
       age: number;
     };
-    const signal = new Signal<Data>();
+    const slot = new Slot<Data>();
     const callback = vi.fn(v => expect(v).toBe('田所'));
-    signal.subscribe(v => v.name, callback);
-    signal.emit({ name: '田所', age: 24 });
+    slot.subscribe(v => v.name, callback);
+    slot.emit({ name: '田所', age: 24 });
     expect(callback).toBeCalledTimes(1);
   });
 });

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -224,7 +224,7 @@ export class DebugMenu extends NonShadowLitElement {
   }
 
   firstUpdated() {
-    this.page.signals.historyUpdated.on(() => {
+    this.page.slots.historyUpdated.on(() => {
       this._canUndo = this.page.canUndo;
       this._canRedo = this.page.canRedo;
     });

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -15,7 +15,7 @@ export interface InitFn {
 
 export const empty: InitFn = (workspace: Workspace) => {
   return new Promise<string>(resolve => {
-    workspace.signals.pageAdded.once(pageId => {
+    workspace.slots.pageAdded.once(pageId => {
       const page = workspace.getPage(pageId) as Page;
 
       // Add page block and surface block at root level
@@ -43,7 +43,7 @@ empty.description = 'Start from empty editor';
 
 export const heavy: InitFn = (workspace: Workspace) => {
   return new Promise<string>(resolve => {
-    workspace.signals.pageAdded.once(pageId => {
+    workspace.slots.pageAdded.once(pageId => {
       const page = workspace.getPage(pageId) as Page;
 
       // Add page block and surface block at root level
@@ -96,7 +96,7 @@ For any feedback, please visit [BlockSuite issues](https://github.com/toeverythi
 
 export const preset: InitFn = (workspace: Workspace) => {
   return new Promise<string>(resolve => {
-    workspace.signals.pageAdded.once(async pageId => {
+    workspace.slots.pageAdded.once(async pageId => {
       const page = workspace.getPage(pageId) as Page;
 
       // Add page block and surface block at root level
@@ -124,7 +124,7 @@ preset.description = 'Start from friendly introduction';
 
 export const database: InitFn = (workspace: Workspace) => {
   return new Promise<string>(resolve => {
-    workspace.signals.pageAdded.once(async pageId => {
+    workspace.slots.pageAdded.once(async pageId => {
       const page = workspace.getPage(pageId) as Page;
       page.awarenessStore.setFlag('enable_database', true);
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -26,7 +26,7 @@ initDebugConfig();
 
 // Subscribe for page update and create editor after page loaded.
 function subscribePage(workspace: Workspace) {
-  const dispose = workspace.signals.pageAdded.on(pageId => {
+  const dispose = workspace.slots.pageAdded.on(pageId => {
     if (typeof globalThis.targetPageId === 'string') {
       if (pageId !== globalThis.targetPageId) {
         // if there's `targetPageId` which not same as the `pageId`
@@ -100,7 +100,7 @@ async function main() {
 
   // Open default examples list when no `?init` param is provided
   const exampleList = document.createElement('start-panel');
-  workspace.signals.pageAdded.once(() => exampleList.remove());
+  workspace.slots.pageAdded.once(() => exampleList.remove());
   document.body.prepend(exampleList);
 }
 

--- a/packages/react/examples/next/src/pages/suspense.tsx
+++ b/packages/react/examples/next/src/pages/suspense.tsx
@@ -22,7 +22,7 @@ const localWorkspace = new Workspace({
 localWorkspace.register(builtInSchemas);
 
 const promise = new Promise<Page>(resolve => {
-  localWorkspace.signals.pageAdded.once(pageId => {
+  localWorkspace.slots.pageAdded.once(pageId => {
     const page = localWorkspace.getPage(pageId) as Page;
     setTimeout(() => {
       pagePromiseLike = page;

--- a/packages/react/src/store/currentWorkspace/index.ts
+++ b/packages/react/src/store/currentWorkspace/index.ts
@@ -59,7 +59,7 @@ export const currentWorkspaceSideEffect = (
   store: CreateBlockSuiteStore
 ) => {
   const dispose: Disposable[] = [
-    workspace.signals.pageAdded.on(id => {
+    workspace.slots.pageAdded.on(id => {
       store.setState(state => {
         return {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -67,7 +67,7 @@ export const currentWorkspaceSideEffect = (
         };
       });
     }),
-    workspace.signals.pageRemoved.on(id => {
+    workspace.slots.pageRemoved.on(id => {
       store.setState(state => {
         const index = state.pages.findIndex(page => page.id === id);
         state.pages.splice(index, 1);
@@ -90,7 +90,7 @@ export const currentWorkspaceSideEffect = (
       if (prev !== workspace) {
         dispose.forEach(d => d.dispose());
       }
-      const disposeAdded = workspace.signals.pageAdded.on(id => {
+      const disposeAdded = workspace.slots.pageAdded.on(id => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const page = workspace.getPage(id)!;
         store.setState(state => {
@@ -99,7 +99,7 @@ export const currentWorkspaceSideEffect = (
           };
         });
       });
-      const disposeRemoved = workspace.signals.pageRemoved.on(id => {
+      const disposeRemoved = workspace.slots.pageRemoved.on(id => {
         store.setState(state => {
           const index = state.pages.findIndex(page => page.id === id);
           state.pages.splice(index, 1);

--- a/packages/react/src/store/manager/index.ts
+++ b/packages/react/src/store/manager/index.ts
@@ -15,7 +15,7 @@ export function bindWorkspaceWithPages(workspace: Workspace) {
     return;
   }
   workspacePages.set(workspace, []);
-  workspace.signals.pageAdded.on(id => {
+  workspace.slots.pageAdded.on(id => {
     console.log('add', id);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const page = workspace.getPage(id)!;
@@ -27,7 +27,7 @@ export function bindWorkspaceWithPages(workspace: Workspace) {
       console.error('not possible');
     }
   });
-  workspace.signals.pageRemoved.on(id => {
+  workspace.slots.pageRemoved.on(id => {
     if (workspacePages.has(workspace)) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const oldPages = workspacePages.get(workspace)!;

--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 // checkout https://vitest.dev/guide/debugging.html for debugging tests
 
-import type { Signal } from '@blocksuite/global/utils';
+import type { Slot } from '@blocksuite/global/utils';
 import { assert, describe, expect, it } from 'vitest';
 
 import { DividerBlockModelSchema } from '../../../blocks/src/divider-block/divider-model.js';
@@ -32,8 +32,8 @@ function serialize(page: Page) {
   return page.doc.toJSON();
 }
 
-function waitOnce<T>(signal: Signal<T>) {
-  return new Promise<T>(resolve => signal.once(val => resolve(val)));
+function waitOnce<T>(slot: Slot<T>) {
+  return new Promise<T>(resolve => slot.once(val => resolve(val)));
 }
 
 async function createRoot(page: Page) {
@@ -42,13 +42,13 @@ async function createRoot(page: Page) {
       title: new page.Text(),
     })
   );
-  const root = await waitOnce(page.signals.rootAdded);
+  const root = await waitOnce(page.slots.rootAdded);
   return root;
 }
 
 async function createPage(workspace: Workspace, pageId = 'page0') {
   queueMicrotask(() => workspace.createPage(pageId));
-  await waitOnce(workspace.signals.pageAdded);
+  await waitOnce(workspace.slots.pageAdded);
   const page = workspace.getPage(pageId);
   assertExists(page);
   return page;
@@ -170,7 +170,7 @@ describe.concurrent('addBlock', () => {
     });
   });
 
-  it('can observe signal events', async () => {
+  it('can observe slot events', async () => {
     const page = await createTestPage();
 
     queueMicrotask(() =>
@@ -178,7 +178,7 @@ describe.concurrent('addBlock', () => {
         title: new page.Text(),
       })
     );
-    const block = await waitOnce(page.signals.rootAdded);
+    const block = await waitOnce(page.slots.rootAdded);
     if (Array.isArray(block)) {
       throw new Error('');
     }
@@ -193,7 +193,7 @@ describe.concurrent('addBlock', () => {
         title: new page.Text(),
       })
     );
-    const roots = await waitOnce(page.signals.rootAdded);
+    const roots = await waitOnce(page.slots.rootAdded);
     const root = Array.isArray(roots) ? roots[0] : roots;
     if (Array.isArray(root)) {
       throw new Error('');

--- a/packages/store/src/awareness.ts
+++ b/packages/store/src/awareness.ts
@@ -1,4 +1,4 @@
-import { Signal } from '@blocksuite/global/utils';
+import { Slot } from '@blocksuite/global/utils';
 import { merge } from 'merge';
 import type { Awareness as YAwareness } from 'y-protocols/awareness.js';
 
@@ -69,8 +69,8 @@ export class AwarenessStore<
   readonly awareness: YAwareness<RawAwarenessState<Flags>>;
   readonly store: Store;
 
-  readonly signals = {
-    update: new Signal<AwarenessEvent<Flags>>(),
+  readonly slots = {
+    update: new Slot<AwarenessEvent<Flags>>(),
   };
 
   constructor(
@@ -81,7 +81,7 @@ export class AwarenessStore<
     this.store = store;
     this.awareness = awareness;
     this.awareness.on('change', this._onAwarenessChange);
-    this.signals.update.on(this._onAwarenessMessage);
+    this.slots.update.on(this._onAwarenessMessage);
     const upstreamFlags = awareness.getLocalState()?.flags;
     if (upstreamFlags) {
       this.awareness.setLocalStateField(
@@ -212,21 +212,21 @@ export class AwarenessStore<
 
     const states = this.awareness.getStates();
     added.forEach(id => {
-      this.signals.update.emit({
+      this.slots.update.emit({
         id,
         type: 'add',
         state: states.get(id) as RawAwarenessState<Flags>,
       });
     });
     updated.forEach(id => {
-      this.signals.update.emit({
+      this.slots.update.emit({
         id,
         type: 'update',
         state: states.get(id) as RawAwarenessState<Flags>,
       });
     });
     removed.forEach(id => {
-      this.signals.update.emit({
+      this.slots.update.emit({
         id,
         type: 'remove',
       });
@@ -308,7 +308,7 @@ export class AwarenessStore<
   destroy() {
     if (this.awareness) {
       this.awareness.off('change', this._onAwarenessChange);
-      this.signals.update.dispose();
+      this.slots.update.dispose();
     }
   }
 }

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -1,5 +1,5 @@
 import type { BlockModels } from '@blocksuite/global/types';
-import { Signal } from '@blocksuite/global/utils';
+import { Slot } from '@blocksuite/global/utils';
 import type * as Y from 'yjs';
 import { z } from 'zod';
 
@@ -105,8 +105,8 @@ export class BaseBlockModel<Props = unknown>
   id: string;
 
   page: Page;
-  propsUpdated = new Signal();
-  childrenUpdated = new Signal();
+  propsUpdated = new Slot();
+  childrenUpdated = new Slot();
   childMap = new Map<string, number>();
 
   type?: string;

--- a/packages/store/src/persistence/blob/__tests__/test-entry.ts
+++ b/packages/store/src/persistence/blob/__tests__/test-entry.ts
@@ -47,7 +47,7 @@ async function testBasic() {
     let called = false;
     let idCalled: string | null = null;
 
-    storage.signals.onBlobSyncStateChange.on(state => {
+    storage.slots.onBlobSyncStateChange.on(state => {
       called = true;
       idCalled = state.id;
     });

--- a/packages/store/src/persistence/blob/cloud-sync-manager.ts
+++ b/packages/store/src/persistence/blob/cloud-sync-manager.ts
@@ -1,4 +1,4 @@
-import { Signal, sleep } from '@blocksuite/global/utils';
+import { sleep, Slot } from '@blocksuite/global/utils';
 import ky from 'ky';
 
 import type { BlobOptionsGetter } from './duplex-provider.js';
@@ -23,8 +23,8 @@ export class CloudSyncManager {
 
   private _workspace!: string;
 
-  readonly signals: BlobProvider['signals'] = {
-    onBlobSyncStateChange: new Signal(),
+  readonly slotss: BlobProvider['slots'] = {
+    onBlobSyncStateChange: new Slot(),
   };
 
   constructor(workspace: string, blobOptionsGetter: BlobOptionsGetter) {
@@ -79,7 +79,7 @@ export class CloudSyncManager {
         );
 
         if (resp.status === 404) {
-          this.signals.onBlobSyncStateChange.emit({
+          this.slotss.onBlobSyncStateChange.emit({
             id: task.id,
             state: BlobSyncState.Syncing,
           });
@@ -88,7 +88,7 @@ export class CloudSyncManager {
           });
 
           if (response.status === 200) {
-            this.signals.onBlobSyncStateChange.emit({
+            this.slotss.onBlobSyncStateChange.emit({
               id: task.id,
               state: BlobSyncState.Success,
             });
@@ -102,7 +102,7 @@ export class CloudSyncManager {
             }
             await this._db.set(task.id, { ...task, failed: true });
             this._failed.push({ ...task, failed: true });
-            this.signals.onBlobSyncStateChange.emit({
+            this.slotss.onBlobSyncStateChange.emit({
               id: task.id,
               state: BlobSyncState.Failed,
             });
@@ -116,7 +116,7 @@ export class CloudSyncManager {
         }
       } catch (e) {
         console.warn('Error while syncing blob', e);
-        this.signals.onBlobSyncStateChange.emit({
+        this.slotss.onBlobSyncStateChange.emit({
           id: task.id,
           state: BlobSyncState.Failed,
         });
@@ -138,7 +138,7 @@ export class CloudSyncManager {
       retry: 0,
     });
     this._runTasks();
-    this.signals.onBlobSyncStateChange.emit({
+    this.slotss.onBlobSyncStateChange.emit({
       id,
       state: BlobSyncState.Waiting,
     });

--- a/packages/store/src/persistence/blob/duplex-provider.ts
+++ b/packages/store/src/persistence/blob/duplex-provider.ts
@@ -1,4 +1,4 @@
-import { assertExists, Signal } from '@blocksuite/global/utils';
+import { assertExists, Slot } from '@blocksuite/global/utils';
 
 import { CloudSyncManager } from './cloud-sync-manager.js';
 import type {
@@ -34,8 +34,8 @@ export class DuplexBlobProvider implements BlobProvider {
   private readonly _localDB: IDBInstance;
   private readonly _cloudManager?: CloudSyncManager;
 
-  readonly signals = {
-    onBlobSyncStateChange: new Signal<BlobSyncStateChangeEvent>(),
+  readonly slots = {
+    onBlobSyncStateChange: new Slot<BlobSyncStateChangeEvent>(),
   };
 
   static async init(
@@ -54,8 +54,8 @@ export class DuplexBlobProvider implements BlobProvider {
       assertExists(optionsGetter);
       this._cloudManager = new CloudSyncManager(workspace, optionsGetter);
 
-      this._cloudManager.signals.onBlobSyncStateChange.on(blobState => {
-        this.signals.onBlobSyncStateChange.emit(blobState);
+      this._cloudManager.slotss.onBlobSyncStateChange.on(blobState => {
+        this.slots.onBlobSyncStateChange.emit(blobState);
       });
     }
   }

--- a/packages/store/src/persistence/blob/storage.ts
+++ b/packages/store/src/persistence/blob/storage.ts
@@ -1,4 +1,4 @@
-import { Signal } from '@blocksuite/global/utils';
+import { Slot } from '@blocksuite/global/utils';
 
 import type {
   BlobId,
@@ -18,8 +18,8 @@ function assertProviderExist(
 export class BlobStorage {
   private _provider: BlobProvider | null = null;
 
-  signals = {
-    onBlobSyncStateChange: new Signal<BlobSyncStateChangeEvent>(),
+  slots = {
+    onBlobSyncStateChange: new Slot<BlobSyncStateChangeEvent>(),
   };
 
   get uploading(): boolean {
@@ -36,8 +36,8 @@ export class BlobStorage {
       return;
     }
     this._provider = provider;
-    this._provider.signals.onBlobSyncStateChange.on(state => {
-      this.signals.onBlobSyncStateChange.emit(state);
+    this._provider.slots.onBlobSyncStateChange.on(state => {
+      this.slots.onBlobSyncStateChange.emit(state);
     });
   }
 

--- a/packages/store/src/persistence/blob/types.ts
+++ b/packages/store/src/persistence/blob/types.ts
@@ -1,4 +1,4 @@
-import type { Signal } from '@blocksuite/global/utils';
+import type { Slot } from '@blocksuite/global/utils';
 
 export type BlobId = string;
 export type BlobURL = string;
@@ -18,8 +18,8 @@ export interface BlobSyncStateChangeEvent {
 export interface BlobProvider {
   uploading: boolean;
   blobs: Promise<string[]>;
-  signals: {
-    onBlobSyncStateChange: Signal<BlobSyncStateChangeEvent>;
+  slots: {
+    onBlobSyncStateChange: Slot<BlobSyncStateChangeEvent>;
   };
   get(id: BlobId): Promise<BlobURL | null>;
   set(blob: Blob): Promise<BlobId>;

--- a/packages/store/src/persistence/doc/debug-provider.ts
+++ b/packages/store/src/persistence/doc/debug-provider.ts
@@ -1,4 +1,4 @@
-import { isWeb, Signal } from '@blocksuite/global/utils';
+import { isWeb, Slot } from '@blocksuite/global/utils';
 import type { Awareness } from 'y-protocols/awareness';
 // @ts-ignore
 import { Room, WebrtcProvider } from 'y-webrtc';
@@ -25,7 +25,7 @@ const signaling = isLocalhost ? LOCAL_SIGNALING : DEFAULT_SIGNALING;
 
 export class DebugDocProvider extends WebrtcProvider implements DocProvider {
   private readonly _doc: Y.Doc;
-  public remoteUpdateSignal = new Signal<unknown>();
+  public remoteUpdateSlot = new Slot<unknown>();
   constructor(room: string, doc: Y.Doc, options?: { awareness?: Awareness }) {
     super(room, doc, {
       awareness: options?.awareness,
@@ -36,7 +36,7 @@ export class DebugDocProvider extends WebrtcProvider implements DocProvider {
 
   private _handleRemoteUpdate = (update: unknown, origin: unknown) => {
     if (origin instanceof Room) {
-      this.remoteUpdateSignal.emit(update);
+      this.remoteUpdateSlot.emit(update);
     }
   };
 

--- a/packages/store/src/workspace/__tests__/test-app.ts
+++ b/packages/store/src/workspace/__tests__/test-app.ts
@@ -28,7 +28,7 @@ export class TestApp extends LitElement {
   firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
 
-    this.workspace.signals.pagesUpdated.on(() => {
+    this.workspace.slots.pagesUpdated.on(() => {
       this.pages = this.workspace.meta.pageMetas.map(page => ({
         title: page.title,
         favorite: page.favorite,
@@ -36,7 +36,7 @@ export class TestApp extends LitElement {
       this.requestUpdate();
     });
 
-    this.workspace.signals;
+    this.workspace.slots;
   }
 
   render() {

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -1,7 +1,7 @@
 import type { BlockTag, TagSchema } from '@blocksuite/global/database';
 import { debug } from '@blocksuite/global/debug';
 import type { BlockModelProps } from '@blocksuite/global/types';
-import { assertExists, matchFlavours, Signal } from '@blocksuite/global/utils';
+import { assertExists, matchFlavours, Slot } from '@blocksuite/global/utils';
 import { uuidv4 } from 'lib0/random.js';
 import type { Quill } from 'quill';
 import * as Y from 'yjs';
@@ -62,13 +62,13 @@ export class Page extends Space<PageData> {
     Object.keys(new BaseBlockModel(this, { id: null! }))
   );
 
-  readonly signals = {
-    historyUpdated: new Signal(),
-    rootAdded: new Signal<BaseBlockModel | BaseBlockModel[]>(),
-    rootDeleted: new Signal<string | string[]>(),
-    textUpdated: new Signal<Y.YTextEvent>(),
-    yUpdated: new Signal(),
-    blockUpdated: new Signal<{
+  readonly slots = {
+    historyUpdated: new Slot(),
+    rootAdded: new Slot<BaseBlockModel | BaseBlockModel[]>(),
+    rootDeleted: new Slot<string | string[]>(),
+    textUpdated: new Slot<Y.YTextEvent>(),
+    yUpdated: new Slot(),
+    blockUpdated: new Slot<{
       type: 'add' | 'delete' | 'update';
       id: string;
     }>(),
@@ -433,7 +433,7 @@ export class Page extends Space<PageData> {
       }
     });
 
-    this.signals.blockUpdated.emit({
+    this.slots.blockUpdated.emit({
       type: 'add',
       id,
     });
@@ -542,7 +542,7 @@ export class Page extends Space<PageData> {
       syncBlockProps(schema, defaultProps, yBlock, props, this._ignoredKeys);
     });
 
-    this.signals.blockUpdated.emit({
+    this.slots.blockUpdated.emit({
       type: 'update',
       id: model.id,
     });
@@ -644,7 +644,7 @@ export class Page extends Space<PageData> {
       }
     });
 
-    this.signals.blockUpdated.emit({
+    this.slots.blockUpdated.emit({
       type: 'delete',
       id: model.id,
     });
@@ -692,12 +692,12 @@ export class Page extends Space<PageData> {
   }
 
   dispose() {
-    this.signals.historyUpdated.dispose();
-    this.signals.rootAdded.dispose();
-    this.signals.rootDeleted.dispose();
-    this.signals.textUpdated.dispose();
-    this.signals.yUpdated.dispose();
-    this.signals.blockUpdated.dispose();
+    this.slots.historyUpdated.dispose();
+    this.slots.rootAdded.dispose();
+    this.slots.rootDeleted.dispose();
+    this.slots.textUpdated.dispose();
+    this.slots.yUpdated.dispose();
+    this.slots.blockUpdated.dispose();
 
     this._yBlocks.unobserveDeep(this._handleYEvents);
     this._yBlocks.clear();
@@ -755,7 +755,7 @@ export class Page extends Space<PageData> {
   };
 
   private _historyObserver = () => {
-    this.signals.historyUpdated.emit();
+    this.slots.historyUpdated.emit();
   };
 
   private _createBlockModel(props: Omit<BlockProps, 'children'>) {
@@ -844,10 +844,10 @@ export class Page extends Space<PageData> {
 
     if (isRoot) {
       this._root = model;
-      this.signals.rootAdded.emit(model);
+      this.slots.rootAdded.emit(model);
     } else if (isSurface) {
       this._root = [this.root as BaseBlockModel, model];
-      this.signals.rootAdded.emit(this._root);
+      this.slots.rootAdded.emit(this._root);
     } else {
       const parent = this.getParent(model);
       const index = parent?.childMap.get(model.id);
@@ -861,7 +861,7 @@ export class Page extends Space<PageData> {
   private _handleYBlockDelete(id: string) {
     const model = this._blockMap.get(id);
     if (model === this._root) {
-      this.signals.rootDeleted.emit(id);
+      this.slots.rootDeleted.emit(id);
     } else {
       // TODO dispatch model delete event
     }
@@ -943,7 +943,7 @@ export class Page extends Space<PageData> {
     // event on single block
     else if (event.target.parent === this._yBlocks) {
       if (event instanceof Y.YTextEvent) {
-        this.signals.textUpdated.emit(event);
+        this.slots.textUpdated.emit(event);
       } else if (event instanceof Y.YMapEvent) {
         this._handleYBlockUpdate(event);
       }
@@ -988,7 +988,7 @@ export class Page extends Space<PageData> {
     for (const event of events) {
       this._handleYEvent(event);
     }
-    this.signals.yUpdated.emit();
+    this.slots.yUpdated.emit();
   };
 
   private _handleVersion() {

--- a/packages/virgo/src/virgo.ts
+++ b/packages/virgo/src/virgo.ts
@@ -1,4 +1,4 @@
-import { assertExists, Signal } from '@blocksuite/global/utils';
+import { assertExists, Slot } from '@blocksuite/global/utils';
 import type * as Y from 'yjs';
 import type { z } from 'zod';
 
@@ -169,8 +169,8 @@ export class VEditor<
     this._rootElement.replaceChildren(...lines);
   };
 
-  signals: {
-    updateVRange: Signal<UpdateVRangeProp>;
+  slots: {
+    updateVRange: Slot<UpdateVRangeProp>;
   };
 
   get yText() {
@@ -189,11 +189,11 @@ export class VEditor<
 
     this._yText = yText;
 
-    this.signals = {
-      updateVRange: new Signal<UpdateVRangeProp>(),
+    this.slots = {
+      updateVRange: new Slot<UpdateVRangeProp>(),
     };
 
-    this.signals.updateVRange.on(this._onUpdateVRange);
+    this.slots.updateVRange.on(this._onUpdateVRange);
   }
 
   setAttributesSchema = (schema: z.ZodSchema<TextAttributes>) => {
@@ -385,7 +385,7 @@ export class VEditor<
   }
 
   setVRange(vRange: VRange): void {
-    this.signals.updateVRange.emit([vRange, 'other']);
+    this.slots.updateVRange.emit([vRange, 'other']);
   }
 
   focusEnd(): void {
@@ -732,7 +732,7 @@ export class VEditor<
     const currentVRange = this._vRange;
 
     if (inputType === 'insertText' && currentVRange.index >= 0 && data) {
-      this.signals.updateVRange.emit([
+      this.slots.updateVRange.emit([
         {
           index: currentVRange.index + data.length,
           length: 0,
@@ -742,7 +742,7 @@ export class VEditor<
 
       this.insertText(currentVRange, data);
     } else if (inputType === 'insertParagraph' && currentVRange.index >= 0) {
-      this.signals.updateVRange.emit([
+      this.slots.updateVRange.emit([
         {
           index: currentVRange.index + 1,
           length: 0,
@@ -756,7 +756,7 @@ export class VEditor<
       currentVRange.index >= 0
     ) {
       if (currentVRange.length > 0) {
-        this.signals.updateVRange.emit([
+        this.slots.updateVRange.emit([
           {
             index: currentVRange.index,
             length: 0,
@@ -769,7 +769,7 @@ export class VEditor<
         // https://dev.to/acanimal/how-to-slice-or-get-symbols-from-a-unicode-string-with-emojis-in-javascript-lets-learn-how-javascript-represent-strings-h3a
         const tmpString = this.yText.toString().slice(0, currentVRange.index);
         const deletedCharacter = [...tmpString].slice(-1).join('');
-        this.signals.updateVRange.emit([
+        this.slots.updateVRange.emit([
           {
             index: currentVRange.index - deletedCharacter.length,
             length: 0,
@@ -801,7 +801,7 @@ export class VEditor<
     if (this._vRange.index >= 0 && data) {
       this.insertText(this._vRange, data);
 
-      this.signals.updateVRange.emit([
+      this.slots.updateVRange.emit([
         {
           index: this._vRange.index + data.length,
           length: 0,
@@ -835,7 +835,7 @@ export class VEditor<
 
     const vRange = this.toVRange(selection);
     if (vRange) {
-      this.signals.updateVRange.emit([vRange, 'native']);
+      this.slots.updateVRange.emit([vRange, 'native']);
     }
   };
 
@@ -845,7 +845,7 @@ export class VEditor<
       const vRange = this._vRange;
       if (vRange) {
         this.insertText(vRange, data);
-        this.signals.updateVRange.emit([
+        this.slots.updateVRange.emit([
           {
             index: vRange.index + data.length,
             length: 0,

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -18,7 +18,7 @@ import {
   undoByClick,
   undoByKeyboard,
   waitDefaultPageLoaded,
-  waitForRemoteUpdateSignal,
+  waitForRemoteUpdateSlot,
   waitNextFrame,
 } from './utils/actions/index.js';
 import {
@@ -124,9 +124,9 @@ test('A first open, B first edit', async ({ browser, page: pageA }) => {
   await waitNextFrame(pageB);
   await focusRichText(pageB);
 
-  const signal = waitForRemoteUpdateSignal(pageA);
+  const slot = waitForRemoteUpdateSlot(pageA);
   await pageB.keyboard.type('hello');
-  await signal;
+  await slot;
   // wait until pageA content updated
   await assertText(pageA, 'hello');
   await assertText(pageB, 'hello');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -53,7 +53,7 @@ async function initEmptyEditor(
   await page.evaluate(flags => {
     const { workspace } = window;
 
-    workspace.signals.pageAdded.once(async pageId => {
+    workspace.slots.pageAdded.once(async pageId => {
       const page = workspace.getPage(pageId) as StorePage;
       for (const [key, value] of Object.entries(flags)) {
         page.awarenessStore.setFlag(key as keyof typeof flags, value);
@@ -139,7 +139,7 @@ export async function waitNextFrame(page: Page) {
   await page.waitForTimeout(NEXT_FRAME_TIMEOUT);
 }
 
-export async function waitForRemoteUpdateSignal(page: Page) {
+export async function waitForRemoteUpdateSlot(page: Page) {
   return page.evaluate(() => {
     return new Promise<void>(resolve => {
       const DebugDocProvider = window.$blocksuite.store.DebugDocProvider;
@@ -150,7 +150,7 @@ export async function waitForRemoteUpdateSignal(page: Page) {
         disposable.dispose();
         resolve();
       }, 500);
-      const disposable = debugProvider.remoteUpdateSignal.on(callback);
+      const disposable = debugProvider.remoteUpdateSlot.on(callback);
     });
   });
 }


### PR DESCRIPTION
This avoids the ambiguity with the recent `Signal` concept, making room for our future potential reactivity primitives.

Note that this doesn't affect the `AbortController.signal`, which also reduces ambiguity.