### PR TITLE
fix: init _cssVariables

### DIFF
--- a/packages/blocks/src/__internal__/theme/theme-observer.ts
+++ b/packages/blocks/src/__internal__/theme/theme-observer.ts
@@ -34,6 +34,7 @@ export class ThemeObserver extends Slot<CssVariablesMap> {
 
   observer(element: Element) {
     this._observer?.disconnect();
+    this._cssVariables = extractCssVariables(element);
     this._observer = new MutationObserver(() => {
       const mode = element.getAttribute('data-theme');
       if (this._mode !== mode) {


### PR DESCRIPTION
this pr will fix:
https://github.com/toeverything/AFFiNE/issues/2141

previously `_cssVariables` won't have a value until theme changed