### PR TITLE
fix: keep paragraph block's type when pasting excerpt text type (quote block)

### DIFF
--- a/packages/blocks/src/paragraph-block/paragraph-service.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-service.ts
@@ -1,5 +1,9 @@
+import type { BaseBlockModel } from '@blocksuite/store';
+
+import type { BlockRange, SerializedBlock } from '../__internal__/index.js';
 import type { BlockTransformContext } from '../__internal__/index.js';
 import { BaseService } from '../__internal__/service/index.js';
+import { json2block } from '../__internal__/service/json2block.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
 export class ParagraphBlockService extends BaseService<ParagraphBlockModel> {
@@ -27,6 +31,18 @@ export class ParagraphBlockService extends BaseService<ParagraphBlockModel> {
       default:
         return text;
     }
+  }
+
+  override async json2Block(
+    focusedBlockModel: BaseBlockModel,
+    pastedBlocks: SerializedBlock[],
+    range?: BlockRange
+  ) {
+    const convertToPastedIfEmpty = focusedBlockModel.type !== 'text';
+    return json2block(focusedBlockModel, pastedBlocks, {
+      range,
+      convertToPastedIfEmpty,
+    });
   }
 }
 

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -684,3 +684,73 @@ test('copy and paste to selection block selection', async ({ page }) => {
   await pasteByKeyboard(page, false);
   await assertRichTexts(page, ['1234', '']);
 });
+
+test("should keep paragraph block's type when pasting at the start of empty paragraph block except type text", async ({
+  page,
+}) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/2336',
+  });
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await focusRichText(page);
+  await type(page, '>');
+  await page.keyboard.press('Space', { delay: 50 });
+
+  await page.evaluate(() => {
+    const input = document.createElement('input');
+    input.setAttribute('id', 'input-test');
+    input.value = '123';
+    document.body.appendChild(input);
+  });
+  await page.focus('#input-test');
+  await page.dblclick('#input-test');
+  await copyByKeyboard(page);
+  await focusRichText(page);
+  await pasteByKeyboard(page);
+  await waitNextFrame(page);
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:page>
+  <affine:frame
+    prop:background="--affine-background-secondary-color"
+  >
+    <affine:paragraph
+      prop:text="123"
+      prop:type="quote"
+    />
+  </affine:frame>
+</affine:page>`
+  );
+
+  // when pasting a quote into a text paragraph block, the paragraph type should be text
+  await selectAllByKeyboard(page);
+  await copyByKeyboard(page);
+  await waitNextFrame(page);
+
+  await pressEnter(page);
+  await pasteByKeyboard(page);
+  await waitNextFrame(page);
+
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:page>
+  <affine:frame
+    prop:background="--affine-background-secondary-color"
+  >
+    <affine:paragraph
+      prop:text="123"
+      prop:type="quote"
+    />
+    <affine:paragraph
+      prop:text="123"
+      prop:type="quote"
+    />
+  </affine:frame>
+</affine:page>`
+  );
+});


### PR DESCRIPTION
Close https://github.com/toeverything/blocksuite/issues/2336