### PR TITLE
fix: should cancel when select selected point outside the selected element

### DIFF
--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -164,6 +164,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
     const selected = this._pick(e.x, e.y);
 
     if (selected) {
+      // See https://github.com/toeverything/blocksuite/pull/1484
       if (this._blockSelectionState.type === 'single') {
         if (this._blockSelectionState.selected !== selected) {
           this._setNoneSelectionState();

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -69,6 +69,8 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
 
   private _setNoneSelectionState() {
     this._blockSelectionState = { type: 'none' };
+    this._edgeless.slots.updateSelection.emit(this._blockSelectionState);
+    resetNativeSelection(null);
   }
 
   private _setSingleSelectionState(selected: Selectable, active: boolean) {
@@ -147,8 +149,6 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
       this._handleClickOnSelected(selected, e);
     } else {
       this._setNoneSelectionState();
-      this._edgeless.slots.updateSelection.emit(this.blockSelectionState);
-      resetNativeSelection(null);
     }
   }
 
@@ -164,10 +164,13 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
     const selected = this._pick(e.x, e.y);
 
     if (selected) {
-      if (isTopLevelBlock(selected)) {
-        switch (this.blockSelectionState.type) {
-          case 'none':
-            this._setSingleSelectionState(selected, true);
+      if (this._blockSelectionState.type === 'single') {
+        if (this._blockSelectionState.selected !== selected) {
+          this._setNoneSelectionState();
+        }
+      } else {
+        if (isTopLevelBlock(selected)) {
+          this._setSingleSelectionState(selected, true);
         }
       }
     } else {
@@ -176,9 +179,6 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
         start: new DOMPoint(e.x, e.y),
         end: new DOMPoint(e.x, e.y),
       };
-
-      this._edgeless.slots.updateSelection.emit(this.blockSelectionState);
-      resetNativeSelection(null);
     }
 
     const [x, y] = [e.raw.clientX, e.raw.clientY];

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -469,3 +469,27 @@ test('pan tool shortcut when user is editing', async ({ page }) => {
   const panButton = locatorPanButton(page);
   expect(await panButton.getAttribute('active')).toBeNull();
 });
+
+test('should cancel select when the selected point is outside the current selected element', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const firstStart = { x: 100, y: 100 };
+  const firstEnd = { x: 200, y: 200 };
+  await addBasicRectShapeElement(page, firstStart, firstEnd);
+
+  const secondStart = { x: 300, y: 300 };
+  const secondEnd = { x: 400, y: 400 };
+  await addBasicRectShapeElement(page, secondStart, secondEnd);
+
+  // select the first rect
+  await page.mouse.click(150, 150);
+
+  await dragBetweenCoords(page, { x: 350, y: 350 }, { x: 350, y: 450 });
+
+  await page.mouse.move(150, 150);
+  await assertEdgelessHoverRect(page, [100, 100, 100, 100]);
+});


### PR DESCRIPTION
Fix the following problem(when we select the first elipse, move to the second eplise, and try to drag on the second eplise, the first elipse is dragged):

https://user-images.githubusercontent.com/24316656/222884616-767a90c4-ed39-457f-8567-83ecc00738bd.mp4

