### PR TITLE
fix: `compareDocumentPosition` usage

### DIFF
--- a/packages/virgo/src/utils/guard.ts
+++ b/packages/virgo/src/utils/guard.ts
@@ -14,7 +14,10 @@ export function isVElement(element: unknown): element is HTMLElement {
 }
 
 export function isVLine(element: unknown): element is HTMLElement {
-  return element instanceof HTMLElement && element instanceof VirgoLine;
+  return (
+    element instanceof HTMLElement &&
+    (element instanceof VirgoLine || element.parentElement instanceof VirgoLine)
+  );
 }
 
 export function isVRoot(element: unknown): element is HTMLElement {

--- a/packages/virgo/src/utils/point-conversion.ts
+++ b/packages/virgo/src/utils/point-conversion.ts
@@ -157,8 +157,8 @@ function getTextPointFromElementByOffset(
 
 function AInsideB(a: Node, b: Node): boolean {
   return (
-    a.compareDocumentPosition(b) === Node.DOCUMENT_POSITION_CONTAINED_BY ||
-    a.compareDocumentPosition(b) === 20
+    b.compareDocumentPosition(a) === Node.DOCUMENT_POSITION_CONTAINED_BY ||
+    b.compareDocumentPosition(a) === 20
   );
 }
 

--- a/packages/virgo/src/utils/point-conversion.ts
+++ b/packages/virgo/src/utils/point-conversion.ts
@@ -158,7 +158,8 @@ function getTextPointFromElementByOffset(
 function AInsideB(a: Node, b: Node): boolean {
   return (
     b.compareDocumentPosition(a) === Node.DOCUMENT_POSITION_CONTAINED_BY ||
-    b.compareDocumentPosition(a) === 20
+    b.compareDocumentPosition(a) ===
+      (Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING)
   );
 }
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition

<img width="319" alt="image" src="https://user-images.githubusercontent.com/17165520/233447472-3293add4-c133-4df0-8762-4ffe2b49148b.png">

<img width="364" alt="image" src="https://user-images.githubusercontent.com/17165520/233446753-ca618c54-1d06-4e58-934c-e7864af9b376.png">

The code

```ts
a.compareDocumentPosition(b) === Node.DOCUMENT_POSITION_CONTAINED_BY
```

means that `a` is an ancestor of `b`, so `a` inside `b` may need implemented by 

```ts
b.compareDocumentPosition(a) === Node. DOCUMENT_POSITION_CONTAINED_BY
```

---
btw:
The magic number 20 should be refactored to 

```ts
Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING
```

I'm not sure what this code does, it just improves readability