### PR TITLE
refactor(store): use id from `idGenerator` as page id

### DIFF
--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -266,9 +266,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
   private _createPage() {
     const pageName = this._query || DEFAULT_PAGE_NAME;
-    const workspace = this._page.workspace;
-    const id = workspace.idGenerator();
-    const page = this._page.workspace.createPage(id);
+    const page = this._page.workspace.createPage();
 
     initDefaultBlocks(page, pageName);
     this._insertLinkedNode('LinkedPage', page.id);
@@ -276,9 +274,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
   private _createSubpage() {
     const pageName = this._query || DEFAULT_PAGE_NAME;
-    const workspace = this._page.workspace;
-    const id = workspace.idGenerator();
-    const page = this._page.workspace.createPage(id, this._page.id);
+    const page = this._page.workspace.createPage(this._page.id);
 
     initDefaultBlocks(page, pageName);
     this._insertLinkedNode('Subpage', page.id);

--- a/packages/editor/src/components/simple-affine-editor.ts
+++ b/packages/editor/src/components/simple-affine-editor.ts
@@ -22,7 +22,7 @@ export class SimpleAffineEditor extends ShadowlessElement {
     super();
 
     this.workspace = new Workspace({ id: 'test' }).register(AffineSchemas);
-    this.page = this.workspace.createPage('page0');
+    this.page = this.workspace.createPage();
 
     const pageBlockId = this.page.addBlock('affine:page');
     const frameId = this.page.addBlock('affine:frame', {}, pageBlockId);

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -29,7 +29,7 @@ import {
   plate,
 } from '@blocksuite/global/config';
 import { assertExists } from '@blocksuite/global/utils';
-import { nanoid, Utils, type Workspace } from '@blocksuite/store';
+import { Utils, type Workspace } from '@blocksuite/store';
 import type { SlDropdown, SlTab, SlTabGroup } from '@shoelace-style/shoelace';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { GUI } from 'dat.gui';

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -512,10 +512,7 @@ export class DebugMenu extends ShadowlessElement {
 
 function createPage(workspace: Workspace) {
   const pageName = 'Untitled';
-  // TODO use id generator
-  // const id = workspace.idGenerator();
-  const id = nanoid();
-  const newPage = workspace.createPage(id);
+  const newPage = workspace.createPage();
   const pageBlockId = newPage.addBlock('affine:page', {
     title: new newPage.Text(pageName),
   });

--- a/packages/playground/src/data/index.ts
+++ b/packages/playground/src/data/index.ts
@@ -17,7 +17,7 @@ export interface InitFn {
 }
 
 export const empty: InitFn = (workspace: Workspace) => {
-  const page = workspace.createPage('page0');
+  const page = workspace.createPage();
 
   // Add page block and surface block at root level
   const pageBlockId = page.addBlock('affine:page', {
@@ -38,7 +38,7 @@ empty.displayName = 'Empty Editor';
 empty.description = 'Start from empty editor';
 
 export const heavy: InitFn = (workspace: Workspace) => {
-  const page = workspace.createPage('page0');
+  const page = workspace.createPage();
 
   // Add page block and surface block at root level
   const pageBlockId = page.addBlock('affine:page', {
@@ -84,7 +84,7 @@ As a pro tip, you can combine multiple providers! For example, feel free to open
 For any feedback, please visit [BlockSuite issues](https://github.com/toeverything/blocksuite/issues) 📍`;
 
 export const preset: InitFn = (workspace: Workspace) => {
-  const page = workspace.createPage('page0');
+  const page = workspace.createPage();
 
   // Add page block and surface block at root level
   const pageBlockId = page.addBlock('affine:page', {
@@ -119,7 +119,7 @@ preset.displayName = 'BlockSuite Starter';
 preset.description = 'Start from friendly introduction';
 
 export const database: InitFn = (workspace: Workspace) => {
-  const page = workspace.createPage('page0');
+  const page = workspace.createPage();
   page.awarenessStore.setFlag('enable_database', true);
 
   // Add page block and surface block at root level

--- a/packages/store/src/__tests__/database.unit.spec.ts
+++ b/packages/store/src/__tests__/database.unit.spec.ts
@@ -46,7 +46,7 @@ describe('DatabaseManager', () => {
   beforeEach(() => {
     const options = createTestOptions();
     workspace = new Workspace(options).register(AffineSchemas);
-    page = workspace.createPage('page0');
+    page = workspace.createPage();
     page.awarenessStore.setFlag('enable_database', true);
     db = page.db;
 

--- a/packages/store/src/workspace/__tests__/test-app.ts
+++ b/packages/store/src/workspace/__tests__/test-app.ts
@@ -19,8 +19,8 @@ export class TestApp extends LitElement {
   }
 
   private _createPage() {
-    this.workspace.createPage();
-    this.workspace.setPageMeta(id, { title: this.input.value });
+    const page = this.workspace.createPage();
+    this.workspace.setPageMeta(page.id, { title: this.input.value });
     this.input.value = '';
   }
 

--- a/packages/store/src/workspace/__tests__/test-app.ts
+++ b/packages/store/src/workspace/__tests__/test-app.ts
@@ -19,8 +19,7 @@ export class TestApp extends LitElement {
   }
 
   private _createPage() {
-    const id = `${this.pages.length}`;
-    this.workspace.createPage(id);
+    this.workspace.createPage();
     this.workspace.setPageMeta(id, { title: this.input.value });
     this.input.value = '';
   }

--- a/packages/store/src/workspace/__tests__/test-entry.ts
+++ b/packages/store/src/workspace/__tests__/test-entry.ts
@@ -13,13 +13,13 @@ import type { TestApp } from './test-app.js';
 
 async function testBasic() {
   testSerial('can create page', async () => {
-    workspace.createPage();
-    workspace.setPageMeta(id, { title: 'hello' });
+    const page = workspace.createPage();
+    workspace.setPageMeta(page.id, { title: 'hello' });
     await nextFrame();
 
     const pageMeta = workspace.meta.pageMetas.pop();
     assertExists(pageMeta);
-    return pageMeta.id === `${i}` && pageMeta.title === 'hello';
+    return pageMeta.id === `${page.id}` && pageMeta.title === 'hello';
   });
 
   await runOnce();

--- a/packages/store/src/workspace/__tests__/test-entry.ts
+++ b/packages/store/src/workspace/__tests__/test-entry.ts
@@ -11,13 +11,9 @@ import {
 import { Workspace } from '../workspace.js';
 import type { TestApp } from './test-app.js';
 
-let i = 0;
-
 async function testBasic() {
   testSerial('can create page', async () => {
-    i++;
-    const id = `${i}`;
-    workspace.createPage(id);
+    workspace.createPage();
     workspace.setPageMeta(id, { title: 'hello' });
     await nextFrame();
 

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -444,7 +444,8 @@ export class Workspace {
     });
   }
 
-  createPage(pageId: string, parentId?: string) {
+  createPage(parentId?: string) {
+    const pageId = this.idGenerator();
     if (this._hasPage(pageId)) {
       throw new Error('page already exists');
     }

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -61,7 +61,7 @@ async function initEmptyEditor(
 ) {
   await page.evaluate(flags => {
     const { workspace } = window;
-    const page = workspace.createPage('page0');
+    const page = workspace.createPage();
 
     for (const [key, value] of Object.entries(flags)) {
       page.awarenessStore.setFlag(key as keyof typeof flags, value);


### PR DESCRIPTION
Use don't need to pass the `id` parameter when creating a new page.