### PR TITLE
fix: incorrect behavior when paste code from GitHub

### DIFF
--- a/packages/blocks/src/__internal__/content-parser/parse-html.ts
+++ b/packages/blocks/src/__internal__/content-parser/parse-html.ts
@@ -419,9 +419,18 @@ export class HtmlParser {
   ): Promise<SerializedBlock[] | null> => {
     // code block doesn't parse other nested Markdown syntax, thus is always one layer deep, example:
     // <pre><code class="language-typescript">code content</code></pre>
-    const content = element.firstChild?.textContent || '';
-    const language =
-      element.children[0]?.getAttribute('class')?.split('-')[1] || 'Plain Text';
+    const firstChild = element.children[0];
+    const languageTag = firstChild?.getAttribute('class')?.split('-');
+    const isNormalMarkdown =
+      firstChild.tagName === 'Code' && languageTag?.[0] === 'language';
+    let content = '';
+    let language = 'Plain Text';
+    if (isNormalMarkdown) {
+      content = element.firstChild?.textContent || '';
+      language = languageTag?.[1] || 'Plain Text';
+    } else {
+      content = element.textContent || '';
+    }
     return [
       {
         flavour: 'affine:code',


### PR DESCRIPTION
Fixes: https://github.com/toeverything/blocksuite/issues/2143

Nodes that do not match will be treated as plain text.