### PR TITLE
fix(blocks): numbered list prefix won't update when previous sibling changed

### DIFF
--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -1,3 +1,6 @@
+import { sleep } from '@blocksuite/global/utils';
+import { expect } from '@playwright/test';
+
 import {
   clickBlockTypeMenuItem,
   enterPlaygroundRoom,
@@ -18,6 +21,7 @@ import {
   assertBlockChildrenIds,
   assertBlockCount,
   assertBlockType,
+  assertListPrefix,
   assertRichTexts,
   assertSelection,
   assertStoreMatchJSX,
@@ -226,6 +230,30 @@ test('nested list blocks', async ({ page }) => {
   </affine:frame>
 </affine:page>`
   );
+});
+
+test.only('update numbered list block prefix', async ({ page }) => {
+  await enterPlaygroundWithList(page, ['', '', ''], 'numbered'); // 0(1(2,3,4))
+
+  await focusRichText(page, 1);
+  await type(page, 'lunatic');
+  await assertRichTexts(page, ['', 'lunatic', '']);
+  await assertListPrefix(page, ['1', '2', '3']);
+
+  await page.keyboard.press('Tab');
+  await assertListPrefix(page, ['1', 'a', '2']);
+
+  await page.keyboard.press('Shift+Tab');
+  await assertListPrefix(page, ['1', '2', '3']);
+
+  await page.keyboard.press('Enter');
+  await assertListPrefix(page, ['1', '2', '3', '4']);
+
+  await type(page, 'concorde');
+  await assertRichTexts(page, ['', 'lunatic', 'concorde', '']);
+
+  await page.keyboard.press('Tab');
+  await assertListPrefix(page, ['1', '2', 'a', '3']);
 });
 
 test('basic indent and unindent', async ({ page }) => {

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -1,6 +1,3 @@
-import { sleep } from '@blocksuite/global/utils';
-import { expect } from '@playwright/test';
-
 import {
   clickBlockTypeMenuItem,
   enterPlaygroundRoom,
@@ -232,7 +229,7 @@ test('nested list blocks', async ({ page }) => {
   );
 });
 
-test.only('update numbered list block prefix', async ({ page }) => {
+test('update numbered list block prefix', async ({ page }) => {
   await enterPlaygroundWithList(page, ['', '', ''], 'numbered'); // 0(1(2,3,4))
 
   await focusRichText(page, 1);

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -176,26 +176,32 @@ export async function resetHistory(page: Page) {
 // XXX: This doesn't add surface yet, the page state should not be switched to edgeless.
 export async function enterPlaygroundWithList(
   page: Page,
-  contents: string[] = ['', '', '']
+  contents: string[] = ['', '', ''],
+  type: ListType = 'bulleted'
 ) {
   const room = generateRandomRoomId();
   await page.goto(`${DEFAULT_PLAYGROUND}?room=${room}`);
   await initEmptyEditor(page);
 
-  await page.evaluate(contents => {
-    const { page } = window;
-    const pageId = page.addBlockByFlavour('affine:page', {
-      title: new page.Text(),
-    });
-    const frameId = page.addBlockByFlavour('affine:frame', {}, pageId);
-    for (let i = 0; i < contents.length; i++) {
-      page.addBlockByFlavour(
-        'affine:list',
-        contents.length > 0 ? { text: new page.Text(contents[i]) } : {},
-        frameId
-      );
-    }
-  }, contents);
+  await page.evaluate(
+    ({ contents, type }: { contents: string[]; type: ListType }) => {
+      const { page } = window;
+      const pageId = page.addBlockByFlavour('affine:page', {
+        title: new page.Text(),
+      });
+      const frameId = page.addBlockByFlavour('affine:frame', {}, pageId);
+      for (let i = 0; i < contents.length; i++) {
+        page.addBlockByFlavour(
+          'affine:list',
+          contents.length > 0
+            ? { text: new page.Text(contents[i]), type }
+            : { type },
+          frameId
+        );
+      }
+    },
+    { contents, type }
+  );
   await waitNextFrame(page);
 }
 

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -151,6 +151,25 @@ export async function assertPageTitleFocus(page: Page) {
   await expect(locator).toBeFocused();
 }
 
+export async function assertListPrefix(
+  page: Page,
+  predict: (string | RegExp)[],
+  range?: [number, number]
+) {
+  const prefixs = await page.locator('.affine-list-block__prefix');
+
+  let start = 0;
+  let end = await prefixs.count();
+  if (range) {
+    [start, end] = range;
+  }
+
+  for (let i = start; i < end; i++) {
+    const prefix = await prefixs.nth(i).innerText();
+    expect(prefix).toContain(predict[i]);
+  }
+}
+
 export async function assertBlockCount(
   page: Page,
   flavour: string,


### PR DESCRIPTION
Before: 


https://user-images.githubusercontent.com/10047788/224622011-b87bbd9f-6e86-4403-998a-82f284ff9868.mov

<br />
<br />

After:


https://user-images.githubusercontent.com/10047788/224622033-ca29b095-57f7-4008-9496-ac24a1b53ef4.mov

