### PR TITLE
fix: test flaky

### DIFF
--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -5,17 +5,11 @@ import { describe, expect, it } from 'vitest';
 // Use manual per-module import/export to support vitest environment on Node.js
 import { PageBlockSchema } from '../../../blocks/src/page-block/page-model.js';
 import { ParagraphBlockSchema } from '../../../blocks/src/paragraph-block/paragraph-model.js';
-import type { Slot } from '../index.js';
 import { Generator, Workspace } from '../index.js';
-import { BlockIndexer } from '../workspace/indexer/base.js';
 
 function createTestOptions() {
   const idGenerator = Generator.AutoIncrement;
   return { id: 'test-workspace', idGenerator, isSSR: true };
-}
-
-function waitOnce<T>(slot: Slot<T>) {
-  return new Promise<T>(resolve => slot.once(val => resolve(val)));
 }
 
 export const BlockSchemas = [ParagraphBlockSchema, PageBlockSchema];
@@ -182,9 +176,6 @@ describe('backlink works', () => {
 
     paragraph2.text.delete(0, paragraph2.text.length);
     page1.updateBlock(paragraph4, { text: new page1.Text() });
-
-    // wait for the backlink index to be updated
-    // await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(backlinkIndexer.getBacklink(page0.id)).toStrictEqual([
       {

--- a/packages/store/src/workspace/indexer/base.ts
+++ b/packages/store/src/workspace/indexer/base.ts
@@ -109,10 +109,7 @@ export class BlockIndexer {
       assertExists(page, `Failed to find page '${pageId}'`);
       const dispose = this._indexPage(pageId, page);
       if (disposeMap[pageId]) {
-        console.warn(
-          `Duplicated pageAdded event! ${pageId} already observed`,
-          disposeMap
-        );
+        // It's possible because the `pageAdded` event is emitted once a new block is added to the page
         return;
       }
       disposeMap[pageId] = dispose;

--- a/packages/store/src/workspace/meta.ts
+++ b/packages/store/src/workspace/meta.ts
@@ -17,6 +17,7 @@ export interface PageMeta {
   createDate: number;
   /**
    * Note: YOU SHOULD NOT UPDATE THIS FIELD MANUALLY.
+   * @deprecated
    */
   subpageIds: string[];
 


### PR DESCRIPTION
- Remove warn when page observer duplicated
- Deprecated subpageIds
- Clean test import