### PR TITLE
feat: add slots for virgo to inspect update

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -461,17 +461,18 @@ export function createKeyboardBindings(
         // }
 
         // we need to insert text before show menu, because the Text node will be
-        // expired if we insert text after show menu because of the re-render
+        // expired if we insert text after show menu because of the rerender
         this.vEditor.insertText(range, context.event.key);
         this.vEditor.setVRange({
           index: range.index + 1,
           length: 0,
         });
 
-        requestAnimationFrame(() => {
+        this.vEditor.slots.rangeUpdated.once(() => {
           const curRange = getCurrentNativeRange();
           showSlashMenu({ model, range: curRange });
         });
+
         return PREVENT_DEFAULT;
       },
     },

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -321,14 +321,12 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
         previousSiblingParent &&
         matchFlavours(previousSiblingParent, ['affine:database'] as const)
       ) {
-        window.requestAnimationFrame(() => {
-          focusBlockByModel(previousSiblingParent, 'end');
-          // We can not delete block if the block has content
-          if (!model.text?.length) {
-            page.captureSync();
-            page.deleteBlock(model);
-          }
-        });
+        focusBlockByModel(previousSiblingParent, 'end');
+        // We can not delete block if the block has content
+        if (!model.text?.length) {
+          page.captureSync();
+          page.deleteBlock(model);
+        }
       } else if (
         previousSibling &&
         matchFlavours(previousSibling, [
@@ -355,14 +353,12 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
           'affine:code',
         ] as const)
       ) {
-        window.requestAnimationFrame(() => {
-          focusBlockByModel(previousSibling);
-          // We can not delete block if the block has content
-          if (!model.text?.length) {
-            page.captureSync();
-            page.deleteBlock(model);
-          }
-        });
+        focusBlockByModel(previousSibling);
+        // We can not delete block if the block has content
+        if (!model.text?.length) {
+          page.captureSync();
+          page.deleteBlock(model);
+        }
       } else {
         // No previous sibling, it's the first block
         // Try to merge with the title

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -240,6 +240,16 @@ export function getBlockElementByModel(
 export function asyncGetBlockElementByModel(
   model: BaseBlockModel
 ): Promise<BlockComponentElement | null> {
+  assertExists(model.page.root);
+  const page = document.querySelector<DefaultPageBlockComponent>(
+    `[${ATTR}="${model.page.root.id}"]`
+  );
+  if (!page) return Promise.resolve(null);
+
+  if (model.id === model.page.root.id) {
+    return Promise.resolve(page);
+  }
+
   let resolved = false;
   return new Promise<BlockComponentElement>((resolve, reject) => {
     const onSuccess = (element: BlockComponentElement) => {
@@ -258,13 +268,15 @@ export function asyncGetBlockElementByModel(
     };
 
     const observer = new MutationObserver(() => {
-      const blockElement = getBlockElementByModel(model);
+      const blockElement = page.querySelector<BlockComponentElement>(
+        `[${ATTR}="${model.id}"]`
+      );
       if (blockElement) {
         onSuccess(blockElement);
       }
     });
 
-    observer.observe(document.body, {
+    observer.observe(page, {
       childList: true,
       subtree: true,
     });

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -70,7 +70,7 @@ async function setNewTop(y: number, editableContainer: Element) {
       if (bottom < SCROLL_THRESHOLD && scrollContainer) {
         scrollContainer.scrollTop =
           scrollContainer.scrollTop - SCROLL_THRESHOLD + bottom;
-        // set scroll may has a animation, wait for over
+        // set scroll may have an animation, wait for over
         requestAnimationFrame(() => {
           finalBottom = editableContainer.getBoundingClientRect().bottom;
         });

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -102,13 +102,11 @@ export class LangList extends NonShadowLitElement {
     lang => lang.toUpperCase()[0] + lang.slice(1)
   );
 
-  override connectedCallback() {
-    super.connectedCallback();
+  override async connectedCallback() {
+    await super.connectedCallback();
     // Avoid triggering click away listener on initial render
-    requestAnimationFrame(() => {
-      document.addEventListener('click', this._clickAwayListener);
-      this.filterInput.focus();
-    });
+    document.addEventListener('click', this._clickAwayListener);
+    this.filterInput.focus();
   }
 
   override disconnectedCallback() {
@@ -117,7 +115,7 @@ export class LangList extends NonShadowLitElement {
   }
 
   private _clickAwayListener = (e: Event) => {
-    if (this.contains(e.target as Node)) {
+    if (this.renderRoot.parentElement?.contains(e.target as Node)) {
       return;
     }
     this.dispatchEvent(createEvent('dispose', null));
@@ -146,31 +144,33 @@ export class LangList extends NonShadowLitElement {
       'padding-left': '4px',
     });
 
-    return html`<div class="lang-list-container">
-      <div style="${styles}">
-        <div class="search-icon">${SearchIcon}</div>
-        <input
-          id="filter-input"
-          type="text"
-          placeholder="Search"
-          @input=${() => (this._filterText = this.filterInput?.value)}
-        />
+    return html`
+      <div class="lang-list-container">
+        <div style="${styles}">
+          <div class="search-icon">${SearchIcon}</div>
+          <input
+            id="filter-input"
+            type="text"
+            placeholder="Search"
+            @input="${() => (this._filterText = this.filterInput?.value)}"
+          />
+        </div>
+        <div class="lang-list-button-container">
+          ${filteredLanguages.map(
+            language => html`
+              <icon-button
+                width="100%"
+                height="32px"
+                @click="${() => this._onLanguageClicked(language)}"
+                class="lang-item"
+              >
+                ${language}
+              </icon-button>
+            `
+          )}
+        </div>
       </div>
-      <div class="lang-list-button-container">
-        ${filteredLanguages.map(
-          language => html`
-            <icon-button
-              width="100%"
-              height="32px"
-              @click="${() => this._onLanguageClicked(language)}"
-              class="lang-item"
-            >
-              ${language}
-            </icon-button>
-          `
-        )}
-      </div>
-    </div> `;
+    `;
   }
 }
 

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -13,13 +13,11 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
-import {
-  asyncGetBlockElementByModel,
-  getRichTextByModel,
-} from '../../__internal__/utils/index.js';
+import { getRichTextByModel } from '../../__internal__/utils/index.js';
 import { formatConfig } from '../../page-block/utils/const.js';
 import {
   getCurrentCombinedFormat,
+  onModelElementUpdated,
   updateBlockType,
 } from '../../page-block/utils/index.js';
 import { compareTopAndBottomSpace } from '../../page-block/utils/position.js';
@@ -180,7 +178,7 @@ export class FormatQuickBar extends LitElement {
           );
         }
         const codeModel = newModels[0];
-        asyncGetBlockElementByModel(codeModel).then(() => {
+        onModelElementUpdated(codeModel, () => {
           restoreSelection({
             type: 'Block',
             startOffset: 0,
@@ -194,11 +192,11 @@ export class FormatQuickBar extends LitElement {
       this.positionUpdated.emit();
     };
 
-    return html`<div
+    return html` <div
       class="paragraph-panel"
       style="${styles}"
-      @mouseover=${this._onHover}
-      @mouseout=${this._onHoverEnd}
+      @mouseover="${this._onHover}"
+      @mouseout="${this._onHoverEnd}"
     >
       ${paragraphConfig.map(
         ({ flavour, type, name, icon }) => html` <format-bar-button
@@ -206,7 +204,7 @@ export class FormatQuickBar extends LitElement {
           style="padding-left: 12px; justify-content: flex-start;"
           text="${name}"
           data-testid="${flavour}/${type}"
-          @click=${() => updateParagraphType(flavour, type)}
+          @click="${() => updateParagraphType(flavour, type)}"
         >
           ${icon}
         </format-bar-button>`
@@ -232,8 +230,8 @@ export class FormatQuickBar extends LitElement {
     const paragraphItems = html` <format-bar-button
       class="paragraph-button"
       width="52px"
-      @mouseover=${this._onHover}
-      @mouseout=${this._onHoverEnd}
+      @mouseover="${this._onHover}"
+      @mouseout="${this._onHoverEnd}"
     >
       ${paragraphIcon} ${ArrowDownIcon}
     </format-bar-button>`;

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -13,7 +13,10 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
-import { getRichTextByModel } from '../../__internal__/utils/index.js';
+import {
+  asyncGetBlockElementByModel,
+  getRichTextByModel,
+} from '../../__internal__/utils/index.js';
 import { formatConfig } from '../../page-block/utils/const.js';
 import {
   getCurrentCombinedFormat,
@@ -177,14 +180,14 @@ export class FormatQuickBar extends LitElement {
           );
         }
         const codeModel = newModels[0];
-        requestAnimationFrame(() =>
+        asyncGetBlockElementByModel(codeModel).then(() => {
           restoreSelection({
             type: 'Block',
             startOffset: 0,
             endOffset: codeModel.text?.length ?? 0,
             models: [codeModel],
-          })
-        );
+          });
+        });
       }
       this.models = newModels;
       this._paragraphType = `${targetFlavour}/${targetType}`;

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -4,7 +4,10 @@ import './format-bar-node.js';
 import { matchFlavours, Page, Slot } from '@blocksuite/store';
 
 import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
-import { getDefaultPageBlock } from '../../__internal__/utils/query.js';
+import {
+  asyncGetBlockElementByModel,
+  getDefaultPageBlock,
+} from '../../__internal__/utils/query.js';
 import { throttle } from '../../__internal__/utils/std.js';
 import {
   calcPositionPointByRange,
@@ -151,7 +154,7 @@ export const showFormatQuickBar = async ({
   // Fix https://github.com/toeverything/AFFiNE/issues/855
   window.addEventListener('popstate', popstateHandler);
 
-  requestAnimationFrame(() => {
+  asyncGetBlockElementByModel(blockRange.models[0]).then(() => {
     updatePos();
   });
 

--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -4,11 +4,9 @@ import './format-bar-node.js';
 import { matchFlavours, Page, Slot } from '@blocksuite/store';
 
 import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
-import {
-  asyncGetBlockElementByModel,
-  getDefaultPageBlock,
-} from '../../__internal__/utils/query.js';
+import { getDefaultPageBlock } from '../../__internal__/utils/query.js';
 import { throttle } from '../../__internal__/utils/std.js';
+import { onModelElementUpdated } from '../../page-block/index.js';
 import {
   calcPositionPointByRange,
   calcSafeCoordinate,
@@ -154,9 +152,7 @@ export const showFormatQuickBar = async ({
   // Fix https://github.com/toeverything/AFFiNE/issues/855
   window.addEventListener('popstate', popstateHandler);
 
-  asyncGetBlockElementByModel(blockRange.models[0]).then(() => {
-    updatePos();
-  });
+  onModelElementUpdated(blockRange.models[0], updatePos);
 
   abortController.signal.addEventListener('abort', () => {
     scrollContainer?.removeEventListener('scroll', updatePos);

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -17,6 +17,7 @@ import type { TemplateResult } from 'lit';
 
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
 import {
+  asyncGetRichTextByModel,
   getCurrentNativeRange,
   getRichTextByModel,
   resetNativeSelection,
@@ -85,14 +86,16 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
                 );
               }
               const codeModel = newModels[0];
-              requestAnimationFrame(() =>
-                restoreSelection({
-                  type: 'Native',
-                  startOffset: 0,
-                  endOffset: 0,
-                  models: [codeModel],
-                })
-              );
+              asyncGetRichTextByModel(codeModel).then(richText => {
+                richText?.vEditor?.slots.updated.once(() => {
+                  restoreSelection({
+                    type: 'Native',
+                    startOffset: 0,
+                    endOffset: 0,
+                    models: [codeModel],
+                  });
+                });
+              });
             }
           },
         })),

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -17,7 +17,6 @@ import type { TemplateResult } from 'lit';
 
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
 import {
-  asyncGetRichTextByModel,
   getCurrentNativeRange,
   getRichTextByModel,
   resetNativeSelection,
@@ -25,7 +24,10 @@ import {
 } from '../../__internal__/utils/index.js';
 import { copyBlock } from '../../page-block/default/utils.js';
 // import { formatConfig } from '../../page-block/utils/const.js';
-import { updateBlockType } from '../../page-block/utils/index.js';
+import {
+  onModelTextUpdated,
+  updateBlockType,
+} from '../../page-block/utils/index.js';
 import { toast } from '../toast.js';
 
 export type SlashItem = {
@@ -86,14 +88,12 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
                 );
               }
               const codeModel = newModels[0];
-              asyncGetRichTextByModel(codeModel).then(richText => {
-                richText?.vEditor?.slots.updated.once(() => {
-                  restoreSelection({
-                    type: 'Native',
-                    startOffset: 0,
-                    endOffset: 0,
-                    models: [codeModel],
-                  });
+              onModelTextUpdated(codeModel, () => {
+                restoreSelection({
+                  type: 'Native',
+                  startOffset: 0,
+                  endOffset: 0,
+                  models: [codeModel],
                 });
               });
             }

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -3,10 +3,10 @@ import './slash-menu-node.js';
 import { assertExists, BaseBlockModel } from '@blocksuite/store';
 
 import {
-  asyncGetBlockElementByModel,
   getRichTextByModel,
   throttle,
 } from '../../__internal__/utils/index.js';
+import { onModelElementUpdated } from '../../page-block/index.js';
 import {
   calcSafeCoordinate,
   compareTopAndBottomSpace,
@@ -141,9 +141,7 @@ export function showSlashMenu({
   // Mount
   container.appendChild(slashMenu);
   // Wait for the format quick bar to be mounted
-  asyncGetBlockElementByModel(model).then(() => {
-    updatePosition();
-  });
+  onModelElementUpdated(model, updatePosition);
 
   // Handle dispose
   abortController.signal.addEventListener('abort', e => {

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -3,6 +3,7 @@ import './slash-menu-node.js';
 import { assertExists, BaseBlockModel } from '@blocksuite/store';
 
 import {
+  asyncGetBlockElementByModel,
   getRichTextByModel,
   throttle,
 } from '../../__internal__/utils/index.js';
@@ -140,7 +141,9 @@ export function showSlashMenu({
   // Mount
   container.appendChild(slashMenu);
   // Wait for the format quick bar to be mounted
-  requestAnimationFrame(() => updatePosition());
+  asyncGetBlockElementByModel(model).then(() => {
+    updatePosition();
+  });
 
   // Handle dispose
   abortController.signal.addEventListener('abort', e => {

--- a/packages/blocks/src/embed-block/embed-block.ts
+++ b/packages/blocks/src/embed-block/embed-block.ts
@@ -1,4 +1,4 @@
-import { css, html } from 'lit';
+import { css, html, PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
 import { NonShadowLitElement } from '../__internal__/index.js';
@@ -42,8 +42,10 @@ export class EmbedBlockComponent extends NonShadowLitElement {
   @state()
   private _caption!: string;
 
-  firstUpdated() {
-    requestAnimationFrame(() => {
+  override firstUpdated(changedProperties: PropertyValues) {
+    super.firstUpdated(changedProperties);
+
+    this.updateComplete.then(() => {
       this._caption = this.model?.caption ?? '';
 
       if (this._caption.length > 0) {

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -575,7 +575,7 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
       defaultPageBlock.selection.clear();
       defaultPageBlock.selection.state.type = type;
 
-      requestAnimationFrame(() => {
+      defaultPageBlock.updateComplete.then(() => {
         // update selection rects
         // block may change its flavour after moved.
         defaultPageBlock.selection.setSelectedBlocks(

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -374,17 +374,15 @@ function formatBlockRange(
   if (!matchFlavours(endModel, ['affine:code'] as const)) {
     endModel.text?.format(0, endOffset, { [key]: format[key] ? null : true });
   }
-
-  const models = blockRange.models
-    .slice(1, -1)
-    .filter(model => !matchFlavours(model, ['affine:code']));
-
   // format between models
-  models.forEach(model => {
-    model.text?.format(0, model.text.length, {
-      [key]: format[key] ? null : true,
+  blockRange.models
+    .slice(1, -1)
+    .filter(model => !matchFlavours(model, ['affine:code']))
+    .forEach(model => {
+      model.text?.format(0, model.text.length, {
+        [key]: format[key] ? null : true,
+      });
     });
-  });
 
   // Native selection maybe shifted after format
   // We need to restore it manually

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -9,6 +9,7 @@ import { BaseBlockModel, Page, Text } from '@blocksuite/store';
 
 import {
   almostEqual,
+  asyncGetRichTextByModel,
   ExtendedModel,
   getDefaultPageBlock,
   hasNativeSelection,
@@ -208,9 +209,14 @@ export function updateBlockType(
     newModels.push(newModel);
   });
 
+  const firstModel = newModels[0];
   const lastModel = newModels.at(-1);
   if (savedBlockRange) {
-    requestAnimationFrame(() => restoreSelection(savedBlockRange));
+    asyncGetRichTextByModel(firstModel).then(richText => {
+      richText?.vEditor?.slots.updated.once(() => {
+        restoreSelection(savedBlockRange);
+      });
+    });
   } else {
     if (lastModel) asyncFocusRichText(page, lastModel.id);
   }

--- a/packages/blocks/src/page-block/utils/container-operations.ts
+++ b/packages/blocks/src/page-block/utils/container-operations.ts
@@ -6,7 +6,6 @@ import {
 } from '@blocksuite/global/utils';
 import { deserializeXYWH } from '@blocksuite/phasor';
 import { BaseBlockModel, Page, Text } from '@blocksuite/store';
-import type { VEditor } from '@blocksuite/virgo';
 
 import {
   almostEqual,
@@ -395,16 +394,11 @@ function formatBlockRange(
   // Native selection maybe shifted after format
   // We need to restore it manually
   if (blockRange.type === 'Native') {
-    const textUpdated = blockRange.models
+    const allTextUpdated = blockRange.models
       .filter(model => !matchFlavours(model, ['affine:code']))
-      .map(getRichTextByModel)
-      .map(richText => richText?.vEditor)
-      .filter((vEditor): vEditor is VEditor => !!vEditor)
-      .map(
-        vEditor => new Promise(resolve => vEditor.slots.updated.once(resolve))
-      );
+      .map(model => new Promise(resolve => onModelTextUpdated(model, resolve)));
 
-    Promise.all(textUpdated).then(() => {
+    Promise.all(allTextUpdated).then(() => {
       restoreSelection(blockRange);
     });
   }

--- a/packages/virgo/src/components/virgo-line.ts
+++ b/packages/virgo/src/components/virgo-line.ts
@@ -19,8 +19,14 @@ export class VirgoLine<
     return this.elements.reduce((acc, el) => acc + el.delta.insert, '');
   }
 
+  override async getUpdateComplete() {
+    const result = await super.getUpdateComplete();
+    await Promise.all(this.elements.map(el => el.updateComplete));
+    return result;
+  }
+
   render() {
-    return html`<style>
+    return html` <style>
         v-line {
           display: block;
         }

--- a/packages/virgo/src/components/virgo-line.ts
+++ b/packages/virgo/src/components/virgo-line.ts
@@ -26,7 +26,7 @@ export class VirgoLine<
   }
 
   render() {
-    return html` <style>
+    return html`<style>
         v-line {
           display: block;
         }

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -880,6 +880,7 @@ test('should placeholder works', async ({ page }) => {
   await expect(placeholder).toBeVisible();
   await expect(placeholder).toHaveText('Heading 1');
   await clickBlockTypeMenuItem(page, 'Text');
+  await focusRichText(page, 0);
   await expect(placeholder).toBeVisible();
   await expect(placeholder).toContainText('type');
 


### PR DESCRIPTION
This PR add two slots for virgo:

1. `updated`: this slot will be emitted when dom updated.
2. `rangeUpdated`: this slot will be emited when vRange is applied to dom as range.

And two API introduces:

1. `onModelElementUpdated`: Run a callback after the element of model is updated. This is useful when you want to get the updated DOM after changing a model. For example, calculate the dom boundary rect.
2. `onModelTextUpdated`: Run a callback after the text of model is updated. This is useful when you want to make some dom changes after changing the yText. For example, restore the selection.