### PR TITLE
fix: use `onPress` rather than deprecated `onClick` for nextui components

### DIFF
--- a/packages/react/examples/next/src/components/PageManger.tsx
+++ b/packages/react/examples/next/src/components/PageManger.tsx
@@ -32,7 +32,7 @@ export const PageManger = () => {
             mt: '1rem',
             ml: '1rem',
           }}
-          onClick={() => {
+          onPress={() => {
             createPage();
           }}
         >
@@ -47,7 +47,7 @@ export const PageManger = () => {
                   isPressable
                   isHoverable
                   variant="bordered"
-                  onClick={() => {
+                  onPress={() => {
                     setCurrentPage(page);
                   }}
                 >
@@ -70,7 +70,7 @@ export const PageManger = () => {
             mt: '1rem',
             ml: '1rem',
           }}
-          onClick={() => setCurrentPage(null)}
+          onPress={() => setCurrentPage(null)}
         >
           Back to list
         </Button>
@@ -80,7 +80,7 @@ export const PageManger = () => {
             ml: '1rem',
           }}
           color="error"
-          onClick={() => deletePage(currentPage.id)}
+          onPress={() => deletePage(currentPage.id)}
         >
           Delete Page
         </Button>


### PR DESCRIPTION
This PR removes the usage of the deprecated `onClick` and replaces it with `onPress`.
See [`nextui/Button` document](https://nextui.org/docs/components/button#apis).

![image](https://user-images.githubusercontent.com/9910706/232235111-122ec594-834a-4473-829e-5b7e64c5494c.png)
