### PR TITLE
feat: support Ctrl+P/N to move in slash menu popover

### DIFF
--- a/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
@@ -5,6 +5,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import {
   getRichTextByModel,
+  isControlledKeyboardEvent,
   isFuzzyMatch,
   WithDisposable,
 } from '../../__internal__/utils/index.js';
@@ -114,7 +115,9 @@ export class SlashMenu extends WithDisposable(LitElement) {
           this._hide = false;
         }
 
-        if (e.key === 'ArrowLeft') {
+        const isControlled = isControlledKeyboardEvent(e);
+        const isShift = e.shiftKey;
+        if (e.key === 'ArrowLeft' && !isControlled && !isShift) {
           e.stopPropagation();
           e.preventDefault();
           // If the left panel is hidden, should not activate it
@@ -122,7 +125,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
           this._leftPanelActivated = true;
           return;
         }
-        if (e.key === 'ArrowRight') {
+        if (e.key === 'ArrowRight' && !isControlled && !isShift) {
           e.stopPropagation();
           e.preventDefault();
           this._leftPanelActivated = false;

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -10,6 +10,7 @@ import {
 import {
   enterPlaygroundRoom,
   focusRichText,
+  getVirgoSelectionText,
   initEmptyParagraphState,
   waitNextFrame,
 } from 'utils/actions/misc.js';
@@ -118,7 +119,7 @@ test.describe('slash menu should show and hide correctly', () => {
     await assertRichTexts(page, ['/']);
   });
 
-  test('should slash menu position correct', async () => {
+  test('should position slash menu correctly', async () => {
     const box = await slashMenu.boundingBox();
     if (!box) {
       throw new Error("slashMenu doesn't exist");
@@ -126,6 +127,63 @@ test.describe('slash menu should show and hide correctly', () => {
     const { x, y } = box;
     assertAlmostEqual(x, 120, 6);
     assertAlmostEqual(y, 167, 8);
+  });
+
+  test('should move up down with arrow key', async () => {
+    await page.keyboard.press('ArrowDown');
+    await expect(slashMenu).toBeVisible();
+
+    const slashItems = slashMenu.locator('format-bar-button');
+    const maybeActivatedItem = slashItems.nth(1);
+    await expect(maybeActivatedItem).toHaveText(['Heading 1']);
+    await expect(maybeActivatedItem).toHaveAttribute('hover', '');
+    await assertRichTexts(page, ['/']);
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowUp');
+    await expect(slashMenu).toBeVisible();
+
+    const maybeActivatedItem2 = slashItems.nth(2);
+    await expect(maybeActivatedItem2).toHaveText(['Heading 2']);
+    await expect(maybeActivatedItem2).toHaveAttribute('hover', '');
+    await assertRichTexts(page, ['/']);
+  });
+
+  test('should move up down with ctrl/cmd+N and ctrl/cmd+N', async () => {
+    page.keyboard.press(`${SHORT_KEY}+N`);
+    await expect(slashMenu).toBeVisible();
+
+    const slashItems = slashMenu.locator('format-bar-button');
+    const maybeActivatedItem = slashItems.nth(1);
+    await expect(maybeActivatedItem).toHaveText(['Heading 1']);
+    await expect(maybeActivatedItem).toHaveAttribute('hover', '');
+    await assertRichTexts(page, ['/']);
+
+    page.keyboard.press(`${SHORT_KEY}+P`);
+    await expect(slashMenu).toBeVisible();
+
+    const maybeActivatedItem2 = slashItems.nth(0);
+    await expect(maybeActivatedItem2).toHaveText(['Text']);
+    await expect(maybeActivatedItem2).toHaveAttribute('hover', '');
+    await assertRichTexts(page, ['/']);
+  });
+
+  test('should allow only pressing modifier key', async () => {
+    page.keyboard.press(SHORT_KEY);
+    await expect(slashMenu).toBeVisible();
+
+    page.keyboard.press('Shift');
+    await expect(slashMenu).toBeVisible();
+  });
+
+  test('should allow other hotkey to passthrough', async () => {
+    page.keyboard.press(`${SHORT_KEY}+A`);
+    await expect(slashMenu).not.toBeVisible();
+    await assertRichTexts(page, ['/']);
+
+    const selected = await getVirgoSelectionText(page);
+    expect(selected).toBe('/');
   });
 
   test('left arrow should active left panel', async () => {


### PR DESCRIPTION
closes #2052 

This PR added support for using `Ctrl/Cmd+P` and `Ctrl/Cmd+N` to move in the slash menu

And it also fixed the usage of `Shift+←→` when the slash menu is presented.

These changes will improve the fluency of user input as it allows other hotkeys to pass through and fixed a few edge cases.

