### PR TITLE
refactor(database): optimize column related naming

### DIFF
--- a/packages/blocks/src/database-block/components/cell-container.ts
+++ b/packages/blocks/src/database-block/components/cell-container.ts
@@ -34,7 +34,7 @@ export class DatabaseCellContainer
     queueMicrotask(() => {
       this.databaseModel.page.captureSync();
       this.databaseModel.page.updateBlockColumn(this.rowModel.id, {
-        schemaId: this.columnSchema.id,
+        columnId: this.columnSchema.id,
         value,
       });
     });

--- a/packages/blocks/src/database-block/components/cell-container.ts
+++ b/packages/blocks/src/database-block/components/cell-container.ts
@@ -55,7 +55,7 @@ export class DatabaseCellContainer
   ) {
     const newProperty = apply(this.columnSchema.property);
     this.databaseModel.page.captureSync();
-    this.databaseModel.page.setColumnSchema({
+    this.databaseModel.page.updateColumnSchema({
       ...this.columnSchema,
       property: newProperty,
     });

--- a/packages/blocks/src/database-block/components/cell-container.ts
+++ b/packages/blocks/src/database-block/components/cell-container.ts
@@ -33,7 +33,7 @@ export class DatabaseCellContainer
   setValue(value: unknown) {
     queueMicrotask(() => {
       this.databaseModel.page.captureSync();
-      this.databaseModel.page.updateBlockColumn(this.rowModel.id, {
+      this.databaseModel.page.updateColumn(this.rowModel.id, {
         columnId: this.columnSchema.id,
         value,
       });
@@ -110,9 +110,9 @@ export class DatabaseCellContainer
   }
 
   /* eslint-disable lit/binding-positions, lit/no-invalid-html */
-  protected render() {
+  render() {
     const renderer = getColumnSchemaRenderer(this.columnSchema.type);
-    const column = this.databaseModel.page.getBlockColumnBySchema(
+    const column = this.databaseModel.page.getColumn(
       this.rowModel,
       this.columnSchema
     );

--- a/packages/blocks/src/database-block/components/column-type/rich-text.ts
+++ b/packages/blocks/src/database-block/components/column-type/rich-text.ts
@@ -90,7 +90,7 @@ class TextCell extends DatabaseCellLitElement<Y.Text> {
     if (!this.column) {
       const yText = new this.databaseModel.page.YText();
       this.databaseModel.page.updateBlockColumn(this.rowModel.id, {
-        schemaId: this.columnSchema.id,
+        columnId: this.columnSchema.id,
         value: yText,
       });
       this.vEditor = new VEditor(yText);

--- a/packages/blocks/src/database-block/components/column-type/rich-text.ts
+++ b/packages/blocks/src/database-block/components/column-type/rich-text.ts
@@ -89,7 +89,7 @@ class TextCell extends DatabaseCellLitElement<Y.Text> {
     this.databaseModel.page.captureSync();
     if (!this.column) {
       const yText = new this.databaseModel.page.YText();
-      this.databaseModel.page.updateBlockColumn(this.rowModel.id, {
+      this.databaseModel.page.updateColumn(this.rowModel.id, {
         columnId: this.columnSchema.id,
         value: yText,
       });

--- a/packages/blocks/src/database-block/components/edit-column-popup.ts
+++ b/packages/blocks/src/database-block/components/edit-column-popup.ts
@@ -387,12 +387,12 @@ export class EditColumnPopup extends LitElement {
     // multi-select -> select
     else if (currentType === 'multi-select' && targetType === 'select') {
       this._updateColumnSchema(columnId, { type: targetType });
-      this.targetModel.page.updateColumnValue(columnId, 'select');
+      this.targetModel.page.convertColumn(columnId, 'select');
     }
     // number -> rich-text
     else if (currentType === 'number' && targetType === 'rich-text') {
       this._updateColumnSchema(columnId, { type: targetType });
-      this.targetModel.page.updateColumnValue(columnId, 'rich-text');
+      this.targetModel.page.convertColumn(columnId, 'rich-text');
     } else {
       // incompatible types: clear the value of the column
       const renderer = getColumnSchemaRenderer(targetType);
@@ -400,7 +400,7 @@ export class EditColumnPopup extends LitElement {
         type: targetType,
         property: renderer.propertyCreator(),
       });
-      this.targetModel.page.deleteBlockColumns(columnId);
+      this.targetModel.page.deleteColumn(columnId);
     }
 
     this.closePopup();
@@ -463,7 +463,7 @@ export class EditColumnPopup extends LitElement {
       this.targetModel.page.updateBlock(this.targetModel, {
         columns: newColumns,
       });
-      this.targetModel.page.copyBlockColumnById(copyId, id);
+      this.targetModel.page.copyColumn(copyId, id);
       this.closePopup();
       return;
     }

--- a/packages/blocks/src/database-block/components/edit-column-popup.ts
+++ b/packages/blocks/src/database-block/components/edit-column-popup.ts
@@ -368,7 +368,7 @@ export class EditColumnPopup extends LitElement {
     const currentSchema = this.targetModel.page.getColumnSchema(columnId);
     assertExists(currentSchema);
     const schema = { ...currentSchema, ...schemaProperties };
-    this.targetModel.page.setColumnSchema(schema);
+    this.targetModel.page.updateColumnSchema(schema);
   };
 
   private _changeColumnType = (
@@ -457,7 +457,7 @@ export class EditColumnPopup extends LitElement {
       assertExists(currentSchema);
       const { id: copyId, ...nonIdProps } = currentSchema;
       const schema = { ...nonIdProps };
-      const id = this.targetModel.page.setColumnSchema(schema);
+      const id = this.targetModel.page.updateColumnSchema(schema);
       const newColumns = [...this.targetModel.columns];
       newColumns.splice(this.columnIndex + 1, 0, id);
       this.targetModel.page.updateBlock(this.targetModel, {

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -277,7 +277,7 @@ class DatabaseColumnHeader extends NonShadowLitElement {
   };
 
   private _onUpdateNormalColumn = (name: string, column: ColumnSchema) => {
-    this.targetModel.page.setColumnSchema({
+    this.targetModel.page.updateColumnSchema({
       ...column,
       name,
     });
@@ -845,7 +845,7 @@ export class DatabaseBlockComponent
       },
       property: renderer.propertyCreator(),
     };
-    const id = this.model.page.setColumnSchema(schema);
+    const id = this.model.page.updateColumnSchema(schema);
     const newColumns = [...this.model.columns];
     newColumns.splice(index, 0, id);
     this.model.page.updateBlock(this.model, {

--- a/packages/blocks/src/database-block/database-service.ts
+++ b/packages/blocks/src/database-block/database-service.ts
@@ -32,7 +32,7 @@ export class DatabaseBlockService extends BaseService<DatabaseBlockModel> {
     }
 
     // default column
-    const tagColumnId = page.setColumnSchema({
+    const tagColumnId = page.updateColumnSchema({
       internalProperty: {
         color: '#ff0000',
         width: 200,

--- a/packages/global/src/database.ts
+++ b/packages/global/src/database.ts
@@ -56,7 +56,7 @@ export interface ColumnSchema<
 }
 
 export type BlockColumn<Schema extends ColumnSchema = ColumnSchema> = {
-  schemaId: Schema['id'];
+  columnId: Schema['id'];
   value: Schema extends ColumnSchema<infer _, infer __, infer Value>
     ? Value
     : never;

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -192,12 +192,12 @@ export const database: InitFn = (workspace: Workspace) => {
   );
 
   page.updateBlockColumn(p1, {
-    schemaId: col1,
+    columnId: col1,
     value: 0.1,
   });
 
   page.updateBlockColumn(p2, {
-    schemaId: col2,
+    columnId: col2,
     value: ['TODO'],
   });
 
@@ -205,7 +205,7 @@ export const database: InitFn = (workspace: Workspace) => {
   text.insert(0, '123');
   text.insert(0, 'code');
   page.updateBlockColumn(p2, {
-    schemaId: col3,
+    columnId: col3,
     value: text,
   });
 

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -133,7 +133,7 @@ export const database: InitFn = (workspace: Workspace) => {
 
   type Option = 'Done' | 'TODO' | 'WIP';
   const selection = ['Done', 'TODO', 'WIP'] as Option[];
-  const col1 = page.setColumnSchema({
+  const col1 = page.updateColumnSchema({
     internalProperty: {
       color: '#ff0000',
       width: 200,
@@ -145,7 +145,7 @@ export const database: InitFn = (workspace: Workspace) => {
     name: 'Number',
     type: 'number',
   });
-  const col2 = page.setColumnSchema({
+  const col2 = page.updateColumnSchema({
     internalProperty: {
       color: '#ff0000',
       width: 200,
@@ -157,7 +157,7 @@ export const database: InitFn = (workspace: Workspace) => {
     name: 'Single Select',
     type: 'select',
   });
-  const col3 = page.setColumnSchema({
+  const col3 = page.updateColumnSchema({
     internalProperty: {
       color: '#ff0000',
       width: 200,
@@ -191,12 +191,12 @@ export const database: InitFn = (workspace: Workspace) => {
     databaseId
   );
 
-  page.updateBlockColumn(p1, {
+  page.updateColumn(p1, {
     columnId: col1,
     value: 0.1,
   });
 
-  page.updateBlockColumn(p2, {
+  page.updateColumn(p2, {
     columnId: col2,
     value: ['TODO'],
   });
@@ -204,7 +204,7 @@ export const database: InitFn = (workspace: Workspace) => {
   const text = new page.YText();
   text.insert(0, '123');
   text.insert(0, 'code');
-  page.updateBlockColumn(p2, {
+  page.updateColumn(p2, {
     columnId: col3,
     value: text,
   });

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -212,109 +212,6 @@ export class Page extends Space<FlatBlockMap> {
     this._history.clear();
   };
 
-  updateBlockColumn<Column extends BlockColumn>(
-    id: BaseBlockModel['id'],
-    column: Column
-  ) {
-    const hasColumn = this.yColumns.has(id);
-    let yColumns: Y.Map<unknown>;
-    if (!hasColumn) {
-      yColumns = new Y.Map();
-    } else {
-      yColumns = this.yColumns.get(id) as Y.Map<unknown>;
-    }
-    this.transact(() => {
-      if (!hasColumn) {
-        this.yColumns.set(id, yColumns);
-      }
-      // Related issue: https://github.com/yjs/yjs/issues/255
-      const yColumnMap = new Y.Map();
-      yColumnMap.set('columnId', column.columnId);
-      yColumnMap.set('value', column.value);
-      yColumns.set(column.columnId, yColumnMap);
-    });
-  }
-
-  getBlockColumnBySchema(
-    model: BaseBlockModel,
-    schema: ColumnSchema
-  ): BlockColumn | null {
-    const yColumns = this.yColumns.get(model.id);
-    const yColumnMap = (yColumns?.get(schema.id) as Y.Map<unknown>) ?? null;
-    if (!yColumnMap) return null;
-
-    return {
-      columnId: yColumnMap.get('columnId') as string,
-      value: yColumnMap.get('value') as unknown,
-    };
-  }
-
-  getColumnSchema(id: ColumnSchema['id']): ColumnSchema | null {
-    return (this.yColumnSchema.get(id) ?? null) as ColumnSchema | null;
-  }
-
-  setColumnSchema(
-    schema: Omit<ColumnSchema, 'id'> & { id?: ColumnSchema['id'] }
-  ): string {
-    const id = schema.id ?? this._idGenerator();
-    this.transact(() => this.yColumnSchema.set(id, { ...schema, id }));
-    return id;
-  }
-
-  deleteColumnSchema(id: ColumnSchema['id']) {
-    this.transact(() => this.yColumnSchema.delete(id));
-  }
-
-  copyBlockColumnById(copyId: ColumnSchema['id'], toId: ColumnSchema['id']) {
-    this.transact(() => {
-      this.yColumns.forEach(column => {
-        const copyColumn = column.get(copyId) as Y.Map<unknown>;
-        if (copyColumn) {
-          const columnMap = new Y.Map();
-          columnMap.set('columnId', toId);
-          columnMap.set('value', copyColumn.get('value'));
-          column.set(toId, columnMap);
-        }
-      });
-    });
-  }
-
-  // TODO: remove hard coded types
-  updateColumnValue(columnId: string, newType: 'select' | 'rich-text') {
-    this.transact(() => {
-      this.yColumns.forEach(yColumn => {
-        const yTargetColumn = yColumn.get(columnId) as Y.Map<unknown>;
-        if (!yTargetColumn) return;
-
-        if (newType === 'select') {
-          const value = yTargetColumn.get('value');
-          if (!value) return;
-
-          const yColumnMap = new Y.Map();
-          yColumnMap.set('columnId', columnId);
-          yColumnMap.set('value', [(value as string[])[0]]);
-          yColumn.set(columnId, yColumnMap);
-        } else if (newType === 'rich-text') {
-          const value = yTargetColumn.get('value');
-          if (!value) return;
-
-          const yColumnMap = new Y.Map();
-          yColumnMap.set('columnId', columnId);
-          yColumnMap.set('value', new Y.Text((value as number) + ''));
-          yColumn.set(columnId, yColumnMap);
-        }
-      });
-    });
-  }
-
-  deleteBlockColumns(id: BaseBlockModel['id']) {
-    this.transact(() => {
-      this.yColumns.forEach(yColumn => {
-        yColumn.delete(id);
-      });
-    });
-  }
-
   getBlockById(id: string) {
     return this._blockMap.get(id) ?? null;
   }
@@ -716,6 +613,100 @@ export class Page extends Space<FlatBlockMap> {
     this.slots.blockUpdated.emit({
       type: 'delete',
       id: model.id,
+    });
+  }
+
+  getColumnSchema(id: ColumnSchema['id']): ColumnSchema | null {
+    return (this.yColumnSchema.get(id) ?? null) as ColumnSchema | null;
+  }
+
+  setColumnSchema(
+    schema: Omit<ColumnSchema, 'id'> & { id?: ColumnSchema['id'] }
+  ): string {
+    const id = schema.id ?? this._idGenerator();
+    this.transact(() => this.yColumnSchema.set(id, { ...schema, id }));
+    return id;
+  }
+
+  deleteColumnSchema(id: ColumnSchema['id']) {
+    this.transact(() => this.yColumnSchema.delete(id));
+  }
+
+  getColumn(model: BaseBlockModel, schema: ColumnSchema): BlockColumn | null {
+    const yColumns = this.yColumns.get(model.id);
+    const yColumnMap = (yColumns?.get(schema.id) as Y.Map<unknown>) ?? null;
+    if (!yColumnMap) return null;
+
+    return {
+      columnId: yColumnMap.get('columnId') as string,
+      value: yColumnMap.get('value') as unknown,
+    };
+  }
+
+  updateColumn(columnId: string, column: BlockColumn) {
+    const hasColumn = this.yColumns.has(columnId);
+    let yColumns: Y.Map<unknown>;
+    if (!hasColumn) {
+      yColumns = new Y.Map();
+    } else {
+      yColumns = this.yColumns.get(columnId) as Y.Map<unknown>;
+    }
+    this.transact(() => {
+      if (!hasColumn) {
+        this.yColumns.set(columnId, yColumns);
+      }
+      // Related issue: https://github.com/yjs/yjs/issues/255
+      const yColumnMap = new Y.Map();
+      yColumnMap.set('columnId', column.columnId);
+      yColumnMap.set('value', column.value);
+      yColumns.set(column.columnId, yColumnMap);
+    });
+  }
+
+  copyColumn(fromId: ColumnSchema['id'], toId: ColumnSchema['id']) {
+    this.transact(() => {
+      this.yColumns.forEach(column => {
+        const copyColumn = column.get(fromId) as Y.Map<unknown>;
+        if (copyColumn) {
+          const columnMap = new Y.Map();
+          columnMap.set('columnId', toId);
+          columnMap.set('value', copyColumn.get('value'));
+          column.set(toId, columnMap);
+        }
+      });
+    });
+  }
+
+  deleteColumn(id: string) {
+    this.transact(() => {
+      this.yColumns.forEach(yColumn => yColumn.delete(id));
+    });
+  }
+
+  convertColumn(columnId: string, newType: 'select' | 'rich-text') {
+    this.transact(() => {
+      this.yColumns.forEach(yColumn => {
+        const yTargetColumn = yColumn.get(columnId) as Y.Map<unknown>;
+        if (!yTargetColumn) return;
+
+        if (newType === 'select') {
+          const value = yTargetColumn.get('value');
+          if (!value) return;
+
+          const yColumnMap = new Y.Map();
+          yColumnMap.set('columnId', columnId);
+          yColumnMap.set('value', [(value as string[])[0]]);
+          yColumn.set(columnId, yColumnMap);
+        } else if (newType === 'rich-text') {
+          const value = yTargetColumn.get('value');
+          if (!value) return;
+
+          const yColumnMap = new Y.Map();
+          yColumnMap.set('columnId', columnId);
+          yColumnMap.set('value', new Y.Text((value as number) + ''));
+          yColumn.set(columnId, yColumnMap);
+        }
+      });
     });
   }
 

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -229,9 +229,9 @@ export class Page extends Space<FlatBlockMap> {
       }
       // Related issue: https://github.com/yjs/yjs/issues/255
       const yColumnMap = new Y.Map();
-      yColumnMap.set('schemaId', column.schemaId);
+      yColumnMap.set('columnId', column.columnId);
       yColumnMap.set('value', column.value);
-      yColumns.set(column.schemaId, yColumnMap);
+      yColumns.set(column.columnId, yColumnMap);
     });
   }
 
@@ -244,7 +244,7 @@ export class Page extends Space<FlatBlockMap> {
     if (!yColumnMap) return null;
 
     return {
-      schemaId: yColumnMap.get('schemaId') as string,
+      columnId: yColumnMap.get('columnId') as string,
       value: yColumnMap.get('value') as unknown,
     };
   }
@@ -271,7 +271,7 @@ export class Page extends Space<FlatBlockMap> {
         const copyColumn = column.get(copyId) as Y.Map<unknown>;
         if (copyColumn) {
           const columnMap = new Y.Map();
-          columnMap.set('schemaId', toId);
+          columnMap.set('columnId', toId);
           columnMap.set('value', copyColumn.get('value'));
           column.set(toId, columnMap);
         }
@@ -291,7 +291,7 @@ export class Page extends Space<FlatBlockMap> {
           if (!value) return;
 
           const yColumnMap = new Y.Map();
-          yColumnMap.set('schemaId', columnId);
+          yColumnMap.set('columnId', columnId);
           yColumnMap.set('value', [(value as string[])[0]]);
           yColumn.set(columnId, yColumnMap);
         } else if (newType === 'rich-text') {
@@ -299,7 +299,7 @@ export class Page extends Space<FlatBlockMap> {
           if (!value) return;
 
           const yColumnMap = new Y.Map();
-          yColumnMap.set('schemaId', columnId);
+          yColumnMap.set('columnId', columnId);
           yColumnMap.set('value', new Y.Text((value as number) + ''));
           yColumn.set(columnId, yColumnMap);
         }

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -620,7 +620,7 @@ export class Page extends Space<FlatBlockMap> {
     return (this.yColumnSchema.get(id) ?? null) as ColumnSchema | null;
   }
 
-  setColumnSchema(
+  updateColumnSchema(
     schema: Omit<ColumnSchema, 'id'> & { id?: ColumnSchema['id'] }
   ): string {
     const id = schema.id ?? this._idGenerator();


### PR DESCRIPTION
* `updateBlockColumn` -> `updateColumn`
* `setColumnSchema` -> `updateColumnSchema`
* `getBlockColumnBySchema` -> `getColumn`
* `updateColumnValue` -> `convertColumn`
* `deleteBlockColumns` -> `deleteColumn`
* `copyBlockColumnById` -> `copyColumn`
* `schemaId` -> `columnId`

This brings following API surface:

* `ColumnSchema` related:
  * `getColumnSchema`
  * `updateColumnSchema`
  * `deleteColumnSchema`
* `Column` related:
  * `getColumn`
  * `updateColumn`
  * `deleteColumn`
  * `copyColumn`
  * `convertColumn`

/cc @zqran @Himself65 