### PR TITLE
fix(blocks): prevent default browser behavior for undo/redo

### DIFF
--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -83,11 +83,13 @@ export function bindCommonHotkey(page: Page) {
   });
 
   hotkey.addListener(HOTKEYS.UNDO, e => {
+    e.preventDefault();
     if (page.canUndo) clearSelection(page);
     page.undo();
   });
 
   hotkey.addListener(HOTKEYS.REDO, e => {
+    e.preventDefault();
     if (page.canRedo) clearSelection(page);
     page.redo();
   });


### PR DESCRIPTION
For some browsers, such as Arc. `<Mod+z>` will trigger the browser shortcuts.