### PR TITLE
fix: delete emoji completely

### DIFF
--- a/packages/virgo/src/utils/transform-input.ts
+++ b/packages/virgo/src/utils/transform-input.ts
@@ -57,13 +57,13 @@ function handleDelete(vRange: VRange, editor: VEditor) {
     }
 
     if (vRange.index > 0) {
-      // https://dev.to/acanimal/how-to-slice-or-get-symbols-from-a-unicode-string-with-emojis-in-javascript-lets-learn-how-javascript-represent-strings-h3a
-      const tmpString = editor.yText.toString().slice(0, vRange.index);
-      const deletedCharacter = [...tmpString].slice(-1).join('');
+      const originalString = editor.yText.toString();
+      const segments = [...new Intl.Segmenter().segment(originalString)];
+      const deletedLength = segments[segments.length - 1].segment.length;
       editor.slots.updated.once(() => {
         editor.slots.vRangeUpdated.emit([
           {
-            index: vRange.index - deletedCharacter.length,
+            index: vRange.index - deletedLength,
             length: 0,
           },
           'input',
@@ -71,8 +71,8 @@ function handleDelete(vRange: VRange, editor: VEditor) {
       });
 
       editor.deleteText({
-        index: vRange.index - deletedCharacter.length,
-        length: deletedCharacter.length,
+        index: vRange.index - deletedLength,
+        length: deletedLength,
       });
     }
   }

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -373,3 +373,16 @@ test('change theme', async ({ page }) => {
   const nextEditorTheme = await getCurrentEditorTheme(page);
   expect(nextEditorTheme).toBe(expectNextTheme);
 });
+
+test('should be able to delete an emoji completely by pressing backspace once', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await type(page, '🌷🙅‍♂️🏳️‍🌈');
+  await pressBackspace(page);
+  await pressBackspace(page);
+  await pressBackspace(page);
+  await assertText(page, '');
+});


### PR DESCRIPTION
Fix #2138 , but there is a small problem, `Intl.Segmenter` is not compatible with Firefox, one solution to use [polyfill](https://github.com/surferseo/intl-segmenter-polyfill), another solution is to use lodash directly, which one do you prefer?