### PR TITLE
fix(playground): clear selection on clicking undo/redo buttons

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -242,6 +242,16 @@ export function resetNativeSelection(range: Range | null) {
   range && selection.addRange(range);
 }
 
+export function clearSelection(page: Page) {
+  if (!page.root) return;
+  const defaultPageBlock = getDefaultPageBlock(page.root);
+
+  if ('selection' in defaultPageBlock) {
+    // this is not EdgelessPageBlockComponent
+    defaultPageBlock.selection.clear();
+  }
+}
+
 /**
  * @deprecated Use {@link focusBlockByModel} instead.
  */

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -20,6 +20,7 @@ import { getCurrentBlockRange } from '../../__internal__/utils/block-range.js';
 import { isAtLineEdge } from '../../__internal__/utils/check-line.js';
 import {
   asyncFocusRichText,
+  clearSelection,
   focusNextBlock,
   focusPreviousBlock,
   focusTitle,
@@ -454,15 +455,6 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
   // Don't forget to remove hotkeys at `removeHotkeys`
 }
 
-function clearSelection(page: Page) {
-  if (!page.root) return;
-  const defaultPageBlock = getDefaultPageBlock(page.root);
-
-  if ('selection' in defaultPageBlock) {
-    // this is not EdgelessPageBlockComponent
-    defaultPageBlock.selection.clear();
-  }
-}
 export function removeHotkeys() {
   removeCommonHotKey();
   hotkey.removeListener([

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -16,6 +16,7 @@ import {
   createEvent,
   getCurrentBlockRange,
   NonShadowLitElement,
+  SelectionUtils,
   updateBlockType,
 } from '@blocksuite/blocks';
 import type { EditorContainer } from '@blocksuite/editor';
@@ -315,7 +316,10 @@ export class DebugMenu extends NonShadowLitElement {
                 size="small"
                 content="Undo"
                 .disabled=${!this._canUndo}
-                @click=${() => this.page.undo()}
+                @click=${() => {
+                  SelectionUtils.clearSelection(this.page);
+                  this.page.undo();
+                }}
               >
                 <sl-icon name="arrow-counterclockwise" label="Undo"></sl-icon>
               </sl-button>
@@ -326,7 +330,10 @@ export class DebugMenu extends NonShadowLitElement {
                 size="small"
                 content="Redo"
                 .disabled=${!this._canRedo}
-                @click=${() => this.page.redo()}
+                @click=${() => {
+                  SelectionUtils.clearSelection(this.page);
+                  this.page.redo();
+                }}
               >
                 <sl-icon name="arrow-clockwise" label="Redo"></sl-icon>
               </sl-button>


### PR DESCRIPTION
fix the following problem of the playground debug menu

https://user-images.githubusercontent.com/24316656/225934558-a5714fd3-64fe-4f70-9533-66f6bb707438.mp4

The behavior do not consist with the handler of undo/redo key
https://github.com/toeverything/blocksuite/blob/master/packages/blocks/src/page-block/utils/bind-hotkey.ts#L69
```ts
hotkey.addListener(HOTKEYS.UNDO, e => {
    if (page.canUndo) clearSelection(page);
    page.undo();
});

hotkey.addListener(HOTKEYS.REDO, e => {
    if (page.canRedo) clearSelection(page);
    page.redo();
});
```