### PR TITLE
fix(edgeless): when zooming with the mouse, the behavior is not as expected

### DIFF
--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -100,7 +100,6 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
     }
     // zoom
     else {
-      const delta = e.deltaX !== 0 ? -e.deltaX : -e.deltaY;
       const { centerX, centerY } = viewport;
       const prevZoom = viewport.zoom;
 
@@ -111,6 +110,11 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
         e.clientY - rect.y
       );
 
+      // The delta step when using the mouse wheel is greater than 100, resulting in overly fast zooming
+      let delta = e.deltaX !== 0 ? -e.deltaX : -e.deltaY;
+      if (Math.abs(delta) > 100) {
+        delta = delta / 10;
+      }
       viewport.applyDeltaZoom(delta);
       const newZoom = viewport.zoom;
 

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -110,10 +110,12 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
         e.clientY - rect.y
       );
 
-      // The delta step when using the mouse wheel is greater than 100, resulting in overly fast zooming
       let delta = e.deltaX !== 0 ? -e.deltaX : -e.deltaY;
+      // The delta step when using the mouse wheel is greater than 100, resulting in overly fast zooming
+      // Chromium reports deltaX/deltaY scaled by host device scale factor.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1324819
       if (Math.abs(delta) > 100) {
-        delta = delta / 10;
+        delta = 10 * Math.sign(delta);
       }
       viewport.applyDeltaZoom(delta);
       const newZoom = viewport.zoom;

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -103,16 +103,16 @@ export function initWheelEventHandlers(container: EdgelessContainer) {
       const delta = e.deltaX !== 0 ? -e.deltaX : -e.deltaY;
       const { centerX, centerY } = viewport;
       const prevZoom = viewport.zoom;
-      viewport.applyDeltaZoom(delta);
 
-      const newZoom = viewport.zoom;
       const rect = container.getBoundingClientRect();
-
       // Perform zooming relative to the mouse position
       const [baseX, baseY] = container.surface.toModelCoord(
         e.clientX - rect.x,
         e.clientY - rect.y
       );
+
+      viewport.applyDeltaZoom(delta);
+      const newZoom = viewport.zoom;
 
       const offsetX = centerX - baseX;
       const offsetY = centerY - baseY;

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -120,10 +120,10 @@ test('zoom by mouse', async ({ page }) => {
   const original = [90, 264, 720, 72];
   await assertEdgelessHoverRect(page, original);
 
-  await zoomByMouseWheel(page, 125);
+  await zoomByMouseWheel(page, 0, 125);
   await page.mouse.move(CENTER_X, CENTER_Y);
 
-  const zoomed = [180, 273, original[2] * 0.75, original[3] * 0.75];
+  const zoomed = [126, 268, original[2] * 0.9, original[3] * 0.9];
   await assertEdgelessHoverRect(page, zoomed);
 });
 

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -22,6 +22,7 @@ import {
   setMouseMode,
   switchEditorMode,
   updateExistedBrushElementSize,
+  zoomByMouseWheel,
 } from './utils/actions/edgeless.js';
 import {
   addBasicBrushElement,
@@ -106,6 +107,24 @@ test('can zoom viewport', async ({ page }) => {
   await increaseZoomLevel(page);
   await page.mouse.move(CENTER_X, CENTER_Y);
   await assertEdgelessHoverRect(page, original);
+});
+
+test('zoom by mouse', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+  await assertFrameXYWH(page, [0, 0, 720, 72]);
+  await page.mouse.move(CENTER_X, CENTER_Y);
+
+  const original = [90, 264, 720, 72];
+  await assertEdgelessHoverRect(page, original);
+
+  await zoomByMouseWheel(page, 125);
+  await page.mouse.move(CENTER_X, CENTER_Y);
+
+  const zoomed = [180, 273, original[2] * 0.75, original[3] * 0.75];
+  await assertEdgelessHoverRect(page, zoomed);
 });
 
 test('cursor for active and inactive state', async ({ page }) => {

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -6,6 +6,7 @@ import { expect } from '@playwright/test';
 
 import type { FrameBlockModel } from '../../../packages/blocks/src/index.js';
 import { dragBetweenCoords } from './drag.js';
+import { SHORT_KEY } from './keyboard.js';
 
 export async function getFrameRect(
   page: Page,
@@ -270,4 +271,10 @@ export async function clickComponentToolbarMoreMenuButton(
     .filter({ hasText: text });
 
   await btn.click();
+}
+
+export async function zoomByMouseWheel(page: Page, step: number) {
+  await page.keyboard.down(SHORT_KEY);
+  await page.mouse.wheel(0, step);
+  await page.keyboard.up(SHORT_KEY);
 }

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -273,8 +273,15 @@ export async function clickComponentToolbarMoreMenuButton(
   await btn.click();
 }
 
-export async function zoomByMouseWheel(page: Page, step: number) {
+// stepX/Y may not equal to wheel event delta.
+// Chromium reports deltaX/deltaY scaled by host device scale factor.
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1324819
+export async function zoomByMouseWheel(
+  page: Page,
+  stepX: number,
+  stepY: number
+) {
   await page.keyboard.down(SHORT_KEY);
-  await page.mouse.wheel(0, step);
+  await page.mouse.wheel(stepX, stepY);
   await page.keyboard.up(SHORT_KEY);
 }


### PR DESCRIPTION
fix #1862 

* should get baseX and basxY before zooming
* zoom fastly when use mouse