### PR TITLE
fix(edgeless): brush menu cannot be closed after switch editor mode

### DIFF
--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
@@ -89,6 +89,12 @@ export class EdgelessBrushToolButton extends LitElement {
     }
   }
 
+  disconnectedCallback() {
+    this._brushMenu?.dispose();
+    this._brushMenu = null;
+    super.disconnectedCallback();
+  }
+
   render() {
     const type = this.mouseMode?.type;
 

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -184,6 +184,21 @@ test('add shape element', async ({ page }) => {
   await assertEdgelessHoverRect(page, [100, 100, 100, 100]);
 });
 
+test('change editor mode when brush color palette opening', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+  await setMouseMode(page, 'brush');
+
+  const brushMenu = page.locator('edgeless-brush-menu');
+  await expect(brushMenu).toBeVisible();
+
+  await switchEditorMode(page);
+  await expect(brushMenu).toBeHidden();
+});
+
 test('add brush element', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);


### PR DESCRIPTION
fix #1534 