### PR TITLE
fix(format-bar): update state on change in keyboard selection

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/index.ts
+++ b/packages/blocks/src/components/format-quick-bar/index.ts
@@ -124,29 +124,10 @@ export const showFormatQuickBar = async ({
     abortController.abort();
   };
 
-  const selectionChangeHandler = () => {
-    const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      abortController.abort();
-      return;
-    }
-    // If the selection is collapsed, abort the format quick bar
-    if (
-      blockRange.type === 'Native' &&
-      blockRange.models.length === 1 &&
-      blockRange.startOffset === blockRange.endOffset
-    ) {
-      abortController.abort();
-      return;
-    }
-    updatePos();
-  };
-
   const popstateHandler = () => {
     abortController.abort();
   };
   document.addEventListener('mousedown', mouseDownHandler);
-  document.addEventListener('selectionchange', selectionChangeHandler);
   // Fix https://github.com/toeverything/AFFiNE/issues/855
   window.addEventListener('popstate', popstateHandler);
 
@@ -156,7 +137,6 @@ export const showFormatQuickBar = async ({
     scrollContainer?.removeEventListener('scroll', updatePos);
     window.removeEventListener('resize', updatePos);
     document.removeEventListener('mousedown', mouseDownHandler);
-    document.removeEventListener('selectionchange', selectionChangeHandler);
     window.removeEventListener('popstate', popstateHandler);
     positionUpdatedSlot.dispose();
   });

--- a/tests/format-quick-bar.spec.ts
+++ b/tests/format-quick-bar.spec.ts
@@ -968,7 +968,7 @@ test('should format quick bar show after convert to code block', async ({
   await expect(formatBarController.formatQuickBar).toBeVisible();
   const rects = page.locator('affine-selected-blocks > *');
   await expect(rects).toHaveCount(1);
-  await formatBarController.assertBoundingBox(395, 99);
+  await formatBarController.assertBoundingBox(377, 99);
   await assertStoreMatchJSX(
     page,
     `


### PR DESCRIPTION
Close https://github.com/toeverything/blocksuite/issues/2005

And fix the incorrect test. 
In the following picture, you can see the correct left position for quick format bar should be 377 instead of 395. It is wrong before I fix this problem.

<img width="1578" alt="CleanShot 2023-04-15 at 20 19 33@2x" src="https://user-images.githubusercontent.com/24316656/232225860-13b130bd-62c5-469a-ba4c-9b8ccfa761da.png">

The key point is "convert-to-database" button is shown when range type is block(https://github.com/toeverything/blocksuite/blob/master/packages/blocks/src/page-block/utils/const.ts#L143). 

But the range type is changed asynchronous after the render, and before the next render which is caused by update position there is no another render. The following picture shows that the quick bar has already been changed but the database button is not shown.

<img width="1716" alt="CleanShot 2023-04-15 at 20 07 04@2x" src="https://user-images.githubusercontent.com/24316656/232226415-bb924db6-27f8-43c2-9f19-f76a1ae7d06e.png">

So when the update position function is called, it used the incorret dom to calculate. https://github.com/toeverything/blocksuite/blob/master/packages/blocks/src/components/format-quick-bar/index.ts#L86
The bounding client rect's width only includes two buttons.

However, after I fix the problem, it will rerender before to call update position function because I change the reactive state this._format. This time the range type is block and "convert-to-database" button is shown so that we can calculate the correct position.

The inner logic seems depend on the correct timing, which is a little tricky. Maybe there is a better design to avoid that happens.


