### PR TITLE
refactor: migrate nativeKeydown to hotkey

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -7,7 +7,6 @@ import { showSlashMenu } from '../../components/slash-menu/index.js';
 import { getService } from '../service.js';
 import { getCurrentNativeRange, hasNativeSelection } from '../utils/index.js';
 import { createBracketAutoCompleteBindings } from './bracket-complete.js';
-import { handleIndent, handleUnindent } from './rich-text-operations.js';
 import type { AffineVEditor } from './virgo/types.js';
 
 // Type definitions is ported from quill
@@ -65,76 +64,6 @@ export function createKeyboardBindings(
   vEditor: AffineVEditor
 ): KeyboardBindings {
   const page = model.page;
-  function onTab(this: KeyboardEventThis, e: KeyboardEvent, vRange: VRange) {
-    if (matchFlavours(model, ['affine:code'] as const)) {
-      e.stopPropagation();
-
-      const lastLineBreakBeforeCursor = this.vEditor.yText
-        .toString()
-        .lastIndexOf('\n', vRange.index - 1);
-
-      const lineStart =
-        lastLineBreakBeforeCursor !== -1 ? lastLineBreakBeforeCursor + 1 : 0;
-      this.vEditor.insertText(
-        {
-          index: lineStart,
-          length: 0,
-        },
-        '  '
-      );
-      this.vEditor.setVRange({
-        index: vRange.index + 2,
-        length: 0,
-      });
-
-      return PREVENT_DEFAULT;
-    }
-
-    const index = vRange.index;
-    handleIndent(page, model, index);
-    e.stopPropagation();
-    return PREVENT_DEFAULT;
-  }
-
-  function onShiftTab(
-    this: KeyboardEventThis,
-    e: KeyboardEvent,
-    vRange: VRange
-  ) {
-    if (matchFlavours(model, ['affine:code'] as const)) {
-      e.stopPropagation();
-
-      const lastLineBreakBeforeCursor = this.vEditor.yText
-        .toString()
-        .lastIndexOf('\n', vRange.index - 1);
-
-      const lineStart =
-        lastLineBreakBeforeCursor !== -1 ? lastLineBreakBeforeCursor + 1 : 0;
-      if (
-        this.vEditor.yText.length >= 2 &&
-        this.vEditor.yText.toString().slice(lineStart, lineStart + 2) === '  '
-      ) {
-        this.vEditor.deleteText({
-          index: lineStart,
-          length: 2,
-        });
-        this.vEditor.setVRange({
-          index: vRange.index - 2,
-          length: 0,
-        });
-      }
-
-      return PREVENT_DEFAULT;
-    }
-
-    const index = vRange.index;
-    handleUnindent(page, model, index);
-    e.stopPropagation();
-    return PREVENT_DEFAULT;
-  }
-
-  onTab;
-  onShiftTab;
 
   const service = getService(model.flavour);
   const blockKeyBinding = service.defineKeymap(model, vEditor);

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -206,3 +206,11 @@ export function maxBy<T>(items: T[], value: (item: T) => number): T | null {
 
   return maxItem;
 }
+
+export function isControlledKeyboardEvent(e: KeyboardEvent) {
+  return e.ctrlKey || e.metaKey || e.altKey;
+}
+
+export function isPrintableKeyEvent(event: KeyboardEvent): boolean {
+  return event.key.length === 1 && !isControlledKeyboardEvent(event);
+}

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -4,7 +4,11 @@ import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { getRichTextByModel } from '../../__internal__/utils/index.js';
+import {
+  getRichTextByModel,
+  isControlledKeyboardEvent,
+  isPrintableKeyEvent,
+} from '../../__internal__/utils/index.js';
 import { menuGroups, type SlashItem } from './config.js';
 import { styles } from './styles.js';
 
@@ -126,7 +130,13 @@ export class SlashMenu extends LitElement {
       this._hide = false;
       return;
     }
-    if (e.key === ' ' || e.key === 'Escape') {
+    if (
+      // Abort when press modifier key to avoid weird behavior
+      // e.g. press ctrl + a to select all or press ctrl + v to paste
+      isControlledKeyboardEvent(e) ||
+      e.key === ' ' ||
+      e.key === 'Escape'
+    ) {
       this.abortController.abort();
       return;
     }
@@ -139,7 +149,7 @@ export class SlashMenu extends LitElement {
       return;
     }
     // Assume input a character, append it to the search string
-    if (e.key.length === 1) {
+    if (isPrintableKeyEvent(e)) {
       this._searchString += e.key;
       this._filterItems = this._updateItem();
       if (!this._filterItems.length) {

--- a/packages/blocks/src/page-block/default/utils.ts
+++ b/packages/blocks/src/page-block/default/utils.ts
@@ -468,10 +468,6 @@ async function getUrlByModel(model: BaseBlockModel) {
   return url;
 }
 
-export function isControlledKeyboardEvent(e: KeyboardEvent) {
-  return e.ctrlKey || e.metaKey || e.shiftKey;
-}
-
 export function copyCode(codeBlockModel: CodeBlockModel) {
   copy({
     type: 'Block',

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -7,9 +7,13 @@ import {
 import type { Page } from '@blocksuite/store';
 
 import {
+  blockRangeToNativeRange,
   focusBlockByModel,
+  getVirgoByModel,
   hotkey,
+  isMultiBlockRange,
   isPageMode,
+  isPrintableKeyEvent,
 } from '../../__internal__/index.js';
 import { handleMultiBlockIndent } from '../../__internal__/rich-text/rich-text-operations.js';
 import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
@@ -72,6 +76,44 @@ export function bindCommonHotkey(page: Page) {
     page.redo();
   });
 
+  // Fixes: https://github.com/toeverything/blocksuite/issues/200
+  // We shouldn't prevent user input, because there could have CN/JP/KR... input,
+  // that have pop-up for selecting local characters.
+  // So we could just hook on the keydown event and detect whether user input a new character.
+  hotkey.addListener(HOTKEYS.ANY_KEY, e => {
+    if (!isPrintableKeyEvent(e) || page.readonly) return;
+    const blockRange = getCurrentBlockRange(page);
+    if (!blockRange || blockRange.type === 'Block') return;
+
+    const range = blockRangeToNativeRange(blockRange);
+    if (!range || !isMultiBlockRange(range)) return;
+    deleteModelsByRange(page);
+
+    // handle user input
+    if (
+      !blockRange ||
+      blockRange.models.length === 0 ||
+      blockRange.type !== 'Native'
+    ) {
+      return;
+    }
+    const startBlock = blockRange.models[0];
+    const vEditor = getVirgoByModel(startBlock);
+    if (vEditor) {
+      vEditor.insertText(
+        {
+          index: blockRange.startOffset,
+          length: 0,
+        },
+        e.key
+      );
+      vEditor.setVRange({
+        index: blockRange.startOffset + 1,
+        length: 0,
+      });
+    }
+  });
+
   // !!!
   // Don't forget to remove hotkeys at `removeCommonHotKey`
 }
@@ -84,6 +126,7 @@ export function removeCommonHotKey() {
       .filter((i): i is string => !!i),
     HOTKEYS.UNDO,
     HOTKEYS.REDO,
+    HOTKEYS.ANY_KEY,
   ]);
 }
 

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -9,6 +9,7 @@ export const ALLOW_DEFAULT = true;
 export type ALLOW_DEFAULT = typeof ALLOW_DEFAULT;
 
 export const HOTKEYS = {
+  ANY_KEY: '*',
   UNDO: 'command+z,ctrl+z',
   REDO: 'command+shift+z,ctrl+shift+z,ctrl+y',
   BACKSPACE: 'backspace',

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -301,6 +301,7 @@ test.describe('slash menu with code block', () => {
 
     await waitNextFrame(page);
     await type(page, '111');
+    await waitNextFrame(page);
     await assertRichTexts(page, ['111000']);
   });
 });


### PR DESCRIPTION
- Remove unused code from `keyboard`
- Migrate `_handlenativeKeydown` from `default-page-block` to `bind-hotkey`
- Filter out the controlled events from the slash menu listener