### PR TITLE
refactor(selection): keep setSelectedBlocks logic simple

### DIFF
--- a/packages/blocks/src/page-block/default/selection-manager/utils.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/utils.ts
@@ -5,13 +5,12 @@ import {
 import {
   type BlockComponentElement,
   contains,
-  getModelByElement,
   getRectByBlockElement,
   type IPoint,
 } from '@blocksuite/blocks/std';
 import type { Page, UserRange } from '@blocksuite/store';
 
-import type { PageSelectionState, PageSelectionType } from './index.js';
+import type { PageSelectionState } from './index.js';
 
 function intersects(a: DOMRect, b: DOMRect, offset: IPoint) {
   return (

--- a/packages/blocks/src/page-block/default/selection-manager/utils.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/utils.ts
@@ -102,11 +102,13 @@ export function updateLocalSelectionRange(page: Page) {
   }
 }
 
+/*
 function computeSelectionType(
   selectedBlocks: Element[],
   selectionType?: PageSelectionType
 ) {
   let newSelectionType: PageSelectionType = selectionType ?? 'native';
+
   const isOnlyBlock = selectedBlocks.length === 1;
   for (const block of selectedBlocks) {
     if (selectionType) continue;
@@ -133,16 +135,15 @@ function computeSelectionType(
   }
   return newSelectionType;
 }
+*/
 
 export function setSelectedBlocks(
   state: PageSelectionState,
   slots: DefaultSelectionSlots,
   selectedBlocks: BlockComponentElement[],
-  rects?: DOMRect[],
-  selectionType?: PageSelectionType
+  rects?: DOMRect[]
 ) {
   state.selectedBlocks = selectedBlocks;
-  state.type = selectionType ?? state.type;
 
   if (rects) {
     slots.selectedRectsUpdated.emit(rects);
@@ -154,7 +155,5 @@ export function setSelectedBlocks(
     calculatedRects.push(getRectByBlockElement(block));
   }
 
-  const newSelectionType = computeSelectionType(selectedBlocks, selectionType);
-  state.type = newSelectionType;
   slots.selectedRectsUpdated.emit(calculatedRects);
 }

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -519,9 +519,8 @@ export function createDragHandle(defaultPageBlock: DefaultPageBlockComponent) {
         model,
         distanceToTop < distanceToBottom
       );
-      const type = defaultPageBlock.selection.state.type;
       defaultPageBlock.selection.clear();
-      defaultPageBlock.selection.state.type = type;
+      defaultPageBlock.selection.state.type = 'block';
 
       defaultPageBlock.updateComplete.then(() => {
         // update selection rects


### PR DESCRIPTION
1. click a image, `selection.state.type` switch to `embed`
2. drag-and-drop image block, `selection.state.type` switch to `block`

The following methods are all for `block`:
https://github.com/toeverything/blocksuite/blob/9df30f433795a314367a271526c66b106b149d00/packages/blocks/src/page-block/default/selection-manager/utils.ts#L144-L148

I think we can set the state after the drag and drop to block first to avoid confusion.