### PR TITLE
refactor(editor): move content parser out of editor lifecycle

### DIFF
--- a/packages/blocks/content-parser.d.ts
+++ b/packages/blocks/content-parser.d.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+// @ts-ignore
+export * from './dist/content-parser';

--- a/packages/blocks/content-parser.js
+++ b/packages/blocks/content-parser.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+/// <reference types="./dist/content-parser.d.ts" />
+export * from './dist/content-parser';

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -34,7 +34,8 @@
     "./dist/*": "./dist/*",
     ".": "./src/index.ts",
     "./std": "./src/std.ts",
-    "./models": "./src/models.ts"
+    "./models": "./src/models.ts",
+    "./content-parser": "./src/content-parser.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -54,6 +55,10 @@
       "./models": {
         "types": "./dist/models.d.ts",
         "default": "./dist/models.js"
+      },
+      "./content-parser": {
+        "types": "./dist/content-parser.d.ts",
+        "default": "./dist/content-parser.js"
       }
     }
   },

--- a/packages/blocks/src/__internal__/content-parser/index.ts
+++ b/packages/blocks/src/__internal__/content-parser/index.ts
@@ -6,7 +6,7 @@ import { Slot } from '@blocksuite/store';
 import { marked } from 'marked';
 
 import { getFileFromClipboard } from '../clipboard/utils.js';
-import { getService, getServiceOrRegister } from '../service.js';
+import { getServiceOrRegister } from '../service.js';
 import { FileExporter } from './file-exporter/file-exporter.js';
 import { HtmlParser } from './parse-html.js';
 import type { SelectedBlock } from './types.js';
@@ -155,7 +155,7 @@ export class ContentParser {
     const insertBlockModel = this._page.getBlockById(insertPositionId);
 
     assertExists(insertBlockModel);
-    const service = getService(insertBlockModel.flavour);
+    const service = await getServiceOrRegister(insertBlockModel.flavour);
 
     service.json2Block(insertBlockModel, blocks);
   }

--- a/packages/blocks/src/content-parser.ts
+++ b/packages/blocks/src/content-parser.ts
@@ -1,0 +1,1 @@
+export { ContentParser } from './__internal__/content-parser/index.js';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -13,7 +13,6 @@ import './surface-block/index.js';
 import './components/slash-menu/index.js';
 import './database-block/index.js';
 
-export * from './__internal__/content-parser/index.js';
 export * from './__internal__/rich-text/rich-text-operations.js';
 export { getServiceOrRegister } from './__internal__/service.js';
 export type { BaseService } from './__internal__/service/index.js';

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -5,14 +5,13 @@ import {
   type PageBlockModel,
 } from '@blocksuite/blocks';
 import {
-  ContentParser,
   NonShadowLitElement,
   type SurfaceBlockModel,
 } from '@blocksuite/blocks';
 import type { Page } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { html } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 
 import { checkEditorElementActive, createBlockHub } from '../utils/editor.js';
