### PR TITLE
style: unify subpage and slot naming

### DIFF
--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -72,7 +72,7 @@ describe.concurrent('basic', () => {
         pages: [
           {
             id: 'page0',
-            subPageIds: [],
+            subpageIds: [],
             title: '',
           },
         ],

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -71,10 +71,10 @@ export class Page extends Space<FlatBlockMap> {
       type: 'add' | 'delete' | 'update';
       id: string;
     }>(),
-    subPageUpdate: new Slot<{
+    subpageUpdated: new Slot<{
       type: 'add' | 'delete';
       id: string;
-      subPageIds: string[];
+      subpageIds: string[];
     }>(),
   };
 

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -21,7 +21,7 @@ export interface PageMeta {
   id: string;
   title: string;
   createDate: number;
-  subPageIds: string[];
+  subpageIds: string[];
 
   [key: string]: string | number | boolean | undefined | (string | number)[];
 }
@@ -414,21 +414,21 @@ export class Workspace {
       id: pageId,
       title: '',
       createDate: +new Date(),
-      subPageIds: [],
+      subpageIds: [],
     });
 
     if (parentId) {
       const parentPage = this.getPage(parentId) as Page;
       const parentPageMeta = this.meta.getPageMeta(parentId);
-      const subPageIds = [...parentPageMeta.subPageIds, pageId];
+      const subpageIds = [...parentPageMeta.subpageIds, pageId];
       this.setPageMeta(parentId, {
-        subPageIds,
+        subpageIds,
       });
 
-      parentPage.slots.subPageUpdate.emit({
+      parentPage.slots.subpageUpdated.emit({
         type: 'add',
         id: pageId,
-        subPageIds,
+        subpageIds,
       });
     }
 
@@ -443,22 +443,22 @@ export class Workspace {
   removePage(pageId: string) {
     const pageMeta = this.meta.getPageMeta(pageId);
     const parentId = this.meta.pageMetas.find(meta =>
-      meta.subPageIds.includes(pageId)
+      meta.subpageIds.includes(pageId)
     )?.id;
 
     if (parentId) {
       const parentPageMeta = this.meta.getPageMeta(parentId);
       const parentPage = this.getPage(parentId) as Page;
-      const subPageIds = parentPageMeta.subPageIds.filter(
-        (subPageId: string) => subPageId !== pageMeta.id
+      const subpageIds = parentPageMeta.subpageIds.filter(
+        (subpageId: string) => subpageId !== pageMeta.id
       );
       this.setPageMeta(parentPage.id, {
-        subPageIds,
+        subpageIds,
       });
-      parentPage.slots.subPageUpdate.emit({
+      parentPage.slots.subpageUpdated.emit({
         type: 'delete',
         id: pageId,
-        subPageIds,
+        subpageIds,
       });
     }
 

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -39,7 +39,7 @@ export const defaultStore: SerializedStore = {
     pages: [
       {
         id: 'page0',
-        subPageIds: [],
+        subpageIds: [],
         title: '',
       },
     ],


### PR DESCRIPTION
We use the term "subpage" instead of "sub-page". Naming suggestion from GPT:

> Both "subpage" and "sub-page" are commonly used and accepted spellings, and both convey the same meaning.
> However, if you are using either of these terms in the context of website design or development, it is worth noting that the convention in web design is to use "subpage" without a hyphen. This is because hyphens are typically reserved for separating words in URLs and can cause confusion or errors in some web programming languages.

/cc @QiShaoXuan @lawvs @joebeijing 