### PR TITLE
feat: add support for block level key map

### DIFF
--- a/packages/blocks/src/__internal__/content-parser/index.ts
+++ b/packages/blocks/src/__internal__/content-parser/index.ts
@@ -1,4 +1,4 @@
-import type { BaseService, PageBlockModel } from '@blocksuite/blocks';
+import type { PageBlockModel } from '@blocksuite/blocks';
 import type { OpenBlockInfo } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
@@ -205,7 +205,7 @@ export class ContentParser {
       childText && children.push(childText);
     }
 
-    const service = (await getServiceOrRegister(model.flavour)) as BaseService;
+    const service = await getServiceOrRegister(model.flavour);
 
     return service.block2html(model, {
       childText: children.join(''),
@@ -230,7 +230,6 @@ export class ContentParser {
 
     const service = await getServiceOrRegister(model.flavour);
 
-    // @ts-ignore
     return service.block2Text(model, {
       childText: children.join(''),
       begin: selectedBlock.startPos,

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -1,32 +1,19 @@
 import { ALLOW_DEFAULT, PREVENT_DEFAULT } from '@blocksuite/global/config';
-import { assertExists, matchFlavours } from '@blocksuite/global/utils';
-import type { BaseBlockModel, Page } from '@blocksuite/store';
+import { matchFlavours } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
 import type { VRange } from '@blocksuite/virgo';
 
 import { showSlashMenu } from '../../components/slash-menu/index.js';
-import {
-  getCurrentNativeRange,
-  hasNativeSelection,
-  isCollapsedAtBlockStart,
-} from '../utils/index.js';
+import { getService } from '../service.js';
+import { getCurrentNativeRange, hasNativeSelection } from '../utils/index.js';
 import { createBracketAutoCompleteBindings } from './bracket-complete.js';
-import { markdownConvert, tryMatchSpaceHotkey } from './markdown-convert.js';
-import {
-  handleBlockEndEnter,
-  handleBlockSplit,
-  handleIndent,
-  handleKeyDown,
-  handleKeyUp,
-  handleLineStartBackspace,
-  handleSoftEnter,
-  handleUnindent,
-} from './rich-text-operations.js';
+import { handleIndent, handleUnindent } from './rich-text-operations.js';
 import type { AffineVEditor } from './virgo/types.js';
 
 // Type definitions is ported from quill
 // https://github.com/quilljs/quill/blob/6159f6480482dde0530920dc41033ebc6611a9e7/modules/keyboard.ts#L15-L46
 
-interface BindingContext {
+export interface BindingContext {
   collapsed: boolean;
   empty: boolean;
   offset: number;
@@ -36,7 +23,7 @@ interface BindingContext {
   event: KeyboardEvent;
 }
 
-type KeyboardBinding = {
+export type KeyboardBinding = {
   /**
    * See https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
    */
@@ -73,138 +60,11 @@ const IS_IOS =
   (/Mobile\/\w+/.test(navigator.userAgent) || navigator.maxTouchPoints > 2);
 const IS_MAC = /Mac/i.test(navigator.platform);
 
-// If a block is soft enterable, the rule is:
-// 1. In the end of block, first press Enter will insert a \n to break the line, second press Enter will insert a new block
-// 2. In the middle and start of block, press Enter will insert a \n to break the line
-// TODO this should be configurable per-block
-function isSoftEnterable(model: BaseBlockModel) {
-  if (matchFlavours(model, ['affine:code'] as const)) return true;
-  if (matchFlavours(model, ['affine:paragraph'] as const)) {
-    return model.type === 'quote';
-  }
-  return false;
-}
-
 export function createKeyboardBindings(
-  page: Page,
-  model: BaseBlockModel
+  model: BaseBlockModel,
+  vEditor: AffineVEditor
 ): KeyboardBindings {
-  function enterMarkdownMatch(
-    this: KeyboardEventThis,
-    range: VRange,
-    context: BindingContext
-  ) {
-    const { prefix } = context;
-    markdownConvert(this.vEditor, model, prefix);
-    return ALLOW_DEFAULT;
-  }
-
-  function spaceMarkdownMatch(
-    this: KeyboardEventThis,
-    range: VRange,
-    context: BindingContext
-  ) {
-    const { prefix } = context;
-    return markdownConvert(this.vEditor, model, prefix)
-      ? PREVENT_DEFAULT
-      : ALLOW_DEFAULT;
-  }
-
-  function hardEnter(
-    e: KeyboardEvent,
-    range: VRange,
-    /**
-     * @deprecated
-     */
-    vEditor: AffineVEditor,
-    shortKey = false
-  ) {
-    e.stopPropagation();
-    const parent = page.getParent(model);
-    const isLastChild = parent?.lastChild() === model;
-    const isEmptyList =
-      matchFlavours(model, ['affine:list'] as const) && model.text.length === 0;
-
-    assertExists(model.text, 'Failed to hardEnter! model.text not exists!');
-
-    if (
-      isEmptyList &&
-      parent &&
-      matchFlavours(parent, ['affine:frame'] as const) &&
-      model.children.length === 0
-    ) {
-      // TODO use `handleLineStartBackspace` directly is not concise enough,
-      // we should extract a function to handle this case
-      //
-      // Before
-      // - list
-      // - | <-- press Enter
-      //
-      // After
-      // - list
-      // |   <-- will replace with a new text block
-      handleLineStartBackspace(page, model);
-      return PREVENT_DEFAULT;
-    }
-    if (isEmptyList && isLastChild) {
-      // Before
-      // - line1
-      //   - ↩ <-- press Enter
-      //
-      // After
-      // - line1
-      // - | <-- will unindent the block
-      handleUnindent(page, model, range.index);
-      return PREVENT_DEFAULT;
-    }
-
-    const isEnd = model.text.length === range.index;
-    if (isEnd || shortKey) {
-      const softEnterable = isSoftEnterable(model);
-      const textStr = model.text.toString();
-      const endWithTwoBlankLines = textStr === '\n' || textStr.endsWith('\n');
-      const shouldSoftEnter = softEnterable && !endWithTwoBlankLines;
-
-      if (shouldSoftEnter) {
-        // TODO handle ctrl+enter in code/quote block or other force soft enter block
-        onSoftEnter(range, vEditor);
-        return PREVENT_DEFAULT;
-      }
-
-      // delete the \n at the end of block
-      if (softEnterable) {
-        // Before
-        // >
-        // > ↩ <-- press Enter
-        //
-        // After
-        // - line1
-        // - | <-- will unindent the block
-        model.text.delete(range.index - 1, 1);
-      }
-      handleBlockEndEnter(page, model);
-      return PREVENT_DEFAULT;
-    }
-
-    const isSoftEnterBlock = isSoftEnterable(model);
-    if (isSoftEnterBlock) {
-      onSoftEnter(range, vEditor);
-      return PREVENT_DEFAULT;
-    }
-
-    handleBlockSplit(page, model, range.index, range.length);
-    return PREVENT_DEFAULT;
-  }
-
-  function onSoftEnter(range: VRange, vEditor: AffineVEditor) {
-    handleSoftEnter(page, model, range.index, range.length);
-    vEditor.setVRange({
-      index: range.index + 1,
-      length: 0,
-    });
-    return PREVENT_DEFAULT;
-  }
-
+  const page = model.page;
   function onTab(this: KeyboardEventThis, e: KeyboardEvent, vRange: VRange) {
     if (matchFlavours(model, ['affine:code'] as const)) {
       e.stopPropagation();
@@ -273,165 +133,14 @@ export function createKeyboardBindings(
     return PREVENT_DEFAULT;
   }
 
-  function onKeyLeft(e: KeyboardEvent, range: VRange) {
-    // range.length === 0 means collapsed selection
-    if (range.length !== 0) {
-      e.stopPropagation();
-      return ALLOW_DEFAULT;
-    }
-    const lineStart = range.index === 0;
-    if (!lineStart) {
-      e.stopPropagation();
-      return ALLOW_DEFAULT;
-    }
-    // Need jump to previous block
-    return PREVENT_DEFAULT;
-  }
+  onTab;
+  onShiftTab;
 
-  function onKeyRight(e: KeyboardEvent, range: VRange) {
-    if (range.length !== 0) {
-      e.stopPropagation();
-      return ALLOW_DEFAULT;
-    }
-    assertExists(model.text, 'Failed to onKeyRight! model.text not exists!');
-    const textLength = model.text.length;
-    const lineEnd = textLength === range.index;
-    if (!lineEnd) {
-      e.stopPropagation();
-      return ALLOW_DEFAULT;
-    }
-    // Need jump to next block
-    return PREVENT_DEFAULT;
-  }
-
-  function onSpace(
-    this: KeyboardEventThis,
-    range: VRange,
-    context: BindingContext
-  ) {
-    const { vEditor } = this;
-    const { prefix } = context;
-    return tryMatchSpaceHotkey(page, model, vEditor, prefix, range);
-  }
-
-  function onBackspace(e: KeyboardEvent, vEditor: AffineVEditor) {
-    e.stopPropagation();
-    if (isCollapsedAtBlockStart(vEditor)) {
-      handleLineStartBackspace(page, model);
-      return PREVENT_DEFAULT;
-    }
-    return ALLOW_DEFAULT;
-  }
+  const service = getService(model.flavour);
+  const blockKeyBinding = service.defineKeymap(model, vEditor);
 
   const keyboardBindings: KeyboardBindings = {
-    // Note: Since quill's default handlers are added at initialization,
-    // the only way to prevent them is to add yours in the configuration.
-    // See https://quilljs.com/docs/modules/keyboard/#configuration
-    // The defaultOptions can found at https://github.com/quilljs/quill/blob/6159f6480482dde0530920dc41033ebc6611a9e7/modules/keyboard.ts#L334-L607
-    'code exit': {
-      key: 'Enter',
-      // override default behavior
-      handler: () => ALLOW_DEFAULT,
-    },
-    bold: {
-      key: 'b',
-      shortKey: true,
-      handler: () => ALLOW_DEFAULT,
-    },
-    italic: {
-      key: 'i',
-      shortKey: true,
-      handler: () => ALLOW_DEFAULT,
-    },
-    underline: {
-      key: 'u',
-      shortKey: true,
-      handler: () => ALLOW_DEFAULT,
-    },
-
-    enterMarkdownMatch: {
-      key: 'Enter',
-      handler: enterMarkdownMatch,
-    },
-    hardEnter: {
-      key: 'Enter',
-      handler(range, context) {
-        return hardEnter(context.event, range, this.vEditor);
-      },
-    },
-    softEnter: {
-      key: 'Enter',
-      shiftKey: true,
-      handler(range, context) {
-        return onSoftEnter(range, this.vEditor);
-      },
-    },
-    // shortKey+enter
-    insertLineAfter: {
-      key: 'Enter',
-      shortKey: true,
-      handler(range, context) {
-        return hardEnter(context.event, range, this.vEditor, true);
-      },
-    },
-    tab: {
-      key: 'Tab',
-      handler(range, context) {
-        return onTab.call(this, context.event, range);
-      },
-    },
-    shiftTab: {
-      key: 'Tab',
-      shiftKey: true,
-      handler(range, context) {
-        return onShiftTab.call(this, context.event, range);
-      },
-    },
-    spaceMarkdownMatch: {
-      key: ' ',
-      handler: spaceMarkdownMatch,
-    },
-    // https://github.com/quilljs/quill/blob/v1.3.7/modules/keyboard.js#L249-L282
-    'list autofill': {
-      key: ' ',
-      shiftKey: null,
-      prefix: /^(\d+\.|-|\*|\[ ?\]|\[x\]|(#){1,6}|(-){3}|(\*){3}|>)$/,
-      handler: onSpace,
-    },
-    backspace: {
-      key: 'Backspace',
-      handler(range, context) {
-        return onBackspace(context.event, this.vEditor);
-      },
-    },
-    up: {
-      key: 'ArrowUp',
-      shiftKey: false,
-      handler(range, context) {
-        return handleKeyUp(context.event, this.vEditor.rootElement);
-      },
-    },
-    down: {
-      key: 'ArrowDown',
-      shiftKey: false,
-      handler(range, context) {
-        return handleKeyDown(context.event, this.vEditor.rootElement);
-      },
-    },
-    left: {
-      key: 'ArrowLeft',
-      shiftKey: false,
-      handler(range, context) {
-        return onKeyLeft(context.event, range);
-      },
-    },
-    right: {
-      key: 'ArrowRight',
-      shiftKey: false,
-      handler(range, context) {
-        return onKeyRight(context.event, range);
-      },
-    },
+    ...blockKeyBinding,
 
     slash: {
       key: [
@@ -582,17 +291,15 @@ export function createKeyDownHandler(
       if (binding.suffix != null && !binding.suffix.test(curContext.suffix)) {
         return false;
       }
-      return (
-        binding.handler.call(
-          {
-            vEditor,
-            options: {
-              bindings,
-            },
+      return !binding.handler.call(
+        {
+          vEditor,
+          options: {
+            bindings,
           },
-          vRange,
-          curContext
-        ) !== true
+        },
+        vRange,
+        curContext
       );
     });
     if (prevented) {

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -65,10 +65,7 @@ export class RichText extends NonShadowLitElement {
       this._vEditor.setAttributesSchema(affineTextAttributes);
     }
 
-    const keyboardBindings = createKeyboardBindings(
-      this.model.page,
-      this.model
-    );
+    const keyboardBindings = createKeyboardBindings(this.model, this._vEditor);
     const keyDownHandler = createKeyDownHandler(
       this._vEditor,
       keyboardBindings

--- a/packages/blocks/src/__internal__/service.ts
+++ b/packages/blocks/src/__internal__/service.ts
@@ -1,9 +1,5 @@
-import {
-  type BlockService,
-  blockService,
-  type BlockServiceInstance,
-  type Flavour,
-} from '../models.js';
+import type { BlockServiceInstanceByKey } from '../models.js';
+import { type BlockService, blockService, type Flavour } from '../models.js';
 import { BaseService } from './service/index.js';
 
 const services = new Map<string, BaseService>();
@@ -40,17 +36,17 @@ export function registerService(
  */
 export function getService<Key extends Flavour>(
   flavour: Key
-): BlockServiceInstance[Key] {
+): BlockServiceInstanceByKey<Key> {
   const service = services.get(flavour);
   if (!service) {
     throw new Error(`cannot find service by flavour ${flavour}`);
   }
-  return service as BlockServiceInstance[Key];
+  return service as BlockServiceInstanceByKey<Key>;
 }
 
 export function getServiceOrRegister<Key extends Flavour>(
   flavour: Key
-): BlockServiceInstance[Key] | Promise<BlockServiceInstance[Key]> {
+): BlockServiceInstanceByKey<Key> | Promise<BlockServiceInstanceByKey<Key>> {
   const service = services.get(flavour);
   if (!service) {
     const Constructor =
@@ -58,11 +54,11 @@ export function getServiceOrRegister<Key extends Flavour>(
     const result = registerService(flavour, Constructor);
     if (result instanceof Promise) {
       return result.then(
-        () => services.get(flavour) as BlockServiceInstance[Key]
+        () => services.get(flavour) as BlockServiceInstanceByKey<Key>
       );
     } else {
-      return services.get(flavour) as BlockServiceInstance[Key];
+      return services.get(flavour) as BlockServiceInstanceByKey<Key>;
     }
   }
-  return service as BlockServiceInstance[Key];
+  return service as BlockServiceInstanceByKey<Key>;
 }

--- a/packages/blocks/src/__internal__/service/keymap.ts
+++ b/packages/blocks/src/__internal__/service/keymap.ts
@@ -1,0 +1,213 @@
+import { ALLOW_DEFAULT, PREVENT_DEFAULT } from '@blocksuite/global/config';
+import { assertExists, matchFlavours } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
+import type { VRange } from '@blocksuite/virgo';
+
+import type { BindingContext } from '../rich-text/keyboard.js';
+import {
+  markdownConvert,
+  tryMatchSpaceHotkey,
+} from '../rich-text/markdown-convert.js';
+import {
+  handleBlockEndEnter,
+  handleBlockSplit,
+  handleLineStartBackspace,
+  handleSoftEnter,
+  handleUnindent,
+} from '../rich-text/rich-text-operations.js';
+import type { AffineVEditor } from '../rich-text/virgo/types.js';
+import { isCollapsedAtBlockStart } from '../utils/index.js';
+
+export function onSoftEnter(
+  model: BaseBlockModel,
+  range: VRange,
+  vEditor: AffineVEditor
+) {
+  handleSoftEnter(model.page, model, range.index, range.length);
+  vEditor.setVRange({
+    index: range.index + 1,
+    length: 0,
+  });
+  return PREVENT_DEFAULT;
+}
+
+export function hardEnter(
+  model: BaseBlockModel,
+  range: VRange,
+  /**
+   * @deprecated
+   */
+  vEditor: AffineVEditor,
+  e: KeyboardEvent,
+  shortKey = false
+) {
+  const page = model.page;
+  e.stopPropagation();
+  const parent = page.getParent(model);
+  const isLastChild = parent?.lastChild() === model;
+  const isEmptyList =
+    matchFlavours(model, ['affine:list'] as const) && model.text.length === 0;
+
+  assertExists(model.text, 'Failed to hardEnter! model.text not exists!');
+
+  if (
+    isEmptyList &&
+    parent &&
+    matchFlavours(parent, ['affine:frame'] as const) &&
+    model.children.length === 0
+  ) {
+    // TODO use `handleLineStartBackspace` directly is not concise enough,
+    // we should extract a function to handle this case
+    //
+    // Before
+    // - list
+    // - | <-- press Enter
+    //
+    // After
+    // - list
+    // |   <-- will replace with a new text block
+    handleLineStartBackspace(page, model);
+    return PREVENT_DEFAULT;
+  }
+  if (isEmptyList && isLastChild) {
+    // Before
+    // - line1
+    //   - ↩ <-- press Enter
+    //
+    // After
+    // - line1
+    // - | <-- will unindent the block
+    handleUnindent(page, model, range.index);
+    return PREVENT_DEFAULT;
+  }
+
+  const isEnd = model.text.length === range.index;
+  if (isEnd || shortKey) {
+    const softEnterable = isSoftEnterable(model);
+    const textStr = model.text.toString();
+    const endWithTwoBlankLines = textStr === '\n' || textStr.endsWith('\n');
+    const shouldSoftEnter = softEnterable && !endWithTwoBlankLines;
+
+    if (shouldSoftEnter) {
+      // TODO handle ctrl+enter in code/quote block or other force soft enter block
+      onSoftEnter(model, range, vEditor);
+      return PREVENT_DEFAULT;
+    }
+
+    // delete the \n at the end of block
+    if (softEnterable) {
+      // Before
+      // >
+      // > ↩ <-- press Enter
+      //
+      // After
+      // - line1
+      // - | <-- will unindent the block
+      model.text.delete(range.index - 1, 1);
+    }
+    handleBlockEndEnter(page, model);
+    return PREVENT_DEFAULT;
+  }
+
+  const isSoftEnterBlock = isSoftEnterable(model);
+  if (isSoftEnterBlock) {
+    onSoftEnter(model, range, vEditor);
+    return PREVENT_DEFAULT;
+  }
+
+  handleBlockSplit(page, model, range.index, range.length);
+  return PREVENT_DEFAULT;
+}
+
+// If a block is soft enterable, the rule is:
+// 1. In the end of block, first press Enter will insert a \n to break the line, second press Enter will insert a new block
+// 2. In the middle and start of block, press Enter will insert a \n to break the line
+// TODO this should be configurable per-block
+function isSoftEnterable(model: BaseBlockModel) {
+  if (matchFlavours(model, ['affine:code'] as const)) return true;
+  if (matchFlavours(model, ['affine:paragraph'] as const)) {
+    return model.type === 'quote';
+  }
+  return false;
+}
+
+export function enterMarkdownMatch(
+  model: BaseBlockModel,
+  virgo: AffineVEditor,
+  range: VRange,
+  context: BindingContext
+) {
+  const { prefix } = context;
+  markdownConvert(virgo, model, prefix);
+  return ALLOW_DEFAULT;
+}
+
+export function spaceMarkdownMatch(
+  model: BaseBlockModel,
+  virgo: AffineVEditor,
+  range: VRange,
+  context: BindingContext
+) {
+  const { prefix } = context;
+  return markdownConvert(virgo, model, prefix)
+    ? PREVENT_DEFAULT
+    : ALLOW_DEFAULT;
+}
+
+export function onSpace(
+  model: BaseBlockModel,
+  virgo: AffineVEditor,
+  range: VRange,
+  context: BindingContext
+) {
+  const { prefix } = context;
+  return tryMatchSpaceHotkey(model.page, model, virgo, prefix, range);
+}
+
+export function onBackspace(
+  model: BaseBlockModel,
+  e: KeyboardEvent,
+  vEditor: AffineVEditor
+) {
+  e.stopPropagation();
+  if (isCollapsedAtBlockStart(vEditor)) {
+    handleLineStartBackspace(model.page, model);
+    return PREVENT_DEFAULT;
+  }
+  return ALLOW_DEFAULT;
+}
+
+export function onKeyLeft(e: KeyboardEvent, range: VRange) {
+  // range.length === 0 means collapsed selection
+  if (range.length !== 0) {
+    e.stopPropagation();
+    return ALLOW_DEFAULT;
+  }
+  const lineStart = range.index === 0;
+  if (!lineStart) {
+    e.stopPropagation();
+    return ALLOW_DEFAULT;
+  }
+  // Need jump to previous block
+  return PREVENT_DEFAULT;
+}
+
+export function onKeyRight(
+  model: BaseBlockModel,
+  e: KeyboardEvent,
+  range: VRange
+) {
+  if (range.length !== 0) {
+    e.stopPropagation();
+    return ALLOW_DEFAULT;
+  }
+  assertExists(model.text, 'Failed to onKeyRight! model.text not exists!');
+  const textLength = model.text.length;
+  const lineEnd = textLength === range.index;
+  if (!lineEnd) {
+    e.stopPropagation();
+    return ALLOW_DEFAULT;
+  }
+  // Need jump to next block
+  return PREVENT_DEFAULT;
+}

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -2,15 +2,20 @@ import type { ShapeType } from '@blocksuite/phasor';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import type { FrameBlockModel } from '../../frame-block/index.js';
-import type { BlockServiceInstance, ServiceFlavour } from '../../models.js';
+import type {
+  BlockServiceInstanceByKey,
+  ServiceFlavour,
+} from '../../models.js';
 import type { Clipboard } from '../clipboard/index.js';
 import type { AffineTextAttributes } from '../rich-text/virgo/types.js';
 import type { Point } from './rect.js';
 
 export type SelectionPosition = 'start' | 'end' | Point;
 
-export interface IService {
-  onLoad?: () => Promise<void>;
+export interface BlockTransformContext {
+  childText?: string;
+  begin?: number;
+  end?: number;
 }
 
 /** Common context interface definition for block models. */
@@ -21,7 +26,7 @@ export interface IService {
 export interface BlockHostContext {
   getService: <Key extends ServiceFlavour>(
     flavour: Key
-  ) => BlockServiceInstance[Key];
+  ) => BlockServiceInstanceByKey<Key>;
 }
 
 export interface BlockHost extends BlockHostContext {

--- a/packages/blocks/src/code-block/code-service.ts
+++ b/packages/blocks/src/code-block/code-service.ts
@@ -1,12 +1,18 @@
-import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
+import { BLOCK_ID_ATTR, PREVENT_DEFAULT } from '@blocksuite/global/config';
 import type { BaseBlockModel, DeltaOperation } from '@blocksuite/store';
 import { assertExists } from '@blocksuite/store';
 
+import type { KeyboardBindings } from '../__internal__/rich-text/keyboard.js';
+import type { AffineVEditor } from '../__internal__/rich-text/virgo/types.js';
 import { BaseService } from '../__internal__/service/index.js';
-import type { BlockRange, OpenBlockInfo } from '../__internal__/utils/index.js';
+import type {
+  BlockRange,
+  BlockTransformContext,
+  OpenBlockInfo,
+} from '../__internal__/utils/index.js';
 import type { CodeBlockModel } from './code-model.js';
 
-export class CodeBlockService extends BaseService {
+export class CodeBlockService extends BaseService<CodeBlockModel> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hljs: any;
   onLoad = async () => {
@@ -20,15 +26,7 @@ export class CodeBlockService extends BaseService {
 
   override block2html(
     block: CodeBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ): string {
     const codeElement = document.querySelector(
       `[${BLOCK_ID_ATTR}="${block.id}"] pre`
@@ -58,5 +56,76 @@ export class CodeBlockService extends BaseService {
       .map(op => op.insert)
       .join('');
     focusedBlockModel.text?.insert(text, range.startOffset);
+  }
+
+  override defineKeymap(
+    block: CodeBlockModel,
+    virgo: AffineVEditor
+  ): KeyboardBindings {
+    const keymap = super.defineKeymap(block, virgo);
+
+    return {
+      ...keymap,
+      tab: {
+        key: 'Tab',
+        handler(range, context) {
+          context.event.stopPropagation();
+
+          const lastLineBreakBeforeCursor = this.vEditor.yText
+            .toString()
+            .lastIndexOf('\n', range.index - 1);
+
+          const lineStart =
+            lastLineBreakBeforeCursor !== -1
+              ? lastLineBreakBeforeCursor + 1
+              : 0;
+          this.vEditor.insertText(
+            {
+              index: lineStart,
+              length: 0,
+            },
+            '  '
+          );
+          this.vEditor.setVRange({
+            index: range.index + 2,
+            length: 0,
+          });
+
+          return PREVENT_DEFAULT;
+        },
+      },
+      shiftTab: {
+        key: 'Tab',
+        shiftKey: true,
+        handler(range, context) {
+          context.event.stopPropagation();
+
+          const lastLineBreakBeforeCursor = this.vEditor.yText
+            .toString()
+            .lastIndexOf('\n', range.index - 1);
+
+          const lineStart =
+            lastLineBreakBeforeCursor !== -1
+              ? lastLineBreakBeforeCursor + 1
+              : 0;
+          if (
+            this.vEditor.yText.length >= 2 &&
+            this.vEditor.yText.toString().slice(lineStart, lineStart + 2) ===
+              '  '
+          ) {
+            this.vEditor.deleteText({
+              index: lineStart,
+              length: 2,
+            });
+            this.vEditor.setVRange({
+              index: range.index - 2,
+              length: 0,
+            });
+          }
+
+          return PREVENT_DEFAULT;
+        },
+      },
+    };
   }
 }

--- a/packages/blocks/src/divider-block/divider-service.ts
+++ b/packages/blocks/src/divider-block/divider-service.ts
@@ -1,18 +1,11 @@
+import type { BlockTransformContext } from '../__internal__/index.js';
 import { BaseService } from '../__internal__/service/index.js';
 import type { DividerBlockModel } from './divider-model.js';
 
-export class DividerBlockService extends BaseService {
+export class DividerBlockService extends BaseService<DividerBlockModel> {
   override block2html(
     block: DividerBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ): string {
     return `<hr/>`;
   }

--- a/packages/blocks/src/embed-block/embed-service.ts
+++ b/packages/blocks/src/embed-block/embed-service.ts
@@ -1,29 +1,20 @@
 import { BaseService } from '../__internal__/service/index.js';
-import type { OpenBlockInfo } from '../__internal__/utils/index.js';
+import type {
+  BlockTransformContext,
+  OpenBlockInfo,
+} from '../__internal__/utils/index.js';
 import type { EmbedBlockModel } from './embed-model.js';
-export class EmbedBlockService extends BaseService {
+export class EmbedBlockService extends BaseService<EmbedBlockModel> {
   override block2html(
     block: EmbedBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     return `<figure><img src="${block.sourceId}" alt="${block.caption}"><figcaption>${block.caption}</figcaption></figure>`;
   }
 
   override block2Text(
     block: EmbedBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: { childText?: string; begin?: number; end?: number } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ): string {
     return block.caption;
   }

--- a/packages/blocks/src/frame-block/frame-service.ts
+++ b/packages/blocks/src/frame-block/frame-service.ts
@@ -3,7 +3,8 @@ import type { BaseBlockModel } from '@blocksuite/store';
 import { BaseService } from '../__internal__/service/index.js';
 import { addBlocks } from '../__internal__/service/json2block.js';
 import type { OpenBlockInfo } from '../__internal__/utils/index.js';
-export class FrameBlockService extends BaseService {
+import type { FrameBlockModel } from './frame-model.js';
+export class FrameBlockService extends BaseService<FrameBlockModel> {
   async json2Block(
     focusedBlockModel: BaseBlockModel,
     pastedBlocks: OpenBlockInfo[]

--- a/packages/blocks/src/list-block/list-service.ts
+++ b/packages/blocks/src/list-block/list-service.ts
@@ -1,18 +1,11 @@
+import type { BlockTransformContext } from '../__internal__/index.js';
 import { BaseService } from '../__internal__/service/index.js';
 import type { ListBlockModel } from './list-model.js';
 
-export class ListBlockService extends BaseService {
+export class ListBlockService extends BaseService<ListBlockModel> {
   override block2html(
     block: ListBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     let text = super.block2html(block, {
       childText,

--- a/packages/blocks/src/models.ts
+++ b/packages/blocks/src/models.ts
@@ -1,5 +1,6 @@
 /// <reference types="@blocksuite/global" />
 // Import models only, the bundled file should not include anything else.
+import type { UnionToIntersection } from '@blocksuite/global/types';
 import type { BlockSchema } from '@blocksuite/store';
 import type { z } from 'zod';
 
@@ -97,3 +98,6 @@ export type BlockServiceInstance = {
       : never
     : InstanceType<typeof BaseService>;
 };
+
+export type BlockServiceInstanceByKey<Key extends Flavour> =
+  UnionToIntersection<BlockServiceInstance[Key]>;

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -3,36 +3,23 @@ import { assertExists } from '@blocksuite/store';
 
 import { getService } from '../__internal__/service.js';
 import { BaseService } from '../__internal__/service/index.js';
-import type { OpenBlockInfo } from '../__internal__/utils/index.js';
+import type {
+  BlockTransformContext,
+  OpenBlockInfo,
+} from '../__internal__/utils/index.js';
 import type { PageBlockModel } from './page-model.js';
 
-export class PageBlockService extends BaseService {
+export class PageBlockService extends BaseService<PageBlockModel> {
   override block2html(
     block: PageBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     return `<div>${block.title.toString()}${childText}</div>`;
   }
 
   override block2Text(
     block: PageBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     const text = (block.title.toString() || '').slice(begin || 0, end);
     return `${text}${childText}`;

--- a/packages/blocks/src/paragraph-block/paragraph-service.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-service.ts
@@ -1,18 +1,11 @@
+import type { BlockTransformContext } from '../__internal__/index.js';
 import { BaseService } from '../__internal__/service/index.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
-export class ParagraphBlockService extends BaseService {
+export class ParagraphBlockService extends BaseService<ParagraphBlockModel> {
   block2html(
     model: ParagraphBlockModel,
-    {
-      childText = '',
-      begin,
-      end,
-    }: {
-      childText?: string;
-      begin?: number;
-      end?: number;
-    } = {}
+    { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     const text = super.block2html(model, {
       childText,

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -4,7 +4,9 @@ export * from './consts/block-hub.js';
 export const BLOCK_ID_ATTR = 'data-block-id';
 export const BLOCK_SERVICE_LOADING_ATTR = 'data-service-loading';
 export const PREVENT_DEFAULT = false;
+export type PREVENT_DEFAULT = typeof PREVENT_DEFAULT;
 export const ALLOW_DEFAULT = true;
+export type ALLOW_DEFAULT = typeof ALLOW_DEFAULT;
 
 export const HOTKEYS = {
   UNDO: 'command+z,ctrl+z',

--- a/packages/global/src/types.ts
+++ b/packages/global/src/types.ts
@@ -49,3 +49,9 @@ export type BlockModels = {
 export type BlockModelProps = {
   [K in keyof BlockSchemas]: ReturnType<BlockSchemas[K]['model']['props']>;
 };
+
+export type UnionToIntersection<T> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (T extends any ? (x: T) => any : never) extends (x: infer R) => any
+    ? R
+    : never;

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -21,8 +21,8 @@ export const SHORT_KEY = IS_MAC ? 'Meta' : 'Control';
  */
 export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
-export async function type(page: Page, content: string) {
-  await page.keyboard.type(content, { delay: 50 });
+export async function type(page: Page, content: string, delay = 50) {
+  await page.keyboard.type(content, { delay });
 }
 
 export async function withPressKey(


### PR DESCRIPTION
# Motivation
Currently, we handle key map all in one file. However, when we have more and more blocks, they have some custom behavior of key map. For example, for code block, the `Tab` and `Shift+Tab` won't be split the whole block. They should indent or unindent the text in block.

# Solution
Since we already have block level services which can provide methods for blocks. Why don't we just move key map into the services? A block can define it's own key map to override the default block level key map or add new key map.

```ts
class CodeBlockService extends BaseService {
  override defineKeymap(block, virgo) {
    const defaultKeymap = super.defineKeymap(block, virgo);
    return {
      ...defaultKeymap,
      ...myOverrideKeymap,
    }
  }
}
```