### PR TITLE
fix(edgeless): the edgeless toolbar should not be able to display two submenus

### DIFF
--- a/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
@@ -69,13 +69,6 @@ export class EdgelessShapeToolButton extends LitElement {
     super.firstUpdated(changedProperties);
   }
 
-  updated(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('mouseMode')) {
-      this._shapeMenuPopper?.hide();
-    }
-    super.updated(changedProperties);
-  }
-
   disconnectedCallback() {
     this._disposables?.dispose();
     super.disconnectedCallback();
@@ -90,7 +83,14 @@ export class EdgelessShapeToolButton extends LitElement {
         .tooltip=${getTooltipWithShortcut('Shape', 'S')}
         .active=${type === 'shape'}
         .testId=${'shape'}
-        @tool.click=${() => this._toggleShapeMenu()}
+        @tool.click=${() => {
+          this._setMouseMode({
+            type: 'shape',
+            shape: 'rect',
+            color: '#000000',
+          });
+          this._toggleShapeMenu();
+        }}
       >
         ${ShapeIcon}
       </edgeless-tool-icon-button>


### PR DESCRIPTION
fix #1808 
When clicking the shape button, we should set the default shape mode. Using click away to control the shape panel's visibility.

https://user-images.githubusercontent.com/21084335/226867497-be7cda4e-0d33-434c-b9b5-5608eaabbc8d.mov

