### PR TITLE
fix(blocks): drop-down arrow for code language switching should not be displayed

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -366,7 +366,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
         ?disabled=${this.readonly}
         @click=${this._onClickLangBtn}
       >
-        ${this.model.language} ${ArrowDownIcon}
+        ${this.model.language} ${!this.readonly ? ArrowDownIcon : html``}
       </icon-button>
       ${this._showLangList
         ? html`<lang-list


### PR DESCRIPTION
Close #1868