### PR TITLE
fix(blocks): move cursor at the last line of the last block to the en…

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -561,6 +561,7 @@ export function handleKeyUp(event: KeyboardEvent, editableContainer: Element) {
 }
 
 export function handleKeyDown(
+  block: BaseBlockModel,
   event: KeyboardEvent,
   editableContainer: HTMLElement
 ) {
@@ -572,10 +573,14 @@ export function handleKeyDown(
   }
   const isLastLine = checkLastLine(range, editableContainer);
   if (isLastLine) {
-    // If the caret is at the last line of the block,
-    // default behavior will move the caret to the end of the line,
-    // which is not expected. so we need to prevent default behavior.
-    return PREVENT_DEFAULT;
+    // When the cursor is at the last line of the block,
+    // default ArrowDown behavior will move the cursor to the end of the line
+    // If the block is the last block of the page,
+    // we want the cursor to move to next block instead of the end of the line,
+    // thus we should prevent the default behavior.
+    // If the block is the last block of the page,
+    // let the cursor move to the end of line as default.
+    return getNextBlock(block) ? PREVENT_DEFAULT : ALLOW_DEFAULT;
   }
   // Avoid triggering hotkey bindings
   event.stopPropagation();

--- a/packages/blocks/src/__internal__/service/index.ts
+++ b/packages/blocks/src/__internal__/service/index.ts
@@ -223,7 +223,7 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
         key: 'ArrowDown',
         shiftKey: false,
         handler(range, context) {
-          return handleKeyDown(context.event, this.vEditor.rootElement);
+          return handleKeyDown(block, context.event, this.vEditor.rootElement);
         },
       },
       left: {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -443,12 +443,20 @@ export async function initEmptyCodeBlockState(page: Page) {
   return ids;
 }
 
-export async function focusRichText(page: Page, i = 0) {
+type FocusRichTextOptions = {
+  clickPosition?: { x: number; y: number };
+};
+
+export async function focusRichText(
+  page: Page,
+  i = 0,
+  options?: FocusRichTextOptions
+) {
   await page.mouse.move(0, 0);
   const editor = getEditorLocator(page);
   const locator = editor.locator(RICH_TEXT_SELECTOR).nth(i);
   // need to set `force` to true when clicking on `affine-selected-blocks`
-  await locator.click({ force: true });
+  await locator.click({ force: true, position: options?.clickPosition });
 }
 
 export async function focusRichTextEnd(page: Page, i = 0) {


### PR DESCRIPTION
Fix #2417

As [discucssed in #2351](https://github.com/toeverything/blocksuite/discussions/2351#discussioncomment-5800778), the cursor at the last line of a block should be move to the end of the line _if the block is the last block in the page_.

---

CLA sign at #2421