### PR TITLE
fix(edgeless): auto remove empty text frame

### DIFF
--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -11,6 +11,7 @@ import {
   getRectByBlockElement,
   handleNativeRangeClick,
   handleNativeRangeDragMove,
+  isEmpty,
   noop,
   Point,
   Rect,
@@ -222,7 +223,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   private _tryDeleteEmptyBlocks() {
-    const emptyBlocks = this._blocks.filter(b => !b.children.length);
+    const emptyBlocks = this._blocks.filter(b => isEmpty(b));
     // always keep at least one frame block
     if (emptyBlocks.length === this._blocks.length) {
       emptyBlocks.shift();

--- a/tests/edgeless.spec.ts
+++ b/tests/edgeless.spec.ts
@@ -350,7 +350,7 @@ test('add Text', async ({ page }) => {
   await assertEdgelessSelectedRect(page, [0, 0, 448, 72]);
 });
 
-test.skip('add empty Text', async ({ page }) => {
+test('add empty Text', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
 
@@ -366,14 +366,14 @@ test.skip('add empty Text', async ({ page }) => {
 
   // assert add text success
   await page.mouse.move(30, 40);
-  await assertEdgelessHoverRect(page, [0, 0, 448, 104]);
+  await assertEdgelessSelectedRect(page, [0, 0, 448, 104]);
 
   // click out of text
   await page.mouse.click(0, 200);
 
   // assert empty text is removed
   await page.mouse.move(30, 40);
-  await assertEdgelessNonHoverRect(page);
+  await assertEdgelessNonSelectedRect(page);
 });
 
 test('always keep at least 1 frame block', async ({ page }) => {


### PR DESCRIPTION
In this pr, skip the test for auto-remove empty text frames. The current test does not match the previous design and is causing issues.

https://github.com/toeverything/blocksuite/pull/1712/files