### PR TITLE
fix(database): show the add column button on the right side of database correctly

### DIFF
--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -1309,42 +1309,6 @@ const styles = css`
   .affine-database-block-footer {
     display: flex;
     width: 100%;
-    height: 42px;
-    background-color: rgba(0, 0, 0, 0.04);
-  }
-
-  .affine-database-block-add-row {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-    user-select: none;
-    font-size: 14px;
-  }
-  .affine-database-block-add-row svg {
-    width: 16px;
-    height: 16px;
-  }
-
-  .affine-database-add-column-button {
-    position: absolute;
-    top: 58px;
-    right: -40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    cursor: pointer;
-  }
-
-  .affine-database-block-footer {
-    display: flex;
-    width: 100%;
     height: 28px;
     background: #fff;
   }
@@ -1372,22 +1336,7 @@ const styles = css`
     height: 16px;
   }
 
-  .affine-database-add-column-button {
-    position: absolute;
-    top: 58px;
-    right: -40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    cursor: pointer;
-  }
-
   ${tooltipStyle}
-  .invisible {
-    display: none;
-  }
 `;
 
 @customElement('affine-database')

--- a/tests/utils/actions/database.ts
+++ b/tests/utils/actions/database.ts
@@ -2,7 +2,11 @@ import type { ColumnType } from '@blocksuite/global/database';
 import { expect, type Locator, type Page } from '@playwright/test';
 
 import { assertClassName } from '../asserts.js';
-import { getBoundingClientRect, waitNextFrame } from './misc.js';
+import {
+  getBoundingBox,
+  getBoundingClientRect,
+  waitNextFrame,
+} from './misc.js';
 
 export async function performColumnAction(
   page: Page,
@@ -88,11 +92,11 @@ export async function clickDatabaseOutside(page: Page) {
 }
 
 export async function assertColumnWidth(locator: Locator, width: number) {
-  const box = await locator.boundingBox();
-  if (!box) throw new Error('Missing column box');
+  const box = await getBoundingBox(locator);
   expect(box.width).toBe(width);
   return box;
 }
+
 export async function waitSearchTransitionEnd(page: Page) {
   await waitNextFrame(page, 400);
 }
@@ -103,6 +107,12 @@ export async function focusDatabaseSearch(page: Page) {
   await searchIcon.click();
   await waitSearchTransitionEnd(page);
   return searchIcon;
+}
+
+export async function focusDatabaseHeader(page: Page) {
+  const header = page.locator('.affine-database-column-header');
+  const box = await getBoundingBox(header);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
 }
 
 export async function getDatabaseMouse(page: Page) {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -2,7 +2,7 @@
 import '../declare-test-window.js';
 
 import type { DatabaseBlockModel } from '@blocksuite/blocks';
-import type { ConsoleMessage, Page } from '@playwright/test';
+import type { ConsoleMessage, Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 import type { RichText } from '../../../packages/playground/examples/virgo/test-page.js';
@@ -617,6 +617,12 @@ export const getBoundingClientRect: (
     return document.querySelector(selector)?.getBoundingClientRect() as DOMRect;
   }, selector);
 };
+
+export async function getBoundingBox(locator: Locator) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error('Missing column box');
+  return box;
+}
 
 export async function getBlockModel<Model extends BaseBlockModel>(
   page: Page,


### PR DESCRIPTION

https://user-images.githubusercontent.com/15389209/230251472-77e26da2-9b36-4253-89c2-b5db52e319b4.mov

Database has two buttons to add column:
1. in the last column of the header
2. on the right side of database

When button 1 is shown, button 2 should be hidden.