### PR TITLE
fix: linked page keyboard shortcut not working on German keyboards

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -68,8 +68,10 @@ export function createKeyboardBindings(
 
     linkedPage: {
       key: ['[', '【', '@'],
+      altKey: null,
       shiftKey: null,
       handler(range, { event, prefix }) {
+        console.log('event.key: ', event.key);
         if (
           (event.key === '[' || event.key === '【') &&
           !prefix.endsWith(event.key)

--- a/packages/blocks/src/__internal__/rich-text/keyboard.ts
+++ b/packages/blocks/src/__internal__/rich-text/keyboard.ts
@@ -71,7 +71,6 @@ export function createKeyboardBindings(
       altKey: null,
       shiftKey: null,
       handler(range, { event, prefix }) {
-        console.log('event.key: ', event.key);
         if (
           (event.key === '[' || event.key === '【') &&
           !prefix.endsWith(event.key)


### PR DESCRIPTION
On German keyboards, you have to press "Option" + "L" in order to get "@". This PR fixes it, by setting "altKey" (this seems to be the option key on Mac) to null there