### PR TITLE
refactor: remove redundant selection manager fields

### DIFF
--- a/packages/blocks/src/__internal__/utils/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture.ts
@@ -95,7 +95,7 @@ export function initMouseEventHandlers(
   onContainerMouseOut: (e: SelectionEvent) => void,
   onContainerContextMenu: (e: SelectionEvent) => void,
   onSelectionChangeWithDebounce: (e: Event) => void,
-  onSelectionChangeWithOutDebounce: (e: Event) => void
+  onSelectionChangeWithoutDebounce: (e: Event) => void
 ) {
   let startX = -Infinity;
   let startY = -Infinity;
@@ -209,8 +209,8 @@ export function initMouseEventHandlers(
     onSelectionChangeWithDebounce(e as Event);
   }, 300);
 
-  const selectionChangeHandlerWithOutDebounce = (e: Event) => {
-    onSelectionChangeWithOutDebounce(e);
+  const selectionChangeHandlerWithoutDebounce = (e: Event) => {
+    onSelectionChangeWithoutDebounce(e);
   };
 
   container.addEventListener('mousedown', mouseDownHandler);
@@ -223,7 +223,7 @@ export function initMouseEventHandlers(
   );
   document.addEventListener(
     'selectionchange',
-    selectionChangeHandlerWithOutDebounce
+    selectionChangeHandlerWithoutDebounce
   );
 
   const dispose = () => {
@@ -237,7 +237,7 @@ export function initMouseEventHandlers(
     );
     document.removeEventListener(
       'selectionchange',
-      selectionChangeHandlerWithOutDebounce
+      selectionChangeHandlerWithoutDebounce
     );
   };
   return dispose;

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -27,7 +27,6 @@ export interface BlockHost extends BlockHostContext {
   page: Page;
   flavour: string;
   readonly: boolean;
-  readonly isCompositionStart?: boolean;
 }
 
 export interface CommonBlockElement extends HTMLElement {

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -12,7 +12,7 @@ import { toolTipStyle } from '../../components/tooltip/tooltip.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
 import type {
   CodeBlockOption,
-  DefaultPageSlots,
+  DefaulSelectionSlots,
   EmbedEditingState,
   ViewportState,
 } from './default-page-block.js';
@@ -25,7 +25,7 @@ import {
   toggleWrap,
 } from './utils.js';
 
-export function FrameSelectionRect(rect: DOMRect | null) {
+export function DraggingArea(rect: DOMRect | null) {
   if (rect === null) return null;
 
   const style = {
@@ -36,17 +36,14 @@ export function FrameSelectionRect(rect: DOMRect | null) {
   };
   return html`
     <style>
-      .affine-page-frame-selection-rect {
+      .affine-page-dragging-area {
         position: absolute;
         background: var(--affine-selected-color);
         z-index: 1;
         pointer-events: none;
       }
     </style>
-    <div
-      class="affine-page-frame-selection-rect"
-      style=${styleMap(style)}
-    ></div>
+    <div class="affine-page-dragging-area" style=${styleMap(style)}></div>
   `;
 }
 
@@ -116,7 +113,7 @@ export function SelectedRectsContainer(
 
 export function EmbedEditingContainer(
   embedEditingState: EmbedEditingState | null,
-  slots: DefaultPageSlots,
+  slots: DefaulSelectionSlots,
   viewportState: ViewportState
 ) {
   if (!embedEditingState) return null;

--- a/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
@@ -1,8 +1,7 @@
 import '../../../components/drag-handle.js';
 
-import { getCurrentBlockRange } from '@blocksuite/blocks';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
-import type { Page, UserRange } from '@blocksuite/store';
+import type { Page } from '@blocksuite/store';
 import { BaseBlockModel, DisposableGroup } from '@blocksuite/store';
 
 import {
@@ -10,7 +9,6 @@ import {
   getBlockElementByModel,
   getCurrentNativeRange,
   getDefaultPageBlock,
-  getModelByElement,
   handleNativeRangeClick,
   handleNativeRangeDblClick,
   handleNativeRangeDragMove,
@@ -33,8 +31,8 @@ import {
   repairContextMenuRange,
 } from '../../utils/position.js';
 import type {
+  DefaulSelectionSlots,
   DefaultPageBlockComponent,
-  DefaultPageSlots,
   EmbedEditingState,
   ViewportState,
 } from '../default-page-block.js';
@@ -49,20 +47,25 @@ import {
 } from './selection-state.js';
 import {
   clearSubtree,
+  computeSelectionType,
   createSelectionRect,
   filterSelectedBlockByIndex,
   filterSelectedBlockByIndexAndBound,
   filterSelectedBlockWithoutSubtree,
   findBlocksWithSubtree,
+  updateLocalSelectionRange,
 } from './utils.js';
 
+/**
+ * The selection manager used in default mode.
+ */
 export class DefaultSelectionManager {
   readonly page: Page;
   readonly state = new PageSelectionState('none');
   private readonly _mouseRoot: HTMLElement;
   private readonly _container: DefaultPageBlockComponent;
   private readonly _disposables = new DisposableGroup();
-  private readonly _slots: DefaultPageSlots;
+  private readonly _slots: DefaulSelectionSlots;
   private readonly _embedResizeManager: EmbedResizeManager;
   private readonly _threshold: number; // distance to the upper and lower boundaries of the viewport
 
@@ -75,7 +78,7 @@ export class DefaultSelectionManager {
   }: {
     page: Page;
     mouseRoot: HTMLElement;
-    slots: DefaultPageSlots;
+    slots: DefaulSelectionSlots;
     container: DefaultPageBlockComponent;
     threshold: number;
   }) {
@@ -113,38 +116,6 @@ export class DefaultSelectionManager {
     return this.page.root ? getAllowSelectedBlocks(this.page.root) : [];
   }
 
-  private _computeSelectionType(
-    selectedBlocks: Element[],
-    selectionType?: PageSelectionType
-  ): PageSelectionType {
-    let newSelectionType: PageSelectionType = selectionType ?? 'native';
-    const isOnlyBlock = selectedBlocks.length === 1;
-    for (const block of selectedBlocks) {
-      if (selectionType) continue;
-      if (!('model' in block)) continue;
-
-      // Calculate selection type
-      const model = getModelByElement(block);
-      newSelectionType = 'block';
-
-      // Other selection types are possible if only one block is selected
-      if (!isOnlyBlock) continue;
-
-      const flavour = model.flavour;
-      switch (flavour) {
-        case 'affine:embed': {
-          newSelectionType = 'embed';
-          break;
-        }
-        case 'affine:database': {
-          newSelectionType = 'database';
-          break;
-        }
-      }
-    }
-    return newSelectionType;
-  }
-
   setSelectedBlocks(
     selectedBlocks: BlockComponentElement[],
     rects?: DOMRect[],
@@ -163,7 +134,7 @@ export class DefaultSelectionManager {
       calculatedRects.push(block.getBoundingClientRect());
     }
 
-    const newSelectionType = this._computeSelectionType(
+    const newSelectionType = computeSelectionType(
       selectedBlocks,
       selectionType
     );
@@ -217,7 +188,7 @@ export class DefaultSelectionManager {
         endPoint.y += d;
         auto = Math.ceil(scrollTop) < max;
         viewport.scrollTop = scrollTop;
-        this.updateSelectionRect(startPoint, endPoint);
+        this.updateDraggingArea(startPoint, endPoint);
       } else if (scrollTop > 0 && y < this._threshold) {
         // ↑
         const d = (y - this._threshold) * 0.25;
@@ -225,10 +196,10 @@ export class DefaultSelectionManager {
         endPoint.y += d;
         auto = scrollTop > 0;
         viewport.scrollTop = scrollTop;
-        this.updateSelectionRect(startPoint, endPoint);
+        this.updateDraggingArea(startPoint, endPoint);
       } else {
         auto = false;
-        const selectionRect = this.updateSelectionRect(startPoint, endPoint);
+        const selectionRect = this.updateDraggingArea(startPoint, endPoint);
         this.selecting(this.state.blockCache, selectionRect, viewportState);
       }
     };
@@ -240,14 +211,14 @@ export class DefaultSelectionManager {
   private _onBlockSelectionDragEnd(_: SelectionEvent) {
     this.state.type = 'block';
     this.state.clearBlockSelectionRect();
-    this._slots.updateFrameSelectionRect.emit(null);
+    this._slots.updateDraggingArea.emit(null);
     // do not clear selected rects here
   }
 
   private _onNativeSelectionDragStart(e: SelectionEvent) {
     this.state.resetStartRange(e);
     this.state.type = 'native';
-    this._slots.nativeSelection.emit(false);
+    this._slots.toggleNativeSelection.emit(false);
   }
 
   private _onNativeSelectionDragMove(e: SelectionEvent) {
@@ -256,7 +227,7 @@ export class DefaultSelectionManager {
   }
 
   private _onNativeSelectionDragEnd(_: SelectionEvent) {
-    this._slots.nativeSelection.emit(true);
+    this._slots.toggleNativeSelection.emit(true);
   }
 
   private _onContainerDragStart = (e: SelectionEvent) => {
@@ -546,7 +517,7 @@ export class DefaultSelectionManager {
   };
 
   private _onSelectionChangeWithoutDebounce = (_: Event) => {
-    this.updateLocalSelection();
+    updateLocalSelectionRange(this.page);
   };
 
   // clear selection: `block`, `embed`, `native`
@@ -556,7 +527,7 @@ export class DefaultSelectionManager {
     if (type === 'block') {
       state.clearBlock();
       _slots.updateSelectedRects.emit([]);
-      _slots.updateFrameSelectionRect.emit(null);
+      _slots.updateDraggingArea.emit(null);
     } else if (type === 'embed') {
       state.clearEmbed();
       _slots.updateEmbedRects.emit([]);
@@ -568,13 +539,15 @@ export class DefaultSelectionManager {
 
   dispose() {
     this._slots.updateSelectedRects.dispose();
-    this._slots.updateFrameSelectionRect.dispose();
+    this._slots.updateDraggingArea.dispose();
     this._slots.updateEmbedEditingState.dispose();
     this._slots.updateEmbedRects.dispose();
+    this._slots.updateCodeBlockOption.dispose();
+    this._slots.toggleNativeSelection.dispose();
     this._disposables.dispose();
   }
 
-  updateSelectionRect(
+  updateDraggingArea(
     startPoint: { x: number; y: number },
     endPoint: { x: number; y: number }
   ): DOMRect {
@@ -582,19 +555,19 @@ export class DefaultSelectionManager {
       this.state.focusedBlockIndex = -1;
     }
     const selectionRect = createSelectionRect(endPoint, startPoint);
-    this._slots.updateFrameSelectionRect.emit(selectionRect);
+    this._slots.updateDraggingArea.emit(selectionRect);
     return selectionRect;
   }
 
   selecting(
     blockCache: Map<BlockComponentElement, DOMRect>,
-    selectionRect: DOMRect,
+    draggingArea: DOMRect,
     viewportState: ViewportState
   ) {
     const { scrollLeft, scrollTop, left, top } = viewportState;
     const selectedBlocksWithoutSubtrees = filterSelectedBlockWithoutSubtree(
       blockCache,
-      selectionRect,
+      draggingArea,
       // subtracting the left/top of the container is required.
       {
         y: scrollTop - top,
@@ -630,7 +603,7 @@ export class DefaultSelectionManager {
     } else {
       this.state.setStartPoint(null);
       this.state.setEndPoint(null);
-      this._slots.updateFrameSelectionRect.emit(null);
+      this._slots.updateDraggingArea.emit(null);
       this.refreshSelectedBlocksRects();
     }
   }
@@ -818,18 +791,5 @@ export class DefaultSelectionManager {
     }
 
     return null;
-  }
-
-  updateLocalSelection() {
-    const page = this.page;
-    const blockRange = getCurrentBlockRange(page);
-    if (blockRange && blockRange.type === 'Native') {
-      const userRange: UserRange = {
-        startOffset: blockRange.startOffset,
-        endOffset: blockRange.endOffset,
-        blockIds: blockRange.models.map(m => m.id),
-      };
-      page.awarenessStore.setLocalRange(page, userRange);
-    }
   }
 }

--- a/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
@@ -1,12 +1,12 @@
 import { assertExists } from '@blocksuite/global/utils';
 
-import type { DefaultPageSlots } from '../../../index.js';
+import type { DefaulSelectionSlots } from '../../../index.js';
 import { getModelByElement, IPoint, SelectionEvent } from '../../../std.js';
 import type { PageSelectionState } from './selection-state.js';
 
 export class EmbedResizeManager {
   state: PageSelectionState;
-  slots: DefaultPageSlots;
+  slots: DefaulSelectionSlots;
   private _originPosition: IPoint = { x: 0, y: 0 };
   private _dropContainer: HTMLElement | null = null;
   private _dropContainerSize: { w: number; h: number; left: number } = {
@@ -16,7 +16,7 @@ export class EmbedResizeManager {
   };
   private _dragMoveTarget = 'right';
 
-  constructor(state: PageSelectionState, slots: DefaultPageSlots) {
+  constructor(state: PageSelectionState, slots: DefaulSelectionSlots) {
     this.state = state;
     this.slots = slots;
   }

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -26,7 +26,7 @@ import {
   getRichTextByModel,
   Point,
 } from '../../__internal__/utils/index.js';
-import type { DefaultPageSlots } from '../default/default-page-block.js';
+import type { DefaulSelectionSlots } from '../default/default-page-block.js';
 import type { DefaultSelectionManager } from '../default/selection-manager/index.js';
 import { handleSelectAll } from '../utils/index.js';
 import { formatConfig } from './const.js';
@@ -279,7 +279,7 @@ function handleTab(
 export function bindHotkeys(
   page: Page,
   selection: DefaultSelectionManager,
-  slots: DefaultPageSlots
+  slots: DefaulSelectionSlots
 ) {
   const {
     BACKSPACE,

--- a/tests/selection.spec.ts
+++ b/tests/selection.spec.ts
@@ -623,7 +623,7 @@ test('selection on heavy page', async ({ page }) => {
     {
       beforeMouseUp: async () => {
         const rect = await page
-          .locator('.affine-page-frame-selection-rect')
+          .locator('.affine-page-dragging-area')
           .evaluate(element => element.getBoundingClientRect());
         assertAlmostEqual(rect.x, first.x - 1, 1);
         assertAlmostEqual(rect.y, first.y - 1, 1);


### PR DESCRIPTION
part of #1480

* Extract some methods that doesn't depend heavily on `this` as utils
* Naming: `frameSelectionRect` -> `draggingArea`
* Naming: `slots.nativeSelection` -> `slots.toggleNativeSelection`
* Fix typos
