### PR TITLE
fix(blocks): cursor in codeblock moves to start

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -190,7 +190,11 @@ export class CodeBlockComponent extends NonShadowLitElement {
     assertExists(richText);
     const vEditor = richText.vEditor;
     assertExists(vEditor);
+    const range = vEditor.getVRange();
     vEditor.requestUpdate();
+    if (range) {
+      vEditor.setVRange(range);
+    }
   }
 
   get readonly() {
@@ -258,7 +262,6 @@ export class CodeBlockComponent extends NonShadowLitElement {
 
   protected firstUpdated() {
     this._startHighlight(codeLanguages);
-
     this.model.text.yText.observe(() => {
       setTimeout(() => {
         this._updateLineNumbers();


### PR DESCRIPTION
When highlighter is loaded slowly, the cursor will jump to start of the code block and cannot continue typing.

Before:

https://user-images.githubusercontent.com/10047788/224532332-910c25d1-f698-4039-b1e5-b625683da0a8.mov

<br />
<br />

After:


https://user-images.githubusercontent.com/10047788/224532334-1a64e716-3b2b-4e01-b25b-29a6bb69a9f4.mov

