### PR TITLE
fix: the vRange is wrong in some cases

### DIFF
--- a/packages/virgo/src/services/event.ts
+++ b/packages/virgo/src/services/event.ts
@@ -262,7 +262,7 @@ export class VirgoEventService<TextAttributes extends BaseTextAttributes> {
     event.preventDefault();
 
     if (this._editor.isReadonly || this._isComposing) return;
-
+    this._onSelectionChange();
     const vRange = this._editor.getVRange();
     if (!vRange) return;
 


### PR DESCRIPTION
Fixes: https://github.com/toeverything/blocksuite/issues/1901

This PR recompute vRange before each 'beforeinput' trigger

If the problem can be resolved. Then we can consider how to optimize the performance of this code.