### PR TITLE
fix(blocks): paste issue causing empty single-line block to not focus

### DIFF
--- a/packages/blocks/src/__internal__/service/json2block.ts
+++ b/packages/blocks/src/__internal__/service/json2block.ts
@@ -68,7 +68,7 @@ export async function json2block(
 
       assertExists(model);
       if (model.text) {
-        await setRange(focusedBlockModel, {
+        await setRange(model, {
           index: textLength,
           length: 0,
         });


### PR DESCRIPTION
Closes #2334 

Before:
![](https://i.ibb.co/G34yhqg/2023-04-27-18-44-54.gif)
After:
![](https://i.ibb.co/r7Pzn3B/2023-04-27-18-46-52.gif)

`focusedBlockModel` has been deleted.