### PR TITLE
perf(phasor,playground): optimize phasor example build size

### DIFF
--- a/packages/playground/examples/canvas/main.ts
+++ b/packages/playground/examples/canvas/main.ts
@@ -5,9 +5,7 @@ import {
   // Uncomment to batch load mock data
   // initMockData,
 } from '@blocksuite/phasor';
-import { Workspace } from '@blocksuite/store';
-
-const { Y } = Workspace;
+import * as Y from 'yjs';
 
 function testClick(surface: SurfaceManager, e: MouseEvent) {
   const [modelX, modelY] = surface.toModelCoord(e.offsetX, e.offsetY);


### PR DESCRIPTION
Before (by only enabling `'examples/canvas': resolve(__dirname, 'examples/canvas/index.html')` in playground vite config):

```
dist/examples/canvas/index.html            0.73 kB
dist/assets/examples/canvas-9351325d.js  310.65 kB │ gzip: 87.04 kB
```

After

```
dist/examples/canvas/index.html           0.73 kB
dist/assets/examples/canvas-2d7e18b7.js  89.47 kB │ gzip: 28.21 kB
```

70% smaller for phasor-only build.