### PR TITLE
fix: remove extra whitespace after reference node

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -1,4 +1,4 @@
-import { FontLinkIcon } from '@blocksuite/global/config';
+import { FontPageIcon, FontPageSubpageIcon } from '@blocksuite/global/config';
 import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 import type { PageMeta } from '@blocksuite/store';
 import {
@@ -137,7 +137,7 @@ export class AffineReference extends NonShadowLitElement {
       class="affine-reference"
       style=${style}
       @click=${this._onClick}
-      >${FontLinkIcon}<span
+      >${type === 'LinkedPage' ? FontPageSubpageIcon : FontPageIcon}<span
         class="affine-reference-title"
         data-title=${title}
         data-virgo-text="true"

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -27,9 +27,17 @@ export class AffineReference extends NonShadowLitElement {
       word-break: break-word;
       color: var(--affine-link-color);
       fill: var(--affine-link-color);
+      border-radius: 2px;
       text-decoration: none;
       cursor: pointer;
       user-select: none;
+    }
+    .affine-reference:hover {
+      background: var(--affine-hover-background);
+    }
+
+    .affine-reference > svg {
+      margin-right: 4px;
     }
 
     .affine-reference > span {

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -26,6 +26,10 @@ export class AffineReference extends NonShadowLitElement {
     .affine-reference > span {
       white-space: pre-wrap;
     }
+
+    .affine-reference-title::before {
+      content: attr(data-title);
+    }
   `;
 
   @property({ type: Object })
@@ -89,14 +93,14 @@ export class AffineReference extends NonShadowLitElement {
     const type = this.delta.attributes?.reference?.type;
     assertExists(type, 'Unable to get reference type!');
 
-    // TODO fix cursor with white space
     // TODO update icon
 
     // This node is under contenteditable="true",
     // so we should not add any extra white space between HTML tags
     return html`<span class="affine-reference" @click=${this._onClick}
-      >${FontLinkIcon}<span contenteditable="false">${title}</span>${this.delta
-        .insert}</span
+      >${FontLinkIcon}<span class="affine-reference-title" data-title=${title}
+        >${this.delta.insert}</span
+      ></span
     >`;
   }
 }

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -1,7 +1,11 @@
 import { FontLinkIcon } from '@blocksuite/global/config';
 import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 import type { PageMeta } from '@blocksuite/store';
-import { type DeltaInsert, ZERO_WIDTH_SPACE } from '@blocksuite/virgo';
+import {
+  type DeltaInsert,
+  ZERO_WIDTH_NON_JOINER,
+  ZERO_WIDTH_SPACE,
+} from '@blocksuite/virgo';
 import { css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -84,10 +88,11 @@ export class AffineReference extends NonShadowLitElement {
     if (!refMeta || refMeta.id === model.page.id) {
       return;
     }
-    // const targetPageId = refMeta.id;
+    const targetPageId = refMeta.id;
     // TODO jump to the reference
     const editor = getEditorContainer(model.page);
-    editor.page = model.page.workspace.getPage(refMeta.id);
+    // @ts-expect-error
+    editor.page = model.page.workspace.getPage(targetPageId);
   }
 
   render() {
@@ -96,7 +101,7 @@ export class AffineReference extends NonShadowLitElement {
     const isDisabled = !refMeta;
     const title = isDisabled
       ? // Maybe the page is deleted
-        'Linked page is deleted'
+        'Deleted page'
       : refMeta.title;
     const attributes = this.delta.attributes;
     assertExists(attributes, 'Failed to get attributes!');
@@ -128,7 +133,7 @@ export class AffineReference extends NonShadowLitElement {
         class="affine-reference-title"
         data-title=${title}
         data-virgo-text="true"
-        >${this.delta.insert}</span
+        >${ZERO_WIDTH_NON_JOINER}</span
       ></span
     >`;
   }

--- a/packages/blocks/src/__internal__/service/index.ts
+++ b/packages/blocks/src/__internal__/service/index.ts
@@ -38,7 +38,7 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
   ): string {
     const delta = block.text?.sliceToDelta(begin || 0, end) || [];
     const text = delta.reduce((html: string, item: DeltaOperation) => {
-      return html + BaseService.deltaLeaf2Html(item);
+      return html + BaseService.deltaLeaf2Html(block, item);
     }, '');
     return `${text}${childText}`;
   }
@@ -79,7 +79,10 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
     return json2block(focusedBlockModel, pastedBlocks, range);
   }
 
-  private static deltaLeaf2Html(deltaLeaf: DeltaOperation) {
+  private static deltaLeaf2Html(
+    block: BaseBlockModel,
+    deltaLeaf: DeltaOperation
+  ) {
     let text: string = deltaLeaf.insert;
     const attributes = deltaLeaf.attributes;
     if (!attributes) {
@@ -102,6 +105,18 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
     }
     if (attributes.link) {
       text = `<a href="${attributes.link}">${text}</a>`;
+    }
+    if (attributes.reference) {
+      const refPageId = attributes.reference.pageId;
+      const workspace = block.page.workspace;
+      const pageMeta = workspace.meta.pageMetas.find(
+        page => page.id === refPageId
+      );
+      const host = window.location.origin;
+      // maybe should use public link at here?
+      const referenceLink = `${host}/workspace/${workspace.id}/${refPageId}`;
+      const referenceTitle = pageMeta ? pageMeta.title : 'Deleted page';
+      text = `<a href="${referenceLink}">${referenceTitle}</a>`;
     }
     return text;
   }

--- a/packages/blocks/src/components/linked-page/index.ts
+++ b/packages/blocks/src/components/linked-page/index.ts
@@ -1,4 +1,8 @@
-import { type BaseBlockModel, DisposableGroup } from '@blocksuite/store';
+import {
+  assertExists,
+  type BaseBlockModel,
+  DisposableGroup,
+} from '@blocksuite/store';
 
 import { getViewportElement } from '../../__internal__/utils/query.js';
 import { throttle } from '../../__internal__/utils/std.js';
@@ -26,7 +30,12 @@ export function showLinkedPagePopover({
 
   // Handle position
   const updatePosition = throttle(() => {
-    const position = getPopperPosition(linkedPage, range);
+    const linkedPageElement = linkedPage.linkedPageElement;
+    assertExists(
+      linkedPageElement,
+      'You should render the linked page node even if no position'
+    );
+    const position = getPopperPosition(linkedPageElement, range);
     linkedPage.updatePosition(position);
   }, 10);
   disposables.addFromEvent(window, 'resize', updatePosition);

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -88,9 +88,13 @@ export function showSlashMenu({
 
   // Handle position
   const updatePosition = throttle(() => {
-    const position = getPopperPosition(slashMenu.slashMenuElement, range);
-    slashMenu.transform = `translate(${position.x}, ${position.y})`;
-    slashMenu.maxHeight = position.height;
+    const slashMenuElement = slashMenu.slashMenuElement;
+    assertExists(
+      slashMenuElement,
+      'You should render the slash menu node even if no position'
+    );
+    const position = getPopperPosition(slashMenuElement, range);
+    slashMenu.updatePosition(position);
   }, 10);
 
   window.addEventListener('resize', updatePosition);

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -56,10 +56,6 @@ export class SlashMenu extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._disposables.addFromEvent(window, 'mousedown', this._onClickAway);
-    this._disposables.addFromEvent(window, 'keydown', this._keyDownListener, {
-      // Workaround: Use capture to prevent the event from triggering the hotkey bindings action
-      capture: true,
-    });
     this._disposables.addFromEvent(this, 'mousedown', e => {
       // Prevent input from losing focus
       e.preventDefault();
@@ -212,6 +208,8 @@ export class SlashMenu extends LitElement {
       }
 
       case 'ArrowLeft':
+        // If the left panel is hidden, should not activate it
+        if (!this._searchString.length) return;
         this._leftPanelActivated = true;
         return;
       case 'ArrowRight':
@@ -230,6 +228,10 @@ export class SlashMenu extends LitElement {
 
   private _updateItem(): SlashItem[] {
     this._activatedItemIndex = 0;
+    // Activate the right panel when search string is not empty
+    if (this._leftPanelActivated) {
+      this._leftPanelActivated = false;
+    }
     const searchStr = this._searchString.toLowerCase();
     if (!searchStr) {
       return menuGroups.flatMap(group => group.items);

--- a/packages/blocks/src/components/slash-menu/slash-menu-node.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-node.ts
@@ -214,7 +214,7 @@ export class SlashMenu extends LitElement {
 
       case 'ArrowLeft':
         // If the left panel is hidden, should not activate it
-        if (!this._searchString.length) return;
+        if (this._searchString.length) return;
         this._leftPanelActivated = true;
         return;
       case 'ArrowRight':

--- a/packages/blocks/src/page-block/utils/const.ts
+++ b/packages/blocks/src/page-block/utils/const.ts
@@ -10,7 +10,10 @@ import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import { createLink } from '../../__internal__/rich-text/link-node/index.js';
 import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';
-import { handleFormat } from '../../page-block/utils/index.js';
+import {
+  getCurrentCombinedFormat,
+  handleFormat,
+} from '../../page-block/utils/index.js';
 
 type ActionProps = {
   page: Page;
@@ -85,7 +88,11 @@ export const formatConfig = [
     activeWhen: (format: AffineTextAttributes) => 'link' in format,
     // Only can show link button when selection is in one line paragraph
     showWhen: (models: BaseBlockModel[]) =>
-      models.length === 1 && noneCodeBlockSelected(models),
+      models.length === 1 &&
+      noneCodeBlockSelected(models) &&
+      // can't create link when selection includes reference node
+      // XXX get loose format at here is not a good practice
+      !getCurrentCombinedFormat(models[0].page, true).reference,
     action: ({ page, abortController, format }: ActionProps) => {
       createLink(page);
       if (format && abortController && !('link' in format)) {

--- a/packages/blocks/src/page-block/utils/position.ts
+++ b/packages/blocks/src/page-block/utils/position.ts
@@ -278,6 +278,12 @@ export function getPopperPosition(
   },
   { gap = 12, offsetY = 5 }: { gap?: number; offsetY?: number } = {}
 ) {
+  if (!popper) {
+    // foolproof, someone may use element with non-null assertion
+    console.warn(
+      'The popper element is not exist. Popper position maybe incorrect'
+    );
+  }
   const { placement, height } = compareTopAndBottomSpace(
     reference,
     document.body,
@@ -294,7 +300,7 @@ export function getPopperPosition(
   const boundaryRect = document.body.getBoundingClientRect();
   // Note: the popperRect.height maybe incorrect
   // because we are calculated its correct height
-  const popperRect = popper.getBoundingClientRect();
+  const popperRect = popper?.getBoundingClientRect();
 
   const safeCoordinate = calcSafeCoordinate({
     positioningPoint,

--- a/packages/global/src/config/icons.ts
+++ b/packages/global/src/config/icons.ts
@@ -1,6 +1,29 @@
-import { html, svg } from 'lit';
+import { html, svg, type TemplateResult } from 'lit';
 
 // Use icons from `@blocksuite/icons`
+
+function fontIcon(svg: TemplateResult<2>) {
+  // Control Icons with Font Size
+  // Set the width and height to be 1em, which will be the font-size of its parent element
+  // See https://css-tricks.com/control-icons-with-font-size/
+  const fontIconStyle = `
+    width: 1em;
+    height: 1em;
+    vertical-align: middle;
+    font-size: inherit;
+    margin-bottom: 0.1em;
+  `;
+
+  return html`<svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    style=${fontIconStyle}
+  >
+    ${svg}
+  </svg>`;
+}
 
 // Paragraph icons
 
@@ -405,26 +428,7 @@ export const LinkIcon = html`<svg
   ${LinkSVG}
 </svg>`;
 
-// Control Icons with Font Size
-// Set the width and height to be 1em, which will be the font-size of its parent element
-// See https://css-tricks.com/control-icons-with-font-size/
-const iconStyle = `
-  width: 1em;
-  height: 1em;
-  vertical-align: middle;
-  font-size: inherit;
-  margin-bottom: 0.1em;
-`;
-
-export const FontLinkIcon = html`<svg
-  width="16"
-  height="16"
-  viewBox="0 0 24 24"
-  xmlns="http://www.w3.org/2000/svg"
-  style="${iconStyle}"
->
-  ${LinkSVG}
-</svg>`;
+export const FontLinkIcon = fontIcon(LinkSVG);
 
 // Slash menu action icons
 export const CopyIcon = html`<svg
@@ -1313,3 +1317,57 @@ export const DatabaseProgress = html`
     />
   </svg>
 `;
+
+// Linked Page
+
+export const PageIconSVG = svg`
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M3.25 6C3.25 4.48122 4.48122 3.25 6 3.25H14C14.4142 3.25 14.75 3.58579 14.75 4C14.75 4.41421 14.4142 4.75 14 4.75H6C5.30964 4.75 4.75 5.30964 4.75 6V20C4.75 20.4142 4.41421 20.75 4 20.75C3.58579 20.75 3.25 20.4142 3.25 20V6Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M20.75 18C20.75 19.5188 19.5188 20.75 18 20.75H10C9.58579 20.75 9.25 20.4142 9.25 20C9.25 19.5858 9.58579 19.25 10 19.25L18 19.25C18.6904 19.25 19.25 18.6904 19.25 18L19.25 4C19.25 3.58579 19.5858 3.25 20 3.25C20.4142 3.25 20.75 3.58579 20.75 4L20.75 18Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M8.25 9C8.25 8.0335 9.0335 7.25 10 7.25H14C14.9665 7.25 15.75 8.0335 15.75 9V11C15.75 11.9665 14.9665 12.75 14 12.75H10C9.0335 12.75 8.25 11.9665 8.25 11V9ZM10 8.75C9.86193 8.75 9.75 8.86193 9.75 9V11C9.75 11.1381 9.86193 11.25 10 11.25H14C14.1381 11.25 14.25 11.1381 14.25 11V9C14.25 8.86193 14.1381 8.75 14 8.75H10Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M8.25 16C8.25 15.5858 8.58579 15.25 9 15.25H15C15.4142 15.25 15.75 15.5858 15.75 16C15.75 16.4142 15.4142 16.75 15 16.75H9C8.58579 16.75 8.25 16.4142 8.25 16Z"
+  />
+`;
+
+export const PageSubpageSVG = svg`<path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M3.25 6C3.25 4.48122 4.48122 3.25 6 3.25H14C14.4142 3.25 14.75 3.58579 14.75 4C14.75 4.41421 14.4142 4.75 14 4.75H6C5.30964 4.75 4.75 5.30964 4.75 6V20C4.75 20.4142 4.41421 20.75 4 20.75C3.58579 20.75 3.25 20.4142 3.25 20V6Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M20 10.75C19.5858 10.75 19.25 10.4142 19.25 10V4C19.25 3.58579 19.5858 3.25 20 3.25C20.4142 3.25 20.75 3.58579 20.75 4V10C20.75 10.4142 20.4142 10.75 20 10.75Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M8.25 9C8.25 8.0335 9.0335 7.25 10 7.25H14C14.9665 7.25 15.75 8.0335 15.75 9V11C15.75 11.9665 14.9665 12.75 14 12.75H10C9.0335 12.75 8.25 11.9665 8.25 11V9ZM10 8.75C9.86193 8.75 9.75 8.86193 9.75 9V11C9.75 11.1381 9.86193 11.25 10 11.25H14C14.1381 11.25 14.25 11.1381 14.25 11V9C14.25 8.86193 14.1381 8.75 14 8.75H10Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M8.25 16C8.25 15.5858 8.58579 15.25 9 15.25H12C12.4142 15.25 12.75 15.5858 12.75 16C12.75 16.4142 12.4142 16.75 12 16.75H9C8.58579 16.75 8.25 16.4142 8.25 16Z"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M18 14.75C17.5858 14.75 17.25 14.4142 17.25 14C17.25 13.5858 17.5858 13.25 18 13.25H20.9C20.9174 13.25 20.9346 13.2505 20.9517 13.2515C21.1594 13.2382 21.3716 13.3109 21.5303 13.4697C21.6891 13.6284 21.7618 13.8406 21.7485 14.0483C21.7495 14.0654 21.75 14.0826 21.75 14.1V17C21.75 17.4142 21.4142 17.75 21 17.75C20.5858 17.75 20.25 17.4142 20.25 17V15.8107L14.5303 21.5303C14.2374 21.8232 13.7626 21.8232 13.4697 21.5303C13.1768 21.2374 13.1768 20.7626 13.4697 20.4697L19.1893 14.75H18Z"
+  />`;
+
+export const FontPageIcon = fontIcon(PageIconSVG);
+export const FontPageSubpageIcon = fontIcon(PageSubpageSVG);

--- a/packages/virgo/src/constant.ts
+++ b/packages/virgo/src/constant.ts
@@ -1,1 +1,3 @@
 export const ZERO_WIDTH_SPACE = '\u200B';
+// see https://en.wikipedia.org/wiki/Zero-width_non-joiner
+export const ZERO_WIDTH_NON_JOINER = '\u200C';

--- a/packages/virgo/src/virgo.ts
+++ b/packages/virgo/src/virgo.ts
@@ -625,13 +625,19 @@ export class VEditor<
     return this._vRange;
   }
 
-  getFormat(vRange: VRange): TextAttributes {
+  getFormat(vRange: VRange, loose = false): TextAttributes {
     const deltas = this.getDeltasByVRange(vRange).filter(
       ([delta, position]) =>
         position.index + position.length > vRange.index &&
         position.index <= vRange.index + vRange.length
     );
     const maybeAttributesArray = deltas.map(([delta]) => delta.attributes);
+    if (loose) {
+      return maybeAttributesArray.reduce(
+        (acc, cur) => ({ ...acc, ...cur }),
+        {}
+      ) as TextAttributes;
+    }
     if (
       !maybeAttributesArray.length ||
       // some text does not have any attributes

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -135,9 +135,9 @@ test.describe('slash menu should show and hide correctly', () => {
     await expect(slashMenu).toBeVisible();
 
     const slashItems = slashMenu.locator('format-bar-button');
-    const activatedItem = slashItems.nth(-3);
-    await expect(activatedItem).toHaveText(['Copy']);
-    await expect(activatedItem).toHaveAttribute('hover', '');
+    const maybeActivatedItem = slashItems.nth(-3);
+    await expect(maybeActivatedItem).toHaveText(['Copy']);
+    await expect(maybeActivatedItem).toHaveAttribute('hover', '');
     await assertRichTexts(page, ['/']);
   });
 


### PR DESCRIPTION
- The `getFormat` supports a new `loose` mode
  - Hide link action on the balloon bar when selection included reference node
- Remove extra whitespace after reference node
- Make consistent on `updatePosition` between slash menu and liked page popper over