### PR TITLE
refactor: `Slot.disposableListener` -> `Slot.fromEvent`

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -237,13 +237,13 @@ export class CodeBlockComponent extends NonShadowLitElement {
       }, HOVER_DELAY);
     });
     this._disposableGroup.add(
-      Slot.disposableListener(this, 'mouseover', e => {
+      Slot.fromEvent(this, 'mouseover', e => {
         this.hoverState.emit(true);
       })
     );
     const HOVER_DELAY = 300;
     this._disposableGroup.add(
-      Slot.disposableListener(this, 'mouseleave', e => {
+      Slot.fromEvent(this, 'mouseleave', e => {
         this.hoverState.emit(false);
       })
     );

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -517,90 +517,60 @@ export class BlockHub extends NonShadowLitElement {
   connectedCallback() {
     super.connectedCallback();
     const disposables = this._disposables;
-    disposables.add(
-      Slot.disposableListener(this, 'dragstart', this._onDragStart)
-    );
-    disposables.add(Slot.disposableListener(this, 'drag', this._onDrag));
-    disposables.add(Slot.disposableListener(this, 'dragend', this._onDragEnd));
+    disposables.add(Slot.fromEvent(this, 'dragstart', this._onDragStart));
+    disposables.add(Slot.fromEvent(this, 'drag', this._onDrag));
+    disposables.add(Slot.fromEvent(this, 'dragend', this._onDragEnd));
 
     disposables.add(
-      Slot.disposableListener(this._mouseRoot, 'dragover', this._onDragOver)
+      Slot.fromEvent(this._mouseRoot, 'dragover', this._onDragOver)
     );
-    disposables.add(
-      Slot.disposableListener(this._mouseRoot, 'drop', this._onDrop)
-    );
+    disposables.add(Slot.fromEvent(this._mouseRoot, 'drop', this._onDrop));
     isFirefox &&
       disposables.add(
-        Slot.disposableListener(
-          this._mouseRoot,
-          'dragover',
-          this._onDragOverDocument
-        )
+        Slot.fromEvent(this._mouseRoot, 'dragover', this._onDragOverDocument)
       );
-    disposables.add(
-      Slot.disposableListener(this, 'mousedown', this._onMouseDown)
-    );
+    disposables.add(Slot.fromEvent(this, 'mousedown', this._onMouseDown));
     this._onResize();
   }
 
   firstUpdated() {
     const disposables = this._disposables;
     this._blockHubCards.forEach(card => {
-      disposables.add(
-        Slot.disposableListener(card, 'mousedown', this._onCardMouseDown)
-      );
-      disposables.add(
-        Slot.disposableListener(card, 'mouseup', this._onCardMouseUp)
-      );
+      disposables.add(Slot.fromEvent(card, 'mousedown', this._onCardMouseDown));
+      disposables.add(Slot.fromEvent(card, 'mouseup', this._onCardMouseUp));
     });
     for (const blockHubMenu of this._blockHubMenus) {
       disposables.add(
-        Slot.disposableListener(
-          blockHubMenu,
-          'mouseover',
-          this._onBlockHubMenuMouseOver
-        )
+        Slot.fromEvent(blockHubMenu, 'mouseover', this._onBlockHubMenuMouseOver)
       );
       if (blockHubMenu.getAttribute('type') === 'blank') {
         disposables.add(
-          Slot.disposableListener(
-            blockHubMenu,
-            'mousedown',
-            this._onBlankMenuMouseDown
-          )
+          Slot.fromEvent(blockHubMenu, 'mousedown', this._onBlankMenuMouseDown)
         );
         disposables.add(
-          Slot.disposableListener(
-            blockHubMenu,
-            'mouseup',
-            this._onBlankMenuMouseUp
-          )
+          Slot.fromEvent(blockHubMenu, 'mouseup', this._onBlankMenuMouseUp)
         );
       }
     }
     disposables.add(
-      Slot.disposableListener(
+      Slot.fromEvent(
         this._blockHubMenuEntry,
         'mouseover',
         this._onBlockHubEntryMouseOver
       )
     );
-    disposables.add(Slot.disposableListener(document, 'click', this._onClick));
+    disposables.add(Slot.fromEvent(document, 'click', this._onClick));
     disposables.add(
-      Slot.disposableListener(
-        this._blockHubButton,
-        'click',
-        this._onBlockHubButtonClick
-      )
+      Slot.fromEvent(this._blockHubButton, 'click', this._onBlockHubButtonClick)
     );
     disposables.add(
-      Slot.disposableListener(
+      Slot.fromEvent(
         this._blockHubIconsContainer,
         'transitionstart',
         this._onTransitionStart
       )
     );
-    disposables.add(Slot.disposableListener(window, 'resize', this._onResize));
+    disposables.add(Slot.fromEvent(window, 'resize', this._onResize));
     this._indicator = <DragIndicator>(
       document.querySelector('affine-drag-indicator')
     );

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -106,9 +106,7 @@ export class FormatQuickBar extends LitElement {
         subtree: true,
       });
     });
-    this._disposableGroup.add({
-      dispose: () => mutationObserver.disconnect(),
-    });
+    this._disposableGroup.add(() => mutationObserver.disconnect());
   }
 
   override disconnectedCallback() {

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -106,8 +106,8 @@ export class FormatQuickBar extends LitElement {
         subtree: true,
       });
     });
-    this._disposableGroup.add(() => {
-      mutationObserver.disconnect();
+    this._disposableGroup.add({
+      dispose: () => mutationObserver.disconnect(),
     });
   }
 

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -55,16 +55,16 @@ export class SlashMenu extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._disposableGroup.add(
-      Slot.disposableListener(window, 'mousedown', this._clickAwayListener)
+      Slot.fromEvent(window, 'mousedown', this._clickAwayListener)
     );
     this._disposableGroup.add(
-      Slot.disposableListener(window, 'keydown', this._keyDownListener, {
+      Slot.fromEvent(window, 'keydown', this._keyDownListener, {
         // Workaround: Use capture to prevent the event from triggering the hotkey bindings action
         capture: true,
       })
     );
     this._disposableGroup.add(
-      Slot.disposableListener(this, 'mousedown', e => {
+      Slot.fromEvent(this, 'mousedown', e => {
         // Prevent input from losing focus
         e.preventDefault();
       })
@@ -79,13 +79,13 @@ export class SlashMenu extends LitElement {
       return;
     }
     this._disposableGroup.add(
-      Slot.disposableListener(richText, 'keydown', this._keyDownListener, {
+      Slot.fromEvent(richText, 'keydown', this._keyDownListener, {
         // Workaround: Use capture to prevent the event from triggering the keyboard bindings action
         capture: true,
       })
     );
     this._disposableGroup.add(
-      Slot.disposableListener(richText, 'focusout', this._clickAwayListener)
+      Slot.fromEvent(richText, 'focusout', this._clickAwayListener)
     );
   }
 

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -69,7 +69,7 @@ export class EditorContainer extends NonShadowLitElement {
 
     // Question: Why do we prevent this?
     this._disposables.add(
-      Slot.disposableListener(window, 'keydown', e => {
+      Slot.fromEvent(window, 'keydown', e => {
         if (e.altKey && e.metaKey && e.code === 'KeyC') {
           e.preventDefault();
         }
@@ -101,17 +101,13 @@ export class EditorContainer extends NonShadowLitElement {
 
     // connect mouse mode event changes
     this._disposables.add(
-      Slot.disposableListener(
-        window,
-        'affine.switch-mouse-mode',
-        ({ detail }) => {
-          this.mouseMode = detail;
-        }
-      )
+      Slot.fromEvent(window, 'affine.switch-mouse-mode', ({ detail }) => {
+        this.mouseMode = detail;
+      })
     );
 
     this._disposables.add(
-      Slot.disposableListener(
+      Slot.fromEvent(
         window,
         'affine:switch-edgeless-display-mode',
         ({ detail }) => {

--- a/packages/global/src/utils.ts
+++ b/packages/global/src/utils.ts
@@ -3,7 +3,7 @@ import type { BaseBlockModel } from '@blocksuite/store';
 import type { BlockModels } from './types.js';
 
 export type { Disposable } from './utils/disposable.js';
-export { DisposableGroup, flattenDisposable } from './utils/disposable.js';
+export { DisposableGroup } from './utils/disposable.js';
 export { Slot } from './utils/slot.js';
 export { caretRangeFromPoint, isFirefox, isWeb } from './utils/web.js';
 export const SYS_KEYS = new Set(['id', 'flavour', 'children']);

--- a/packages/global/src/utils/disposable.ts
+++ b/packages/global/src/utils/disposable.ts
@@ -1,52 +1,47 @@
+// type DisposeCallback = () => void;
+
 export interface Disposable {
   dispose(): void;
 }
 
-type DisposeLogic = Disposable | (() => void);
-
 export class DisposableGroup implements Disposable {
   private _disposed = false;
+  private _disposables: Disposable[] = [];
+
   get disposed() {
     return this._disposed;
   }
-  constructor(private _disposables: DisposeLogic[] = []) {}
+
   /**
    * Add to group to be disposed with others.
-   *
    * This will be immediately disposed if this group has already been disposed.
    */
-  add(disposable: DisposeLogic | undefined | null | false): void {
+  add(disposable: Disposable) {
     if (disposable) {
-      if (this._disposed) execDisposeLogic(disposable);
+      if (this._disposed) disposable.dispose();
       else this._disposables.push(disposable);
     }
   }
-  dispose(): void {
-    disposeAllAndClearArray(this._disposables);
+
+  dispose() {
+    disposeAll(this._disposables);
+    this._disposables = [];
     this._disposed = true;
   }
 }
 
 export function flattenDisposable(disposables: Disposable[]): Disposable {
   return {
-    dispose: disposeAllAndClearArray.bind(null, disposables),
+    dispose: () => disposeAll(disposables),
   };
 }
 
-/** @internal */
-function disposeAllAndClearArray(disposables: DisposeLogic[]) {
+function disposeAll(disposables: Disposable[]) {
   for (const disposable of disposables) {
     try {
-      execDisposeLogic(disposable);
+      disposable.dispose();
     } catch (err) {
       console.error(err);
     }
   }
-  disposables.length = 0;
-}
-
-/** @internal */
-function execDisposeLogic(disposable: DisposeLogic) {
-  if (typeof disposable === 'function') disposable();
-  else disposable.dispose();
 }

--- a/packages/global/src/utils/disposable.ts
+++ b/packages/global/src/utils/disposable.ts
@@ -33,7 +33,7 @@ export class DisposableGroup implements Disposable {
   }
 }
 
-export function flattenDisposable(disposables: Disposable[]): Disposable {
+export function flattenDisposables(disposables: Disposable[]): Disposable {
   return {
     dispose: () => disposeAll(disposables),
   };

--- a/packages/global/src/utils/disposable.ts
+++ b/packages/global/src/utils/disposable.ts
@@ -1,7 +1,7 @@
-// type DisposeCallback = () => void;
+type DisposeCallback = () => void;
 
 export interface Disposable {
-  dispose(): void;
+  dispose: DisposeCallback;
 }
 
 export class DisposableGroup implements Disposable {
@@ -16,10 +16,13 @@ export class DisposableGroup implements Disposable {
    * Add to group to be disposed with others.
    * This will be immediately disposed if this group has already been disposed.
    */
-  add(disposable: Disposable) {
-    if (disposable) {
-      if (this._disposed) disposable.dispose();
-      else this._disposables.push(disposable);
+  add(d: Disposable | DisposeCallback) {
+    if (typeof d === 'function') {
+      if (this._disposed) d();
+      else this._disposables.push({ dispose: d });
+    } else {
+      if (this._disposed) d.dispose();
+      else this._disposables.push(d);
     }
   }
 

--- a/packages/global/src/utils/slot.ts
+++ b/packages/global/src/utils/slot.ts
@@ -1,4 +1,4 @@
-import { Disposable, flattenDisposable } from './disposable.js';
+import { Disposable, flattenDisposables } from './disposable.js';
 
 // borrowed from blocky-editor
 // https://github.com/vincentdchan/blocky-editor
@@ -152,8 +152,9 @@ export class Slot<T = void> implements Disposable {
   }
 
   dispose() {
-    flattenDisposable(this._disposables).dispose();
-    this._callbacks.length = 0;
+    flattenDisposables(this._disposables).dispose();
+    this._callbacks = [];
+    this._disposables = [];
   }
 
   toDispose(disposables: Disposable[]): Slot<T> {

--- a/packages/global/src/utils/slot.ts
+++ b/packages/global/src/utils/slot.ts
@@ -8,27 +8,27 @@ export class Slot<T = void> implements Disposable {
   private _disposables: Disposable[] = [];
 
   /**
-   * This is method will return a disposable that will remove the listener
+   * Returns a disposable that will remove the listener
    */
-  static disposableListener<N extends keyof WindowEventMap>(
+  static fromEvent<N extends keyof WindowEventMap>(
     element: Window,
     eventName: N,
     handler: (e: WindowEventMap[N]) => void,
     options?: boolean | AddEventListenerOptions
   ): Disposable;
-  static disposableListener<N extends keyof DocumentEventMap>(
+  static fromEvent<N extends keyof DocumentEventMap>(
     element: Document,
     eventName: N,
     handler: (e: DocumentEventMap[N]) => void,
     eventOptions?: boolean | AddEventListenerOptions
   ): Disposable;
-  static disposableListener<N extends keyof HTMLElementEventMap>(
+  static fromEvent<N extends keyof HTMLElementEventMap>(
     element: HTMLElement,
     eventName: N,
     handler: (e: HTMLElementEventMap[N]) => void,
     eventOptions?: boolean | AddEventListenerOptions
   ): Disposable;
-  static disposableListener(
+  static fromEvent(
     element: HTMLElement | Window | Document,
     eventName: string,
     handler: (e: Event) => void,


### PR DESCRIPTION
This is not reverting #1114, but using the `Slot.fromEvent` the right way:

``` ts
// Wrong
disposables.add(
  Slot.fromEvent(document, 'click').on(myHandler)
)

// Correct
disposables.add(
  Slot.fromEvent(document, 'click', myHandler)
)
```

So that we don't have to introduce the `disposableListener` concept, which is hard to comprehend IMO.

This also refactors the implementation, removes the ambiguous `DisposeLogic` type.

Let's make this happen and see what's the next step for #1518.