### PR TITLE
fix: dbclick format bar should not hide

### DIFF
--- a/packages/blocks/src/__internal__/utils/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture.ts
@@ -81,6 +81,9 @@ function shouldFilterMouseEvent(event: Event): boolean {
   if (target.tagName === 'INPUT') {
     return true;
   }
+  if (target.tagName === 'FORMAT-QUICK-BAR') {
+    return true;
+  }
   return false;
 }
 

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -1007,3 +1007,16 @@ test('should format bar style active correctly', async ({ page }) => {
   await expect(boldBtn).toHaveAttribute('active', '');
   await expect(codeBtn).not.toHaveAttribute('active', '');
 });
+
+test('should format quick bar show when double click button', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await dragBetweenIndices(page, [0, 0], [2, 3]);
+  const { formatQuickBar, boldBtn } = getFormatBar(page);
+  await expect(formatQuickBar).toBeVisible();
+  await boldBtn.dblclick();
+  await expect(formatQuickBar).toBeVisible();
+});


### PR DESCRIPTION
Double click format button should not hide format bar (Blame to https://github.com/toeverything/blocksuite/pull/1530)

Co-authored-by: Mirone <Saul-Mirone@outlook.com>