### PR TITLE
refactor(blocks): add cache for highlight in code-block

### DIFF
--- a/packages/blocks/src/code-block/affine-code-line.ts
+++ b/packages/blocks/src/code-block/affine-code-line.ts
@@ -3,9 +3,13 @@ import { VText } from '@blocksuite/virgo';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import type { Highlighter, Lang } from 'shiki';
+import type { Highlighter, IThemedToken, Lang } from 'shiki';
 
 import { NonShadowLitElement, queryCurrentMode } from '../std.js';
+import {
+  highlightCache,
+  type highlightCacheKey,
+} from './utils/highlight-cache.js';
 
 @customElement('affine-code-line')
 export class AffineCodeLine extends NonShadowLitElement {
@@ -31,12 +35,25 @@ export class AffineCodeLine extends NonShadowLitElement {
     }
 
     const mode = queryCurrentMode();
+    const cacheKey: highlightCacheKey = `${this.vText.str}-${lang}-${mode}`;
+    const cache = highlightCache.get(cacheKey);
 
-    const tokens = highlighter.codeToThemedTokens(
-      this.vText.str,
-      lang,
-      mode === 'dark' ? 'github-dark' : 'github-light'
-    )[0];
+    let tokens: IThemedToken[] = [
+      {
+        content: this.vText.str,
+      },
+    ];
+    if (cache) {
+      tokens = cache;
+    } else {
+      tokens = highlighter.codeToThemedTokens(
+        this.vText.str,
+        lang,
+        mode === 'dark' ? 'github-dark' : 'github-light'
+      )[0];
+      highlightCache.set(cacheKey, tokens);
+    }
+
     const vTexts = tokens.map(token => {
       const vText = new VText();
       vText.str = token.content;

--- a/packages/blocks/src/code-block/utils/highlight-cache.ts
+++ b/packages/blocks/src/code-block/utils/highlight-cache.ts
@@ -1,0 +1,35 @@
+import type { IThemedToken } from 'shiki';
+
+class LRUCache<K, V> {
+  private maxSize: number;
+  private cache: Map<K, V>;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+    this.cache = new Map();
+  }
+
+  get(key: K): V | null {
+    const value = this.cache.get(key);
+    if (value === undefined) {
+      return null;
+    }
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.cache.size >= this.maxSize) {
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(key, value);
+  }
+}
+
+export type highlightCacheKey = `${string}-${string}-${string}`;
+
+export const highlightCache = new LRUCache<highlightCacheKey, IThemedToken[]>(
+  100
+);


### PR DESCRIPTION
before:

![WvgRyflkdo](https://user-images.githubusercontent.com/50035259/226151787-53801f17-e9ea-47b5-b044-e9a5d61e5876.jpg)

after:

![08264620-3c64-466e-acdb-6568d3d6f6bc](https://user-images.githubusercontent.com/50035259/226151795-65ad7cb1-8583-4af8-89e4-d567c03ce2d7.jpeg)

Close #1728