### PR TITLE
docs: remove line continuation characters in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,7 @@ However, the `SimpleAffineEditor` here is just a [thin wrapper with dozens of li
 - The `packages/editor` package ships a complete BlockSuite-based editor.
 
 ```sh
-pnpm i \
-  @blocksuite/store@nightly \
-  @blocksuite/blocks@nightly \
-  @blocksuite/editor@nightly
+pnpm i @blocksuite/store@nightly @blocksuite/blocks@nightly @blocksuite/editor@nightly
 ```
 
 And here is a minimal collaboration-ready editor showing how these underlying BlockSuite packages are composed together:

--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -52,10 +52,7 @@ However, the `SimpleAffineEditor` here is just a [thin wrapper with dozens of li
 - The `packages/editor` package ships a complete BlockSuite-based editor.
 
 ```sh
-pnpm i \
-  @blocksuite/store@nightly \
-  @blocksuite/blocks@nightly \
-  @blocksuite/editor@nightly
+pnpm i @blocksuite/store@nightly @blocksuite/blocks@nightly @blocksuite/editor@nightly
 ```
 
 In the following chapters, we will continue to demonstrate their usage and the core concepts involved.


### PR DESCRIPTION
This PR removes the line continuation characters(`\`) in documents as it will fail on other platforms/command lines.

| System | Line continuation character |
| --- | --- |
| Windows command prompt | `^` |
| PowerShell | `` ` ``
| Bash | `\` |