### PR TITLE
refactor: replace `getRichTextByModel` with `getVirgoByModel`

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -196,13 +196,7 @@ export function createKeyboardBindings(
     return PREVENT_DEFAULT;
   }
 
-  function onSoftEnter(
-    range: VRange,
-    /**
-     * @deprecated
-     */
-    vEditor: AffineVEditor
-  ) {
+  function onSoftEnter(range: VRange, vEditor: AffineVEditor) {
     handleSoftEnter(page, model, range.index, range.length);
     vEditor.setVRange({
       index: range.index + 1,

--- a/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/create-link.ts
@@ -8,7 +8,7 @@ import {
   blockRangeToNativeRange,
   getCurrentBlockRange,
 } from '../../utils/block-range.js';
-import { getEditorContainer, getRichTextByModel } from '../../utils/index.js';
+import { getEditorContainer, getVirgoByModel } from '../../utils/index.js';
 import { LinkMockSelection } from './mock-selection.js';
 
 export function createLink(page: Page) {
@@ -19,10 +19,7 @@ export function createLink(page: Page) {
   }
   const startModel = blockRange.models[0];
   if (!startModel) return;
-  const richText = getRichTextByModel(startModel);
-  if (!richText) return;
-
-  const { vEditor } = richText;
+  const vEditor = getVirgoByModel(startModel);
   assertExists(vEditor);
   const vRange = {
     index: blockRange.startOffset,

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -17,7 +17,7 @@ import {
   getCurrentNativeRange,
   getModelByElement,
   getPreviousBlock,
-  getRichTextByModel,
+  getVirgoByModel,
   supportsChildren,
 } from '../utils/index.js';
 
@@ -410,8 +410,8 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
         page.deleteBlock(model, {
           bringChildrenTo: previousSibling,
         });
-        const richText = getRichTextByModel(previousSibling);
-        richText?.vEditor?.setVRange({
+        const vEditor = getVirgoByModel(previousSibling);
+        vEditor?.setVRange({
           index: preTextLength,
           length: 0,
         });

--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -3,7 +3,7 @@ import type { Page } from '@blocksuite/store';
 import type { BaseBlockModel } from '@blocksuite/store';
 import type { VEditor, VRange } from '@blocksuite/virgo';
 
-import { asyncGetRichTextByModel, getRichTextByModel } from './query.js';
+import { asyncGetRichTextByModel, getVirgoByModel } from './query.js';
 import type { ExtendedModel } from './types.js';
 
 export async function asyncSetVRange(model: BaseBlockModel, vRange: VRange) {
@@ -133,7 +133,7 @@ export function convertToParagraph(
     page.captureSync();
 
     model.text?.delete(0, prefix.length + 1);
-    const vEditor = getRichTextByModel(model)?.vEditor;
+    const vEditor = getVirgoByModel(model);
     if (vEditor) {
       vEditor.setVRange({
         index: 0,

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -313,6 +313,9 @@ export function getStartModelBySelection(range = getCurrentNativeRange()) {
   return startModel;
 }
 
+/**
+ * @deprecated In most cases, you not need RichText, you can use {@link getVirgoEditorByModel} instead.
+ */
 export function getRichTextByModel(model: BaseBlockModel) {
   const blockElement = getBlockElementByModel(model);
   const richText = blockElement?.querySelector<RichText>('rich-text');
@@ -325,6 +328,13 @@ export async function asyncGetRichTextByModel(model: BaseBlockModel) {
   const richText = blockElement?.querySelector<RichText>('rich-text');
   if (!richText) return null;
   return richText;
+}
+
+export function getVirgoByModel(model: BaseBlockModel) {
+  const blockElement = getBlockElementByModel(model);
+  const richText = blockElement?.querySelector('rich-text') as RichText;
+  if (!richText) return null;
+  return richText.vEditor;
 }
 
 // TODO fix find embed model

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -332,7 +332,7 @@ export async function asyncGetRichTextByModel(model: BaseBlockModel) {
 
 export function getVirgoByModel(model: BaseBlockModel) {
   const blockElement = getBlockElementByModel(model);
-  const richText = blockElement?.querySelector('rich-text') as RichText;
+  const richText = blockElement?.querySelector<RichText>('rich-text');
   if (!richText) return null;
   return richText.vEditor;
 }

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -314,7 +314,7 @@ export function getStartModelBySelection(range = getCurrentNativeRange()) {
 }
 
 /**
- * @deprecated In most cases, you not need RichText, you can use {@link getVirgoEditorByModel} instead.
+ * @deprecated In most cases, you not need RichText, you can use {@link getVirgoByModel} instead.
  */
 export function getRichTextByModel(model: BaseBlockModel) {
   const blockElement = getBlockElementByModel(model);

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -331,8 +331,7 @@ export async function asyncGetRichTextByModel(model: BaseBlockModel) {
 }
 
 export function getVirgoByModel(model: BaseBlockModel) {
-  const blockElement = getBlockElementByModel(model);
-  const richText = blockElement?.querySelector<RichText>('rich-text');
+  const richText = getRichTextByModel(model);
   if (!richText) return null;
   return richText.vEditor;
 }

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -240,6 +240,9 @@ export function resetNativeSelection(range: Range | null) {
   range && selection.addRange(range);
 }
 
+/**
+ * @deprecated Use {@link focusBlockByModel} instead.
+ */
 export function focusRichTextByOffset(richTextParent: HTMLElement, x: number) {
   const richText = richTextParent.querySelector('rich-text');
   assertExists(richText);
@@ -251,6 +254,9 @@ export function focusRichTextByOffset(richTextParent: HTMLElement, x: number) {
   }
 }
 
+/**
+ * @deprecated Use {@link focusBlockByModel} instead.
+ */
 export function focusRichTextStart(richText: RichText) {
   const start = richText.querySelector('p')?.childNodes[0] as ChildNode;
   const range = document.createRange();

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -18,7 +18,7 @@ import type { TemplateResult } from 'lit';
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
 import {
   getCurrentNativeRange,
-  getRichTextByModel,
+  getVirgoByModel,
   resetNativeSelection,
   uploadImageFromLocal,
 } from '../../__internal__/utils/index.js';
@@ -41,8 +41,7 @@ function insertContent(model: BaseBlockModel, text: string) {
   if (!model.text) {
     throw new Error("Can't insert text! Text not found");
   }
-  const richText = getRichTextByModel(model);
-  const vEditor = richText?.vEditor;
+  const vEditor = getVirgoByModel(model);
   if (!vEditor) {
     throw new Error("Can't insert text! vEditor not found");
   }

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -3,10 +3,7 @@ import './slash-menu-node.js';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { assertExists } from '@blocksuite/store';
 
-import {
-  getRichTextByModel,
-  throttle,
-} from '../../__internal__/utils/index.js';
+import { getVirgoByModel, throttle } from '../../__internal__/utils/index.js';
 import { onModelElementUpdated } from '../../page-block/index.js';
 import {
   calcSafeCoordinate,
@@ -84,8 +81,7 @@ function onAbort(
     );
     return;
   }
-  const richText = getRichTextByModel(model);
-  const vEditor = richText?.vEditor;
+  const vEditor = getVirgoByModel(model);
   if (!vEditor) {
     console.warn(
       'Failed to clean slash search text! No vEditor found for model, model:',

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -12,7 +12,7 @@ import {
   BlockChildrenContainer,
   type BlockHost,
   getCurrentNativeRange,
-  getRichTextByModel,
+  getVirgoByModel,
   hasNativeSelection,
   hotkey,
   isMultiBlockRange,
@@ -216,14 +216,6 @@ export class DefaultPageBlockComponent
       const vRange = this._titleVEditor.getVRange();
       assertExists(vRange);
       const right = model.title.split(vRange.index);
-
-      const block = defaultFrame.children.find(block =>
-        getRichTextByModel(block)
-      );
-      if (block) {
-        asyncFocusRichText(page, block.id);
-      }
-
       const newFirstParagraphId = page.addBlockByFlavour(
         'affine:paragraph',
         { text: right },
@@ -376,22 +368,19 @@ export class DefaultPageBlockComponent
           return;
         }
         const startBlock = blockRange.models[0];
-        const richText = getRichTextByModel(startBlock);
-        if (richText) {
-          const vEditor = richText.vEditor;
-          if (vEditor) {
-            vEditor.insertText(
-              {
-                index: blockRange.startOffset,
-                length: 0,
-              },
-              e.key
-            );
-            vEditor.setVRange({
-              index: blockRange.startOffset + 1,
+        const vEditor = getVirgoByModel(startBlock);
+        if (vEditor) {
+          vEditor.insertText(
+            {
+              index: blockRange.startOffset,
               length: 0,
-            });
-          }
+            },
+            e.key
+          );
+          vEditor.setVRange({
+            index: blockRange.startOffset + 1,
+            length: 0,
+          });
         }
       }
       window.removeEventListener('keydown', this._handleNativeKeydown);

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -12,7 +12,7 @@ import {
   doesInSamePath,
   getBlockById,
   getBlockElementByModel,
-  getRichTextByModel,
+  getVirgoByModel,
   type OpenBlockInfo,
 } from '../../__internal__/utils/index.js';
 import { DragHandle } from '../../components/index.js';
@@ -492,9 +492,7 @@ export function isControlledKeyboardEvent(e: KeyboardEvent) {
 }
 
 export function copyCode(model: BaseBlockModel) {
-  const richText = getRichTextByModel(model);
-  assertExists(richText);
-  const vEditor = richText.vEditor;
+  const vEditor = getVirgoByModel(model);
   assertExists(vEditor);
   vEditor.setVRange({
     index: 0,

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -15,6 +15,7 @@ import {
   type BlockComponentElement,
   type ExtendedModel,
   getDefaultPageBlock,
+  getVirgoByModel,
   hasNativeSelection,
   isCollapsedNativeSelection,
   isMultiBlockRange,
@@ -29,10 +30,7 @@ import {
   updateBlockRange,
 } from '../../__internal__/utils/block-range.js';
 import { asyncFocusRichText } from '../../__internal__/utils/common-operations.js';
-import {
-  getBlockElementByModel,
-  getRichTextByModel,
-} from '../../__internal__/utils/query.js';
+import { getBlockElementByModel } from '../../__internal__/utils/query.js';
 import {
   getCurrentNativeRange,
   resetNativeSelection,
@@ -87,9 +85,7 @@ export function deleteModelsByRange(
     throw new Error('startModel or endModel does not have text');
   }
 
-  const firstRichText = getRichTextByModel(startModel);
-  assertExists(firstRichText);
-  const vEditor = firstRichText.vEditor;
+  const vEditor = getVirgoByModel(startModel);
   assertExists(vEditor);
 
   // Only select one block
@@ -274,9 +270,7 @@ export function getCombinedFormat(
   blockRange: BlockRange
 ): AffineTextAttributes {
   if (blockRange.models.length === 1) {
-    const richText = getRichTextByModel(blockRange.models[0]);
-    assertExists(richText);
-    const { vEditor } = richText;
+    const vEditor = getVirgoByModel(blockRange.models[0]);
     assertExists(vEditor);
     const format = vEditor.getFormat({
       index: blockRange.startOffset,
@@ -293,12 +287,11 @@ export function getCombinedFormat(
     startModel.text &&
     startModel.text.length
   ) {
-    const startRichText = getRichTextByModel(startModel);
-    assertExists(startRichText);
-    assertExists(startRichText.vEditor);
-    const startFormat = startRichText.vEditor.getFormat({
+    const vEditor = getVirgoByModel(startModel);
+    assertExists(vEditor);
+    const startFormat = vEditor.getFormat({
       index: blockRange.startOffset,
-      length: startRichText.vEditor.yText.length - blockRange.startOffset,
+      length: vEditor.yText.length - blockRange.startOffset,
     });
     formatArr.push(startFormat);
   }
@@ -309,10 +302,9 @@ export function getCombinedFormat(
     endModel.text &&
     endModel.text.length
   ) {
-    const endRichText = getRichTextByModel(endModel);
-    assertExists(endRichText);
-    assertExists(endRichText.vEditor);
-    const endFormat = endRichText.vEditor.getFormat({
+    const vEditor = getVirgoByModel(endModel);
+    assertExists(vEditor);
+    const endFormat = vEditor.getFormat({
       index: 0,
       length: blockRange.endOffset,
     });
@@ -324,12 +316,11 @@ export function getCombinedFormat(
     .filter(model => !matchFlavours(model, ['affine:code'] as const))
     .filter(model => model.text && model.text.length)
     .forEach(model => {
-      const richText = getRichTextByModel(model);
-      assertExists(richText);
-      assertExists(richText.vEditor);
-      const format = richText.vEditor.getFormat({
+      const vEditor = getVirgoByModel(model);
+      assertExists(vEditor);
+      const format = vEditor.getFormat({
         index: 0,
-        length: richText.vEditor.yText.length - 1,
+        length: vEditor.yText.length - 1,
       });
       formatArr.push(format);
     });
@@ -362,8 +353,8 @@ function formatBlockRange(
   // edge case 2: same model
   if (blockRange.models.length === 1) {
     if (matchFlavours(startModel, ['affine:code'] as const)) return;
-    const richText = getRichTextByModel(startModel);
-    richText?.vEditor?.slots.updated.once(() => {
+    const vEditor = getVirgoByModel(startModel);
+    vEditor?.slots.updated.once(() => {
       restoreSelection(blockRange);
     });
     startModel.text?.format(startOffset, endOffset - startOffset, {

--- a/packages/editor/src/managers/clipboard/paste-manager.ts
+++ b/packages/editor/src/managers/clipboard/paste-manager.ts
@@ -1,7 +1,7 @@
 import {
   getCurrentBlockRange,
   getDefaultPageBlock,
-  getRichTextByModel,
+  getVirgoByModel,
   handleBlockSelectionBatchDelete,
   type OpenBlockInfo,
 } from '@blocksuite/blocks';
@@ -343,8 +343,7 @@ export class PasteManager {
         setTimeout(() => {
           const block = this._editor.page.getBlockById(lastId);
           if (block) {
-            const richText = getRichTextByModel(block);
-            const vEditor = richText?.vEditor;
+            const vEditor = getVirgoByModel(block);
             if (vEditor) {
               vEditor.setVRange({
                 index: position,


### PR DESCRIPTION
Replace `getRichTextByModel` with `getVirgoByModel`.

Update the following pattern

```ts
// Before
  const richText = getRichTextByModel(model);
  assertExists(richText);
  const { vEditor } = richText;
  assertExists(vEditor);

// After
  const vEditor = getVirgoByModel(model);
  assertExists(vEditor);
```
