### PR TITLE
refactor(edgeless): hotkeys

### DIFF
--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -246,7 +246,7 @@ export function clearSelection(page: Page) {
   if (!page.root) return;
   const defaultPageBlock = getDefaultPageBlock(page.root);
 
-  if ('selection' in defaultPageBlock) {
+  if ('clear' in defaultPageBlock.selection) {
     // this is not EdgelessPageBlockComponent
     defaultPageBlock.selection.clear();
   }

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -246,7 +246,7 @@ export function clearSelection(page: Page) {
   if (!page.root) return;
   const defaultPageBlock = getDefaultPageBlock(page.root);
 
-  if ('clear' in defaultPageBlock.selection) {
+  if ('selection' in defaultPageBlock) {
     // this is not EdgelessPageBlockComponent
     defaultPageBlock.selection.clear();
   }

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -4,6 +4,7 @@ import {
   type BlockHost,
   type EditingState,
   hotkey,
+  HOTKEY_SCOPE,
   Rect,
   type SelectionPosition,
 } from '@blocksuite/blocks/std';
@@ -464,6 +465,9 @@ export class DefaultPageBlockComponent
 
   firstUpdated() {
     const { page, selection } = this;
+
+    hotkey.setScope(HOTKEY_SCOPE.AFFINE_PAGE);
+    this._disposables.add(() => hotkey.deleteScope(HOTKEY_SCOPE.AFFINE_PAGE));
 
     bindHotkeys(page, selection);
     hotkey.enableHotkey();

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -157,7 +157,8 @@ export class EdgelessPageBlockComponent
 
   private _disposables = new DisposableGroup();
   private _selection!: EdgelessSelectionManager;
-  get selection() {
+  // FIXME: Many parts of code assume that the `selection` is used in page mode
+  getSelection() {
     return this._selection;
   }
 

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -5,15 +5,12 @@ import './components/edgeless-selected-rect.js';
 import {
   almostEqual,
   type BlockHost,
-  BrushSize,
-  hotkey,
-  HOTKEY_SCOPE,
   type IPoint,
   type Point,
   resetNativeSelection,
   type TopLevelBlockModel,
 } from '@blocksuite/blocks/std';
-import { BLOCK_ID_ATTR, HOTKEYS } from '@blocksuite/global/config';
+import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
 import {
   deserializeXYWH,
   serializeXYWH,
@@ -41,30 +38,25 @@ import type {
 } from '../../index.js';
 import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
 import {
-  bindCommonHotkey,
   EDGELESS_BLOCK_CHILD_PADDING,
-  handleDown,
-  handleUp,
-  removeCommonHotKey,
   tryUpdateFrameSize,
 } from '../utils/index.js';
 import { EdgelessBlockChildrenContainer } from './components/block-children-container.js';
 import { EdgelessDraggingArea } from './components/dragging-area.js';
 import { EdgelessHoverRect } from './components/hover-rect.js';
 import { FrameResizeObserver } from './frame-resize-observer.js';
+import { bindEdgelessHotkeys } from './hotkey.js';
 import {
   EdgelessSelectionManager,
   type EdgelessSelectionState,
 } from './selection-manager.js';
 import {
-  bindEdgelessHotkey,
   createDragHandle,
   DEFAULT_FRAME_HEIGHT,
   DEFAULT_FRAME_OFFSET_X,
   DEFAULT_FRAME_OFFSET_Y,
   DEFAULT_FRAME_WIDTH,
   getCursorMode,
-  isTopLevelBlock,
 } from './utils.js';
 
 export interface EdgelessSelectionSlots {
@@ -165,99 +157,11 @@ export class EdgelessPageBlockComponent
 
   private _disposables = new DisposableGroup();
   private _selection!: EdgelessSelectionManager;
-
-  // When user enters pan mode by pressing space,
-  // we should revert to the last mouse mode once user releases the key.
-  private _shouldRevertMode = false;
-  private _lastMode: MouseMode | null = null;
+  get selection() {
+    return this._selection;
+  }
 
   private _frameResizeObserver = new FrameResizeObserver();
-
-  private _bindHotkeys() {
-    bindEdgelessHotkey(HOTKEYS.BACKSPACE, this._handleBackspace);
-    bindEdgelessHotkey(HOTKEYS.UP, e => handleUp(e, this.page));
-    bindEdgelessHotkey(HOTKEYS.DOWN, e => handleDown(e, this.page));
-    bindEdgelessHotkey(HOTKEYS.SPACE, this._handleSpace, { keyup: true });
-    bindEdgelessHotkey('v', () => this._setMouseMode({ type: 'default' }));
-    bindEdgelessHotkey('h', () =>
-      this._setMouseMode({ type: 'pan', panning: false })
-    );
-    bindEdgelessHotkey('t', () => this._setMouseMode({ type: 'text' }));
-    bindEdgelessHotkey('p', () =>
-      this._setMouseMode({
-        type: 'brush',
-        color: '#000',
-        lineWidth: BrushSize.Thin,
-      })
-    );
-    bindEdgelessHotkey('s', () =>
-      this._setMouseMode({ type: 'shape', shape: 'rect', color: '#000000' })
-    );
-    // issue #1814
-    bindEdgelessHotkey('Esc', () => {
-      this._setMouseMode({ type: 'default' });
-      this.slots.selectionUpdated.emit({ selected: [], active: false });
-    });
-
-    hotkey.setScope(HOTKEY_SCOPE.AFFINE_EDGELESS);
-    bindCommonHotkey(this.page);
-
-    return () => {
-      hotkey.deleteScope(HOTKEY_SCOPE.AFFINE_EDGELESS);
-      removeCommonHotKey();
-    };
-  }
-
-  private _setMouseMode(mode: MouseMode) {
-    if (this._selection.isActive) {
-      return;
-    }
-    this.slots.mouseModeUpdated.emit(mode);
-  }
-
-  private _handleBackspace = (e: KeyboardEvent) => {
-    const { selected } = this._selection.blockSelectionState;
-    selected.forEach(element => {
-      if (isTopLevelBlock(element)) {
-        const children = this.page.root?.children ?? [];
-        // FIXME: should always keep at least 1 frame
-        if (children.length > 1) {
-          this.page.deleteBlock(element);
-        }
-      } else {
-        this.surface.removeElement(element.id);
-      }
-    });
-    this._selection.currentController.clearSelection();
-    this.slots.selectionUpdated.emit(this._selection.blockSelectionState);
-  };
-
-  private _handleSpace = (event: KeyboardEvent) => {
-    const { mouseMode, blockSelectionState } = this._selection;
-    if (event.type === 'keydown') {
-      if (mouseMode.type === 'pan') {
-        return;
-      }
-
-      // when user is editing, shouldn't enter pan mode
-      if (mouseMode.type === 'default' && blockSelectionState.active) {
-        return;
-      }
-
-      this.mouseMode = { type: 'pan', panning: false };
-      this._shouldRevertMode = true;
-      this._lastMode = mouseMode;
-    }
-    if (event.type === 'keyup') {
-      if (
-        mouseMode.type === 'pan' &&
-        this._shouldRevertMode &&
-        this._lastMode
-      ) {
-        this.mouseMode = this._lastMode;
-      }
-    }
-  };
 
   private _clearSelection() {
     requestAnimationFrame(() => {
@@ -368,7 +272,7 @@ export class EdgelessPageBlockComponent
     );
     _disposables.add(this._selection);
     _disposables.add(this.surface);
-    _disposables.add(this._bindHotkeys());
+    _disposables.add(bindEdgelessHotkeys(this));
 
     _disposables.add(this._frameResizeObserver);
     _disposables.add(

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -1,7 +1,7 @@
-import type { MouseMode } from '@blocksuite/blocks/std.js';
 import { HOTKEYS } from '@blocksuite/global/config';
 
 import { hotkey, HOTKEY_SCOPE } from '../../__internal__/utils/hotkey.js';
+import type { MouseMode } from '../../__internal__/utils/types.js';
 import { BrushSize } from '../../__internal__/utils/types.js';
 import { bindCommonHotkey, handleDown, handleUp } from '../utils/index.js';
 import type { EdgelessPageBlockComponent } from './edgeless-page-block.js';

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -92,6 +92,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
   hotkey.addListener('s', () =>
     setMouseMode(edgeless, { type: 'shape', shape: 'rect', color: '#000000' })
   );
+
+  // issue #1814
   hotkey.addListener('esc', () => {
     edgeless.slots.selectionUpdated.emit({ selected: [], active: false });
     setMouseMode(edgeless, { type: 'default' }, true);

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -9,8 +9,13 @@ import { isTopLevelBlock } from './utils.js';
 
 function setMouseMode(
   edgeless: EdgelessPageBlockComponent,
-  mouseMode: MouseMode
+  mouseMode: MouseMode,
+  ignoreActiveState = false
 ) {
+  // when editing, should not update mouse mode by shortcut
+  if (!ignoreActiveState && edgeless.selection.isActive) {
+    return;
+  }
   edgeless.slots.mouseModeUpdated.emit(mouseMode);
 }
 

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -13,7 +13,7 @@ function setMouseMode(
   ignoreActiveState = false
 ) {
   // when editing, should not update mouse mode by shortcut
-  if (!ignoreActiveState && edgeless.selection.isActive) {
+  if (!ignoreActiveState && edgeless.getSelection().isActive) {
     return;
   }
   edgeless.slots.mouseModeUpdated.emit(mouseMode);
@@ -27,7 +27,7 @@ function bindSpace(edgeless: EdgelessPageBlockComponent) {
   hotkey.addListener(
     HOTKEYS.SPACE,
     (event: KeyboardEvent) => {
-      const { mouseMode, blockSelectionState } = edgeless.selection;
+      const { mouseMode, blockSelectionState } = edgeless.getSelection();
       if (event.type === 'keydown') {
         if (mouseMode.type === 'pan') {
           return;
@@ -57,7 +57,7 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
   hotkey.setScope(HOTKEY_SCOPE.AFFINE_EDGELESS);
 
   hotkey.addListener(HOTKEYS.BACKSPACE, (e: KeyboardEvent) => {
-    const { selected } = edgeless.selection.blockSelectionState;
+    const { selected } = edgeless.getSelection().blockSelectionState;
     selected.forEach(element => {
       if (isTopLevelBlock(element)) {
         const children = edgeless.page.root?.children ?? [];
@@ -69,9 +69,9 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
         edgeless.surface.removeElement(element.id);
       }
     });
-    edgeless.selection.currentController.clearSelection();
+    edgeless.getSelection().currentController.clearSelection();
     edgeless.slots.selectionUpdated.emit(
-      edgeless.selection.blockSelectionState
+      edgeless.getSelection().blockSelectionState
     );
   });
   hotkey.addListener(HOTKEYS.UP, e => handleUp(e, edgeless.page));

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -92,6 +92,10 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
   hotkey.addListener('s', () =>
     setMouseMode(edgeless, { type: 'shape', shape: 'rect', color: '#000000' })
   );
+  hotkey.addListener('esc', () => {
+    edgeless.slots.selectionUpdated.emit({ selected: [], active: false });
+    setMouseMode(edgeless, { type: 'default' }, true);
+  });
 
   bindSpace(edgeless);
   bindCommonHotkey(edgeless.page);

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -1,0 +1,97 @@
+import type { MouseMode } from '@blocksuite/blocks/std.js';
+import { HOTKEYS } from '@blocksuite/global/config';
+
+import { hotkey, HOTKEY_SCOPE } from '../../__internal__/utils/hotkey.js';
+import { BrushSize } from '../../__internal__/utils/types.js';
+import { bindCommonHotkey, handleDown, handleUp } from '../utils/index.js';
+import type { EdgelessPageBlockComponent } from './edgeless-page-block.js';
+import { isTopLevelBlock } from './utils.js';
+
+function setMouseMode(
+  edgeless: EdgelessPageBlockComponent,
+  mouseMode: MouseMode
+) {
+  edgeless.slots.mouseModeUpdated.emit(mouseMode);
+}
+
+function bindSpace(edgeless: EdgelessPageBlockComponent) {
+  // When user enters pan mode by pressing space,
+  // we should revert to the last mouse mode once user releases the key.
+  let shouldRevertMode = false;
+  let lastMode: MouseMode | null = null;
+  hotkey.addListener(
+    HOTKEYS.SPACE,
+    (event: KeyboardEvent) => {
+      const { mouseMode, blockSelectionState } = edgeless.selection;
+      if (event.type === 'keydown') {
+        if (mouseMode.type === 'pan') {
+          return;
+        }
+
+        // when user is editing, shouldn't enter pan mode
+        if (mouseMode.type === 'default' && blockSelectionState.active) {
+          return;
+        }
+
+        edgeless.mouseMode = { type: 'pan', panning: false };
+        shouldRevertMode = true;
+        lastMode = mouseMode;
+      }
+      if (event.type === 'keyup') {
+        if (mouseMode.type === 'pan' && shouldRevertMode && lastMode) {
+          setMouseMode(edgeless, lastMode);
+        }
+        shouldRevertMode = false;
+      }
+    },
+    { keyup: true }
+  );
+}
+
+export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
+  hotkey.setScope(HOTKEY_SCOPE.AFFINE_EDGELESS);
+
+  hotkey.addListener(HOTKEYS.BACKSPACE, (e: KeyboardEvent) => {
+    const { selected } = edgeless.selection.blockSelectionState;
+    selected.forEach(element => {
+      if (isTopLevelBlock(element)) {
+        const children = edgeless.page.root?.children ?? [];
+        // FIXME: should always keep at least 1 frame
+        if (children.length > 1) {
+          edgeless.page.deleteBlock(element);
+        }
+      } else {
+        edgeless.surface.removeElement(element.id);
+      }
+    });
+    edgeless.selection.currentController.clearSelection();
+    edgeless.slots.selectionUpdated.emit(
+      edgeless.selection.blockSelectionState
+    );
+  });
+  hotkey.addListener(HOTKEYS.UP, e => handleUp(e, edgeless.page));
+  hotkey.addListener(HOTKEYS.DOWN, e => handleDown(e, edgeless.page));
+
+  hotkey.addListener('v', () => setMouseMode(edgeless, { type: 'default' }));
+  hotkey.addListener('h', () =>
+    setMouseMode(edgeless, { type: 'pan', panning: false })
+  );
+  hotkey.addListener('t', () => setMouseMode(edgeless, { type: 'text' }));
+  hotkey.addListener('p', () =>
+    setMouseMode(edgeless, {
+      type: 'brush',
+      color: '#000',
+      lineWidth: BrushSize.Thin,
+    })
+  );
+  hotkey.addListener('s', () =>
+    setMouseMode(edgeless, { type: 'shape', shape: 'rect', color: '#000000' })
+  );
+
+  bindSpace(edgeless);
+  bindCommonHotkey(edgeless.page);
+
+  return () => {
+    hotkey.deleteScope(HOTKEY_SCOPE.AFFINE_EDGELESS);
+  };
+}

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -20,7 +20,6 @@ import {
   serializeXYWH,
 } from '@blocksuite/phasor';
 import { assertExists } from '@blocksuite/store';
-import type { KeyHandler } from 'hotkeys-js';
 
 import { isPinchEvent } from '../../__internal__/utils/gesture.js';
 import { DragHandle } from '../../components/index.js';

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -9,8 +9,6 @@ import {
   doesInSamePath,
   getClosestBlockElementByPoint,
   getHoveringFrame,
-  hotkey,
-  HOTKEY_SCOPE,
   Rect,
 } from '@blocksuite/blocks/std';
 import type { Bound, PhasorElement, SurfaceViewport } from '@blocksuite/phasor';
@@ -157,20 +155,6 @@ export function getCursorMode(mouseMode: MouseMode) {
     default:
       return 'default';
   }
-}
-
-export function bindEdgelessHotkey(
-  key: string,
-  listener: KeyHandler,
-  options: {
-    keyup?: boolean;
-    keydown?: boolean;
-  } = {}
-) {
-  hotkey.addListener(key, listener, {
-    scope: HOTKEY_SCOPE.AFFINE_EDGELESS,
-    ...options,
-  });
 }
 
 export function createDragHandle(pageBlock: EdgelessPageBlockComponent) {


### PR DESCRIPTION
fix #1827 

When rendering a page or an edgeless view, `setScope` is called to set a unique scope for each view. All hotkeys are then bound to this scope. When a page or an edgeless view is disconnected, all hotkeys registered during the view's lifetime are destroyed.
