### PR TITLE
fix(blocks): code block indent incorrectly

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -250,10 +250,12 @@ export function createKeyboardBindings(
     if (matchFlavours(model, ['affine:code'] as const)) {
       e.stopPropagation();
 
+      const lastLineBreakBeforeCursor = this.vEditor.yText
+        .toString()
+        .lastIndexOf('\n', vRange.index - 1);
+
       const lineStart =
-        this.vEditor.yText.toString().lastIndexOf('\n', vRange.index) !== -1
-          ? this.vEditor.yText.toString().lastIndexOf('\n', vRange.index) + 1
-          : 0;
+        lastLineBreakBeforeCursor !== -1 ? lastLineBreakBeforeCursor + 1 : 0;
       if (
         this.vEditor.yText.length >= 2 &&
         this.vEditor.yText.toString().slice(lineStart, lineStart + 2) === '  '

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -215,10 +215,12 @@ export function createKeyboardBindings(
     if (matchFlavours(model, ['affine:code'] as const)) {
       e.stopPropagation();
 
+      const lastLineBreakBeforeCursor = this.vEditor.yText
+        .toString()
+        .lastIndexOf('\n', vRange.index - 1);
+
       const lineStart =
-        this.vEditor.yText.toString().lastIndexOf('\n', vRange.index) !== -1
-          ? this.vEditor.yText.toString().lastIndexOf('\n', vRange.index) + 1
-          : 0;
+        lastLineBreakBeforeCursor !== -1 ? lastLineBreakBeforeCursor + 1 : 0;
       this.vEditor.insertText(
         {
           index: lineStart,

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -589,10 +589,17 @@ test('should tab works in code block', async ({ page }) => {
 
   await type(page, 'const a = 10;');
   await assertRichTexts(page, ['const a = 10;']);
-  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab', { delay: 50 });
   await assertRichTexts(page, ['  const a = 10;']);
-  await page.keyboard.press(`Shift+Tab`);
+  await page.keyboard.press(`Shift+Tab`, { delay: 50 });
   await assertRichTexts(page, ['const a = 10;']);
+
+  await page.keyboard.press('Enter', { delay: 50 });
+  await type(page, 'const b = "NothingToSay";');
+  await page.keyboard.press('ArrowUp', { delay: 50 });
+  await page.keyboard.press('Enter', { delay: 50 });
+  await page.keyboard.press('Tab', { delay: 50 });
+  await assertRichTexts(page, ['const a = 10;\n  \nconst b = "NothingToSay";']);
 });
 
 test('should code block wrap active after click', async ({ page }) => {


### PR DESCRIPTION
The unexpected behavior occurs when trying to use `Tab` to indent a line between two lines of texts.

https://user-images.githubusercontent.com/10047788/224629844-23f17395-d655-4c37-9364-5959ec693bcd.mov

