### PR TITLE
fix: fix the console error when dragging the dividing line

### DIFF
--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -16,6 +16,7 @@ export function asyncFocusRichText(
     if (!model) {
       throw new Error(`Cannot find block with id ${id}`);
     }
+    if (matchFlavours(model, ['affine:divider'] as const)) return;
     const richText = getRichTextByModel(model);
     if (!richText) {
       throw new Error(`Cannot find rich text with id ${id}`);


### PR DESCRIPTION
error message:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/15389209/223892258-638b311e-fce1-49d4-b865-86bfb09b3c78.png">


The dividing line does not contain text content by default.