### PR TITLE
fix: exported html content color

### DIFF
--- a/packages/blocks/src/__internal__/content-parser/file-exporter/exporter-style.ts
+++ b/packages/blocks/src/__internal__/content-parser/file-exporter/exporter-style.ts
@@ -107,6 +107,6 @@ export const globalCSS = css`
   }
   body {
     font-family: var(--affine-font-family);
-    color: var(--affine-primary-color);
+    color: var(--affine-text-primary-color);
   }
 `;


### PR DESCRIPTION
fix[#2228 ](https://github.com/toeverything/blocksuite/issues/2228)