### PR TITLE
fix: remove redundant `scrollIntoViewIfNeeded`

### DIFF
--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -265,15 +265,6 @@ export class SlashMenu extends LitElement {
     if (!ele) {
       return;
     }
-    // `scrollIntoViewIfNeeded` is not a standard API
-    // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded
-    if (
-      'scrollIntoViewIfNeeded' in ele &&
-      ele.scrollIntoViewIfNeeded instanceof Function
-    ) {
-      ele.scrollIntoViewIfNeeded();
-      return;
-    }
     ele.scrollIntoView(true);
   }
 


### PR DESCRIPTION
close: #1574

`ele.scrollIntoViewIfNeeded()`: the element will be aligned so it is **centered** within the visible area of the scrollable ancestor.
/cc @lawvs 