### PR TITLE
fix(editor): some safari compatibility issues

### DIFF
--- a/packages/blocks/src/__internal__/utils/components.ts
+++ b/packages/blocks/src/__internal__/utils/components.ts
@@ -33,6 +33,7 @@ export function BlockElement(
         <${model.tag}
           .model=${model}
           .host=${host}
+          class="affine-block-element"
           ${unsafeStatic(BLOCK_ID_ATTR)}=${model.id}
         ></${model.tag}>
       `;

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -108,6 +108,10 @@ export class DefaultPageBlockComponent
     .affine-default-page-block-title-container {
     }
     */
+
+    .affine-block-element {
+      display: block;
+    }
   `;
 
   @property()

--- a/packages/playground/examples/virgo/test-page.ts
+++ b/packages/playground/examples/virgo/test-page.ts
@@ -1,5 +1,6 @@
 import '@shoelace-style/shoelace';
 
+import { NonShadowLitElement } from '@blocksuite/blocks';
 import { type BaseTextAttributes, VEditor, VText } from '@blocksuite/virgo';
 import { css, html, LitElement } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
@@ -110,8 +111,8 @@ function toggleStyle(
   vEditor.setVRange(vRange);
 }
 
-@customElement('rich-text')
-export class RichText extends LitElement {
+@customElement('virgo-test-rich-text')
+export class RichText extends NonShadowLitElement {
   vEditor: VEditor;
 
   @query('.rich-text-container')
@@ -167,18 +168,14 @@ export class ToolBar extends LitElement {
   }
 
   protected firstUpdated(): void {
-    if (!this.shadowRoot) {
-      throw new Error('Cannot find shadow root');
-    }
-
-    const boldButton = this.shadowRoot.querySelector('.bold');
-    const italicButton = this.shadowRoot.querySelector('.italic');
-    const underlineButton = this.shadowRoot.querySelector('.underline');
-    const strikeButton = this.shadowRoot.querySelector('.strike');
-    const code = this.shadowRoot.querySelector('.code');
-    const resetButton = this.shadowRoot.querySelector('.reset');
-    const undoButton = this.shadowRoot.querySelector('.undo');
-    const redoButton = this.shadowRoot.querySelector('.redo');
+    const boldButton = this.querySelector('.bold');
+    const italicButton = this.querySelector('.italic');
+    const underlineButton = this.querySelector('.underline');
+    const strikeButton = this.querySelector('.strike');
+    const code = this.querySelector('.code');
+    const resetButton = this.querySelector('.reset');
+    const undoButton = this.querySelector('.undo');
+    const redoButton = this.querySelector('.redo');
 
     if (
       !boldButton ||
@@ -266,7 +263,7 @@ export class ToolBar extends LitElement {
 }
 
 @customElement('test-page')
-export class TestPage extends LitElement {
+export class TestPage extends NonShadowLitElement {
   static styles = css`
     .container {
       display: grid;
@@ -318,12 +315,12 @@ export class TestPage extends LitElement {
     const toolBarA = new ToolBar(editorA);
     const toolBarB = new ToolBar(editorB);
 
-    if (!this.shadowRoot) {
+    if (!this) {
       throw new Error('Cannot find shadow root');
     }
 
-    const docA = this.shadowRoot.querySelector('.doc-a');
-    const docB = this.shadowRoot.querySelector('.doc-b');
+    const docA = this.querySelector('.doc-a');
+    const docB = this.querySelector('.doc-b');
 
     if (!docA || !docB) {
       throw new Error('Cannot find doc');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -565,7 +565,7 @@ export async function getIndexCoordinate(
 }
 
 export function virgoEditorInnerTextToString(innerText: string): string {
-  return innerText.replace('\u200B', '');
+  return innerText.replace('\u200B', '').trim();
 }
 
 export async function focusTitle(page: Page) {


### PR DESCRIPTION
This PR fix a few Safari compatibility issues found in Safari test, mainly related to `prop:xywh` inconsistency when comparing yDoc json and make sure the virgo tests can work in Safari.