### PR TITLE
fix: drawing content should not cover the brush menu

### DIFF
--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
@@ -54,6 +54,7 @@ export class EdgelessBrushMenu extends LitElement {
   static styles = css`
     :host {
       width: 260px;
+      z-index: 1;
     }
     .container {
       display: flex;

--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -20,7 +20,7 @@ export class EdgelessToolbar extends LitElement {
   static styles = css`
     :host {
       position: absolute;
-      z-index: 1;
+      z-index: 2;
       bottom: 28px;
       left: calc(50%);
       display: flex;


### PR DESCRIPTION
before:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/15389209/223454739-b95e1e32-7964-448a-8505-2cce28ce3419.png">


after:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/15389209/223454962-47115a40-b586-458e-8868-725058fe88e6.png">