@@ -33,8 +32,6 @@ export class EditorContainer extends NonShadowLitElement {
   @state()
   private showGrid = false;
 
-  contentParser!: ContentParser;
-
   get model() {
     return [this.page.root, this.page.surface] as [
       PageBlockModel | null,
@@ -52,24 +49,14 @@ export class EditorContainer extends NonShadowLitElement {
       : null;
   }
 
-  @query('.affine-block-placeholder-input')
-  private _placeholderInput!: HTMLInputElement;
-
   private _disposables = new DisposableGroup();
 
-  override firstUpdated() {
+  firstUpdated() {
     // todo: refactor to a better solution
     getServiceOrRegister('affine:code');
   }
 
-  protected update(changedProperties: Map<string, unknown>) {
-    super.update(changedProperties);
-    if (changedProperties.has('page')) {
-      this.contentParser = new ContentParser(this.page);
-    }
-  }
-
-  override connectedCallback() {
+  connectedCallback() {
     super.connectedCallback();
 
     // Question: Why do we prevent this?
@@ -133,11 +120,9 @@ export class EditorContainer extends NonShadowLitElement {
         }
       })
     );
-
-    this._placeholderInput?.focus();
   }
 
-  public async createBlockHub() {
+  async createBlockHub() {
     await this.updateComplete;
     if (!this.page.root) {
       await new Promise(res => this.page.slots.rootAdded.once(res));
@@ -145,7 +130,7 @@ export class EditorContainer extends NonShadowLitElement {
     return createBlockHub(this, this.page);
   }
 
-  override disconnectedCallback() {
+  disconnectedCallback() {
     super.disconnectedCallback();
     this.page.awarenessStore.setLocalRange(this.page, null);
     this._disposables.dispose();

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -12,13 +12,13 @@ import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/color-picker/color-picker.js';
 
-import type { ContentParser } from '@blocksuite/blocks';
 import {
   createEvent,
   getCurrentBlockRange,
   NonShadowLitElement,
   updateBlockType,
 } from '@blocksuite/blocks';
+import type { ContentParser } from '@blocksuite/blocks/content-parser';
 import type { EditorContainer } from '@blocksuite/editor';
 import {
   CSSColorProperties,

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -12,6 +12,7 @@ import '@shoelace-style/shoelace/dist/components/icon-button/icon-button.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/color-picker/color-picker.js';
 
+import type { ContentParser } from '@blocksuite/blocks';
 import {
   createEvent,
   getCurrentBlockRange,
@@ -57,6 +58,9 @@ export class DebugMenu extends NonShadowLitElement {
   @property()
   editor!: EditorContainer;
 
+  @property()
+  contentParser!: ContentParser;
+
   @state()
   private _connected = true;
 
@@ -86,10 +90,6 @@ export class DebugMenu extends NonShadowLitElement {
 
   get page() {
     return this.editor.page;
-  }
-
-  get contentParser() {
-    return this.editor.contentParser;
   }
 
   createRenderRoot() {

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -111,7 +111,7 @@ export const preset: InitFn = (workspace: Workspace) => {
       // Add frame block inside page block
       const frameId = page.addBlockByFlavour('affine:frame', {}, pageBlockId);
       // Import preset markdown content inside frame block
-      await window.editor.contentParser.importMarkdown(presetMarkdown, frameId);
+      await window.contentParser.importMarkdown(presetMarkdown, frameId);
 
       addShapeElement(page, {
         id: '0',

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -111,7 +111,8 @@ export const preset: InitFn = (workspace: Workspace) => {
       // Add frame block inside page block
       const frameId = page.addBlockByFlavour('affine:frame', {}, pageBlockId);
       // Import preset markdown content inside frame block
-      await window.contentParser.importMarkdown(presetMarkdown, frameId);
+      const contentParser = new window.ContentParser(page);
+      contentParser.importMarkdown(presetMarkdown, frameId);
 
       addShapeElement(page, {
         id: '0',

--- a/packages/playground/src/env.d.ts
+++ b/packages/playground/src/env.d.ts
@@ -9,7 +9,7 @@ declare global {
     page: Page;
     workspace: Workspace;
     blockSchemas: z.infer<typeof BlockSchema>[];
-    contentParser: ContentParser;
+    ContentParser: typeof ContentParser;
     Y: typeof Workspace.Y;
     std: typeof std;
   }

--- a/packages/playground/src/env.d.ts
+++ b/packages/playground/src/env.d.ts
@@ -1,3 +1,4 @@
+import type { ContentParser } from '@blocksuite/blocks';
 import type { EditorContainer } from '@blocksuite/editor';
 import type { BlockSchema, Page, Workspace } from '@blocksuite/store';
 import type { z } from 'zod';
@@ -8,6 +9,7 @@ declare global {
     page: Page;
     workspace: Workspace;
     blockSchemas: z.infer<typeof BlockSchema>[];
+    contentParser: ContentParser;
     Y: typeof Workspace.Y;
     std: typeof std;
   }

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -5,7 +5,7 @@ import './components/start-panel';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import '@blocksuite/editor/themes/affine.css';
 
-import { ContentParser } from '@blocksuite/blocks';
+import { ContentParser } from '@blocksuite/blocks/content-parser';
 import { __unstableSchemas, builtInSchemas } from '@blocksuite/blocks/models';
 import std from '@blocksuite/blocks/std';
 import { EditorContainer } from '@blocksuite/editor';

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -47,6 +47,7 @@ function subscribePage(workspace: Workspace) {
     debugMenu.workspace = workspace;
     debugMenu.editor = editor;
     debugMenu.mode = defaultMode;
+    debugMenu.contentParser = contentParser;
     document.body.appendChild(debugMenu);
     editor.createBlockHub().then(blockHub => {
       document.body.appendChild(blockHub);

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -55,7 +55,6 @@ function subscribePage(workspace: Workspace) {
 
     window.editor = editor;
     window.page = page;
-    window.contentParser = contentParser;
   });
 }
 
@@ -88,8 +87,12 @@ async function main() {
   const workspace = new Workspace(options)
     .register(builtInSchemas)
     .register(__unstableSchemas);
-  [window.workspace, window.blockSchemas] = [workspace, builtInSchemas];
-  [window.Y, window.std] = [Workspace.Y, std];
+
+  window.workspace = workspace;
+  window.blockSchemas = builtInSchemas;
+  window.Y = Workspace.Y;
+  window.std = std;
+  window.ContentParser = ContentParser;
 
   workspace.connect();
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -5,6 +5,7 @@ import './components/start-panel';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import '@blocksuite/editor/themes/affine.css';
 
+import { ContentParser } from '@blocksuite/blocks';
 import { __unstableSchemas, builtInSchemas } from '@blocksuite/blocks/models';
 import std from '@blocksuite/blocks/std';
 import { EditorContainer } from '@blocksuite/editor';
@@ -27,7 +28,7 @@ initDebugConfig();
 
 // Subscribe for page update and create editor after page loaded.
 function subscribePage(workspace: Workspace) {
-  const dispose = workspace.slots.pageAdded.on(pageId => {
+  workspace.slots.pageAdded.once(pageId => {
     if (typeof globalThis.targetPageId === 'string') {
       if (pageId !== globalThis.targetPageId) {
         // if there's `targetPageId` which not same as the `pageId`
@@ -41,6 +42,7 @@ function subscribePage(workspace: Workspace) {
 
     document.getElementById('app')?.append(editor);
 
+    const contentParser = new ContentParser(page);
     const debugMenu = new DebugMenu();
     debugMenu.workspace = workspace;
     debugMenu.editor = editor;
@@ -50,8 +52,9 @@ function subscribePage(workspace: Workspace) {
       document.body.appendChild(blockHub);
     });
 
-    [window.editor, window.page] = [editor, page];
-    dispose.dispose();
+    window.editor = editor;
+    window.page = page;
+    window.contentParser = contentParser;
   });
 }
 

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -101,7 +101,8 @@ async function initWithMarkdownContent(workspace: Workspace, url: URL) {
   assertExists(page);
   assertExists(page.root);
   const content = await fetch(url).then(res => res.text());
-  return window.contentParser.importMarkdown(content, page.root.id);
+  const contentParser = new window.ContentParser(page);
+  return contentParser.importMarkdown(content, page.root.id);
 }
 
 export async function tryInitExternalContent(

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -101,7 +101,7 @@ async function initWithMarkdownContent(workspace: Workspace, url: URL) {
   assertExists(page);
   assertExists(page.root);
   const content = await fetch(url).then(res => res.text());
-  return window.editor.contentParser.importMarkdown(content, page.root.id);
+  return window.contentParser.importMarkdown(content, page.root.id);
 }
 
 export async function tryInitExternalContent(

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -11,8 +11,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
     "noEmit": true,
     "jsx": "react-jsx",
     "experimentalDecorators": true

--- a/packages/react/examples/next/next.config.js
+++ b/packages/react/examples/next/next.config.js
@@ -20,6 +20,13 @@ const nextConfig = {
     config.resolve.alias = {
       ...config.resolve.alias,
       '@blocksuite/editor': path.resolve(baseDir, 'packages', 'editor'),
+      '@blocksuite/blocks/content-parser': path.resolve(
+        baseDir,
+        'packages',
+        'blocks',
+        'src',
+        'content-parser'
+      ),
       '@blocksuite/blocks/models': path.resolve(
         baseDir,
         'packages',

--- a/packages/react/examples/next/src/components/PageManger.tsx
+++ b/packages/react/examples/next/src/components/PageManger.tsx
@@ -1,3 +1,4 @@
+import { ContentParser } from '@blocksuite/blocks';
 import { type EditorProps, useBlockSuiteStore } from '@blocksuite/react';
 import { Button, Card, Grid, Text } from '@nextui-org/react';
 import dynamic from 'next/dynamic';
@@ -107,7 +108,8 @@ export const PageManger = () => {
               pageBlockId
             );
             // Import preset markdown content inside frame block
-            await editor.contentParser.importMarkdown(presetMarkdown, frameId);
+            const contentParser = new ContentParser(page);
+            await contentParser.importMarkdown(presetMarkdown, frameId);
             page.resetHistory();
           }}
         />

--- a/packages/react/examples/next/src/components/PageManger.tsx
+++ b/packages/react/examples/next/src/components/PageManger.tsx
@@ -1,4 +1,4 @@
-import { ContentParser } from '@blocksuite/blocks';
+import { ContentParser } from '@blocksuite/blocks/content-parser';
 import { type EditorProps, useBlockSuiteStore } from '@blocksuite/react';
 import { Button, Card, Grid, Text } from '@nextui-org/react';
 import dynamic from 'next/dynamic';

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -418,7 +418,8 @@ export async function importMarkdown(
 ) {
   await page.evaluate(
     ({ data, focusedBlockId }) => {
-      window.contentParser.importMarkdown(data, focusedBlockId);
+      const contentParser = new window.ContentParser(window.page);
+      contentParser.importMarkdown(data, focusedBlockId);
     },
     { data, focusedBlockId }
   );

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -418,9 +418,7 @@ export async function importMarkdown(
 ) {
   await page.evaluate(
     ({ data, focusedBlockId }) => {
-      document
-        .getElementsByTagName('editor-container')[0]
-        .contentParser.importMarkdown(data, focusedBlockId);
+      window.contentParser.importMarkdown(data, focusedBlockId);
     },
     { data, focusedBlockId }
   );

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -21,7 +21,7 @@ declare global {
       editor: typeof import('../../packages/editor/src/index.js');
     };
     workspace: Workspace;
-    contentParser: ContentParser;
+    ContentParser: typeof ContentParser;
     blockSchema: Record<string, typeof BaseBlockModel>;
     page: Page;
     debugMenu: DebugMenu;

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import type { EditorContainer } from '../../packages/editor/src/components/editor-container.js';
+import type { ContentParser } from '../../packages/blocks/src/index.js';
+import type { EditorContainer } from '../../packages/editor/src/index.js';
 import type {} from '../../packages/playground/src/components/debug-menu.js';
 import type { DebugMenu } from '../../packages/playground/src/components/debug-menu.js';
 import type {
@@ -20,6 +21,7 @@ declare global {
       editor: typeof import('../../packages/editor/src/index.js');
     };
     workspace: Workspace;
+    contentParser: ContentParser;
     blockSchema: Record<string, typeof BaseBlockModel>;
     page: Page;
     debugMenu: DebugMenu;

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import type { ContentParser } from '../../packages/blocks/src/index.js';
+import type { ContentParser } from '../../packages/blocks/src/content-parser.js';
 import type { EditorContainer } from '../../packages/editor/src/index.js';
 import type {} from '../../packages/playground/src/components/debug-menu.js';
 import type { DebugMenu } from '../../packages/playground/src/components/debug-menu.js';


### PR DESCRIPTION
Fixes #1742 since we can `new ContentParser(page)` when we have a new page, no need to wait for the editor instance

/cc @Himself65 @QiShaoXuan 