### PR TITLE
feat: keep ratio when press shift to create shape

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -34,8 +34,14 @@ export class HandleResizeManager {
 
     let [minX, minY, maxX, maxY] = this._commonBound;
 
-    const deltaX = e.clientX - startX;
-    const deltaY = e.clientY - startY;
+    let deltaX = e.clientX - startX;
+    let deltaY = e.clientY - startY;
+    if (e.shiftKey) {
+      const { w, h } = getCommonBound([...this._bounds.values()]) as Bound;
+      const aspectRatio = w / h;
+      deltaX = deltaX > deltaY ? deltaX : deltaY * aspectRatio;
+      deltaY = deltaY > deltaX ? deltaY : deltaX / aspectRatio;
+    }
 
     switch (direction) {
       case HandleDirection.TopLeft:

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -74,7 +74,17 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
 
     const { viewport } = this._edgeless.surface;
 
-    this._draggingArea.end = new DOMPoint(e.x, e.y);
+    let endX = e.x;
+    let endY = e.y;
+    if (e.keys.shift) {
+      const { x: startX, y: startY } = this._draggingArea.start;
+      const w = Math.abs(endX - startX) / viewport.zoom;
+      const h = Math.abs(endY - startY) / viewport.zoom;
+      const maxLength = Math.max(w, h);
+      endX = endX > startX ? startX + maxLength : startX - maxLength;
+      endY = endY > startY ? startY + maxLength : startY - maxLength;
+    }
+    this._draggingArea.end = new DOMPoint(endX, endY);
 
     const [x, y] = viewport.toModelCoord(
       Math.min(this._draggingArea.start.x, this._draggingArea.end.x),


### PR DESCRIPTION
A small improvement, like Miro, is that when the shift key is held down:
1. When creating a shape, the shape created is a regular polygon
2. When resizing, keep the aspect ratio