### PR TITLE
refactor(database): remove `mode` in crdt model

### DIFF
--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -16,11 +16,7 @@ import {
   ColumnInsertPosition,
   type ColumnSchema,
 } from '@blocksuite/global/database';
-import {
-  assertEquals,
-  assertExists,
-  DisposableGroup,
-} from '@blocksuite/global/utils';
+import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 import { VEditor } from '@blocksuite/virgo';
 import { createPopper } from '@popperjs/core';
 import { css, type TemplateResult } from 'lit';
@@ -36,7 +32,6 @@ import { setupVirgoScroll } from '../__internal__/utils/virgo.js';
 import { registerInternalRenderer } from './components/column-type/index.js';
 import { EditColumnPopup } from './components/edit-column-popup.js';
 import type { DatabaseBlockModel } from './database-model.js';
-import { DatabaseBlockDisplayMode } from './database-model.js';
 import { getColumnSchemaRenderer } from './register.js';
 import { onClickOutside } from './utils.js';
 
@@ -362,7 +357,6 @@ function DataBaseRowContainer(
   searchState: SearchState
 ) {
   const databaseModel = databaseBlock.model;
-  assertEquals(databaseModel.mode, DatabaseBlockDisplayMode.Database);
 
   const filteredChildren =
     searchState === SearchState.Searching

--- a/packages/blocks/src/database-block/database-model.ts
+++ b/packages/blocks/src/database-block/database-model.ts
@@ -2,18 +2,11 @@ import type { ColumnSchema } from '@blocksuite/global/database';
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 import { literal } from 'lit/static-html.js';
 
-export enum DatabaseBlockDisplayMode {
-  Text,
-  Grid,
-  Database,
-}
-
 export const DatabaseBlockSchema = defineBlockSchema(
   'affine:database',
   internal => ({
     title: internal.Text(),
     columns: [] as ColumnSchema['id'][],
-    mode: DatabaseBlockDisplayMode.Database,
     titleColumn: '',
   }),
   {


### PR DESCRIPTION
@Himself65 @zqran I suggest we should not writing the `mode` into database block model, it's redundant and changing it will create unnecessary undo/redo actions.