### PR TITLE
fix: tooltip should be hidden when the submenu list is opened

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-brush-button.ts
@@ -5,7 +5,7 @@ import type { BrushElement, Color, SurfaceManager } from '@blocksuite/phasor';
 import type { Page } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { countBy, maxBy } from '../../../../__internal__/utils/std.js';
@@ -107,6 +107,9 @@ export class EdgelessChangeBrushButton extends LitElement {
   @property()
   slots!: EdgelessSelectionSlots;
 
+  @state()
+  private _popperShow = false;
+
   @query('.color-panel-container')
   private _colorPanel!: EdgelessColorPanel;
 
@@ -138,7 +141,13 @@ export class EdgelessChangeBrushButton extends LitElement {
   firstUpdated(changedProperties: Map<string, unknown>) {
     const _disposables = this._disposables;
 
-    this._colorPanelPopper = createButtonPopper(this, this._colorPanel);
+    this._colorPanelPopper = createButtonPopper(
+      this,
+      this._colorPanel,
+      ({ display }) => {
+        this._popperShow = display === 'show';
+      }
+    );
     _disposables.add(this._colorPanelPopper);
     super.firstUpdated(changedProperties);
   }
@@ -176,7 +185,7 @@ export class EdgelessChangeBrushButton extends LitElement {
       </edgeless-tool-icon-button>
       <menu-divider .vertical=${true}></menu-divider>
       <edgeless-tool-icon-button
-        .tooltip=${'Color'}
+        .tooltip=${this._popperShow ? '' : 'Color'}
         .active=${false}
         @tool.click=${() => this._colorPanelPopper?.toggle()}
       >

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
@@ -5,7 +5,7 @@ import type { ShapeElement, SurfaceManager } from '@blocksuite/phasor';
 import type { Page } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 
 import { countBy, maxBy } from '../../../../__internal__/utils/std.js';
 import type { ShapeMouseMode } from '../../../../__internal__/utils/types.js';
@@ -53,6 +53,9 @@ export class EdgelessChangeShapeButton extends LitElement {
   @property()
   surface!: SurfaceManager;
 
+  @state()
+  private _popperShow = false;
+
   @query('edgeless-shape-menu')
   private _shapeMenu!: EdgelessShapeMenu;
 
@@ -63,7 +66,13 @@ export class EdgelessChangeShapeButton extends LitElement {
   firstUpdated(changedProperties: Map<string, unknown>) {
     const _disposables = this._disposables;
 
-    this._shapeMenuPopper = createButtonPopper(this, this._shapeMenu);
+    this._shapeMenuPopper = createButtonPopper(
+      this,
+      this._shapeMenu,
+      ({ display }) => {
+        this._popperShow = display === 'show';
+      }
+    );
     _disposables.add(this._shapeMenuPopper);
     _disposables.add(
       this._shapeMenu.slots.select.on(shapeType => {
@@ -88,7 +97,7 @@ export class EdgelessChangeShapeButton extends LitElement {
       : null;
     return html`
       <edgeless-tool-icon-button
-        .tooltip=${'Shape'}
+        .tooltip=${this._popperShow ? '' : 'Shape'}
         .active=${false}
         @tool.click=${() => this._shapeMenuPopper?.toggle()}
       >

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -6,7 +6,7 @@ import type { SurfaceManager } from '@blocksuite/phasor';
 import type { Page } from '@blocksuite/store';
 import { DisposableGroup } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import type { EdgelessSelectionSlots } from '../../edgeless-page-block.js';
@@ -104,6 +104,9 @@ export class EdgelessMoreButton extends LitElement {
   @property()
   slots!: EdgelessSelectionSlots;
 
+  @state()
+  private _popperShow = false;
+
   @query('.more-actions-container')
   private _actionsMenu!: HTMLDivElement;
 
@@ -148,7 +151,13 @@ export class EdgelessMoreButton extends LitElement {
   firstUpdated(changedProperties: Map<string, unknown>) {
     const _disposables = this._disposables;
 
-    this._actionsMenuPopper = createButtonPopper(this, this._actionsMenu);
+    this._actionsMenuPopper = createButtonPopper(
+      this,
+      this._actionsMenu,
+      ({ display }) => {
+        this._popperShow = display === 'show';
+      }
+    );
     _disposables.add(this._actionsMenuPopper);
     super.firstUpdated(changedProperties);
   }
@@ -157,7 +166,7 @@ export class EdgelessMoreButton extends LitElement {
     const actions = Actions(this._runAction);
     return html`
       <edgeless-tool-icon-button
-        .tooltip=${'More'}
+        .tooltip=${this._popperShow ? '' : 'More'}
         .active=${false}
         @tool.click=${() => this._actionsMenuPopper?.toggle()}
       >

--- a/packages/blocks/src/page-block/edgeless/components/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/tool-icon-button.ts
@@ -49,9 +49,6 @@ export class EdgelessToolIconButton extends LitElement {
   @property()
   active = false;
 
-  @property()
-  testId?: string;
-
   private _dispatchClickEvent() {
     if (this.disabled) return;
 
@@ -71,7 +68,6 @@ export class EdgelessToolIconButton extends LitElement {
         role="button"
         ?disabled=${this.disabled}
         ?active=${this.active}
-        data-test-id=${this.testId ?? ''}
         @click=${this._dispatchClickEvent}
       >
         <slot></slot>

--- a/packages/blocks/src/page-block/edgeless/components/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/components/utils.ts
@@ -109,7 +109,10 @@ const ATTR_SHOW = 'data-show';
  */
 export function createButtonPopper(
   reference: HTMLElement,
-  popperElement: HTMLElement
+  popperElement: HTMLElement,
+  stateUpdated: (state: { display: 'show' | 'hidden' }) => void = () => {
+    /** DEFAULT EMPTY FUNCTION */
+  }
 ) {
   const popper = createPopper(reference, popperElement, {
     placement: 'top',
@@ -133,6 +136,7 @@ export function createButtonPopper(
       ],
     }));
     popper.update();
+    stateUpdated({ display: 'show' });
   };
 
   const hide = () => {
@@ -145,6 +149,7 @@ export function createButtonPopper(
         { name: 'eventListeners', enabled: false },
       ],
     }));
+    stateUpdated({ display: 'hidden' });
   };
 
   const toggle = () => {

--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
@@ -4,7 +4,7 @@ import './brush-menu.js';
 import { PenIcon } from '@blocksuite/global/config';
 import { createPopper } from '@popperjs/core';
 import { css, html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 import type { MouseMode } from '../../../../__internal__/index.js';
 import { getTooltipWithShortcut } from '../../components/utils.js';
@@ -54,16 +54,21 @@ export class EdgelessBrushToolButton extends LitElement {
   @property()
   edgeless!: EdgelessPageBlockComponent;
 
+  @state()
+  private _popperShow = false;
+
   private _brushMenu: BrushMenuPopper | null = null;
 
   private _toggleBrushMenu() {
     if (this._brushMenu) {
       this._brushMenu.dispose();
       this._brushMenu = null;
+      this._popperShow = false;
     } else {
       this._brushMenu = createBrushMenuPopper(this);
       this._brushMenu.element.mouseMode = this.mouseMode;
       this._brushMenu.element.edgeless = this.edgeless;
+      this._popperShow = true;
     }
   }
 
@@ -101,7 +106,7 @@ export class EdgelessBrushToolButton extends LitElement {
 
     return html`
       <edgeless-tool-icon-button
-        .tooltip=${getTooltipWithShortcut('Pen', 'P')}
+        .tooltip=${this._popperShow ? '' : getTooltipWithShortcut('Pen', 'P')}
         .active=${type === 'brush'}
         @tool.click=${() => {
           this._trySetBrushMode();

--- a/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
@@ -4,7 +4,7 @@ import './shape-menu.js';
 import { ShapeIcon } from '@blocksuite/global/config';
 import { DisposableGroup } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 
 import type {
   MouseMode,
@@ -37,6 +37,9 @@ export class EdgelessShapeToolButton extends LitElement {
   @property()
   edgeless!: EdgelessPageBlockComponent;
 
+  @state()
+  private _popperShow = false;
+
   @query('edgeless-shape-menu')
   private _shapeMenu!: EdgelessShapeMenu;
 
@@ -55,7 +58,13 @@ export class EdgelessShapeToolButton extends LitElement {
   firstUpdated(changedProperties: Map<string, unknown>) {
     const _disposables = this._disposables;
 
-    this._shapeMenuPopper = createButtonPopper(this, this._shapeMenu);
+    this._shapeMenuPopper = createButtonPopper(
+      this,
+      this._shapeMenu,
+      ({ display }) => {
+        this._popperShow = display === 'show';
+      }
+    );
     _disposables.add(this._shapeMenuPopper);
     _disposables.add(
       this._shapeMenu.slots.select.on(shape => {
@@ -80,9 +89,8 @@ export class EdgelessShapeToolButton extends LitElement {
 
     return html`
       <edgeless-tool-icon-button
-        .tooltip=${getTooltipWithShortcut('Shape', 'S')}
+        .tooltip=${this._popperShow ? '' : getTooltipWithShortcut('Shape', 'S')}
         .active=${type === 'shape'}
-        .testId=${'shape'}
         @tool.click=${() => {
           this._setMouseMode({
             type: 'shape',

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -13,6 +13,7 @@ import {
   getFrameBoundBoxInEdgeless,
   getFrameRect,
   increaseZoomLevel,
+  locatorEdgelessComponentToolButton,
   locatorEdgelessToolButton,
   openComponentToolbarMoreMenu,
   pickColorAtPoints,
@@ -418,7 +419,7 @@ test('edgeless toolbar menu shows up and close normally', async ({ page }) => {
   const toolbarLocator = page.locator('edgeless-toolbar');
   await expect(toolbarLocator).toBeVisible();
 
-  const shapeTool = page.locator('.icon-container[data-test-id="shape"]');
+  const shapeTool = locatorEdgelessToolButton(page, 'shape');
   const shapeToolBox = await shapeTool.boundingBox();
 
   assertExists(shapeToolBox);
@@ -1078,7 +1079,6 @@ test('bring to front', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
-
   const rect0 = {
     start: { x: 100, y: 100 },
     end: { x: 200, y: 200 },
@@ -1134,4 +1134,164 @@ test('send to back', async ({ page }) => {
   // should be rect0
   await page.mouse.click(175, 175);
   await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+});
+
+test('the tooltip of shape tool button should be hidden when the shape menu is shown', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const shapeTool = locatorEdgelessToolButton(page, 'shape');
+  const shapeToolBox = await shapeTool.boundingBox();
+  const tooltip = shapeTool.locator('tool-tip');
+
+  assertExists(shapeToolBox);
+
+  await page.mouse.move(shapeToolBox.x + 10, shapeToolBox.y + 10);
+  await expect(tooltip).toBeVisible();
+
+  await page.mouse.click(shapeToolBox.x + 10, shapeToolBox.y + 10);
+  await expect(tooltip).toBeHidden();
+
+  await page.mouse.click(shapeToolBox.x + 10, shapeToolBox.y + 10);
+  await expect(tooltip).toBeVisible();
+});
+
+test('the tooltip of brush tool button should be hidden when the brush menu is shown', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const brushTool = locatorEdgelessToolButton(page, 'brush');
+  const brushToolBox = await brushTool.boundingBox();
+  const tooltip = brushTool.locator('tool-tip');
+
+  assertExists(brushToolBox);
+
+  await page.mouse.move(brushToolBox.x + 10, brushToolBox.y + 10);
+  await expect(tooltip).toBeVisible();
+
+  await page.mouse.click(brushToolBox.x + 10, brushToolBox.y + 10);
+  await expect(tooltip).toBeHidden();
+
+  await page.mouse.click(brushToolBox.x + 10, brushToolBox.y + 10);
+  await expect(tooltip).toBeVisible();
+});
+
+test('the tooltip of more button should be hidden when the action menu is shown', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const start = { x: 100, y: 100 };
+  const end = { x: 200, y: 200 };
+  await addBasicBrushElement(page, start, end);
+
+  await page.mouse.click(start.x + 5, start.y + 5);
+  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
+
+  const moreButton = locatorEdgelessComponentToolButton(page, 'more');
+  await expect(moreButton).toBeVisible();
+
+  const moreButtonBox = await moreButton.boundingBox();
+  const tooltip = moreButton.locator('tool-tip');
+
+  assertExists(moreButtonBox);
+
+  await page.mouse.move(moreButtonBox.x + 10, moreButtonBox.y + 10);
+  await expect(tooltip).toBeVisible();
+
+  await page.mouse.click(moreButtonBox.x + 10, moreButtonBox.y + 10);
+  await expect(tooltip).toBeHidden();
+
+  await page.mouse.click(moreButtonBox.x + 10, moreButtonBox.y + 10);
+  await expect(tooltip).toBeVisible();
+});
+
+test('the tooltip of change color button should be hidden when the color menu is shown', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const start = { x: 100, y: 100 };
+  const end = { x: 200, y: 200 };
+  await addBasicBrushElement(page, start, end);
+
+  await page.mouse.click(start.x + 5, start.y + 5);
+  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
+
+  const changeColorButton = locatorEdgelessComponentToolButton(page, 'brush');
+  await expect(changeColorButton).toBeVisible();
+
+  const changeColorButtonBox = await changeColorButton.boundingBox();
+  const tooltip = changeColorButton.locator('tool-tip');
+
+  assertExists(changeColorButtonBox);
+
+  await page.mouse.move(
+    changeColorButtonBox.x + 10,
+    changeColorButtonBox.y + 10
+  );
+  await expect(tooltip).toBeVisible();
+
+  await page.mouse.click(
+    changeColorButtonBox.x + 10,
+    changeColorButtonBox.y + 10
+  );
+  await expect(tooltip).toBeHidden();
+
+  await page.mouse.click(
+    changeColorButtonBox.x + 10,
+    changeColorButtonBox.y + 10
+  );
+  await expect(tooltip).toBeVisible();
+});
+
+test('the tooltip of change shape button should be hidden when the shape menu is shown', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const start = { x: 100, y: 100 };
+  const end = { x: 200, y: 200 };
+  await addBasicRectShapeElement(page, start, end);
+
+  await page.mouse.click(start.x + 5, start.y + 5);
+  await assertEdgelessHoverRect(page, [100, 100, 100, 100]);
+
+  const changeShapeButton = locatorEdgelessComponentToolButton(page, 'shape');
+  await expect(changeShapeButton).toBeVisible();
+
+  const changeShapeButtonBox = await changeShapeButton.boundingBox();
+  const tooltip = changeShapeButton.locator('tool-tip');
+
+  assertExists(changeShapeButtonBox);
+
+  await page.mouse.move(
+    changeShapeButtonBox.x + 10,
+    changeShapeButtonBox.y + 10
+  );
+  await expect(tooltip).toBeVisible();
+
+  await page.mouse.click(
+    changeShapeButtonBox.x + 10,
+    changeShapeButtonBox.y + 10
+  );
+  await expect(tooltip).toBeHidden();
+
+  await page.mouse.click(
+    changeShapeButtonBox.x + 10,
+    changeShapeButtonBox.y + 10
+  );
+  await expect(tooltip).toBeVisible();
 });

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -1159,29 +1159,6 @@ test('the tooltip of shape tool button should be hidden when the shape menu is s
   await expect(tooltip).toBeVisible();
 });
 
-test('the tooltip of brush tool button should be hidden when the brush menu is shown', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await switchEditorMode(page);
-
-  const brushTool = locatorEdgelessToolButton(page, 'brush');
-  const brushToolBox = await brushTool.boundingBox();
-  const tooltip = brushTool.locator('tool-tip');
-
-  assertExists(brushToolBox);
-
-  await page.mouse.move(brushToolBox.x + 10, brushToolBox.y + 10);
-  await expect(tooltip).toBeVisible();
-
-  await page.mouse.click(brushToolBox.x + 10, brushToolBox.y + 10);
-  await expect(tooltip).toBeHidden();
-
-  await page.mouse.click(brushToolBox.x + 10, brushToolBox.y + 10);
-  await expect(tooltip).toBeVisible();
-});
-
 test('the tooltip of more button should be hidden when the action menu is shown', async ({
   page,
 }) => {
@@ -1211,87 +1188,5 @@ test('the tooltip of more button should be hidden when the action menu is shown'
   await expect(tooltip).toBeHidden();
 
   await page.mouse.click(moreButtonBox.x + 10, moreButtonBox.y + 10);
-  await expect(tooltip).toBeVisible();
-});
-
-test('the tooltip of change color button should be hidden when the color menu is shown', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await switchEditorMode(page);
-
-  const start = { x: 100, y: 100 };
-  const end = { x: 200, y: 200 };
-  await addBasicBrushElement(page, start, end);
-
-  await page.mouse.click(start.x + 5, start.y + 5);
-  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
-
-  const changeColorButton = locatorEdgelessComponentToolButton(page, 'brush');
-  await expect(changeColorButton).toBeVisible();
-
-  const changeColorButtonBox = await changeColorButton.boundingBox();
-  const tooltip = changeColorButton.locator('tool-tip');
-
-  assertExists(changeColorButtonBox);
-
-  await page.mouse.move(
-    changeColorButtonBox.x + 10,
-    changeColorButtonBox.y + 10
-  );
-  await expect(tooltip).toBeVisible();
-
-  await page.mouse.click(
-    changeColorButtonBox.x + 10,
-    changeColorButtonBox.y + 10
-  );
-  await expect(tooltip).toBeHidden();
-
-  await page.mouse.click(
-    changeColorButtonBox.x + 10,
-    changeColorButtonBox.y + 10
-  );
-  await expect(tooltip).toBeVisible();
-});
-
-test('the tooltip of change shape button should be hidden when the shape menu is shown', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await switchEditorMode(page);
-
-  const start = { x: 100, y: 100 };
-  const end = { x: 200, y: 200 };
-  await addBasicRectShapeElement(page, start, end);
-
-  await page.mouse.click(start.x + 5, start.y + 5);
-  await assertEdgelessHoverRect(page, [100, 100, 100, 100]);
-
-  const changeShapeButton = locatorEdgelessComponentToolButton(page, 'shape');
-  await expect(changeShapeButton).toBeVisible();
-
-  const changeShapeButtonBox = await changeShapeButton.boundingBox();
-  const tooltip = changeShapeButton.locator('tool-tip');
-
-  assertExists(changeShapeButtonBox);
-
-  await page.mouse.move(
-    changeShapeButtonBox.x + 10,
-    changeShapeButtonBox.y + 10
-  );
-  await expect(tooltip).toBeVisible();
-
-  await page.mouse.click(
-    changeShapeButtonBox.x + 10,
-    changeShapeButtonBox.y + 10
-  );
-  await expect(tooltip).toBeHidden();
-
-  await page.mouse.click(
-    changeShapeButtonBox.x + 10,
-    changeShapeButtonBox.y + 10
-  );
   await expect(tooltip).toBeVisible();
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -39,6 +39,7 @@ export function locatorPanButton(page: Page, innerContainer = true) {
 
 type MouseMode = 'default' | 'shape' | 'brush' | 'pan' | 'text';
 type ToolType = MouseMode | 'zoomIn' | 'zoomOut' | 'fitToScreen';
+type ComponentToolType = 'shape' | 'thin' | 'thick' | 'brush' | 'more';
 
 export function locatorEdgelessToolButton(
   page: Page,
@@ -57,6 +58,27 @@ export function locatorEdgelessToolButton(
   }[type];
   const button = page
     .locator('edgeless-toolbar edgeless-tool-icon-button')
+    .filter({
+      hasText: text,
+    });
+
+  return innerContainer ? button.locator('.icon-container') : button;
+}
+
+export function locatorEdgelessComponentToolButton(
+  page: Page,
+  type: ComponentToolType,
+  innerContainer = true
+) {
+  const text = {
+    shape: 'Shape',
+    brush: 'Color',
+    thin: 'Thin',
+    thick: 'Thick',
+    more: 'More',
+  }[type];
+  const button = page
+    .locator('edgeless-component-toolbar edgeless-tool-icon-button')
     .filter({
       hasText: text,
     });


### PR DESCRIPTION
Close https://github.com/toeverything/blocksuite/issues/1845

I had two considerations in fixing this issue:
1. It seems that I can either create a new prop to control whether a tooltip should be displayed or just clear tooltip. I choose the latter because I think the value of tooltip can potentially represent whether it should be displayed. Just like the code written in file:
```ts
${tooltip
  ? html`<tool-tip inert role="tooltip" tip-position="top" arrow
      >${tooltip}</tool-tip
    >`
  : nothing}
```
2. I create a state to track the state of the popper so that I can request a render when the state changes reactively.