### PR TITLE
fix(edgeless): should not add text when double click toolbar button

### DIFF
--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -140,6 +140,7 @@ export class EdgelessToolbar extends LitElement {
     return html`
       <div
         class="edgeless-toolbar-container"
+        @dblclick=${stopPropagation}
         @mousedown=${stopPropagation}
         @mouseup=${stopPropagation}
       >

--- a/tests/edgeless/frame.spec.ts
+++ b/tests/edgeless/frame.spec.ts
@@ -6,6 +6,7 @@ import {
   getFrameBoundBoxInEdgeless,
   getFrameRect,
   locatorComponentToolbar,
+  locatorEdgelessToolButton,
   selectFrameInEdgeless,
   setMouseMode,
   switchEditorMode,
@@ -412,6 +413,18 @@ test('double click blank space to add text', async ({ page }) => {
   await waitNextFrame(page);
 
   await assertEdgelessSelectedRect(page, [0, 100, 448, 72]);
+});
+
+test('double click toolbar zoom button, should not add text', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  const zoomOutButton = locatorEdgelessToolButton(page, 'zoomOut', false);
+  await zoomOutButton.dblclick();
+  await assertEdgelessNonSelectedRect(page);
 });
 
 test('change frame color', async ({ page }) => {


### PR DESCRIPTION
fix #2192 