### PR TITLE
fix(virgo): container should be non-editable when in read-only mode

### DIFF
--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -215,6 +215,7 @@ export class DefaultPageBlockComponent
       this.requestUpdate();
     });
     this._titleVEditor.focusEnd();
+    this._titleVEditor.setReadOnly(this.readonly);
   }
 
   private _onTitleKeyDown = (e: KeyboardEvent) => {

--- a/packages/virgo/src/virgo.ts
+++ b/packages/virgo/src/virgo.ts
@@ -505,6 +505,7 @@ export class VEditor<
   }
 
   setReadOnly(isReadOnly: boolean): void {
+    this.rootElement.contentEditable = isReadOnly ? 'false' : 'true';
     this._isReadOnly = isReadOnly;
   }
 


### PR DESCRIPTION
Try to fix #1498 but not sure if it work well in AFFiNE.
cc @Himself65