### PR TITLE
fix(link): consecutive identical reference nodes should not be merged

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
+++ b/packages/blocks/src/__internal__/rich-text/virgo/attribute-renderer.ts
@@ -1,6 +1,8 @@
 import { html } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 
 import type { BlockHost } from '../../index.js';
+import { REFERENCE_NODE } from '../reference-node.js';
 import type { AffineTextSchema } from './types.js';
 
 export const attributeRenderer: AffineTextSchema['textRenderer'] =
@@ -24,10 +26,21 @@ export const attributeRenderer: AffineTextSchema['textRenderer'] =
       return html`<affine-link .host=${host} .delta=${delta}></affine-link>`;
     }
     if (attributes.reference) {
-      return html`<affine-reference
-        .host=${host}
-        .delta=${delta}
-      ></affine-reference>`;
+      // https://github.com/toeverything/blocksuite/issues/2136
+      return html`${repeat(
+        Array.from(delta.insert).map((_, index) => ({
+          delta: {
+            insert: REFERENCE_NODE,
+            attributes,
+          },
+          index,
+        })),
+        item => item.index,
+        item => html`<affine-reference
+          .host=${host}
+          .delta=${item.delta}
+        ></affine-reference>`
+      )}`;
     }
 
     return defaultTemplate;

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -377,6 +377,10 @@ test.describe('reference node', () => {
   test('should not merge consecutive identical reference nodes for rendering', async ({
     page,
   }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/toeverything/blocksuite/issues/2136',
+    });
     await enterPlaygroundRoom(page);
     await initEmptyParagraphState(page);
     await focusRichText(page);

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -373,6 +373,22 @@ test.describe('reference node', () => {
 </affine:page>`
     );
   });
+
+  test('should not merge consecutive identical reference nodes for rendering', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+    await type(page, '[[');
+    await pressEnter(page);
+    await type(page, '[[');
+    await pressEnter(page);
+
+    const { refNode } = getLinkedPagePopover(page);
+    await assertRichTexts(page, ['  ']);
+    await expect(refNode).toHaveCount(2);
+  });
 });
 
 test.describe('linked page popover', () => {


### PR DESCRIPTION
Close https://github.com/toeverything/blocksuite/issues/2136

Problem is that same attribute text nodes will be merged in yjs in delta mode(https://github.com/toeverything/blocksuite/blob/master/packages/virgo/src/services/delta.ts#L159). We should handle this case.
```js
yText.insert(0, ' ', { type: 'LinkedPage', pageId: 'page0' });
yText.insert(0, ' ', { type: 'LinkedPage', pageId: 'page0' });

console.log(yText.toDelta())
/**
[
  { insert: '  ', attributes: { type: 'LinkedPage', pageId: 'page0' } }
]
*/
```