### PR TITLE
fix: store user can't define own root flavor

### DIFF
--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -693,7 +693,7 @@ export class Page extends Space<FlatBlockMap> {
     if (model.flavour === 'affine:surface') {
       isSurface = true;
     }
-    if (model.flavour === 'affine:page') {
+    if (model.role === 'root') {
       isRoot = true;
     }
     this._blockMap.set(id, model);


### PR DESCRIPTION
I'm using the @blocksuite/store separately and stuck with this bug.