### PR TITLE
fix(drag-handle): should be hidden when moving canvas in edgeless

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -278,6 +278,7 @@ export class EdgelessPageBlockComponent
           this.style.setProperty('--affine-zoom', `${newZoom}`);
           this.components.dragHandle?.setScale(newZoom);
         }
+        this.components.dragHandle?.hide();
         if (this._selection.selectedBlocks.length) {
           slots.selectedBlocksUpdated.emit(this._selection.selectedBlocks);
         }


### PR DESCRIPTION
Two fingers on the trackpad.

### before


https://user-images.githubusercontent.com/27926/232663272-e1119b5f-fe54-444e-a3f8-8313beedcf47.mov


### after


https://user-images.githubusercontent.com/27926/232663404-c7e031bc-1bcd-4bab-9ce1-692dd9f7dd16.mov

