### PR TITLE
refactor: extract `setSelectedBlocks` and slot effects

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -165,7 +165,7 @@ export function focusBlockByModel(
     }
     defaultPageBlock.selection.state.clearSelection();
     const rect = getBlockElementByModel(model)?.getBoundingClientRect();
-    rect && defaultPageBlock.slots.updateSelectedRects.emit([rect]);
+    rect && defaultPageBlock.slots.selectedRectsUpdated.emit([rect]);
     const element = getBlockElementByModel(model);
     assertExists(element);
     defaultPageBlock.selection.state.selectedBlocks.push(element);

--- a/packages/blocks/src/components/blockhub.ts
+++ b/packages/blocks/src/components/blockhub.ts
@@ -56,7 +56,7 @@ export class BlockHub extends NonShadowLitElement {
   public getAllowedBlocks: () => BaseBlockModel[];
 
   @property()
-  updateSelectedRectsSlot: Slot<DOMRect[]> | null = null;
+  selectedRectsUpdated: Slot<DOMRect[]> | null = null;
 
   @property()
   blockHubStatusUpdated: Slot<boolean> = new Slot<boolean>();
@@ -664,7 +664,7 @@ export class BlockHub extends NonShadowLitElement {
       data.type = affineType;
     }
     event.dataTransfer.setData('affine/block-hub', JSON.stringify(data));
-    this.updateSelectedRectsSlot && this.updateSelectedRectsSlot.emit([]);
+    this.selectedRectsUpdated && this.selectedRectsUpdated.emit([]);
   };
 
   private _onMouseDown = (e: MouseEvent) => {

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -16,14 +16,14 @@ import { ListIcon } from './utils/get-list-icon.js';
 import { getListInfo } from './utils/get-list-info.js';
 
 function selectList(model: ListBlockModel) {
-  const selectionManager = getDefaultPageBlock(model).selection;
+  const { selection } = getDefaultPageBlock(model);
 
   const blockElement = getBlockElementByModel(model);
   if (!blockElement) {
     console.error('list block model:', model, 'blockElement:', blockElement);
     throw new Error('Failed to select list! blockElement not found!');
   }
-  selectionManager.resetSelectedBlockByRect(blockElement);
+  selection.resetSelectedBlockByRect(blockElement);
 }
 
 @customElement('affine-list')

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -146,7 +146,7 @@ export function EmbedEditingContainer(
           width="100%"
           @click=${() => {
             focusCaption(model);
-            slots.updateEmbedRects.emit([]);
+            slots.embedRectsUpdated.emit([]);
           }}
         >
           ${CaptionIcon}
@@ -183,7 +183,7 @@ export function EmbedEditingContainer(
           width="100%"
           @click="${() => {
             model.page.deleteBlock(model);
-            slots.updateEmbedRects.emit([]);
+            slots.embedRectsUpdated.emit([]);
           }}"
         >
           ${DeleteIcon}

--- a/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
@@ -60,7 +60,7 @@ export class EmbedResizeManager {
 
       height = width * (this._dropContainerSize.h / this._dropContainerSize.w);
       if (this._dropContainer) {
-        this.slots.updateEmbedRects.emit([
+        this.slots.embedRectsUpdated.emit([
           new DOMRect(
             left,
             this._dropContainer.getBoundingClientRect().top,

--- a/packages/editor/src/utils/editor.ts
+++ b/packages/editor/src/utils/editor.ts
@@ -54,8 +54,7 @@ export const createBlockHub: (
   if (editor.mode === 'page') {
     const defaultPageBlock = editor.querySelector('affine-default-page');
     assertExists(defaultPageBlock);
-    blockHub.updateSelectedRectsSlot =
-      defaultPageBlock.slots.updateSelectedRects;
+    blockHub.selectedRectsUpdated = defaultPageBlock.slots.selectedRectsUpdated;
     blockHub.getAllowedBlocks = () =>
       getAllowSelectedBlocks(defaultPageBlock.model);
   } else {


### PR DESCRIPTION
part of #1480

* Unify `slots` pattern (used for subscribe effects)
* Expose clarified `setSelectedBlocks` API
* Extract class methods as utils