### PR TITLE
refactor: move `codeBlockOption` to code block

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -2,8 +2,9 @@ import '../__internal__/rich-text/rich-text.js';
 import './components/lang-list.js';
 
 import { ArrowDownIcon } from '@blocksuite/global/config';
+import { DisposableGroup } from '@blocksuite/store';
 import { css, html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 import {
   BlockChildrenContainer,
@@ -187,18 +188,30 @@ export class CodeBlockComponent extends NonShadowLitElement {
   @property()
   host!: BlockHost;
 
-  @query('.lang-container')
-  langContainerElement!: HTMLElement;
-
-  @query('lang-list')
-  langListElement!: HTMLElement;
-
   @state()
   private _showLangList = false;
+
+  @state()
+  private _disposableGroup = new DisposableGroup();
 
   get highlight() {
     const service = this.host.getService(this.model.flavour);
     return service.hljs.default.highlight;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this._disposableGroup.add(
+      this.model.propsUpdated.on(() => this.requestUpdate())
+    );
+    this._disposableGroup.add(
+      this.model.childrenUpdated.on(() => this.requestUpdate())
+    );
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._disposableGroup.dispose();
   }
 
   private _onClick() {

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -203,7 +203,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
   private _disposableGroup = new DisposableGroup();
 
   @state()
-  private _showOption = true;
+  private _showOption = false;
 
   get highlight() {
     const service = this.host.getService(this.model.flavour);
@@ -265,6 +265,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
       style="${this._showLangList ? 'visibility: visible;' : ''}"
     >
       <icon-button
+        data-testid="lang-button"
         width="101px"
         height="24px"
         ?hover=${this._showLangList}

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -181,7 +181,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
     ${toolTipStyle}
   `;
 
-  @property({ hasChanged: () => true })
+  @property()
   model!: CodeBlockModel;
 
   @property()
@@ -199,11 +199,6 @@ export class CodeBlockComponent extends NonShadowLitElement {
   get highlight() {
     const service = this.host.getService(this.model.flavour);
     return service.hljs.default.highlight;
-  }
-
-  firstUpdated() {
-    this.model.propsUpdated.on(() => this.requestUpdate());
-    this.model.childrenUpdated.on(() => this.requestUpdate());
   }
 
   private _onClick() {

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -1,6 +1,6 @@
 import '../__internal__/rich-text/rich-text.js';
 import './components/lang-list.js';
-import './components/code-block-option.js';
+import './components/code-option.js';
 import '../components/portal.js';
 
 import { ArrowDownIcon } from '@blocksuite/global/config';
@@ -15,7 +15,7 @@ import {
 } from '../__internal__/index.js';
 import { toolTipStyle } from '../components/tooltip/tooltip.js';
 import type { CodeBlockModel } from './code-model.js';
-import { CodeBlockOptionContainer } from './components/code-block-option.js';
+import { CodeOptionTemplate } from './components/code-option.js';
 
 const hljsStyles = css`
   //<editor-fold desc="highlight.js/styles/color-brewer.css">
@@ -298,7 +298,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
     );
 
     const rect = this.getBoundingClientRect();
-    const codeBlockOptionPortal = CodeBlockOptionContainer({
+    const codeBlockOptionPortal = CodeOptionTemplate({
       model: this.model,
       position: { x: rect.right + 12, y: rect.top },
       hoverState: this.hoverState,

--- a/packages/blocks/src/code-block/components/code-block-option.ts
+++ b/packages/blocks/src/code-block/components/code-block-option.ts
@@ -9,11 +9,12 @@ import type { BaseBlockModel } from '@blocksuite/store';
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { type CodeBlockOption, copyCode, toolTipStyle } from '../../index.js';
+import { toolTipStyle } from '../../components/tooltip/tooltip.js';
+import { copyCode } from '../../page-block/default/utils.js';
 
-export function toggleWrap(codeBlockOption: CodeBlockOption) {
+export function toggleWrap(model: BaseBlockModel) {
   const syntaxElem = document.querySelector(
-    `[${BLOCK_ID_ATTR}="${codeBlockOption.model.id}"] .ql-syntax`
+    `[${BLOCK_ID_ATTR}="${model.id}"] .ql-syntax`
   );
   assertExists(syntaxElem);
   syntaxElem.classList.toggle('wrap');
@@ -55,7 +56,7 @@ export function CodeBlockOptionContainer(codeBlockOption: {
       <div style=${styleMap(style)} class="code-block-option">
         <format-bar-button
           class="has-tool-tip"
-          @click=${() => copyCode(codeBlockOption)}
+          @click=${() => copyCode(codeBlockOption.model)}
         >
           ${CopyIcon}
           <tool-tip inert tip-position="right-start" role="tooltip"
@@ -64,7 +65,7 @@ export function CodeBlockOptionContainer(codeBlockOption: {
         </format-bar-button>
         <format-bar-button
           class="has-tool-tip ${isWrapped ? 'filled' : ''}"
-          @click=${() => toggleWrap(codeBlockOption)}
+          @click=${() => toggleWrap(codeBlockOption.model)}
         >
           ${LineWrapIcon}
           <tool-tip inert tip-position="right-start" role="tooltip"

--- a/packages/blocks/src/code-block/components/code-block-option.ts
+++ b/packages/blocks/src/code-block/components/code-block-option.ts
@@ -1,0 +1,91 @@
+import {
+  BLOCK_ID_ATTR,
+  CopyIcon,
+  DeleteIcon,
+  LineWrapIcon,
+} from '@blocksuite/global/config';
+import { assertExists, Slot } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
+import { html } from 'lit';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import { type CodeBlockOption, copyCode, toolTipStyle } from '../../index.js';
+
+export function toggleWrap(codeBlockOption: CodeBlockOption) {
+  const syntaxElem = document.querySelector(
+    `[${BLOCK_ID_ATTR}="${codeBlockOption.model.id}"] .ql-syntax`
+  );
+  assertExists(syntaxElem);
+  syntaxElem.classList.toggle('wrap');
+}
+
+export function CodeBlockOptionContainer(codeBlockOption: {
+  position: { x: number; y: number };
+  model: BaseBlockModel;
+  hoverState: Slot<boolean>;
+}) {
+  const page = codeBlockOption.model.page;
+  const readonly = page.readonly;
+
+  const style = {
+    left: codeBlockOption.position.x + 'px',
+    top: codeBlockOption.position.y + 'px',
+  };
+  const syntaxElem = document.querySelector(
+    `[${BLOCK_ID_ATTR}="${codeBlockOption.model.id}"] .ql-syntax`
+  );
+  if (!syntaxElem) return html``;
+
+  const isWrapped = syntaxElem.classList.contains('wrap');
+  return html`
+    <style>
+      .affine-codeblock-option-container > div {
+          position: fixed;
+          z-index: 1;
+      }
+
+      ${toolTipStyle}
+    </style>
+
+    <div
+      class="affine-codeblock-option-container"
+      @mouseover=${() => codeBlockOption.hoverState.emit(true)}
+      @mouseout=${() => codeBlockOption.hoverState.emit(false)}
+    >
+      <div style=${styleMap(style)} class="code-block-option">
+        <format-bar-button
+          class="has-tool-tip"
+          @click=${() => copyCode(codeBlockOption)}
+        >
+          ${CopyIcon}
+          <tool-tip inert tip-position="right-start" role="tooltip"
+            >Copy to Clipboard
+          </tool-tip>
+        </format-bar-button>
+        <format-bar-button
+          class="has-tool-tip ${isWrapped ? 'filled' : ''}"
+          @click=${() => toggleWrap(codeBlockOption)}
+        >
+          ${LineWrapIcon}
+          <tool-tip inert tip-position="right-start" role="tooltip"
+            >Wrap code
+          </tool-tip>
+        </format-bar-button>
+        ${readonly
+          ? ''
+          : html`<format-bar-button
+              class="has-tool-tip"
+              @click=${() => {
+                const model = codeBlockOption.model;
+                model.page.deleteBlock(model);
+              }}
+            >
+              ${DeleteIcon}
+              <tool-tip inert tip-position="right-start" role="tooltip"
+                >Delete
+              </tool-tip>
+            </format-bar-button>`}
+      </div>
+    </div>
+  `;
+}

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -20,7 +20,7 @@ export function toggleWrap(model: BaseBlockModel) {
   syntaxElem.classList.toggle('wrap');
 }
 
-export function CodeBlockOptionContainer(codeBlockOption: {
+export function CodeOptionTemplate(codeBlockOption: {
   position: { x: number; y: number };
   model: BaseBlockModel;
   hoverState: Slot<boolean>;
@@ -60,8 +60,8 @@ export function CodeBlockOptionContainer(codeBlockOption: {
         >
           ${CopyIcon}
           <tool-tip inert tip-position="right-start" role="tooltip"
-            >Copy to Clipboard
-          </tool-tip>
+            >Copy to Clipboard</tool-tip
+          >
         </format-bar-button>
         <format-bar-button
           class="has-tool-tip ${isWrapped ? 'filled' : ''}"
@@ -69,22 +69,23 @@ export function CodeBlockOptionContainer(codeBlockOption: {
         >
           ${LineWrapIcon}
           <tool-tip inert tip-position="right-start" role="tooltip"
-            >Wrap code
-          </tool-tip>
+            >Wrap code</tool-tip
+          >
         </format-bar-button>
         ${readonly
           ? ''
           : html`<format-bar-button
               class="has-tool-tip"
               @click=${() => {
+                if (readonly) return;
                 const model = codeBlockOption.model;
                 model.page.deleteBlock(model);
               }}
             >
               ${DeleteIcon}
               <tool-tip inert tip-position="right-start" role="tooltip"
-                >Delete
-              </tool-tip>
+                >Delete</tool-tip
+              >
             </format-bar-button>`}
       </div>
     </div>

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -44,6 +44,7 @@ export class IconButton extends LitElement {
     :host([disabled]),
     :host(:disabled) {
       background: transparent;
+      color: var(--affine-popover-color);
       fill: var(--affine-icon-color);
       cursor: not-allowed;
     }

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -72,6 +72,9 @@ export const showFormatQuickBar = async ({
 
   // Once performance problems occur, it can be mitigated increasing throttle limit
   const updatePos = throttle(() => {
+    if (abortController.signal.aborted) {
+      return;
+    }
     const positioningPoint =
       anchorEl instanceof Range
         ? calcPositionPointByRange(anchorEl, direction)

--- a/packages/blocks/src/components/portal.ts
+++ b/packages/blocks/src/components/portal.ts
@@ -1,0 +1,36 @@
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('affine-portal')
+export class Portal extends LitElement {
+  @property()
+  public container = document.body;
+
+  @property()
+  public template = html``;
+
+  private _portalRoot: HTMLElement | null = null;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._portalRoot?.remove();
+  }
+
+  override createRenderRoot() {
+    const portalRoot = document.createElement('div');
+    portalRoot.classList.add('affine-portal');
+    this.container.append(portalRoot);
+    this._portalRoot = portalRoot;
+    return portalRoot;
+  }
+
+  override render() {
+    return this.template;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'affine-portal': Portal;
+  }
+}

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -1,8 +1,8 @@
-import { BLOCK_ID_ATTR, CopyIcon, DeleteIcon } from '@blocksuite/global/config';
 import {
   CaptionIcon,
+  CopyIcon,
+  DeleteIcon,
   DownloadIcon,
-  LineWrapIcon,
 } from '@blocksuite/global/config';
 import { html } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
@@ -11,19 +11,11 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { toolTipStyle } from '../../components/tooltip/tooltip.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
 import type {
-  CodeBlockOption,
   DefaultSelectionSlots,
   EmbedEditingState,
 } from './default-page-block.js';
 import type { PageViewport } from './selection-manager/selection-state.js';
-import {
-  copyCode,
-  copyImage,
-  deleteCodeBlock,
-  downloadImage,
-  focusCaption,
-  toggleWrap,
-} from './utils.js';
+import { copyImage, downloadImage, focusCaption } from './utils.js';
 
 export function DraggingArea(rect: DOMRect | null) {
   if (rect === null) return null;
@@ -190,65 +182,6 @@ export function EmbedEditingContainer(
           <tool-tip inert tip-position="right-start" role="tooltip"
             >Delete</tool-tip
           >
-        </format-bar-button>
-      </div>
-    </div>
-  `;
-}
-
-export function CodeBlockOptionContainer(
-  codeBlockOption: CodeBlockOption | null
-) {
-  if (!codeBlockOption) return null;
-
-  const style = {
-    left: codeBlockOption.position.x + 'px',
-    top: codeBlockOption.position.y + 'px',
-  };
-  const syntaxElem = document.querySelector(
-    `[${BLOCK_ID_ATTR}="${codeBlockOption.model.id}"] .ql-syntax`
-  );
-  if (!syntaxElem) return null;
-
-  const isWrapped = syntaxElem.classList.contains('wrap');
-  return html`
-    <style>
-      .affine-codeblock-option-container > div {
-          position: fixed;
-          z-index: 1;
-      }
-
-      ${toolTipStyle}
-    </style>
-
-    <div class="affine-codeblock-option-container">
-      <div style=${styleMap(style)} class="code-block-option">
-        <format-bar-button
-          class="has-tool-tip"
-          @click=${() => copyCode(codeBlockOption)}
-        >
-          ${CopyIcon}
-          <tool-tip inert tip-position="right-start" role="tooltip"
-            >Copy to Clipboard
-          </tool-tip>
-        </format-bar-button>
-        <format-bar-button
-          class="has-tool-tip ${isWrapped ? 'filled' : ''}"
-          @click=${() => toggleWrap(codeBlockOption)}
-        >
-          ${LineWrapIcon}
-          <tool-tip inert tip-position="right-start" role="tooltip"
-            >Wrap code
-          </tool-tip>
-        </format-bar-button>
-        <format-bar-button
-          class="has-tool-tip"
-          @click=${() => deleteCodeBlock(codeBlockOption)}
-        >
-          ${DeleteIcon}
-          <tool-tip inert tip-position="right-start" role="tooltip"
-            >Delete
-          </tool-tip>
         </format-bar-button>
       </div>
     </div>

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -25,7 +25,6 @@ import type { PageBlockModel } from '../index.js';
 import { bindHotkeys, removeHotkeys } from '../utils/bind-hotkey.js';
 import { deleteModelsByRange, tryUpdateFrameSize } from '../utils/index.js';
 import {
-  CodeBlockOptionContainer,
   DraggingArea,
   EmbedEditingContainer,
   EmbedSelectedRectsContainer,
@@ -43,14 +42,12 @@ export interface EmbedEditingState {
   model: BaseBlockModel;
 }
 
-export type CodeBlockOption = EmbedEditingState;
-
 export interface DefaultSelectionSlots {
   draggingAreaUpdated: Slot<DOMRect | null>;
   selectedRectsUpdated: Slot<DOMRect[]>;
   embedRectsUpdated: Slot<DOMRect[]>;
   embedEditingStateUpdated: Slot<EmbedEditingState | null>;
-  codeBlockOptionUpdated: Slot<CodeBlockOption | null>;
+  codeBlockOptionUpdated?: Slot;
   nativeSelectionToggled: Slot<boolean>;
 }
 
@@ -147,9 +144,6 @@ export class DefaultPageBlockComponent
 
   private _resizeObserver: ResizeObserver | null = null;
 
-  @property()
-  codeBlockOption!: CodeBlockOption | null;
-
   @query('.affine-default-viewport')
   viewportElement!: HTMLDivElement;
 
@@ -158,7 +152,6 @@ export class DefaultPageBlockComponent
     selectedRectsUpdated: new Slot<DOMRect[]>(),
     embedRectsUpdated: new Slot<DOMRect[]>(),
     embedEditingStateUpdated: new Slot<EmbedEditingState | null>(),
-    codeBlockOptionUpdated: new Slot<CodeBlockOption | null>(),
     nativeSelectionToggled: new Slot<boolean>(),
   };
 
@@ -425,10 +418,6 @@ export class DefaultPageBlockComponent
       this._embedEditingState = embedEditingState;
       this.requestUpdate();
     });
-    slots.codeBlockOptionUpdated.on(codeBlockOption => {
-      this.codeBlockOption = codeBlockOption;
-      this.requestUpdate();
-    });
     slots.nativeSelectionToggled.on(flag => {
       if (flag) window.addEventListener('keydown', this._handleNativeKeydown);
       else window.removeEventListener('keydown', this._handleNativeKeydown);
@@ -519,9 +508,6 @@ export class DefaultPageBlockComponent
       this.slots,
       viewport
     );
-    const codeBlockOptionContainer = CodeBlockOptionContainer(
-      page.readonly ? null : this.codeBlockOption
-    );
 
     return html`
       <div class="affine-default-viewport">
@@ -538,7 +524,7 @@ export class DefaultPageBlockComponent
           ${childrenContainer}
         </div>
         ${selectedRectsContainer} ${draggingArea} ${selectedEmbedContainer}
-        ${embedEditingContainer} ${codeBlockOptionContainer}
+        ${embedEditingContainer}
       </div>
     `;
   }

--- a/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
@@ -317,12 +317,8 @@ export class DefaultSelectionManager {
         hoverEditingState.position.x = hoverEditingState.position.right + 10;
       }
       this.slots.embedEditingStateUpdated.emit(hoverEditingState);
-    } else if (hoverEditingState?.model.flavour === 'affine:code') {
-      hoverEditingState.position.x = hoverEditingState.position.right + 12;
-      this.slots.codeBlockOptionUpdated.emit(hoverEditingState);
     } else {
       this.slots.embedEditingStateUpdated.emit(null);
-      this.slots.codeBlockOptionUpdated.emit(null);
     }
   };
 
@@ -615,7 +611,6 @@ export class DefaultSelectionManager {
     this.slots.draggingAreaUpdated.dispose();
     this.slots.embedEditingStateUpdated.dispose();
     this.slots.embedRectsUpdated.dispose();
-    this.slots.codeBlockOptionUpdated.dispose();
     this.slots.nativeSelectionToggled.dispose();
     this._disposables.dispose();
   }

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -1,6 +1,5 @@
 import {
   BLOCK_CHILDREN_CONTAINER_PADDING_LEFT,
-  BLOCK_ID_ATTR,
   BLOCK_SERVICE_LOADING_ATTR,
   DRAG_HANDLE_OFFSET_LEFT,
 } from '@blocksuite/global/config';
@@ -21,10 +20,7 @@ import {
 import { DragHandle } from '../../components/index.js';
 import { toast } from '../../components/toast.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
-import type {
-  CodeBlockOption,
-  DefaultPageBlockComponent,
-} from './default-page-block.js';
+import type { DefaultPageBlockComponent } from './default-page-block.js';
 
 export interface EditingState {
   model: BaseBlockModel;
@@ -497,8 +493,8 @@ export function isControlledKeyboardEvent(e: KeyboardEvent) {
   return e.ctrlKey || e.metaKey || e.shiftKey;
 }
 
-export function copyCode(codeBlockOption: CodeBlockOption) {
-  const richText = getRichTextByModel(codeBlockOption.model);
+export function copyCode(model: BaseBlockModel) {
+  const richText = getRichTextByModel(model);
   assertExists(richText);
   const quill = richText.quill;
   quill.setSelection(0, quill.getLength());
@@ -510,19 +506,6 @@ export function copyCode(codeBlockOption: CodeBlockOption) {
   resetNativeSelection(range);
 
   toast('Copied to clipboard');
-}
-
-export function deleteCodeBlock(codeBlockOption: CodeBlockOption) {
-  const model = codeBlockOption.model;
-  model.page.deleteBlock(model);
-}
-
-export function toggleWrap(codeBlockOption: CodeBlockOption) {
-  const syntaxElem = document.querySelector(
-    `[${BLOCK_ID_ATTR}="${codeBlockOption.model.id}"] .ql-syntax`
-  );
-  assertExists(syntaxElem);
-  syntaxElem.classList.toggle('wrap');
 }
 
 export function getAllowSelectedBlocks(

--- a/packages/blocks/src/page-block/index.ts
+++ b/packages/blocks/src/page-block/index.ts
@@ -1,8 +1,5 @@
-export { CodeBlockOptionContainer } from './default/components.js';
 export * from './default/default-page-block.js';
-export { copyCode, getAllowSelectedBlocks } from './default/utils.js';
-export { deleteCodeBlock } from './default/utils.js';
-export { toggleWrap } from './default/utils.js';
+export { getAllowSelectedBlocks } from './default/utils.js';
 export * from './edgeless/edgeless-page-block.js';
 export * from './page-model.js';
 export * from './utils/index.js';

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 
 import {
   addCodeBlock,
@@ -25,6 +25,20 @@ import {
   assertStoreMatchJSX,
 } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
+
+function getCodeBlock(page: Page) {
+  const codeBlock = page.locator('affine-code');
+  const languageButton = codeBlock.getByTestId('lang-button');
+  const clickLanguageButton = async () => {
+    await codeBlock.hover();
+    await languageButton.click();
+  };
+  return {
+    codeBlock,
+    languageButton,
+    clickLanguageButton,
+  };
+}
 
 test('use debug menu can create code block', async ({ page }) => {
   await enterPlaygroundRoom(page);
@@ -71,7 +85,8 @@ test('support ```[lang] to add code block with language', async ({ page }) => {
   await type(page, '```ts');
   await type(page, ' ');
 
-  const codeLocator = page.locator('affine-code');
+  const codeBlockController = getCodeBlock(page);
+  const codeLocator = codeBlockController.codeBlock;
   await expect(codeLocator).toBeVisible();
 
   const codeRect = await codeLocator.boundingBox();
@@ -84,9 +99,9 @@ test('support ```[lang] to add code block with language', async ({ page }) => {
   };
   await page.mouse.move(position.x, position.y);
 
-  const locator = page.locator('.lang-container > icon-button');
-  await expect(locator).toBeVisible();
-  const languageText = await locator.innerText();
+  const languageButton = codeBlockController.languageButton;
+  await expect(languageButton).toBeVisible();
+  const languageText = await languageButton.innerText();
   expect(languageText).toEqual('TypeScript');
 });
 
@@ -121,22 +136,11 @@ test('use shortcut can create code block', async ({ page }) => {
 
 test('change code language can work', async ({ page }) => {
   await enterPlaygroundRoom(page);
-  await initEmptyCodeBlockState(page);
+  const { codeBlockId } = await initEmptyCodeBlockState(page);
   await focusRichText(page);
 
-  const position = await page.evaluate(() => {
-    const codeBlock = document.querySelector('affine-code');
-    const bbox = codeBlock?.getBoundingClientRect() as DOMRect;
-    return {
-      x: bbox.left + bbox.width / 2,
-      y: bbox.top + bbox.height / 2,
-    };
-  });
-
-  await page.mouse.move(position.x, position.y);
-
-  const codeLangSelector = '.lang-container > icon-button:nth-child(1)';
-  await page.click(codeLangSelector);
+  const codeBlockController = getCodeBlock(page);
+  await codeBlockController.clickLanguageButton();
   const locator = page.locator('.lang-list-button-container');
   await expect(locator).toBeVisible();
   await assertKeyboardWorkInInput(page, page.locator('#filter-input'));
@@ -145,19 +149,24 @@ test('change code language can work', async ({ page }) => {
   await page.click('.lang-list-button-container > icon-button:nth-child(1)');
   await expect(locator).toBeHidden();
 
-  await page.mouse.move(position.x, position.y);
-  await expect(page.locator(codeLangSelector)).toHaveText('Rust');
+  await expect(codeBlockController.languageButton).toHaveText('Rust');
 
   await assertStoreMatchJSX(
     page,
     /*xml*/ `
-<affine:page>
-  <affine:frame>
-    <affine:code
-      prop:language="Rust"
-    />
-  </affine:frame>
-</affine:page>`
+<affine:code
+  prop:language="Rust"
+/>`,
+    codeBlockId
+  );
+  await undoByKeyboard(page);
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:code
+  prop:language="JavaScript"
+/>`,
+    codeBlockId
   );
 });
 
@@ -168,8 +177,8 @@ test('language select list can disappear when click other place', async ({
   await initEmptyCodeBlockState(page);
   await focusRichText(page);
 
-  const codeLangSelector = '.lang-container > icon-button:nth-child(1)';
-  await page.click(codeLangSelector);
+  const codeBlock = getCodeBlock(page);
+  await codeBlock.clickLanguageButton();
   const locator = page.locator('.lang-list-button-container');
   await expect(locator).toBeVisible();
 
@@ -340,6 +349,16 @@ test('code block copy button can work', async ({ page }) => {
   await focusRichText(page);
 
   await type(page, 'use');
+  const codeBlockController = getCodeBlock(page);
+  const codeBlockRect = await codeBlockController.codeBlock.boundingBox();
+  if (!codeBlockRect) {
+    throw new Error();
+  }
+  await page.mouse.move(
+    codeBlockRect.x + codeBlockRect.width / 2,
+    codeBlockRect.y + codeBlockRect.height / 2
+  );
+
   const position = await getCenterPosition(
     page,
     '.code-block-option > format-bar-button:nth-child(1)'
@@ -401,7 +420,8 @@ test('drag select code block can delete it', async ({ page }) => {
   await initEmptyCodeBlockState(page);
   await focusRichText(page);
 
-  const bbox = await page.locator('affine-code').boundingBox();
+  const codeBlock = page.locator('affine-code');
+  const bbox = await codeBlock.boundingBox();
   if (!bbox) {
     throw new Error("Failed to get code block's bounding box");
   }
@@ -415,8 +435,10 @@ test('drag select code block can delete it', async ({ page }) => {
   await dragBetweenCoords(
     page,
     { x: position.startX, y: position.startY },
-    { x: position.endX, y: position.endY }
+    { x: position.endX, y: position.endY },
+    { steps: 10 }
   );
+  await page.waitForTimeout(10);
   await page.keyboard.press('Backspace');
   const locator = page.locator('affine-code');
   await expect(locator).toBeHidden();


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/1513
Part of https://github.com/toeverything/blocksuite/issues/1480

CodeOption should be maintained by the code block itself