### PR TITLE
fix(drag-handle): height of drag handle line when zooming in/out in edgeless mode

### DIFF
--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -227,7 +227,7 @@ export class DragHandle extends LitElement {
       }
       const rect = modelState.rect;
       this.style.display = 'block';
-      this.style.height = `${rect.height}px`;
+      this.style.height = `${rect.height / this._scale}px`;
       this.style.width = `${DRAG_HANDLE_WIDTH}px`;
       this.style.left = '0';
       this.style.top = '0';
@@ -248,7 +248,7 @@ export class DragHandle extends LitElement {
 
       const top = this._calcDragHandleY(
         event.raw.clientY,
-        yOffset,
+        rect.top,
         rect.height,
         this._scale
       );
@@ -362,10 +362,9 @@ export class DragHandle extends LitElement {
       return;
     }
     const { rect } = this._handleAnchorState;
-    const yOffset = rect.top - this._container.getBoundingClientRect().top;
     const top = this._calcDragHandleY(
       e.clientY,
-      yOffset,
+      rect.top,
       rect.height,
       this._scale
     );


### PR DESCRIPTION
### Before
<img width="957" alt="Screenshot 2023-03-20 at 5 50 28 PM" src="https://user-images.githubusercontent.com/27926/226304488-94720821-e286-4b7e-b5fc-f68ef4dd7f65.png">

### After
<img width="991" alt="Screenshot 2023-03-20 at 5 52 31 PM" src="https://user-images.githubusercontent.com/27926/226304713-7c6b2c6c-2819-401a-b837-bb136c2564c6.png">
