### PR TITLE
fix(format-bar): safari compatibility

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/button.ts
+++ b/packages/blocks/src/components/format-quick-bar/button.ts
@@ -29,6 +29,8 @@ export class FormatBarButton extends IconButton {
   private readonly _mousedown = (e: MouseEvent) => {
     // prevents catching or bubbling in editor-container
     e.stopPropagation();
+    // disable default behavior (e.g., change selection focus)
+    e.preventDefault();
   };
 
   override connectedCallback() {


### PR DESCRIPTION
fix https://github.com/toeverything/blocksuite/issues/1639

Root cause is that on Safari without preventDefault the browser still change selection on click, even if the mousedown event is stopped.