### PR TITLE
fix: date & time string can not be inserted using the slash menu

### DIFF
--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -103,6 +103,10 @@ function onAbort(
     return;
   }
   text.delete(idx, searchStr.length);
+  vEditor.setVRange({
+    index: idx,
+    length: 0,
+  });
 }
 
 export function showSlashMenu({

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -291,3 +291,64 @@ test.describe('slash menu with code block', () => {
     await assertRichTexts(page, ['111000']);
   });
 });
+
+test.describe('slash menu with date & time', () => {
+  test("should insert Today's time string", async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    await type(page, '/');
+    const slashMenu = page.locator(`.slash-menu`);
+    await expect(slashMenu).toBeVisible();
+
+    const todayBlock = page.getByTestId('Today');
+    await todayBlock.click();
+    await todayBlock.waitFor({ state: 'hidden' });
+
+    const date = new Date();
+    const strTime = date.toISOString().split('T')[0];
+
+    await assertRichTexts(page, [strTime]);
+  });
+
+  test("should create Tomorrow's time string", async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    await type(page, '/');
+    const slashMenu = page.locator(`.slash-menu`);
+    await expect(slashMenu).toBeVisible();
+
+    const todayBlock = page.getByTestId('Tomorrow');
+    await todayBlock.click();
+    await todayBlock.waitFor({ state: 'hidden' });
+
+    const date = new Date();
+    date.setDate(date.getDate() + 1);
+    const strTime = date.toISOString().split('T')[0];
+
+    await assertRichTexts(page, [strTime]);
+  });
+
+  test("should insert Yesterday's time string", async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    await type(page, '/');
+    const slashMenu = page.locator(`.slash-menu`);
+    await expect(slashMenu).toBeVisible();
+
+    const todayBlock = page.getByTestId('Yesterday');
+    await todayBlock.click();
+    await todayBlock.waitFor({ state: 'hidden' });
+
+    const date = new Date();
+    date.setDate(date.getDate() - 1);
+    const strTime = date.toISOString().split('T')[0];
+
+    await assertRichTexts(page, [strTime]);
+  });
+});


### PR DESCRIPTION
The issue is that vEditor does not synchronize its state vRange when deleting search string.

https://user-images.githubusercontent.com/24316656/224102751-1d580025-d50c-450d-b43f-a51b9b71f7e0.mp4

