### PR TITLE
refactor: switch to `exportHtml` and `exportMarkdown`

### DIFF
--- a/packages/blocks/src/__internal__/content-parser/index.ts
+++ b/packages/blocks/src/__internal__/content-parser/index.ts
@@ -29,7 +29,7 @@ export class ContentParser {
     this._htmlParser.registerParsers();
   }
 
-  public async onExportHtml() {
+  public async exportHtml() {
     const root = this._page.root;
     if (!root) return;
     const htmlContent = await this.block2Html(
@@ -41,7 +41,7 @@ export class ContentParser {
     );
   }
 
-  public async onExportMarkdown() {
+  public async exportMarkdown() {
     const root = this._page.root;
     if (!root) return;
     const htmlContent = await this.block2Html(

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -272,11 +272,11 @@ export class DebugMenu extends ShadowlessElement {
   }
 
   private _exportHtml() {
-    this.contentParser.onExportHtml();
+    this.contentParser.exportHtml();
   }
 
   private _exportMarkDown() {
-    this.contentParser.onExportMarkdown();
+    this.contentParser.exportMarkdown();
   }
 
   private _exportYDoc() {


### PR DESCRIPTION
We are writing documentation for export API, so this would better fit our convention.

/cc @Himself65 for bump in AFFiNE (`onExportHtml` -> `exportHtml`) next time.