### PR TITLE
perf: use transform-based layout & remove redundant `requestUpdate`

### DIFF
--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -32,9 +32,10 @@ export class DragIndicator extends LitElement {
     .affine-drag-indicator {
       position: fixed;
       height: 3px;
+      top: 0;
+      left: 0;
       background: var(--affine-primary-color);
-      transition: top, left 300ms, 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
-        transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+      transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     }
   `;
 
@@ -51,13 +52,13 @@ export class DragIndicator extends LitElement {
     const rect = this.targetRect;
     const distanceToTop = Math.abs(rect.top - this.cursorPosition.y);
     const distanceToBottom = Math.abs(rect.bottom - this.cursorPosition.y);
+    const offsetY = distanceToTop < distanceToBottom ? rect.top : rect.bottom;
     return html`
       <div
         class="affine-drag-indicator"
         style=${styleMap({
           width: `${rect.width + 10}px`,
-          left: `${rect.left}px`,
-          top: `${distanceToTop < distanceToBottom ? rect.top : rect.bottom}px`,
+          transform: `translate(${rect.left}px, ${offsetY}px)`,
         })}
       ></div>
     `;
@@ -234,26 +235,33 @@ export class DragHandle extends LitElement {
       this.style.display = 'block';
       this.style.height = `${rect.height}px`;
       this.style.width = `${DRAG_HANDLE_WIDTH}px`;
+      this.style.left = '0';
+      this.style.top = '0';
       const containerRect = this._container.getBoundingClientRect();
-      this.style.left = `${
+
+      const xOffset =
         rect.left -
         containerRect.left -
         DRAG_HANDLE_WIDTH -
-        DRAG_HANDLE_OFFSET_LEFT
-      }px`;
-      this.style.top = `${rect.top - containerRect.top}px`;
+        DRAG_HANDLE_OFFSET_LEFT;
+
+      const yOffset = rect.top - containerRect.top;
+
+      this.style.transform = `translate(${xOffset}px, ${yOffset}px)`;
       this.style.opacity = `${(
         1 -
         (event.raw.clientX - rect.left) / rect.width
       ).toFixed(2)}`;
-      const top = Math.max(
+
+      const handleYOffset = Math.max(
         0,
         Math.min(
           event.raw.clientY - rect.top - DRAG_HANDLE_HEIGHT / 2,
           rect.height - DRAG_HANDLE_HEIGHT
         )
       );
-      this._dragHandle.style.top = `${top}px`;
+
+      this._dragHandle.style.transform = `translateY(${handleYOffset}px)`;
     }
   }
 
@@ -354,7 +362,7 @@ export class DragHandle extends LitElement {
     );
 
     this._dragHandle.style.cursor = 'grab';
-    this._dragHandle.style.top = `${top}px`;
+    this._dragHandle.style.transform = `translateY(${top}px)`;
     e.stopPropagation();
   }
 
@@ -507,6 +515,10 @@ export class DragHandle extends LitElement {
         :host(:hover) .affine-drag-handle-hover {
           display: block !important;
           /* padding-top: 5px !important; FIXME */
+        }
+
+        .affine-drag-handle {
+          position: absolute;
         }
       </style>
       <div class="affine-drag-handle-line"></div>

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -147,8 +147,8 @@ export class DefaultPageBlockComponent
 
   private _resizeObserver: ResizeObserver | null = null;
 
-  @property()
-  codeBlockOption!: CodeBlockOption | null;
+  @state()
+  private _codeBlockOption!: CodeBlockOption | null;
 
   @query('.affine-default-viewport')
   viewportElement!: HTMLDivElement;
@@ -408,26 +408,21 @@ export class DefaultPageBlockComponent
 
     slots.draggingAreaUpdated.on(rect => {
       this._draggingArea = rect;
-      this.requestUpdate();
     });
     slots.selectedRectsUpdated.on(rects => {
       this._selectedRects = rects;
-      this.requestUpdate();
     });
     slots.embedRectsUpdated.on(rects => {
       this._selectedEmbedRects = rects;
       if (rects.length === 0) {
         this._embedEditingState = null;
       }
-      this.requestUpdate();
     });
     slots.embedEditingStateUpdated.on(embedEditingState => {
       this._embedEditingState = embedEditingState;
-      this.requestUpdate();
     });
     slots.codeBlockOptionUpdated.on(codeBlockOption => {
-      this.codeBlockOption = codeBlockOption;
-      this.requestUpdate();
+      this._codeBlockOption = codeBlockOption;
     });
     slots.nativeSelectionToggled.on(flag => {
       if (flag) window.addEventListener('keydown', this._handleNativeKeydown);
@@ -520,7 +515,7 @@ export class DefaultPageBlockComponent
       viewport
     );
     const codeBlockOptionContainer = CodeBlockOptionContainer(
-      page.readonly ? null : this.codeBlockOption
+      page.readonly ? null : this._codeBlockOption
     );
 
     return html`

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -418,6 +418,11 @@ export class DefaultPageBlockComponent
       if (flag) window.addEventListener('keydown', this._handleNativeKeydown);
       else window.removeEventListener('keydown', this._handleNativeKeydown);
     });
+
+    this.model.page.slots.blockUpdated.on(() => {
+      // TODO: optimize
+      this.requestUpdate();
+    });
   }
 
   private _initFrameSizeEffect() {


### PR DESCRIPTION
- transform is faster than left/top because it does not trigger layout shift
- set `state` value will trigger update and thus `requestUpdate` should not be needed (fix some issues in https://github.com/toeverything/blocksuite/issues/1258)

After the changes above, heavy example should be much smoother.

I also found that block updating rendering in master branch is dependent on mousemove event, which seems not right.
See the video recording I did in the latest master branch. By calling `page.addBlockByFlavour('affine:frame', {})`, the new `affine-frame` will not be added to DOM immediately, but will after I move my cursor in the page.

## Before
https://user-images.githubusercontent.com/584378/223318539-1e07e67e-43f5-4434-89f8-8042d3ad627c.mp4

## After

https://user-images.githubusercontent.com/584378/223318705-8c5989d9-e70e-4f5d-80d4-5e3cc7e3f750.mp4



