### PR TITLE
feat: expose public slots from editor container

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -1,7 +1,11 @@
 import { FontPageIcon, FontPageSubpageIcon } from '@blocksuite/global/config';
 import type { Slot } from '@blocksuite/global/utils';
 import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
-import type { DeltaOperation, PageMeta } from '@blocksuite/store';
+import type {
+  BaseBlockModel,
+  DeltaOperation,
+  PageMeta,
+} from '@blocksuite/store';
 import {
   type DeltaInsert,
   ZERO_WIDTH_NON_JOINER,
@@ -81,8 +85,9 @@ export class AffineReference extends NonShadowLitElement {
   host!: BlockHost<RefNodeSlots>;
 
   // Since the linked page may be deleted, the `_refMeta` could be undefined.
-  @state()
   private _refMeta?: PageMeta;
+
+  private _model?: BaseBlockModel;
 
   private _refAttribute: NonNullable<AffineTextAttributes['reference']> = {
     type: 'LinkedPage',
@@ -99,6 +104,7 @@ export class AffineReference extends NonShadowLitElement {
       );
     }
     const model = getModelByElement(this);
+    this._model = model;
     const refAttribute = this.delta.attributes?.reference;
     assertExists(refAttribute, 'Failed to get reference attribute!');
     this._refAttribute = refAttribute;
@@ -133,9 +139,10 @@ export class AffineReference extends NonShadowLitElement {
     if (this._refAttribute.type !== 'Subpage') {
       return;
     }
-    const model = getModelByElement(this);
+    const model = this._model;
+    assertExists(model, 'Failed to get model!');
     const text = model.text;
-    assertExists(text, 'Unable to get text!');
+    assertExists(text, 'Failed to get text');
     const delta = text.toDelta();
 
     if (!isRefPageInDelta(delta, this._refAttribute.pageId)) {

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -12,7 +12,7 @@ import {
   ZERO_WIDTH_SPACE,
 } from '@blocksuite/virgo';
 import { css, html } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import {
   type BlockHost,

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -82,7 +82,7 @@ export class AffineReference extends NonShadowLitElement {
   };
 
   @property()
-  host!: BlockHost<RefNodeSlots>;
+  host!: BlockHost;
 
   // Since the linked page may be deleted, the `_refMeta` could be undefined.
   private _refMeta?: PageMeta;
@@ -154,10 +154,15 @@ export class AffineReference extends NonShadowLitElement {
   }
 
   private _onClick(e: MouseEvent) {
-    e.preventDefault();
     const refMeta = this._refMeta;
     const model = getModelByElement(this);
-    if (!refMeta || refMeta.id === model.page.id) {
+    if (!refMeta) {
+      // The page is deleted
+      console.warn('The page is deleted', this._refAttribute.pageId);
+      return;
+    }
+    if (refMeta.id === model.page.id) {
+      // the page is the current page.
       return;
     }
     const targetPageId = refMeta.id;

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -10,6 +10,7 @@ import { css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import {
+  type BlockHost,
   getEditorContainer,
   getModelByElement,
   NonShadowLitElement,
@@ -54,6 +55,9 @@ export class AffineReference extends NonShadowLitElement {
     insert: ZERO_WIDTH_SPACE,
     attributes: {},
   };
+
+  @property()
+  host!: BlockHost;
 
   @state()
   private _refMeta?: PageMeta;

--- a/packages/blocks/src/__internal__/rich-text/reference-node.ts
+++ b/packages/blocks/src/__internal__/rich-text/reference-node.ts
@@ -28,12 +28,12 @@ export type RefNodeSlots = {
   /**
    * Emit when the subpage is linked to the current page.
    */
-  onLinkPage: Slot<{ pageId: string }>;
+  subpageLinked: Slot<{ pageId: string }>;
   /**
    * Emit when the subpage is unlinked from the current page.
    */
-  onUnlinkPage: Slot<{ pageId: string }>;
-  onJumpToPage: Slot<{ pageId: string }>;
+  subpageUnlinked: Slot<{ pageId: string }>;
+  pageLinkClicked: Slot<{ pageId: string }>;
 };
 
 function isRefPageInDelta(delta: DeltaOperation[], pageId: string) {
@@ -129,7 +129,7 @@ export class AffineReference extends NonShadowLitElement {
         return;
       }
       // User may create a subpage ref node by paste or undo/redo.
-      this.host.slots.onLinkPage.emit({ pageId: refAttribute.pageId });
+      this.host.slots.subpageLinked.emit({ pageId: refAttribute.pageId });
     }
   }
 
@@ -147,7 +147,9 @@ export class AffineReference extends NonShadowLitElement {
 
     if (!isRefPageInDelta(delta, this._refAttribute.pageId)) {
       // The subpage is deleted
-      this.host.slots.onUnlinkPage.emit({ pageId: this._refAttribute.pageId });
+      this.host.slots.subpageUnlinked.emit({
+        pageId: this._refAttribute.pageId,
+      });
     }
   }
 
@@ -159,7 +161,7 @@ export class AffineReference extends NonShadowLitElement {
       return;
     }
     const targetPageId = refMeta.id;
-    this.host.slots.onJumpToPage.emit({ pageId: targetPageId });
+    this.host.slots.pageLinkClicked.emit({ pageId: targetPageId });
 
     // const editor = getEditorContainer(model.page);
     // editor.page = model.page.workspace.getPage(targetPageId);

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -37,7 +37,7 @@ export class RichText extends NonShadowLitElement {
   }
 
   @property()
-  host!: BlockHost<CommonSlots>;
+  host!: BlockHost;
 
   @property()
   model!: BaseBlockModel;

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -3,7 +3,7 @@ import { VEditor } from '@blocksuite/virgo';
 import { css, html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
-import { type BlockHost, type CommonSlots } from '../utils/index.js';
+import { type BlockHost } from '../utils/index.js';
 import { NonShadowLitElement } from '../utils/lit.js';
 import { setupVirgoScroll } from '../utils/virgo.js';
 import { InlineSuggestionController } from './inline-suggestion.js';

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -64,7 +64,7 @@ export class RichText extends NonShadowLitElement {
       'Failed to render rich-text! textSchema not found'
     );
     this._vEditor.setAttributeSchema(textSchema.attributesSchema);
-    this._vEditor.setAttributeRenderer(textSchema.textRenderer);
+    this._vEditor.setAttributeRenderer(textSchema.textRenderer(this.host));
 
     const keyboardBindings = createKeyboardBindings(this.model, this._vEditor);
     const keyDownHandler = createKeyDownHandler(

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -3,7 +3,7 @@ import { VEditor } from '@blocksuite/virgo';
 import { css, html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
-import { type BlockHost } from '../utils/index.js';
+import { type BlockHost, type CommonSlots } from '../utils/index.js';
 import { NonShadowLitElement } from '../utils/lit.js';
 import { setupVirgoScroll } from '../utils/virgo.js';
 import { InlineSuggestionController } from './inline-suggestion.js';
@@ -37,7 +37,7 @@ export class RichText extends NonShadowLitElement {
   }
 
   @property()
-  host!: BlockHost;
+  host!: BlockHost<CommonSlots>;
 
   @property()
   model!: BaseBlockModel;

--- a/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
@@ -1,10 +1,10 @@
 import { html } from 'lit';
 
-import type { BlockHost } from '../../index.js';
+import type { BlockHost, CommonSlots } from '../../index.js';
 import type { AffineTextSchema } from './types.js';
 
 export const attributeRenderer: AffineTextSchema['textRenderer'] =
-  (host: BlockHost) => delta => {
+  (host: BlockHost<CommonSlots>) => delta => {
     const defaultTemplate = html`<affine-text
       .host=${host}
       .delta=${delta}

--- a/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
@@ -1,29 +1,34 @@
-import type { AttributeRenderer } from '@blocksuite/virgo';
 import { html } from 'lit';
 
-import type { AffineTextAttributes } from './types.js';
+import type { BlockHost } from '../../index.js';
+import type { AffineTextSchema } from './types.js';
 
-export const attributeRenderer: AttributeRenderer<
-  AffineTextAttributes
-> = delta => {
-  const defaultTemplate = html`<affine-text .delta=${delta}></affine-text>`;
-  if (!delta.attributes) {
-    return defaultTemplate;
-  }
-  const attributes = delta.attributes;
-
-  if (attributes.link) {
-    if (attributes.reference) {
-      console.error(
-        'Invalid attributes: link and reference cannot be used together',
-        delta
-      );
+export const attributeRenderer: AffineTextSchema['textRenderer'] =
+  (host: BlockHost) => delta => {
+    const defaultTemplate = html`<affine-text
+      .host=${host}
+      .delta=${delta}
+    ></affine-text>`;
+    if (!delta.attributes) {
+      return defaultTemplate;
     }
-    return html`<affine-link .delta=${delta}></affine-link>`;
-  }
-  if (attributes.reference) {
-    return html`<affine-reference .delta=${delta}></affine-reference>`;
-  }
+    const attributes = delta.attributes;
 
-  return defaultTemplate;
-};
+    if (attributes.link) {
+      if (attributes.reference) {
+        console.error(
+          'Invalid attributes: link and reference cannot be used together',
+          delta
+        );
+      }
+      return html`<affine-link .host=${host} .delta=${delta}></affine-link>`;
+    }
+    if (attributes.reference) {
+      return html`<affine-reference
+        .host=${host}
+        .delta=${delta}
+      ></affine-reference>`;
+    }
+
+    return defaultTemplate;
+  };

--- a/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
@@ -6,13 +6,24 @@ import type { AffineTextAttributes } from './types.js';
 export const attributeRenderer: AttributeRenderer<
   AffineTextAttributes
 > = delta => {
-  if (delta?.attributes?.link) {
+  const defaultTemplate = html`<affine-text .delta=${delta}></affine-text>`;
+  if (!delta.attributes) {
+    return defaultTemplate;
+  }
+  const attributes = delta.attributes;
+
+  if (attributes.link) {
+    if (attributes.reference) {
+      console.error(
+        'Invalid attributes: link and reference cannot be used together',
+        delta
+      );
+    }
     return html`<affine-link .delta=${delta}></affine-link>`;
   }
-
-  if (delta?.attributes?.reference) {
+  if (attributes.reference) {
     return html`<affine-reference .delta=${delta}></affine-reference>`;
   }
 
-  return html`<affine-text .delta=${delta}></affine-text>`;
+  return defaultTemplate;
 };

--- a/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
@@ -1,10 +1,10 @@
 import { html } from 'lit';
 
-import type { BlockHost, CommonSlots } from '../../index.js';
+import type { BlockHost } from '../../index.js';
 import type { AffineTextSchema } from './types.js';
 
 export const attributeRenderer: AffineTextSchema['textRenderer'] =
-  (host: BlockHost<CommonSlots>) => delta => {
+  (host: BlockHost) => delta => {
     const defaultTemplate = html`<affine-text
       .host=${host}
       .delta=${delta}

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -1,11 +1,13 @@
 import type {
-  AttributesRenderer,
+  AttributeRenderer,
   BaseTextAttributes,
   DeltaInsert,
   VEditor,
 } from '@blocksuite/virgo';
 import { baseTextAttributes } from '@blocksuite/virgo';
 import { z, type ZodTypeDef } from 'zod';
+
+import type { BlockHost } from '../../index.js';
 
 export const affineTextAttributes = baseTextAttributes.extend({
   reference: z
@@ -26,5 +28,5 @@ export type AffineTextSchema<
   TextAttributes extends BaseTextAttributes = AffineTextAttributes
 > = {
   attributesSchema: z.ZodSchema<TextAttributes, ZodTypeDef, unknown>;
-  textRenderer: AttributesRenderer<TextAttributes>;
+  textRenderer: (host: BlockHost) => AttributeRenderer<TextAttributes>;
 };

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -28,7 +28,5 @@ export type AffineTextSchema<
   TextAttributes extends BaseTextAttributes = AffineTextAttributes
 > = {
   attributesSchema: z.ZodSchema<TextAttributes, ZodTypeDef, unknown>;
-  textRenderer: (
-    host: BlockHost<CommonSlots>
-  ) => AttributeRenderer<TextAttributes>;
+  textRenderer: (host: BlockHost) => AttributeRenderer<TextAttributes>;
 };

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -1,6 +1,10 @@
-import type { DeltaInsert, VEditor } from '@blocksuite/virgo';
+import type {
+  AttributesRenderer,
+  DeltaInsert,
+  VEditor,
+} from '@blocksuite/virgo';
 import { baseTextAttributes } from '@blocksuite/virgo';
-import { z } from 'zod';
+import { z, type ZodTypeDef } from 'zod';
 
 export const affineTextAttributes = baseTextAttributes.extend({
   reference: z
@@ -16,3 +20,8 @@ export type AffineTextAttributes = z.infer<typeof affineTextAttributes>;
 export type AffineDeltaInsert = DeltaInsert<AffineTextAttributes>;
 
 export type AffineVEditor = VEditor<AffineTextAttributes>;
+
+export type AffineTextSchema = {
+  attributesSchema: z.ZodSchema<AffineTextAttributes, ZodTypeDef, unknown>;
+  textRenderer: AttributesRenderer<AffineTextAttributes>;
+};

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -7,7 +7,7 @@ import type {
 import { baseTextAttributes } from '@blocksuite/virgo';
 import { z, type ZodTypeDef } from 'zod';
 
-import type { BlockHost, CommonSlots } from '../../utils/types.js';
+import type { BlockHost } from '../../utils/types.js';
 
 export const affineTextAttributes = baseTextAttributes.extend({
   reference: z

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -7,7 +7,7 @@ import type {
 import { baseTextAttributes } from '@blocksuite/virgo';
 import { z, type ZodTypeDef } from 'zod';
 
-import type { BlockHost } from '../../index.js';
+import type { BlockHost, CommonSlots } from '../../utils/types.js';
 
 export const affineTextAttributes = baseTextAttributes.extend({
   reference: z
@@ -28,5 +28,7 @@ export type AffineTextSchema<
   TextAttributes extends BaseTextAttributes = AffineTextAttributes
 > = {
   attributesSchema: z.ZodSchema<TextAttributes, ZodTypeDef, unknown>;
-  textRenderer: (host: BlockHost) => AttributeRenderer<TextAttributes>;
+  textRenderer: (
+    host: BlockHost<CommonSlots>
+  ) => AttributeRenderer<TextAttributes>;
 };

--- a/packages/blocks/src/__internal__/rich-text/virgo/types.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/types.ts
@@ -1,5 +1,6 @@
 import type {
   AttributesRenderer,
+  BaseTextAttributes,
   DeltaInsert,
   VEditor,
 } from '@blocksuite/virgo';
@@ -21,7 +22,9 @@ export type AffineDeltaInsert = DeltaInsert<AffineTextAttributes>;
 
 export type AffineVEditor = VEditor<AffineTextAttributes>;
 
-export type AffineTextSchema = {
-  attributesSchema: z.ZodSchema<AffineTextAttributes, ZodTypeDef, unknown>;
-  textRenderer: AttributesRenderer<AffineTextAttributes>;
+export type AffineTextSchema<
+  TextAttributes extends BaseTextAttributes = AffineTextAttributes
+> = {
+  attributesSchema: z.ZodSchema<TextAttributes, ZodTypeDef, unknown>;
+  textRenderer: AttributesRenderer<TextAttributes>;
 };

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -419,8 +419,9 @@ export function getModelsByRange(range: Range): BaseBlockModel[] {
 }
 
 export function getModelByElement(element: Element): BaseBlockModel {
-  // maybe should check element.closest(ATTR_SELECTOR) is not null
-  return getModelByBlockElement(element.closest(ATTR_SELECTOR) as Element);
+  const closestBlock = element.closest(ATTR_SELECTOR);
+  assertExists(closestBlock, 'Cannot find block element by element');
+  return getModelByBlockElement(closestBlock);
 }
 
 function mergeRect(a: DOMRect, b: DOMRect) {

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -14,7 +14,14 @@ export const IS_MAC = /Mac/i.test(globalThis.navigator?.platform);
  * Whether the block supports rendering its children.
  */
 export function supportsChildren(model: BaseBlockModel): boolean {
-  if (matchFlavours(model, ['affine:embed', 'affine:divider', 'affine:code'])) {
+  if (
+    matchFlavours(model, [
+      'affine:database',
+      'affine:embed',
+      'affine:divider',
+      'affine:code',
+    ])
+  ) {
     return false;
   }
   if (

--- a/packages/blocks/src/__internal__/utils/std.ts
+++ b/packages/blocks/src/__internal__/utils/std.ts
@@ -16,7 +16,7 @@ export const IS_MAC = /Mac/i.test(globalThis.navigator?.platform);
 export function supportsChildren(model: BaseBlockModel): boolean {
   if (
     matchFlavours(model, [
-      'affine:database',
+      // 'affine:database',
       'affine:embed',
       'affine:divider',
       'affine:code',

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -7,6 +7,7 @@ import type {
   ServiceFlavour,
 } from '../../models.js';
 import type { Clipboard } from '../clipboard/index.js';
+import type { RefNodeSlots } from '../rich-text/reference-node.js';
 import type { AffineTextAttributes } from '../rich-text/virgo/types.js';
 import type { BlockComponentElement } from './query.js';
 import type { Point } from './rect.js';
@@ -36,12 +37,18 @@ export interface BlockHostContext {
   ) => BlockServiceInstanceByKey<Key>;
 }
 
-export interface BlockHost extends BlockHostContext {
+export type CommonSlots = RefNodeSlots;
+
+export interface BlockHost<Slots = unknown> extends BlockHostContext {
   page: Page;
   flavour: string;
   clipboard: Clipboard;
+  readonly slots: Slots;
 }
 
+/**
+ * @deprecated Not used yet
+ */
 export interface CommonBlockElement extends HTMLElement {
   host: BlockHost;
   model: BaseBlockModel;

--- a/packages/blocks/src/__internal__/utils/types.ts
+++ b/packages/blocks/src/__internal__/utils/types.ts
@@ -39,11 +39,11 @@ export interface BlockHostContext {
 
 export type CommonSlots = RefNodeSlots;
 
-export interface BlockHost<Slots = unknown> extends BlockHostContext {
+export interface BlockHost extends BlockHostContext {
   page: Page;
   flavour: string;
   clipboard: Clipboard;
-  readonly slots: Slots;
+  readonly slots: CommonSlots;
 }
 
 /**

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -1,7 +1,7 @@
 import '../__internal__/rich-text/rich-text.js';
-import './components/lang-list.js';
-import './components/code-option.js';
 import '../components/portal.js';
+import './components/code-option.js';
+import './components/lang-list.js';
 
 import { ArrowDownIcon } from '@blocksuite/global/config';
 import { assertExists, DisposableGroup, Slot } from '@blocksuite/store';
@@ -173,8 +173,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
   @state()
   private _wrap = false;
 
-  @state()
-  textSchema: AffineTextSchema = {
+  readonly textSchema: AffineTextSchema = {
     attributesSchema: z.object({}),
     textRenderer: () =>
       getCodeLineRenderer(() => ({

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -9,6 +9,7 @@ import { css, html, render } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { getHighlighter, type Highlighter, type Lang } from 'shiki';
+import { z } from 'zod';
 
 import {
   type BlockHost,
@@ -21,6 +22,7 @@ import { tooltipStyle } from '../components/tooltip/tooltip.js';
 import type { CodeBlockModel } from './code-model.js';
 import { CodeOptionTemplate } from './components/code-option.js';
 import { codeLanguages } from './utils/code-languages.js';
+import { getCodeLineRenderer } from './utils/code-line-renderer.js';
 
 @customElement('affine-code')
 export class CodeBlockComponent extends NonShadowLitElement {
@@ -168,6 +170,15 @@ export class CodeBlockComponent extends NonShadowLitElement {
 
   @state()
   private _wrap = false;
+
+  @state()
+  textSchema = {
+    attributesSchema: z.object({}),
+    textRenderer: getCodeLineRenderer(() => ({
+      lang: this.model.language.toLowerCase() as Lang,
+      highlighter: this._highlighter,
+    })),
+  };
 
   private _richTextResizeObserver: ResizeObserver = new ResizeObserver(() => {
     this._updateLineNumbers();
@@ -454,10 +465,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
           <rich-text
             .host=${this.host}
             .model=${this.model}
-            .codeBlockHighlighterOptionsGetter=${() => ({
-              lang: this.model.language.toLowerCase() as Lang,
-              highlighter: this._highlighter,
-            })}
+            .textSchema=${this.textSchema}
           >
           </rich-text>
         </div>

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -18,6 +18,7 @@ import {
   NonShadowLitElement,
   queryCurrentMode,
 } from '../__internal__/index.js';
+import type { AffineTextSchema } from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import { tooltipStyle } from '../components/tooltip/tooltip.js';
 import type { CodeBlockModel } from './code-model.js';
@@ -173,12 +174,13 @@ export class CodeBlockComponent extends NonShadowLitElement {
   private _wrap = false;
 
   @state()
-  textSchema = {
+  textSchema: AffineTextSchema = {
     attributesSchema: z.object({}),
-    textRenderer: getCodeLineRenderer(() => ({
-      lang: this.model.language.toLowerCase() as Lang,
-      highlighter: this._highlighter,
-    })),
+    textRenderer: () =>
+      getCodeLineRenderer(() => ({
+        lang: this.model.language.toLowerCase() as Lang,
+        highlighter: this._highlighter,
+      })),
   };
 
   private _richTextResizeObserver: ResizeObserver = new ResizeObserver(() => {

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -13,7 +13,6 @@ import { z } from 'zod';
 
 import {
   type BlockHost,
-  type CommonSlots,
   getViewportElement,
   NonShadowLitElement,
   queryCurrentMode,
@@ -159,7 +158,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
   model!: CodeBlockModel;
 
   @property()
-  host!: BlockHost<CommonSlots>;
+  host!: BlockHost;
 
   @state()
   private _showLangList = false;

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 
 import {
   type BlockHost,
+  type CommonSlots,
   getViewportElement,
   NonShadowLitElement,
   queryCurrentMode,
@@ -157,7 +158,7 @@ export class CodeBlockComponent extends NonShadowLitElement {
   model!: CodeBlockModel;
 
   @property()
-  host!: BlockHost;
+  host!: BlockHost<CommonSlots>;
 
   @state()
   private _showLangList = false;

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -436,10 +436,14 @@ function DataBaseRowContainer(
 @customElement('affine-database')
 export class DatabaseBlockComponent
   extends NonShadowLitElement
-  implements BlockHost<undefined>
+  implements BlockHost
 {
   flavour = 'affine:database' as const;
-  slots: undefined;
+
+  get slots() {
+    return this.host.slots;
+  }
+
   get page() {
     return this.host.page;
   }

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -436,9 +436,10 @@ function DataBaseRowContainer(
 @customElement('affine-database')
 export class DatabaseBlockComponent
   extends NonShadowLitElement
-  implements BlockHost
+  implements BlockHost<undefined>
 {
   flavour = 'affine:database' as const;
+  slots: undefined;
   get page() {
     return this.host.page;
   }
@@ -889,7 +890,6 @@ export class DatabaseBlockComponent
     </div>`;
   };
 
-  /* eslint-disable lit/binding-positions, lit/no-invalid-html */
   render() {
     const totalWidth =
       this.columns.map(column => column.width).reduce((t, x) => t + x, 0) +
@@ -943,6 +943,7 @@ export class DatabaseBlockComponent
           data-test-id="affine-database-add-column-button"
           @click=${() => this._addColumn(this.columns.length)}
         >
+          <!-- Fix move to icon -->
           <svg
             viewBox="0 0 16 16"
             style=${styleMap({

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -433,12 +433,201 @@ function DataBaseRowContainer(
   `;
 }
 
+const styles = css`
+  affine-database {
+    position: relative;
+  }
+
+  .affine-database-block-title-container {
+    display: flex;
+    align-items: center;
+    height: 44px;
+    margin: 12px 0px;
+  }
+
+  .affine-database-block-title {
+    flex: 1;
+    position: sticky;
+    width: 300px;
+    height: 30px;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 24px;
+    color: #424149;
+    font-family: inherit;
+    overflow: hidden;
+    cursor: text;
+  }
+
+  .affine-database-block-title [data-virgo-text='true'] {
+    display: inline-block;
+    width: 300px;
+    max-width: 300px;
+    white-space: nowrap !important;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  .affine-database-block-title:focus {
+    outline: none;
+  }
+
+  .affine-database-block-title:disabled {
+    background-color: transparent;
+  }
+
+  .affine-database-block-title-empty::before {
+    content: 'Database';
+    color: var(--affine-placeholder-color);
+    position: absolute;
+    opacity: 0.5;
+  }
+
+  .affine-database-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 26px;
+  }
+  .affine-database-toolbar-search svg,
+  .affine-database-toolbar svg {
+    width: 16px;
+    height: 16px;
+  }
+  .affine-database-toolbar-item {
+    display: flex;
+    align-items: center;
+  }
+  .affine-database-toolbar-item.search {
+    overflow: hidden;
+  }
+  .affine-database-search-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 138px;
+    height: 32px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background-color: rgba(0, 0, 0, 0);
+    transform: translate(110px, 0px);
+    transition: all 0.3s ease;
+  }
+  .affine-database-search-container > svg {
+    min-width: 16px;
+    min-height: 16px;
+  }
+  .search-container-expand {
+    transform: translate(0px, 0px);
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+  .search-input-container {
+    display: flex;
+    align-items: center;
+  }
+  .affine-database-search-input-icon {
+    display: inline-flex;
+  }
+  .affine-database-search-input {
+    flex: 1;
+    height: 16px;
+    width: 80px;
+    border: none;
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-sm);
+    box-sizing: border-box;
+    color: inherit;
+    background: transparent;
+  }
+  .affine-database-search-input:focus {
+    outline: none;
+  }
+  .affine-database-search-input::placeholder {
+    color: #888a9e;
+    font-size: var(--affine-font-sm);
+  }
+
+  .affine-database-toolbar-item.new-record {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 120px;
+    height: 32px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    font-size: 14px;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05),
+      0px 0px 0px 0.5px rgba(0, 0, 0, 0.1);
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.04)),
+      #ffffff;
+  }
+
+  .affine-database-block-table {
+    position: relative;
+    width: 100%;
+    overflow-x: scroll;
+    border-top: 1.5px solid var(--affine-border-color);
+  }
+
+  .affine-database-block-tag-circle {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .affine-database-block-tag {
+    display: inline-flex;
+    border-radius: 11px;
+    align-items: center;
+    padding: 0 8px;
+    cursor: pointer;
+  }
+
+  .affine-database-block-footer {
+    display: flex;
+    width: 100%;
+    height: 42px;
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  .affine-database-block-add-row {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    user-select: none;
+    font-size: 14px;
+  }
+  .affine-database-block-add-row svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .affine-database-add-column-button {
+    position: absolute;
+    top: 58px;
+    right: -40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    cursor: pointer;
+  }
+`;
+
 @customElement('affine-database')
 export class DatabaseBlockComponent
   extends NonShadowLitElement
   implements BlockHost
 {
   flavour = 'affine:database' as const;
+
+  static styles = styles;
 
   get slots() {
     return this.host.slots;
@@ -453,197 +642,6 @@ export class DatabaseBlockComponent
   get getService() {
     return this.host.getService;
   }
-
-  static styles = css`
-    affine-database {
-      position: relative;
-    }
-
-    .affine-database-block-title-container {
-      display: flex;
-      align-items: center;
-      height: 44px;
-      margin: 12px 0px;
-    }
-
-    .affine-database-block-title {
-      flex: 1;
-      position: sticky;
-      width: 300px;
-      height: 30px;
-      font-size: 18px;
-      font-weight: 600;
-      line-height: 24px;
-      color: #424149;
-      font-family: inherit;
-      overflow: hidden;
-      cursor: text;
-    }
-
-    .affine-database-block-title [data-virgo-text='true'] {
-      display: inline-block;
-      width: 300px;
-      max-width: 300px;
-      white-space: nowrap !important;
-      text-overflow: ellipsis;
-      overflow: hidden;
-    }
-
-    .affine-database-block-title:focus {
-      outline: none;
-    }
-
-    .affine-database-block-title:disabled {
-      background-color: transparent;
-    }
-
-    .affine-database-block-title-empty::before {
-      content: 'Database';
-      color: var(--affine-placeholder-color);
-      position: absolute;
-      opacity: 0.5;
-    }
-
-    .affine-database-toolbar {
-      display: flex;
-      align-items: center;
-      gap: 26px;
-    }
-    .affine-database-toolbar-search svg,
-    .affine-database-toolbar svg {
-      width: 16px;
-      height: 16px;
-    }
-    .affine-database-toolbar-item {
-      display: flex;
-      align-items: center;
-    }
-    .affine-database-toolbar-item.search {
-      overflow: hidden;
-    }
-    .affine-database-search-container {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      width: 138px;
-      height: 32px;
-      padding: 8px 12px;
-      border-radius: 8px;
-      background-color: rgba(0, 0, 0, 0);
-      transform: translate(110px, 0px);
-      transition: all 0.3s ease;
-    }
-    .affine-database-search-container > svg {
-      min-width: 16px;
-      min-height: 16px;
-    }
-    .search-container-expand {
-      transform: translate(0px, 0px);
-      background-color: rgba(0, 0, 0, 0.04);
-    }
-    .search-input-container {
-      display: flex;
-      align-items: center;
-    }
-    .affine-database-search-input-icon {
-      display: inline-flex;
-    }
-    .affine-database-search-input {
-      flex: 1;
-      height: 16px;
-      width: 80px;
-      border: none;
-      font-family: var(--affine-font-family);
-      font-size: var(--affine-font-sm);
-      box-sizing: border-box;
-      color: inherit;
-      background: transparent;
-    }
-    .affine-database-search-input:focus {
-      outline: none;
-    }
-    .affine-database-search-input::placeholder {
-      color: #888a9e;
-      font-size: var(--affine-font-sm);
-    }
-
-    .affine-database-toolbar-item.new-record {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      width: 120px;
-      height: 32px;
-      padding: 6px 8px;
-      border-radius: 8px;
-      font-size: 14px;
-      box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05),
-        0px 0px 0px 0.5px rgba(0, 0, 0, 0.1);
-      background: linear-gradient(
-          0deg,
-          rgba(0, 0, 0, 0.04),
-          rgba(0, 0, 0, 0.04)
-        ),
-        #ffffff;
-    }
-
-    .affine-database-block-table {
-      position: relative;
-      width: 100%;
-      overflow-x: scroll;
-      border-top: 1.5px solid var(--affine-border-color);
-    }
-
-    .affine-database-block-tag-circle {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      display: inline-block;
-    }
-
-    .affine-database-block-tag {
-      display: inline-flex;
-      border-radius: 11px;
-      align-items: center;
-      padding: 0 8px;
-      cursor: pointer;
-    }
-
-    .affine-database-block-footer {
-      display: flex;
-      width: 100%;
-      height: 42px;
-      background-color: rgba(0, 0, 0, 0.04);
-    }
-
-    .affine-database-block-add-row {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 4px;
-      width: 100%;
-      height: 100%;
-      cursor: pointer;
-      user-select: none;
-      font-size: 14px;
-    }
-    .affine-database-block-add-row svg {
-      width: 16px;
-      height: 16px;
-    }
-
-    .affine-database-add-column-button {
-      position: absolute;
-      top: 58px;
-      right: -40px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      cursor: pointer;
-    }
-  `;
 
   @property()
   model!: DatabaseBlockModel;

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -9,6 +9,8 @@ import {
   getDefaultPageBlock,
   NonShadowLitElement,
 } from '../__internal__/index.js';
+import { attributesRenderer } from '../__internal__/rich-text/virgo/attributes-renderer.js';
+import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ListBlockModel } from './list-model.js';
 import { ListIcon } from './utils/get-list-icon.js';
@@ -80,6 +82,12 @@ export class ListBlockComponent extends NonShadowLitElement {
   @state()
   showChildren = true;
 
+  @state()
+  textSchema = {
+    attributesSchema: affineTextAttributes,
+    textRenderer: attributesRenderer,
+  };
+
   private _select() {
     const { selection } = getDefaultPageBlock(this.model);
     selection?.selectOneBlock(this);
@@ -130,7 +138,11 @@ export class ListBlockComponent extends NonShadowLitElement {
           }`}
         >
           ${listIcon}
-          <rich-text .host=${this.host} .model=${this.model}></rich-text>
+          <rich-text
+            .host=${this.host}
+            .model=${this.model}
+            .textSchema=${this.textSchema}
+          ></rich-text>
         </div>
         ${childrenContainer}
       </div>

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -86,8 +86,7 @@ export class ListBlockComponent extends NonShadowLitElement {
   @state()
   showChildren = true;
 
-  @state()
-  textSchema: AffineTextSchema = {
+  readonly textSchema: AffineTextSchema = {
     attributesSchema: affineTextAttributes,
     textRenderer: attributeRenderer,
   };

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -9,7 +9,7 @@ import {
   getDefaultPageBlock,
   NonShadowLitElement,
 } from '../__internal__/index.js';
-import { attributesRenderer } from '../__internal__/rich-text/virgo/attributes-renderer.js';
+import { attributeRenderer } from '../__internal__/rich-text/virgo/attribute-renderer.js';
 import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ListBlockModel } from './list-model.js';
@@ -85,7 +85,7 @@ export class ListBlockComponent extends NonShadowLitElement {
   @state()
   textSchema = {
     attributesSchema: affineTextAttributes,
-    textRenderer: attributesRenderer,
+    textRenderer: attributeRenderer,
   };
 
   private _select() {

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -6,6 +6,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import {
   type BlockHost,
+  type CommonSlots,
   getDefaultPageBlock,
   NonShadowLitElement,
 } from '../__internal__/index.js';
@@ -77,7 +78,7 @@ export class ListBlockComponent extends NonShadowLitElement {
   model!: ListBlockModel;
 
   @property()
-  host!: BlockHost;
+  host!: BlockHost<CommonSlots>;
 
   @state()
   showChildren = true;

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -6,7 +6,6 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import {
   type BlockHost,
-  type CommonSlots,
   getDefaultPageBlock,
   NonShadowLitElement,
 } from '../__internal__/index.js';
@@ -81,7 +80,7 @@ export class ListBlockComponent extends NonShadowLitElement {
   model!: ListBlockModel;
 
   @property()
-  host!: BlockHost<CommonSlots>;
+  host!: BlockHost;
 
   @state()
   showChildren = true;

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -11,7 +11,10 @@ import {
   NonShadowLitElement,
 } from '../__internal__/index.js';
 import { attributeRenderer } from '../__internal__/rich-text/virgo/attribute-renderer.js';
-import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
+import {
+  affineTextAttributes,
+  type AffineTextSchema,
+} from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ListBlockModel } from './list-model.js';
 import { ListIcon } from './utils/get-list-icon.js';
@@ -84,7 +87,7 @@ export class ListBlockComponent extends NonShadowLitElement {
   showChildren = true;
 
   @state()
-  textSchema = {
+  textSchema: AffineTextSchema = {
     attributesSchema: affineTextAttributes,
     textRenderer: attributeRenderer,
   };

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -2,7 +2,6 @@
 import {
   asyncFocusRichText,
   type BlockHost,
-  type CommonSlots,
   type EditingState,
   hotkey,
   HOTKEY_SCOPE,
@@ -57,7 +56,7 @@ export interface DefaultSelectionSlots {
 @customElement('affine-default-page')
 export class DefaultPageBlockComponent
   extends NonShadowLitElement
-  implements BlockHost<CommonSlots>
+  implements BlockHost
 {
   static styles = css`
     .affine-default-viewport {

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -177,9 +177,9 @@ export class DefaultPageBlockComponent
     embedEditingStateUpdated: new Slot<EditingState | null>(),
     nativeSelectionToggled: new Slot<boolean>(),
 
-    onLinkPage: new Slot<{ pageId: string }>(),
-    onUnlinkPage: new Slot<{ pageId: string }>(),
-    onJumpToPage: new Slot<{ pageId: string }>(),
+    subpageLinked: new Slot<{ pageId: string }>(),
+    subpageUnlinked: new Slot<{ pageId: string }>(),
+    pageLinkClicked: new Slot<{ pageId: string }>(),
   };
 
   @query('.affine-default-page-block-title')

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -2,6 +2,7 @@
 import {
   asyncFocusRichText,
   type BlockHost,
+  type CommonSlots,
   type EditingState,
   hotkey,
   HOTKEY_SCOPE,
@@ -43,6 +44,9 @@ export interface DefaultSelectionSlots {
   selectedRectsUpdated: Slot<DOMRect[]>;
   embedRectsUpdated: Slot<DOMRect[]>;
   embedEditingStateUpdated: Slot<EditingState | null>;
+  /**
+   * @deprecated Not used yet
+   */
   codeBlockOptionUpdated?: Slot;
   /**
    * @deprecated Not used yet
@@ -53,7 +57,7 @@ export interface DefaultSelectionSlots {
 @customElement('affine-default-page')
 export class DefaultPageBlockComponent
   extends NonShadowLitElement
-  implements BlockHost
+  implements BlockHost<CommonSlots>
 {
   static styles = css`
     .affine-default-viewport {
@@ -166,12 +170,16 @@ export class DefaultPageBlockComponent
   @query('.affine-default-page-block-container')
   pageBlockContainer!: HTMLDivElement;
 
-  slots: DefaultSelectionSlots = {
+  slots = {
     draggingAreaUpdated: new Slot<DOMRect | null>(),
     selectedRectsUpdated: new Slot<DOMRect[]>(),
     embedRectsUpdated: new Slot<DOMRect[]>(),
     embedEditingStateUpdated: new Slot<EditingState | null>(),
     nativeSelectionToggled: new Slot<boolean>(),
+
+    onLinkPage: new Slot<{ pageId: string }>(),
+    onUnlinkPage: new Slot<{ pageId: string }>(),
+    onJumpToPage: new Slot<{ pageId: string }>(),
   };
 
   @query('.affine-default-page-block-title')

--- a/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/default-selection-manager.ts
@@ -504,7 +504,7 @@ export class DefaultSelectionManager {
   }
 
   refreshRemoteSelection() {
-    const element = document.querySelector('remote-selection');
+    const element = this._container.querySelector('remote-selection');
     if (element) {
       element.requestUpdate();
     }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -1,11 +1,10 @@
 /// <reference types="vite/client" />
-import './toolbar/edgeless-toolbar.js';
 import './components/edgeless-selected-rect.js';
+import './toolbar/edgeless-toolbar.js';
 
 import {
   almostEqual,
   type BlockHost,
-  type CommonSlots,
   getClosestFrameBlockElementById,
   type Point,
   resetNativeSelection,

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -151,9 +151,9 @@ export class EdgelessPageBlockComponent
     surfaceUpdated: new Slot(),
     mouseModeUpdated: new Slot<MouseMode>(),
 
-    onLinkPage: new Slot<{ pageId: string }>(),
-    onUnlinkPage: new Slot<{ pageId: string }>(),
-    onJumpToPage: new Slot<{ pageId: string }>(),
+    subpageLinked: new Slot<{ pageId: string }>(),
+    subpageUnlinked: new Slot<{ pageId: string }>(),
+    pageLinkClicked: new Slot<{ pageId: string }>(),
   };
 
   surface!: SurfaceManager;

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -77,7 +77,7 @@ export interface EdgelessContainer extends HTMLElement {
 @customElement('affine-edgeless-page')
 export class EdgelessPageBlockComponent
   extends NonShadowLitElement
-  implements EdgelessContainer, BlockHost<CommonSlots>
+  implements EdgelessContainer, BlockHost
 {
   static styles = css`
     .affine-edgeless-page-block-container {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -5,6 +5,7 @@ import './components/edgeless-selected-rect.js';
 import {
   almostEqual,
   type BlockHost,
+  type CommonSlots,
   getClosestFrameBlockElementById,
   type Point,
   resetNativeSelection,
@@ -76,7 +77,7 @@ export interface EdgelessContainer extends HTMLElement {
 @customElement('affine-edgeless-page')
 export class EdgelessPageBlockComponent
   extends NonShadowLitElement
-  implements EdgelessContainer, BlockHost
+  implements EdgelessContainer, BlockHost<CommonSlots>
 {
   static styles = css`
     .affine-edgeless-page-block-container {
@@ -143,12 +144,16 @@ export class EdgelessPageBlockComponent
 
   clipboard = new EdgelessClipboard(this.page);
 
-  slots: EdgelessSelectionSlots = {
+  slots = {
     viewportUpdated: new Slot(),
     selectionUpdated: new Slot<EdgelessSelectionState>(),
     hoverUpdated: new Slot(),
     surfaceUpdated: new Slot(),
     mouseModeUpdated: new Slot<MouseMode>(),
+
+    onLinkPage: new Slot<{ pageId: string }>(),
+    onUnlinkPage: new Slot<{ pageId: string }>(),
+    onJumpToPage: new Slot<{ pageId: string }>(),
   };
 
   surface!: SurfaceManager;

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -9,6 +9,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import {
   type BlockHost,
+  type CommonSlots,
   isPageMode,
   NonShadowLitElement,
 } from '../__internal__/index.js';
@@ -167,7 +168,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   model!: ParagraphBlockModel;
 
   @property()
-  host!: BlockHost;
+  host!: BlockHost<CommonSlots>;
 
   @state()
   private _tipsPlaceholderTemplate = html``;

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -9,7 +9,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import {
   type BlockHost,
-  type CommonSlots,
   isPageMode,
   NonShadowLitElement,
 } from '../__internal__/index.js';
@@ -171,7 +170,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   model!: ParagraphBlockModel;
 
   @property()
-  host!: BlockHost<CommonSlots>;
+  host!: BlockHost;
 
   @state()
   private _tipsPlaceholderTemplate = html``;

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -180,8 +180,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   @state()
   private _isFocus = false;
 
-  @state()
-  textSchema: AffineTextSchema = {
+  readonly textSchema: AffineTextSchema = {
     attributesSchema: affineTextAttributes,
     textRenderer: attributeRenderer,
   };

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -14,7 +14,10 @@ import {
   NonShadowLitElement,
 } from '../__internal__/index.js';
 import { attributeRenderer } from '../__internal__/rich-text/virgo/attribute-renderer.js';
-import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
+import {
+  affineTextAttributes,
+  type AffineTextSchema,
+} from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
@@ -178,7 +181,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   private _isFocus = false;
 
   @state()
-  textSchema = {
+  textSchema: AffineTextSchema = {
     attributesSchema: affineTextAttributes,
     textRenderer: attributeRenderer,
   };

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -13,7 +13,7 @@ import {
   isPageMode,
   NonShadowLitElement,
 } from '../__internal__/index.js';
-import { attributesRenderer } from '../__internal__/rich-text/virgo/attributes-renderer.js';
+import { attributeRenderer } from '../__internal__/rich-text/virgo/attribute-renderer.js';
 import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
@@ -180,7 +180,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   @state()
   textSchema = {
     attributesSchema: affineTextAttributes,
-    textRenderer: attributesRenderer,
+    textRenderer: attributeRenderer,
   };
 
   private _placeholderDisposables = new DisposableGroup();

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 import '../__internal__/rich-text/rich-text.js';
 
 import { BlockHubIcon20 } from '@blocksuite/global/config';

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -13,6 +13,8 @@ import {
   isPageMode,
   NonShadowLitElement,
 } from '../__internal__/index.js';
+import { attributesRenderer } from '../__internal__/rich-text/virgo/attributes-renderer.js';
+import { affineTextAttributes } from '../__internal__/rich-text/virgo/types.js';
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
@@ -174,6 +176,13 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
   private _isComposing = false;
   @state()
   private _isFocus = false;
+
+  @state()
+  textSchema = {
+    attributesSchema: affineTextAttributes,
+    textRenderer: attributesRenderer,
+  };
+
   private _placeholderDisposables = new DisposableGroup();
 
   override connectedCallback() {
@@ -250,6 +259,7 @@ export class ParagraphBlockComponent extends NonShadowLitElement {
         <rich-text
           .host=${this.host}
           .model=${this.model}
+          .textSchema=${this.textSchema}
           @focusin=${this._onFocusIn}
           @focusout=${this._onFocusOut}
           style=${styleMap({

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -1,4 +1,7 @@
 import type {
+  CommonSlots,
+  DefaultPageBlockComponent,
+  EdgelessPageBlockComponent,
   MouseMode,
   PageBlockModel,
   SurfaceBlockModel,
@@ -8,14 +11,23 @@ import {
   getServiceOrRegister,
   NonShadowLitElement,
 } from '@blocksuite/blocks';
-import type { Page } from '@blocksuite/store';
+import { type Page, Slot } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { html } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 import { keyed } from 'lit/directives/keyed.js';
 
 import { checkEditorElementActive, createBlockHub } from '../utils/editor.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function forwardSlot<T extends Record<string, Slot<any>>>(from: T, to: T) {
+  Object.entries(from).forEach(([key, slot]) => {
+    if (key in to) {
+      slot.pipe(to[key]);
+    }
+  });
+}
 
 @customElement('editor-container')
 export class EditorContainer extends NonShadowLitElement {
@@ -55,19 +67,17 @@ export class EditorContainer extends NonShadowLitElement {
 
   private _disposables = new DisposableGroup();
 
-  firstUpdated() {
-    // todo: refactor to a better solution
-    getServiceOrRegister('affine:code');
+  @query('affine-default-page')
+  private _defaultPageBlock?: DefaultPageBlockComponent;
 
-    if (this.mode === 'page') {
-      setTimeout(() => {
-        const defaultPage = this.querySelector('affine-default-page');
-        if (this.autofocus) {
-          defaultPage?.titleVEditor.focusEnd();
-        }
-      });
-    }
-  }
+  @query('affine-edgeless-page')
+  private _edgelessPageBlock?: EdgelessPageBlockComponent;
+
+  slots: CommonSlots = {
+    onJumpToPage: new Slot(),
+    onLinkPage: new Slot(),
+    onUnlinkPage: new Slot(),
+  };
 
   connectedCallback() {
     super.connectedCallback();
@@ -138,18 +148,44 @@ export class EditorContainer extends NonShadowLitElement {
     );
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.page.awarenessStore.setLocalRange(this.page, null);
+    this._disposables.dispose();
+  }
+
+  firstUpdated() {
+    // todo: refactor to a better solution
+    getServiceOrRegister('affine:code');
+
+    if (this.mode === 'page') {
+      setTimeout(() => {
+        const defaultPage = this.querySelector('affine-default-page');
+        if (this.autofocus) {
+          defaultPage?.titleVEditor.focusEnd();
+        }
+      });
+    }
+  }
+
+  updated(changedProperties: Map<string, unknown>) {
+    if (!changedProperties.has('page') && !changedProperties.has('mode')) {
+      return;
+    }
+    if (this._defaultPageBlock) {
+      forwardSlot(this._defaultPageBlock.slots, this.slots);
+    }
+    if (this._edgelessPageBlock) {
+      forwardSlot(this._edgelessPageBlock.slots, this.slots);
+    }
+  }
+
   async createBlockHub() {
     await this.updateComplete;
     if (!this.page.root) {
       await new Promise(res => this.page.slots.rootAdded.once(res));
     }
     return createBlockHub(this, this.page);
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.page.awarenessStore.setLocalRange(this.page, null);
-    this._disposables.dispose();
   }
 
   render() {

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -74,9 +74,9 @@ export class EditorContainer extends NonShadowLitElement {
   private _edgelessPageBlock?: EdgelessPageBlockComponent;
 
   slots: CommonSlots = {
-    onJumpToPage: new Slot(),
-    onLinkPage: new Slot(),
-    onUnlinkPage: new Slot(),
+    pageLinkClicked: new Slot(),
+    subpageLinked: new Slot(),
+    subpageUnlinked: new Slot(),
   };
 
   connectedCallback() {

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -40,6 +40,13 @@ function subscribePage(workspace: Workspace) {
     const editor = new EditorContainer();
     editor.page = page;
     editor.autofocus = true;
+    editor.slots.onJumpToPage.on(({ pageId }) => {
+      const page = workspace.getPage(pageId);
+      if (!page) {
+        throw new Error(`Failed to jump to page ${pageId}`);
+      }
+      editor.page = page;
+    });
 
     document.getElementById('app')?.append(editor);
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -40,18 +40,18 @@ function subscribePage(workspace: Workspace) {
     const editor = new EditorContainer();
     editor.page = page;
     editor.autofocus = true;
-    editor.slots.onJumpToPage.on(({ pageId }) => {
+    editor.slots.pageLinkClicked.on(({ pageId }) => {
       const page = workspace.getPage(pageId);
       if (!page) {
         throw new Error(`Failed to jump to page ${pageId}`);
       }
       editor.page = page;
     });
-    editor.slots.onLinkPage.on(({ pageId }) => {
-      console.log('onLinkPage', page);
+    editor.slots.subpageLinked.on(({ pageId }) => {
+      console.log('subpageLinked', page);
     });
-    editor.slots.onUnlinkPage.on(({ pageId }) => {
-      console.log('onUnlinkPage', page);
+    editor.slots.subpageUnlinked.on(({ pageId }) => {
+      console.log('subpageUnlinked', page);
     });
 
     document.getElementById('app')?.append(editor);

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -47,6 +47,12 @@ function subscribePage(workspace: Workspace) {
       }
       editor.page = page;
     });
+    editor.slots.onLinkPage.on(({ pageId }) => {
+      console.log('onLinkPage', page);
+    });
+    editor.slots.onUnlinkPage.on(({ pageId }) => {
+      console.log('onUnlinkPage', page);
+    });
 
     document.getElementById('app')?.append(editor);
 

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -14,9 +14,9 @@ import {
   type DocProviderConstructor,
   Generator,
   IndexedDBDocProvider,
-  type StoreOptions,
   Utils,
   Workspace,
+  type WorkspaceOptions,
 } from '@blocksuite/store';
 import { fileOpen } from 'browser-fs-access';
 
@@ -121,10 +121,7 @@ export async function tryInitExternalContent(
  * Provider configuration is specified by `?providers=webrtc` or `?providers=indexeddb,webrtc` in URL params.
  * We use webrtcDocProvider by default if the `providers` param is missing.
  */
-export function createWorkspaceOptions(): Pick<
-  StoreOptions,
-  'providers' | 'idGenerator' | 'id' | 'defaultFlags'
-> {
+export function createWorkspaceOptions(): WorkspaceOptions {
   const providers: DocProviderConstructor[] = [];
   let idGenerator: Generator = Generator.AutoIncrement; // works only in single user mode
 

--- a/packages/playground/src/utils.ts
+++ b/packages/playground/src/utils.ts
@@ -153,7 +153,7 @@ export function createWorkspaceOptions(): WorkspaceOptions {
       enable_block_hub: true,
       enable_database: true,
       enable_edgeless_toolbar: true,
-      enable_linked_page: false,
+      enable_linked_page: true,
       readonly: {
         'space:page0': false,
       },

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -71,7 +71,6 @@ export interface StoreOptions<
   idGenerator?: Generator;
   defaultFlags?: Partial<Flags>;
   blobOptionsGetter?: BlobOptionsGetter;
-  experimentalInlineSuggestionProvider?: InlineSuggestionProvider;
 }
 
 const flagsPreset = {

--- a/packages/store/src/workspace/index.ts
+++ b/packages/store/src/workspace/index.ts
@@ -1,3 +1,3 @@
 export { Page } from './page.js';
-export type { PageMeta } from './workspace.js';
+export type { PageMeta, WorkspaceOptions } from './workspace.js';
 export { Workspace } from './workspace.js';

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -21,6 +21,10 @@ import type { BlockSuiteDoc } from '../yjs/index.js';
 import { Page } from './page.js';
 import { Indexer, type QueryContent } from './search.js';
 
+export type WorkspaceOptions = {
+  experimentalInlineSuggestionProvider?: InlineSuggestionProvider;
+} & StoreOptions;
+
 export interface PageMeta {
   id: string;
   title: string;
@@ -285,17 +289,19 @@ export class Workspace {
 
   readonly inlineSuggestionProvider?: InlineSuggestionProvider;
 
-  constructor(options: StoreOptions) {
-    this.inlineSuggestionProvider =
-      options.experimentalInlineSuggestionProvider;
-    this._store = new Store(options);
+  constructor({
+    experimentalInlineSuggestionProvider,
+    ...storeOptions
+  }: WorkspaceOptions) {
+    this.inlineSuggestionProvider = experimentalInlineSuggestionProvider;
+    this._store = new Store(storeOptions);
     this._indexer = new Indexer(this.doc);
-    if (options.blobOptionsGetter) {
-      this._blobOptionsGetter = options.blobOptionsGetter;
+    if (storeOptions.blobOptionsGetter) {
+      this._blobOptionsGetter = storeOptions.blobOptionsGetter;
     }
 
-    if (!options.isSSR) {
-      this._blobStorage = getBlobStorage(options.id, k => {
+    if (!storeOptions.isSSR) {
+      this._blobStorage = getBlobStorage(storeOptions.id, k => {
         return this._blobOptionsGetter ? this._blobOptionsGetter(k) : '';
       });
       this._initBlobStorage();


### PR DESCRIPTION
Part of https://github.com/toeverything/AFFiNE/issues/1332

- New `CommonSlots` API
```ts
export type CommonSlots = {
  /**
   * Emit when the subpage is linked to the current page.
   * We show restore subpage from the trash in AFFiNE
   */
  onLinkPage: Slot<{ pageId: string }>;
  /**
   * Emit when the subpage is unlinked from the current page.
   * We need to move the subpage to the trash in AFFiNE
   */
  onUnlinkPage: Slot<{ pageId: string }>;
  // Emit when click reference node
  onJumpToPage: Slot<{ pageId: string }>;
};
```
- Add `Slots<T>` to the `BlockHost`
- Implement `CommonSlots` in the `DefaultPageBlockComponent` and `EdgelessPageBlockComponent`
- Forward the `CommonSlots` to the `EditorConintainer` from `DefaultPageBlockComponent` and `EdgelessPageBlockComponent`
- Add `WorkspaceOptions` types


Usages

```ts
    const editor = new EditorContainer();
    editor.page = page;
    editor.slots.onJumpToPage.on(({ pageId }) => {
      const newPage = workspace.getPage(pageId);
      if (!newPage) {
        throw new Error(`Failed to jump to page ${pageId}`);
      }
      editor.page = newPage;
    });
    editor.slots.onLinkPage.on(({ pageId }) => {
      console.log('onLinkPage', page);
    });
    editor.slots.onUnlinkPage.on(({ pageId }) => {
      console.log('onUnlinkPage', page);
    });
```
