### PR TITLE
feat(edgeless): switch to `PointerEvent` for mobile compatibility

### DIFF
--- a/packages/blocks/src/__internal__/utils/gesture/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/gesture.ts
@@ -154,6 +154,7 @@ export function initMouseEventHandlers(
   document.addEventListener('selectionchange', selectionChangeHandler);
 
   const dispose = () => {
+    recognizer.dispose();
     container.removeEventListener('contextmenu', contextMenuHandler);
     document.removeEventListener(
       'selectionchange',

--- a/packages/blocks/src/__internal__/utils/gesture/gesture.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/gesture.ts
@@ -1,0 +1,165 @@
+import { isDatabaseInput, isInsidePageTitle } from '../query.js';
+import { debounce } from '../std.js';
+import { Recognizer } from './recognizer.js';
+import type { SelectionEvent } from './selection-event.js';
+import { toSelectionEvent } from './selection-event.js';
+
+export interface Bound {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function shouldFilterMouseEvent(event: Event): boolean {
+  const target = event.target;
+  if (!target || !(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.tagName === 'INPUT') {
+    return true;
+  }
+  if (target.tagName === 'FORMAT-QUICK-BAR') {
+    return true;
+  }
+  return false;
+}
+
+export function initMouseEventHandlers(
+  container: HTMLElement,
+  onContainerDragStart: (e: SelectionEvent) => void,
+  onContainerDragMove: (e: SelectionEvent) => void,
+  onContainerDragEnd: (e: SelectionEvent) => void,
+  onContainerClick: (e: SelectionEvent) => void,
+  onContainerDblClick: (e: SelectionEvent) => void,
+  onContainerTripleClick: (e: SelectionEvent) => void,
+  onContainerMouseMove: (e: SelectionEvent) => void,
+  onContainerMouseOut: (e: SelectionEvent) => void,
+  onContainerContextMenu: (e: SelectionEvent) => void,
+  onSelectionChangeWithDebounce: (e: Event) => void,
+  onSelectionChangeWithoutDebounce: (e: Event) => void
+) {
+  let isDragging = false;
+
+  const recognizer = new Recognizer(container, {
+    onDragStart: event => {
+      if (shouldFilterMouseEvent(event.raw)) return;
+      if (
+        !isInsidePageTitle(event.raw.target) &&
+        !isDatabaseInput(event.raw.target)
+      ) {
+        event.raw.preventDefault();
+      }
+      isDragging = true;
+      onContainerDragStart(event);
+    },
+    onDragMove: event => {
+      if (shouldFilterMouseEvent(event.raw)) return;
+      if (
+        !isInsidePageTitle(event.raw.target) &&
+        !isDatabaseInput(event.raw.target)
+      ) {
+        event.raw.preventDefault();
+      }
+      onContainerDragMove(event);
+    },
+    onDragEnd: event => {
+      if (
+        !isInsidePageTitle(event.raw.target) &&
+        !isDatabaseInput(event.raw.target)
+      ) {
+        event.raw.preventDefault();
+      }
+      isDragging = false;
+      onContainerDragEnd(event);
+    },
+
+    onPointerDown: event => {
+      //
+    },
+    onPointerMove: event => {
+      if (shouldFilterMouseEvent(event.raw)) return;
+      if (
+        !isInsidePageTitle(event.raw.target) &&
+        !isDatabaseInput(event.raw.target)
+      ) {
+        event.raw.preventDefault();
+      }
+      onContainerMouseMove(event);
+    },
+    onPointerUp: event => {
+      //
+    },
+    onPointerOut: event => {
+      onContainerMouseOut(event);
+    },
+
+    onClick: event => {
+      if (
+        !isInsidePageTitle(event.raw.target) &&
+        !isDatabaseInput(event.raw.target)
+      ) {
+        event.raw.preventDefault();
+      }
+      onContainerClick(event);
+    },
+    onDblClick: event => {
+      if (shouldFilterMouseEvent(event.raw)) return;
+      onContainerDblClick(event);
+    },
+    onTripleClick: event => {
+      if (shouldFilterMouseEvent(event.raw)) return;
+      onContainerTripleClick(event);
+    },
+  });
+
+  const getBoundingClientRect: () => DOMRect = () =>
+    container.getBoundingClientRect();
+
+  const contextMenuHandler = (event: MouseEvent) => {
+    // e.preventDefault();
+    // e.stopPropagation();
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    onContainerContextMenu(selectionEvent);
+  };
+
+  /**
+   * TODO merge to `selectionChangeHandler`
+   * @deprecated use `selectionChangeHandler` instead
+   */
+  const selectionChangeHandlerWithDebounce = debounce((e: Event) => {
+    if (shouldFilterMouseEvent(e)) return;
+    if (isDragging) {
+      return;
+    }
+
+    onSelectionChangeWithDebounce(e as Event);
+  }, 300);
+
+  const selectionChangeHandler = (e: Event) => {
+    onSelectionChangeWithoutDebounce(e);
+  };
+
+  container.addEventListener('contextmenu', contextMenuHandler);
+  document.addEventListener(
+    'selectionchange',
+    selectionChangeHandlerWithDebounce
+  );
+  document.addEventListener('selectionchange', selectionChangeHandler);
+
+  const dispose = () => {
+    container.removeEventListener('contextmenu', contextMenuHandler);
+    document.removeEventListener(
+      'selectionchange',
+      selectionChangeHandlerWithDebounce
+    );
+    document.removeEventListener('selectionchange', selectionChangeHandler);
+  };
+  return dispose;
+}

--- a/packages/blocks/src/__internal__/utils/gesture/index.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/index.ts
@@ -1,0 +1,4 @@
+export { initMouseEventHandlers } from './gesture.js';
+export type { SelectionEvent } from './selection-event.js';
+export type { IPoint } from './utils.js';
+export { createDragEvent, isPinchEvent } from './utils.js';

--- a/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
@@ -1,4 +1,4 @@
-import { assertExists, DisposableGroup } from '@blocksuite/store';
+import { assertExists } from '@blocksuite/store';
 
 import { type SelectionEvent, toSelectionEvent } from './selection-event.js';
 import { isFarEnough } from './utils.js';

--- a/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
@@ -1,0 +1,180 @@
+import { assertExists, DisposableGroup } from '@blocksuite/store';
+
+import { type SelectionEvent, toSelectionEvent } from './selection-event.js';
+import { isFarEnough } from './utils.js';
+
+interface Callbacks {
+  onDragStart?: (e: SelectionEvent) => void;
+  onDragMove?: (e: SelectionEvent) => void;
+  onDragEnd?: (e: SelectionEvent) => void;
+
+  onPointerDown?: (e: SelectionEvent) => void;
+  onPointerMove?: (e: SelectionEvent) => void;
+  onPointerUp?: (e: SelectionEvent) => void;
+  onPointerOut?: (e: SelectionEvent) => void;
+
+  onClick?: (e: SelectionEvent) => void;
+  onDblClick?: (e: SelectionEvent) => void;
+  onTripleClick?: (e: SelectionEvent) => void;
+}
+
+export class Recognizer {
+  private _target: HTMLElement;
+  private _callbacks: Callbacks = {};
+
+  private _pointerDownCount = 0;
+  private _lastPointerDownEvent: PointerEvent | null = null;
+
+  private _startX = -Infinity;
+  private _startY = -Infinity;
+  private _lastSelectionEventForDrag: SelectionEvent | null = null;
+  private _dragging = false;
+
+  constructor(target: HTMLElement, callbacks: Callbacks = {}) {
+    this._target = target;
+    this._callbacks = callbacks;
+
+    this.listen();
+  }
+
+  listen() {
+    this._target.addEventListener('pointerdown', this._pointerdown);
+    this._target.addEventListener(
+      'pointermove',
+      this._pointermoveCaptureByTarget
+    );
+    this._target.addEventListener('pointerout', this._pointerout);
+  }
+
+  dispose() {
+    this._target.removeEventListener('pointerdown', this._pointerdown);
+    this._target.removeEventListener(
+      'pointermove',
+      this._pointermoveCaptureByTarget
+    );
+    this._target.removeEventListener('pointerout', this._pointerout);
+
+    if (this._pointerDownCount) {
+      document.removeEventListener('pointermove', this._pointermove);
+      document.removeEventListener('pointerup', this._pointerup);
+    }
+  }
+
+  private _dispatchEvent(
+    eventName: keyof Callbacks,
+    selectionEvent: SelectionEvent
+  ) {
+    this._callbacks[eventName]?.(selectionEvent);
+  }
+
+  private _getTargetBoundingRect = () => {
+    return this._target.getBoundingClientRect();
+  };
+
+  private _pointerdown = (event: PointerEvent) => {
+    if (
+      this._lastPointerDownEvent &&
+      event.timeStamp - this._lastPointerDownEvent.timeStamp < 500
+    ) {
+      this._pointerDownCount++;
+    } else {
+      this._pointerDownCount = 1;
+    }
+
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect: this._getTargetBoundingRect,
+      startX: this._startX,
+      startY: this._startY,
+      last: null,
+    });
+
+    this._startX = selectionEvent.x;
+    this._startY = selectionEvent.y;
+    this._lastSelectionEventForDrag = selectionEvent;
+    this._lastPointerDownEvent = event;
+
+    this._dispatchEvent('onPointerDown', selectionEvent);
+    document.addEventListener('pointermove', this._pointermove);
+    document.addEventListener('pointerup', this._pointerup);
+  };
+
+  private _pointermove = (event: PointerEvent) => {
+    const lastSelectionEvent = this._lastSelectionEventForDrag;
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect: this._getTargetBoundingRect,
+      startX: this._startX,
+      startY: this._startY,
+      last: lastSelectionEvent,
+    });
+    this._lastSelectionEventForDrag = selectionEvent;
+
+    assertExists(lastSelectionEvent);
+
+    if (
+      !this._dragging &&
+      isFarEnough({ x: this._startX, y: this._startY }, selectionEvent)
+    ) {
+      this._dragging = true;
+      this._dispatchEvent('onDragStart', lastSelectionEvent);
+    }
+
+    if (this._dragging) {
+      this._dispatchEvent('onDragMove', selectionEvent);
+    }
+  };
+
+  private _pointermoveCaptureByTarget = (event: PointerEvent) => {
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect: this._getTargetBoundingRect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    this._dispatchEvent('onPointerMove', selectionEvent);
+  };
+
+  private _pointerup = (event: PointerEvent) => {
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect: this._getTargetBoundingRect,
+      startX: this._startX,
+      startY: this._startY,
+      last: this._lastSelectionEventForDrag,
+    });
+
+    this._dispatchEvent('onPointerUp', selectionEvent);
+
+    if (this._dragging) {
+      this._dispatchEvent('onDragEnd', selectionEvent);
+    } else {
+      this._dispatchEvent('onClick', selectionEvent);
+      if (this._pointerDownCount === 2) {
+        this._dispatchEvent('onDblClick', selectionEvent);
+      } else if (this._pointerDownCount === 3) {
+        this._dispatchEvent('onTripleClick', selectionEvent);
+      }
+    }
+
+    this._startX = -Infinity;
+    this._startY = -Infinity;
+    this._lastSelectionEventForDrag = null;
+    this._dragging = false;
+
+    document.removeEventListener('pointermove', this._pointermove);
+    document.removeEventListener('pointerup', this._pointerup);
+  };
+
+  private _pointerout = (event: PointerEvent) => {
+    const selectionEvent = toSelectionEvent({
+      event,
+      getBoundingClientRect: this._getTargetBoundingRect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    this._dispatchEvent('onPointerOut', selectionEvent);
+  };
+}

--- a/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/recognizer.ts
@@ -74,7 +74,8 @@ export class Recognizer {
   private _pointerdown = (event: PointerEvent) => {
     if (
       this._lastPointerDownEvent &&
-      event.timeStamp - this._lastPointerDownEvent.timeStamp < 500
+      event.timeStamp - this._lastPointerDownEvent.timeStamp < 500 &&
+      !isFarEnough(event, this._lastPointerDownEvent)
     ) {
       this._pointerDownCount++;
     } else {

--- a/packages/blocks/src/__internal__/utils/gesture/selection-event.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/selection-event.ts
@@ -1,0 +1,63 @@
+import type { IPoint } from './utils.js';
+
+export interface SelectionEvent extends IPoint {
+  start: IPoint;
+  delta: IPoint;
+  raw: PointerEvent | MouseEvent;
+  containerOffset: IPoint;
+  keys: {
+    shift: boolean;
+    /** command or control */
+    cmd: boolean;
+    alt: boolean;
+  };
+  button?: number;
+  dragging: boolean;
+}
+
+export function toSelectionEvent({
+  event,
+  getBoundingClientRect,
+  startX,
+  startY,
+  last = null,
+}: {
+  event: PointerEvent | MouseEvent;
+  getBoundingClientRect: () => DOMRect;
+  startX: number;
+  startY: number;
+  last: SelectionEvent | null;
+}): SelectionEvent {
+  const rect = getBoundingClientRect();
+  const delta = { x: 0, y: 0 };
+  const start = { x: startX, y: startY };
+  const offsetX = event.clientX - rect.left;
+  const offsetY = event.clientY - rect.top;
+  const selectionEvent: SelectionEvent = {
+    x: offsetX,
+    y: offsetY,
+    raw: event,
+    // absolute position is still **relative** to the nearest positioned ancestor.
+    //  In our case, it is the editor. For example, if there is padding/margin in editor,
+    //    then the correct absolute `x`/`y` of mouse position is `containerOffset.x - x`
+    // Refs: https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute_positioning
+    containerOffset: {
+      x: rect.left,
+      y: rect.top,
+    },
+    delta,
+    start,
+    keys: {
+      shift: event.shiftKey,
+      cmd: event.metaKey || event.ctrlKey,
+      alt: event.altKey,
+    },
+    button: event.button,
+    dragging: !!last,
+  };
+  if (last) {
+    delta.x = offsetX - last.x;
+    delta.y = offsetY - last.y;
+  }
+  return selectionEvent;
+}

--- a/packages/blocks/src/__internal__/utils/gesture/utils.ts
+++ b/packages/blocks/src/__internal__/utils/gesture/utils.ts
@@ -1,0 +1,39 @@
+import { IS_IOS, IS_MAC } from '@blocksuite/global/config';
+
+export interface IPoint {
+  x: number;
+  y: number;
+}
+
+const MOVE_DETECT_THRESHOLD = 2;
+export function isFarEnough(a: IPoint, b: IPoint, d = MOVE_DETECT_THRESHOLD) {
+  return Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2) > d * d;
+}
+
+export function isPinchEvent(e: WheelEvent) {
+  // two finger pinches on touch pad, ctrlKey is always true.
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=397027
+  if (IS_IOS || IS_MAC) {
+    return e.ctrlKey || e.metaKey;
+  }
+  return e.ctrlKey;
+}
+
+/**
+ * Returns a `DragEvent` via `MouseEvent`.
+ */
+export function createDragEvent(type: string, event?: MouseEvent) {
+  const options = {
+    dataTransfer: new DataTransfer(),
+  };
+  if (event) {
+    const { clientX, clientY, screenX, screenY } = event;
+    Object.assign(options, {
+      clientX,
+      clientY,
+      screenX,
+      screenY,
+    });
+  }
+  return new DragEvent(type, options);
+}

--- a/packages/blocks/src/__internal__/utils/index.ts
+++ b/packages/blocks/src/__internal__/utils/index.ts
@@ -7,9 +7,7 @@
 export * from './block-range.js';
 export * from './common-operations.js';
 export * from './filesys.js';
-export { initMouseEventHandlers } from './gesture/gesture.js';
-export type { SelectionEvent } from './gesture/selection-event.js';
-export { createDragEvent, isPinchEvent } from './gesture/utils.js';
+export * from './gesture/index.js';
 export * from './hotkey.js';
 export * from './lit.js';
 export * from './query.js';

--- a/packages/blocks/src/__internal__/utils/index.ts
+++ b/packages/blocks/src/__internal__/utils/index.ts
@@ -7,7 +7,9 @@
 export * from './block-range.js';
 export * from './common-operations.js';
 export * from './filesys.js';
-export * from './gesture.js';
+export { initMouseEventHandlers } from './gesture/gesture.js';
+export type { SelectionEvent } from './gesture/selection-event.js';
+export { createDragEvent, isPinchEvent } from './gesture/utils.js';
 export * from './hotkey.js';
 export * from './lit.js';
 export * from './query.js';

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -11,7 +11,7 @@ import { getTextNodesFromElement, type VirgoLine } from '@blocksuite/virgo';
 import type { FrameBlockComponent } from '../../frame-block/index.js';
 import type { RichText } from '../rich-text/rich-text.js';
 import { asyncFocusRichText } from './common-operations.js';
-import type { IPoint, SelectionEvent } from './gesture.js';
+import type { IPoint, SelectionEvent } from './gesture/index.js';
 import {
   type BlockComponentElement,
   getBlockElementByModel,

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -20,6 +20,7 @@ import {
   getRichTextByModel,
   WithDisposable,
 } from '../../__internal__/utils/index.js';
+import { stopPropagation } from '../../page-block/edgeless/utils.js';
 import { actionConfig } from '../../page-block/utils/const.js';
 import { formatConfig } from '../../page-block/utils/format-config.js';
 import {
@@ -328,7 +329,11 @@ export class FormatQuickBar extends WithDisposable(LitElement) {
       left: this.left,
       top: this.top,
     });
-    return html` <div class="format-quick-bar" style="${styles}">
+    return html` <div
+      class="format-quick-bar"
+      style="${styles}"
+      @pointerdown=${stopPropagation}
+    >
       ${paragraphItems}
       <div class="divider"></div>
       ${formatItems}

--- a/packages/blocks/src/database-block/components/column-header/column-move/index.ts
+++ b/packages/blocks/src/database-block/components/column-header/column-move/index.ts
@@ -140,9 +140,9 @@ export function initMoveColumnHandlers(
   );
   columnMoveElements.forEach(moveElement => {
     // prevent block selection and drag-handle
-    disposables.addFromEvent(moveElement, 'mousedown', stopPropagation);
-    disposables.addFromEvent(moveElement, 'mousemove', stopPropagation);
-    disposables.addFromEvent(moveElement, 'mouseup', stopPropagation);
+    disposables.addFromEvent(moveElement, 'pointerdown', stopPropagation);
+    disposables.addFromEvent(moveElement, 'pointermove', stopPropagation);
+    disposables.addFromEvent(moveElement, 'pointerup', stopPropagation);
     disposables.addFromEvent(moveElement, 'click', stopPropagation);
 
     // init drag event

--- a/packages/blocks/src/database-block/components/toolbar/index.ts
+++ b/packages/blocks/src/database-block/components/toolbar/index.ts
@@ -156,9 +156,9 @@ export function initAddNewRecordHandlers(
   const stopPropagation = (e: Event) => {
     e.stopPropagation();
   };
-  disposables.addFromEvent(element, 'mousedown', stopPropagation);
-  disposables.addFromEvent(element, 'mousemove', stopPropagation);
-  disposables.addFromEvent(element, 'mouseup', stopPropagation);
+  disposables.addFromEvent(element, 'pointerdown', stopPropagation);
+  disposables.addFromEvent(element, 'pointermove', stopPropagation);
+  disposables.addFromEvent(element, 'pointerup', stopPropagation);
 
   disposables.addFromEvent(element, 'dragstart', onDragStart);
   disposables.addFromEvent(element, 'drag', onDrag);

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -17,6 +17,7 @@ import {
 } from '../__internal__/index.js';
 import { ShadowlessElement } from '../__internal__/utils/lit.js';
 import { tooltipStyle } from '../components/tooltip/tooltip.js';
+import { stopPropagation } from '../page-block/edgeless/utils.js';
 import type { DatabaseColumnHeader } from './components/column-header/column-header.js';
 import { registerInternalRenderer } from './components/column-type/index.js';
 import { DataBaseRowContainer } from './components/row-container.js';
@@ -285,7 +286,10 @@ export class DatabaseBlockComponent
     );
 
     return html`
-      <div class="affine-database-block-container">
+      <div
+        class="affine-database-block-container"
+        @pointerdown=${stopPropagation}
+      >
         <div class="affine-database-block-title-container">
           <affine-database-title
             .addRow=${this._addRow}

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -10,6 +10,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import type { EditingState } from '../../__internal__/index.js';
 import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 import type { EmbedBlockModel } from '../../embed-block/embed-model.js';
+import { stopPropagation } from '../edgeless/utils.js';
 import type { DefaultSelectionSlots } from './default-page-block.js';
 import type { PageViewport } from './selection-manager/selection-state.js';
 import { copyImage, downloadImage, focusCaption } from './utils.js';
@@ -99,7 +100,10 @@ export function EmbedEditingContainer(
       ${tooltipStyle}
     </style>
 
-    <div class="affine-embed-editing-state-container">
+    <div
+      class="affine-embed-editing-state-container"
+      @pointerdown=${stopPropagation}
+    >
       <div style=${styleMap(style)} class="embed-editing-state">
         <format-bar-button
           class="has-tool-tip"

--- a/packages/blocks/src/page-block/default/selection-manager/utils.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/utils.ts
@@ -11,7 +11,7 @@ import { getExtendBlockRange } from '../../../__internal__/utils/block-range.js'
 import type {
   IPoint,
   SelectionEvent,
-} from '../../../__internal__/utils/gesture.js';
+} from '../../../__internal__/utils/gesture/index.js';
 import type { DefaultSelectionSlots } from '../default-page-block.js';
 import type { DefaultSelectionManager, PageSelectionState } from './index.js';
 

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -24,7 +24,7 @@ import type { TopLevelBlockModel } from '../../../../__internal__/utils/types.js
 import type { EdgelessSelectionSlots } from '../../edgeless-page-block.js';
 import type { EdgelessSelectionState } from '../../selection-manager.js';
 import type { Selectable } from '../../selection-manager.js';
-import { isTopLevelBlock } from '../../utils.js';
+import { isTopLevelBlock, stopPropagation } from '../../utils.js';
 
 type CategorizedElements = {
   shape: ShapeElement[];
@@ -156,7 +156,7 @@ export class EdgelessComponentToolbar extends LitElement {
     const divider = !buttons.length
       ? nothing
       : html`<menu-divider .vertical=${true}></menu-divider>`;
-    return html`<div class="container">
+    return html`<div class="container" @pointerdown=${stopPropagation}>
       ${join(buttons, () => '')} ${divider}
       <edgeless-more-button
         .elements=${this.selected}

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -203,9 +203,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     const resizeHandles = ResizeHandles(
       selectedRect,
       resizeMode,
-      (e: MouseEvent, direction: HandleDirection) => {
+      (e: PointerEvent, direction: HandleDirection) => {
         const bounds = getSelectableBounds(this.state.selected);
-        _resizeManager.onMouseDown(e, direction, bounds, this.zoom);
+        _resizeManager.onPointerDown(e, direction, bounds, this.zoom);
       }
     );
 

--- a/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
@@ -1,8 +1,6 @@
 import { html, nothing } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { stopPropagation } from '../utils.js';
-
 export enum HandleDirection {
   Left = 'left',
   Right = 'right',
@@ -25,7 +23,7 @@ function ResizeHandle(
   centerX: number,
   centerY: number,
   handleDirection: HandleDirection,
-  onMouseDown?: (e: MouseEvent, direction: HandleDirection) => void
+  onPointerDown?: (e: PointerEvent, direction: HandleDirection) => void
 ) {
   const style = {
     position: 'absolute',
@@ -39,18 +37,25 @@ function ResizeHandle(
     border: '2px var(--affine-primary-color) solid',
     background: 'white',
     cursor: directionCursors[handleDirection],
+    /**
+     * Fix: pointerEvent stops firing after a short time.
+     * When a gesture is started, the browser intersects the touch-action values of the touched element and its ancestors,
+     * up to the one that implements the gesture (in other words, the first containing scrolling element)
+     * https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action
+     */
+    touchAction: 'none',
   };
 
-  const handlerMouseDown = (e: MouseEvent) => {
-    onMouseDown && onMouseDown(e, handleDirection);
+  const handlerPointerDown = (e: PointerEvent) => {
+    e.stopPropagation();
+    onPointerDown && onPointerDown(e, handleDirection);
   };
 
   return html`
     <div
       aria-label=${`handle-${handleDirection}`}
       style=${styleMap(style)}
-      @mousedown=${handlerMouseDown}
-      @pointerdown=${stopPropagation}
+      @pointerdown=${handlerPointerDown}
     ></div>
   `;
 }
@@ -59,7 +64,7 @@ export type ResizeMode = 'corner' | 'edge' | 'none';
 export function ResizeHandles(
   rect: DOMRect,
   resizeMode: ResizeMode,
-  onMouseDown: (e: MouseEvent, direction: HandleDirection) => void
+  onPointerDown: (e: PointerEvent, direction: HandleDirection) => void
 ) {
   switch (resizeMode) {
     case 'corner': {
@@ -72,25 +77,25 @@ export function ResizeHandles(
         topLeft[0],
         topLeft[1],
         HandleDirection.TopLeft,
-        onMouseDown
+        onPointerDown
       );
       const handleTopRight = ResizeHandle(
         topRight[0],
         topRight[1],
         HandleDirection.TopRight,
-        onMouseDown
+        onPointerDown
       );
       const handleBottomLeft = ResizeHandle(
         bottomLeft[0],
         bottomLeft[1],
         HandleDirection.BottomLeft,
-        onMouseDown
+        onPointerDown
       );
       const handleBottomRight = ResizeHandle(
         bottomRight[0],
         bottomRight[1],
         HandleDirection.BottomRight,
-        onMouseDown
+        onPointerDown
       );
 
       // prettier-ignore
@@ -109,13 +114,13 @@ export function ResizeHandles(
         leftCenter[0],
         leftCenter[1],
         HandleDirection.Left,
-        onMouseDown
+        onPointerDown
       );
       const handleRight = ResizeHandle(
         rightCenter[0],
         rightCenter[1],
         HandleDirection.Right,
-        onMouseDown
+        onPointerDown
       );
 
       return html` ${handleLeft} ${handleRight} `;

--- a/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
@@ -1,6 +1,8 @@
 import { html, nothing } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { stopPropagation } from '../utils.js';
+
 export enum HandleDirection {
   Left = 'left',
   Right = 'right',
@@ -48,6 +50,7 @@ function ResizeHandle(
       aria-label=${`handle-${handleDirection}`}
       style=${styleMap(style)}
       @mousedown=${handlerMouseDown}
+      @pointerdown=${stopPropagation}
     ></div>
   `;
 }

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -23,8 +23,8 @@ export class HandleResizeManager {
     this._onResizeEnd = onResizeEnd;
   }
 
-  onMouseDown = (
-    e: MouseEvent,
+  onPointerDown = (
+    e: PointerEvent,
     direction: HandleDirection,
     bounds: Map<string, Bound>,
     zoom: number
@@ -43,7 +43,7 @@ export class HandleResizeManager {
       y: e.clientY,
     };
 
-    const _onMouseMove = (e: MouseEvent) => {
+    const _onPointerMove = (e: PointerEvent) => {
       const direction = this._dragDirection;
       const { x: startX, y: startY } = this._startDragPos;
 
@@ -137,17 +137,17 @@ export class HandleResizeManager {
       this._onResizeMove(newBounds);
     };
 
-    const _onMouseUp = (_: MouseEvent) => {
+    const _onPointerUp = (_: PointerEvent) => {
       this._onResizeEnd();
 
       this._startDragPos = { x: 0, y: 0 };
       this._bounds.clear();
       this._commonBound = [0, 0, 0, 0];
 
-      window.removeEventListener('mousemove', _onMouseMove);
-      window.removeEventListener('mouseup', _onMouseUp);
+      window.removeEventListener('pointermove', _onPointerMove);
+      window.removeEventListener('pointerup', _onPointerUp);
     };
-    window.addEventListener('mousemove', _onMouseMove);
-    window.addEventListener('mouseup', _onMouseUp);
+    window.addEventListener('pointermove', _onPointerMove);
+    window.addEventListener('pointerup', _onPointerUp);
   };
 }

--- a/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
@@ -19,11 +19,10 @@ import {
   getConnectorAttachedInfo,
   getXYWH,
   pickBy,
-  stopPropagation,
 } from '../utils.js';
 
-function capMousedown(
-  event: MouseEvent,
+function capPointerdown(
+  event: PointerEvent,
   surface: SurfaceManager,
   page: Page,
   element: ConnectorElement,
@@ -41,8 +40,8 @@ function capMousedown(
     x: c.x + element.x,
     y: c.y + element.y,
   }));
-  const mousemove = (mouseMoveEvent: MouseEvent) => {
-    const { clientX, clientY } = mouseMoveEvent;
+  const pointermove = (mousePointerEvent: PointerEvent) => {
+    const { clientX, clientY } = mousePointerEvent;
     const deltaX = clientX - startX;
     const deltaY = clientY - startY;
     const modelX = elementX + deltaX;
@@ -119,13 +118,13 @@ function capMousedown(
     requestUpdate();
   };
 
-  const mouseup = () => {
-    document.removeEventListener('mousemove', mousemove);
-    document.removeEventListener('mouseup', mouseup);
+  const pointerup = () => {
+    document.removeEventListener('pointermove', pointermove);
+    document.removeEventListener('pointerup', pointerup);
   };
 
-  document.addEventListener('mousemove', mousemove);
-  document.addEventListener('mouseup', mouseup);
+  document.addEventListener('pointermove', pointermove);
+  document.addEventListener('pointerup', pointerup);
 }
 
 type Handle = {
@@ -161,8 +160,8 @@ function getControllerHandles(controllers: Controller[]) {
   return handles;
 }
 
-function centerControllerMousedown(
-  event: MouseEvent,
+function centerControllerPointerdown(
+  event: PointerEvent,
   surface: SurfaceManager,
   page: Page,
   element: ConnectorElement,
@@ -173,7 +172,7 @@ function centerControllerMousedown(
   const startY = event.clientY;
   const { controllers, x, y } = element;
 
-  const mousemove = (mouseMoveEvent: MouseEvent) => {
+  const pointermove = (pointerMoveEvent: PointerEvent) => {
     const { isVertical, position } = handle;
     const { zoom } = surface.viewport;
 
@@ -183,8 +182,8 @@ function centerControllerMousedown(
       y: c.y + y,
     }));
 
-    const deltaX = isVertical ? mouseMoveEvent.clientX - startX : 0;
-    const deltaY = isVertical ? 0 : mouseMoveEvent.clientY - startY;
+    const deltaX = isVertical ? pointerMoveEvent.clientX - startX : 0;
+    const deltaY = isVertical ? 0 : pointerMoveEvent.clientY - startY;
 
     const point0 = absoluteControllers[position];
     const newPoint0 = {
@@ -228,12 +227,12 @@ function centerControllerMousedown(
 
     requestUpdate();
   };
-  const mouseup = (mouseUpEvent: MouseEvent) => {
-    document.removeEventListener('mousemove', mousemove);
-    document.removeEventListener('mouseup', mouseup);
+  const pointerup = (pointerUpEvent: PointerEvent) => {
+    document.removeEventListener('pointermove', pointermove);
+    document.removeEventListener('pointerup', pointerup);
   };
-  document.addEventListener('mousemove', mousemove);
-  document.addEventListener('mouseup', mouseup);
+  document.addEventListener('pointermove', pointermove);
+  document.addEventListener('pointerup', pointerup);
 }
 
 export function SingleConnectorHandles(
@@ -270,23 +269,30 @@ export function SingleConnectorHandles(
         cursor: pointer;
         z-index: 10;
         pointer-events: all;
+        /**
+         * Fix: pointerEvent stops firing after a short time.
+         * When a gesture is started, the browser intersects the touch-action values of the touched element and its ancestors,
+         * up to the one that implements the gesture (in other words, the first containing scrolling element)
+         * https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action
+         */
+        touch-action: none;
       }
     </style>
     <div
       class="line-controller line-start"
       style=${styleMap(start)}
-      @mousedown=${(e: MouseEvent) => {
-        capMousedown(e, surface, page, element, 'start', mode, requestUpdate);
+      @pointerdown=${(e: PointerEvent) => {
+        e.stopPropagation();
+        capPointerdown(e, surface, page, element, 'start', mode, requestUpdate);
       }}
-      @pointerdown=${stopPropagation}
     ></div>
     <div
       class="line-controller line-end"
       style=${styleMap(end)}
-      @mousedown=${(e: MouseEvent) => {
-        capMousedown(e, surface, page, element, 'end', mode, requestUpdate);
+      @pointerdown=${(e: PointerEvent) => {
+        e.stopPropagation();
+        capPointerdown(e, surface, page, element, 'end', mode, requestUpdate);
       }}
-      @pointerdown=${stopPropagation}
     ></div>
     ${repeat(
       controllerHandles,
@@ -300,8 +306,9 @@ export function SingleConnectorHandles(
         return html`<div
           class="line-controller"
           style=${styleMap(style)}
-          @mousedown=${(e: MouseEvent) => {
-            centerControllerMousedown(
+          @pointerdown=${(e: PointerEvent) => {
+            e.stopPropagation();
+            centerControllerPointerdown(
               e,
               surface,
               page,
@@ -310,7 +317,6 @@ export function SingleConnectorHandles(
               requestUpdate
             );
           }}
-          @pointerdown=${stopPropagation}
         ></div>`;
       }
     )}

--- a/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
@@ -19,6 +19,7 @@ import {
   getConnectorAttachedInfo,
   getXYWH,
   pickBy,
+  stopPropagation,
 } from '../utils.js';
 
 function capMousedown(
@@ -277,6 +278,7 @@ export function SingleConnectorHandles(
       @mousedown=${(e: MouseEvent) => {
         capMousedown(e, surface, page, element, 'start', mode, requestUpdate);
       }}
+      @pointerdown=${stopPropagation}
     ></div>
     <div
       class="line-controller line-end"
@@ -284,6 +286,7 @@ export function SingleConnectorHandles(
       @mousedown=${(e: MouseEvent) => {
         capMousedown(e, surface, page, element, 'end', mode, requestUpdate);
       }}
+      @pointerdown=${stopPropagation}
     ></div>
     ${repeat(
       controllerHandles,
@@ -307,6 +310,7 @@ export function SingleConnectorHandles(
               requestUpdate
             );
           }}
+          @pointerdown=${stopPropagation}
         ></div>`;
       }
     )}

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -115,6 +115,20 @@ export class EdgelessPageBlockComponent
       z-index: 1;
       pointer-events: none;
     }
+
+    .affine-block-children-container.edgeless {
+      padding-left: 0;
+      position: relative;
+      overflow: hidden;
+      height: 100%;
+      /**
+       * Fix: pointerEvent stops firing after a short time.
+       * When a gesture is started, the browser intersects the touch-action values of the touched element and its ancestors,
+       * up to the one that implements the gesture (in other words, the first containing scrolling element)
+       * https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action
+       */
+      touch-action: none;
+    }
   `;
 
   flavour = 'edgeless' as const;
@@ -562,10 +576,6 @@ export class EdgelessPageBlockComponent
       >
         <style>
           .affine-block-children-container.edgeless {
-            padding-left: 0;
-            position: relative;
-            overflow: hidden;
-            height: 100%;
             background-size: ${gap}px ${gap}px;
             background-position: ${translateX}px ${translateY}px;
             background-color: var(--affine-background-primary-color);

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -173,7 +173,6 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   private _handleBlockDragMove(block: TopLevelBlockModel, e: SelectionEvent) {
-    console.log('e.delta', e.delta);
     const [modelX, modelY, modelW, modelH] = JSON.parse(block.xywh) as XYWH;
     const { zoom } = this._edgeless.surface.viewport;
     const xywh = JSON.stringify([
@@ -338,7 +337,6 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   onContainerDragMove(e: SelectionEvent) {
-    console.log('drag type', this.dragType);
     switch (this.dragType) {
       case DefaultModeDragType.Selecting: {
         const startX = this._dragStartPos.x;

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -173,6 +173,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   private _handleBlockDragMove(block: TopLevelBlockModel, e: SelectionEvent) {
+    console.log('e.delta', e.delta);
     const [modelX, modelY, modelW, modelH] = JSON.parse(block.xywh) as XYWH;
     const { zoom } = this._edgeless.surface.viewport;
     const xywh = JSON.stringify([
@@ -337,6 +338,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   onContainerDragMove(e: SelectionEvent) {
+    console.log('drag type', this.dragType);
     switch (this.dragType) {
       case DefaultModeDragType.Selecting: {
         const startX = this._dragStartPos.x;

--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -143,6 +143,7 @@ export class EdgelessToolbar extends LitElement {
         @dblclick=${stopPropagation}
         @mousedown=${stopPropagation}
         @mouseup=${stopPropagation}
+        @pointerdown=${stopPropagation}
       >
         <edgeless-tool-icon-button
           .tooltip=${getTooltipWithShortcut('Select', 'V')}

--- a/packages/blocks/src/page-block/edgeless/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils.ts
@@ -26,10 +26,8 @@ import {
   Point,
   type TopLevelBlockModel,
 } from '../../__internal__/index.js';
-import {
-  isPinchEvent,
-  type SelectionEvent,
-} from '../../__internal__/utils/gesture.js';
+import type { SelectionEvent } from '../../__internal__/utils/gesture/selection-event.js';
+import { isPinchEvent } from '../../__internal__/utils/index.js';
 import type {
   EdgelessContainer,
   EdgelessPageBlockComponent,

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -20,6 +20,12 @@ import {
 import { BlockChildrenContainer } from '../__internal__/service/components.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
+function tipsPlaceholderPreventDefault(event: Event) {
+  // Call event.preventDefault() to keep the mouse event from being sent as well.
+  // https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
+  event.preventDefault();
+}
+
 function TipsPlaceholder(model: BaseBlockModel) {
   if (!matchFlavours(model, ['affine:paragraph'] as const)) {
     throw new Error("TipsPlaceholder can't be used for this model");
@@ -41,7 +47,11 @@ function TipsPlaceholder(model: BaseBlockModel) {
       blockHub.toggleMenu(true);
     };
     return html`
-      <div class="tips-placeholder" @click=${onClick}>
+      <div
+        class="tips-placeholder"
+        @click=${onClick}
+        @pointerdown=${tipsPlaceholderPreventDefault}
+      >
         Click ${BlockHubIcon20} to insert blocks, type '/' for commands
       </div>
     `;


### PR DESCRIPTION
Using pointer events instead of mouse events for mobile development to achieve better compatibility