### PR TITLE
refactor: code language search

### DIFF
--- a/packages/blocks/src/__internal__/content-parser/parse-html.ts
+++ b/packages/blocks/src/__internal__/content-parser/parse-html.ts
@@ -2,6 +2,8 @@ import type { BlockSchemas } from '@blocksuite/global/types';
 import { assertExists } from '@blocksuite/global/utils';
 import type { DeltaOperation, Page } from '@blocksuite/store';
 
+import { getStandardLanguage } from '../../code-block/utils/code-languages.js';
+import { FALLBACK_LANG } from '../../code-block/utils/consts.js';
 import type { SerializedBlock } from '../utils/index.js';
 import type { ContentParser } from './index.js';
 
@@ -434,10 +436,10 @@ export class HtmlParser {
     const isNormalMarkdown =
       firstChild.tagName === 'Code' && languageTag?.[0] === 'language';
     let content = '';
-    let language = 'Plain Text';
+    let language = FALLBACK_LANG;
     if (isNormalMarkdown) {
       content = element.firstChild?.textContent || '';
-      language = languageTag?.[1] || 'Plain Text';
+      language = getStandardLanguage(languageTag?.[1])?.id || FALLBACK_LANG;
     } else {
       content = element.textContent || '';
     }

--- a/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
+++ b/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
@@ -3,7 +3,8 @@ import { assertExists, matchFlavours } from '@blocksuite/global/utils';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import type { VRange } from '@blocksuite/virgo';
 
-import { getCodeLanguage } from '../../code-block/utils/code-languages.js';
+import { getStandardLanguage } from '../../code-block/utils/code-languages.js';
+import { FALLBACK_LANG } from '../../code-block/utils/consts.js';
 import {
   asyncSetVRange,
   convertToDivider,
@@ -413,7 +414,9 @@ const matches: Match[] = [
 
       const codeId = page.addBlock(
         'affine:code',
-        { language: getCodeLanguage(match?.[1] || '') || 'Plain Text' },
+        {
+          language: getStandardLanguage(match?.[1] || '')?.id ?? FALLBACK_LANG,
+        },
         parent,
         index
       );

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -678,6 +678,9 @@ export function getClosestBlockElementByPoint(
       }
       if (snapToEdge.y) {
         // TODO handle scale
+        if (scale !== 1) {
+          console.warn('scale is not supported yet');
+        }
         point.y = clamp(point.y, rect.top + 1, rect.bottom - 1);
       }
     }

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -363,6 +363,7 @@ export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
   }
 
   private _langListTemplate() {
+    // TODO this is a workaround
     const normalizedLang =
       this.model.language[0].toUpperCase() + this.model.language.slice(1);
     return html`<div

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -9,7 +9,13 @@ import { assertExists, Slot } from '@blocksuite/store';
 import { css, html, render } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { getHighlighter, type Highlighter, type Lang } from 'shiki';
+import {
+  BUNDLED_LANGUAGES,
+  getHighlighter,
+  type Highlighter,
+  type ILanguageRegistration,
+  type Lang,
+} from 'shiki';
 import { z } from 'zod';
 
 import {
@@ -25,9 +31,8 @@ import { listenToThemeChange } from '../__internal__/theme/utils.js';
 import { tooltipStyle } from '../components/tooltip/tooltip.js';
 import type { CodeBlockModel } from './code-model.js';
 import { CodeOptionTemplate } from './components/code-option.js';
-import { codeLanguages } from './utils/code-languages.js';
 import { getCodeLineRenderer } from './utils/code-line-renderer.js';
-import { DARK_THEME, LIGHT_THEME } from './utils/consts.js';
+import { DARK_THEME, FALLBACK_LANG, LIGHT_THEME } from './utils/consts.js';
 
 @customElement('affine-code')
 export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
@@ -186,7 +191,7 @@ export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
 
   private _preLang: string | null = null;
   private _highlighter: Highlighter | null = null;
-  private async _startHighlight(lang: Lang) {
+  private async _startHighlight(lang: ILanguageRegistration) {
     const mode = queryCurrentMode();
     this._highlighter = await getHighlighter({
       theme: mode === 'dark' ? DARK_THEME : LIGHT_THEME,
@@ -298,32 +303,32 @@ export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
       });
     });
 
-    if (this.model.language === 'Plain Text') {
+    if (!this.model.language || this.model.language === FALLBACK_LANG) {
       this._highlighter = null;
       return;
     }
 
-    const lang = codeLanguages.find(
-      lang => lang === this.model.language.toLowerCase()
+    const lang = BUNDLED_LANGUAGES.find(
+      lang => lang.id === this.model.language.toLowerCase()
     );
-    if (lang) {
-      this._startHighlight(lang);
-    } else {
-      this._highlighter = null;
+    if (!lang) {
+      console.warn('Unexpected language: ', this.model.language);
+      return;
     }
+    this._startHighlight(lang);
   }
 
   override updated() {
     if (this.model.language !== this._preLang) {
       this._preLang = this.model.language;
 
-      const lang = codeLanguages.find(
-        lang => lang === this.model.language.toLowerCase()
+      const lang = BUNDLED_LANGUAGES.find(
+        lang => lang.id === this.model.language.toLowerCase()
       );
       if (lang) {
         if (this._highlighter) {
           const currentLangs = this._highlighter.getLoadedLanguages();
-          if (!currentLangs.includes(lang)) {
+          if (!currentLangs.includes(lang.id as Lang)) {
             this._highlighter.loadLanguage(lang).then(() => {
               const richText = this.querySelector('rich-text');
               const vEditor = richText?.vEditor;
@@ -358,6 +363,8 @@ export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
   }
 
   private _langListTemplate() {
+    const normalizedLang =
+      this.model.language[0].toUpperCase() + this.model.language.slice(1);
     return html`<div
       class="lang-list-wrapper"
       style="${this._showLangList ? 'visibility: visible;' : ''}"
@@ -371,7 +378,7 @@ export class CodeBlockComponent extends WithDisposable(ShadowlessElement) {
         ?disabled=${this.readonly}
         @click=${this._onClickLangBtn}
       >
-        ${this.model.language} ${!this.readonly ? ArrowDownIcon : html``}
+        ${normalizedLang} ${!this.readonly ? ArrowDownIcon : html``}
       </icon-button>
       ${this._showLangList
         ? html`<lang-list

--- a/packages/blocks/src/code-block/code-model.ts
+++ b/packages/blocks/src/code-block/code-model.ts
@@ -1,11 +1,13 @@
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 import { literal } from 'lit/static-html.js';
 
+import { FALLBACK_LANG } from './utils/consts.js';
+
 export const CodeBlockSchema = defineBlockSchema({
   flavour: 'affine:code',
   props: internal => ({
     text: internal.Text(),
-    language: 'Plain Text',
+    language: FALLBACK_LANG,
   }),
   metadata: {
     version: 1,

--- a/packages/blocks/src/code-block/code-service.ts
+++ b/packages/blocks/src/code-block/code-service.ts
@@ -12,6 +12,8 @@ import type {
 } from '../__internal__/utils/index.js';
 import { getVirgoByModel } from '../__internal__/utils/index.js';
 import type { CodeBlockModel } from './code-model.js';
+import { getStandardLanguage } from './utils/code-languages.js';
+import { FALLBACK_LANG } from './utils/consts.js';
 
 const INDENT_SYMBOL = '  ';
 const LINE_BREAK_SYMBOL = '\n';
@@ -36,8 +38,12 @@ const allIndexOf = (
 };
 
 export class CodeBlockService extends BaseService<CodeBlockModel> {
-  setLang(model: CodeBlockModel, lang: string) {
-    model.page.updateBlock(model, { language: lang });
+  setLang(model: CodeBlockModel, lang: string | null) {
+    const standardLang = getStandardLanguage(lang);
+    const langName = standardLang?.id ?? FALLBACK_LANG;
+    model.page.updateBlock(model, {
+      language: langName,
+    });
   }
 
   override block2html(

--- a/packages/blocks/src/code-block/utils/code-languages.ts
+++ b/packages/blocks/src/code-block/utils/code-languages.ts
@@ -1,214 +1,79 @@
-import type { Lang } from 'shiki';
+import type { ILanguageRegistration, Lang } from 'shiki';
+import { BUNDLED_LANGUAGES } from 'shiki';
 
-export const codeLanguages: Lang[] = [
-  'abap',
-  'actionscript-3',
-  'ada',
-  'apache',
-  'apex',
-  'apl',
-  'applescript',
-  'ara',
-  'asm',
-  'astro',
-  'awk',
-  'ballerina',
-  'bat',
-  'batch',
-  'berry',
-  'be',
-  'bibtex',
-  'bicep',
-  'blade',
-  'c',
-  'cadence',
-  'cdc',
-  'clarity',
-  'clojure',
-  'cmake',
-  'cobol',
-  'codeql',
-  'ql',
-  'coffee',
-  'cpp',
-  'crystal',
-  'csharp',
-  'css',
-  'cue',
-  'd',
-  'dart',
-  'dax',
-  'diff',
-  'docker',
-  'dream-maker',
-  'elixir',
-  'elm',
-  'erb',
-  'erlang',
-  'fish',
-  'fsharp',
-  'gherkin',
-  'git-commit',
-  'git-rebase',
-  'glsl',
-  'gnuplot',
-  'go',
-  'graphql',
-  'groovy',
-  'hack',
-  'haml',
-  'handlebars',
-  'haskell',
-  'hcl',
-  'hlsl',
-  'html',
-  'http',
-  'imba',
-  'ini',
-  'properties',
-  'java',
-  'javascript',
-  'jinja-html',
-  'jison',
-  'json',
-  'json5',
-  'jsonc',
-  'jsonnet',
-  'jssm',
-  'fsl',
-  'jsx',
-  'julia',
-  'kotlin',
-  'latex',
-  'less',
-  'liquid',
-  'lisp',
-  'logo',
-  'lua',
-  'makefile',
-  'markdown',
-  'marko',
-  'matlab',
-  'mdx',
-  'mermaid',
-  'nginx',
-  'nim',
-  'nix',
-  'objective-c',
-  'objective-cpp',
-  'ocaml',
-  'pascal',
-  'perl',
-  'php',
-  'plsql',
-  'postcss',
-  'powerquery',
-  'powershell',
-  'prisma',
-  'prolog',
-  'proto',
-  'pug',
-  'jade',
-  'puppet',
-  'purescript',
+import { PLAIN_TEXT_REGISTRATION } from './consts.js';
+
+// TIOBE Index for May 2023
+// ref https://www.tiobe.com/tiobe-index/
+const PopularLanguages: Lang[] = [
+  // 1-20
   'python',
-  'r',
-  'raku',
-  'perl6',
-  'razor',
-  'rel',
-  'riscv',
-  'rst',
-  'ruby',
-  'rust',
-  'sas',
-  'sass',
-  'scala',
-  'scheme',
-  'scss',
-  'shaderlab',
-  'shader',
-  'shellscript',
-  'bash',
-  'console',
-  'shell',
-  'zsh',
-  'smalltalk',
-  'solidity',
-  'sparql',
-  'sql',
-  'ssh-config',
-  'stata',
-  'stylus',
-  'svelte',
-  'swift',
-  'system-verilog',
-  'tasl',
-  'tcl',
-  'tex',
-  'toml',
-  'tsx',
-  'turtle',
-  'twig',
-  'typescript',
-  'v',
+  'c',
+  'java',
+  'cpp',
+  'csharp',
   'vb',
-  'cmd',
-  'verilog',
-  'vhdl',
-  'viml',
-  'vim',
-  'vimscript',
-  'vue-html',
-  'vue',
-  'wasm',
-  'wenyan',
-  '文言',
-  'wgsl',
-  'xml',
-  'xsl',
-  'yaml',
-  'zenscript',
+  'javascript',
+  'php',
+  'sql',
+  'asm',
+  'pascal',
+  'go',
+  // 'scratch',
+  'swift',
+  'matlab',
+  'r',
+  'rust',
+  'ruby',
+  // 'fortran',
+  // 'classic-visual-basic',
+
+  // other
+
+  // 24
+  'perl',
+  'objective-c',
+  // 28
+  'dart',
+  'lua',
+  // 33
+  'kotlin',
+  'logo',
+  'scala',
+  'haskell',
+  'fsharp',
+  'scheme',
+  // 40
+  'typescript',
 ];
 
-const languagesWithShortName: Record<string, string> = {
-  clj: 'clojure',
+export const POPULAR_LANGUAGES_MAP: Partial<Record<Lang, number>> =
+  PopularLanguages.reduce((acc, lang, i) => {
+    return {
+      [lang]: i,
+      ...acc,
+    };
+  }, {});
 
-  'c#': 'csharp',
-  cs: 'csharp',
+function isPlaintext(lang: string) {
+  return [
+    PLAIN_TEXT_REGISTRATION.id,
+    ...PLAIN_TEXT_REGISTRATION.aliases,
+  ].includes(lang.toLowerCase());
+}
 
-  erl: 'erlang',
-
-  'f#': 'fsharp',
-  fs: 'fsharp',
-
-  hbs: 'handlebars',
-  hs: 'haskell',
-  js: 'JavaScript',
-  make: 'makefile',
-  md: 'markdown',
-  objc: 'objectivec',
-
-  ps: 'powershell',
-  ps1: 'powershell',
-
-  py: 'Python',
-  rb: 'ruby',
-  rs: 'Rust',
-  sh: 'shell',
-  styl: 'stylus',
-  ts: 'TypeScript',
-  yml: 'yaml',
-};
-
-export const getCodeLanguage = (languageName: string) => {
-  const language = codeLanguages.find(codeLanguage => {
-    return codeLanguage.toLowerCase() === languageName.toLowerCase();
-  });
-
-  if (language) {
-    return language;
+export const getStandardLanguage = (
+  languageName: string | null
+): ILanguageRegistration | null => {
+  if (!languageName) return null;
+  if (isPlaintext(languageName)) {
+    return null;
   }
 
-  return languagesWithShortName[languageName];
+  const language = BUNDLED_LANGUAGES.find(
+    codeLanguage =>
+      codeLanguage.id.toLowerCase() === languageName.toLowerCase() ||
+      codeLanguage.aliases?.includes(languageName.toLowerCase())
+  );
+  return language ?? null;
 };

--- a/packages/blocks/src/code-block/utils/code-languages.ts
+++ b/packages/blocks/src/code-block/utils/code-languages.ts
@@ -28,23 +28,48 @@ const PopularLanguages: Lang[] = [
   // 'fortran',
   // 'classic-visual-basic',
 
-  // other
-
-  // 24
+  // 21-50
+  'sas',
+  // '(Visual) FoxPro',
+  'ada',
   'perl',
   'objective-c',
-  // 28
+  'cobol',
+  'lisp',
   'dart',
   'lua',
-  // 33
+  'julia',
+  // 'transact-SQL',
+  'd',
   'kotlin',
   'logo',
   'scala',
   'haskell',
   'fsharp',
   'scheme',
-  // 40
+  // 'cfml',
   'typescript',
+  'groovy',
+  'abap',
+  'prolog',
+  'plsql',
+  // 'ml',
+  // 'bourne shell',
+  // 'forth',
+  // 'crystal',
+  'bash',
+  'apex',
+  // ⬆️ 50
+
+  // Other
+  'markdown',
+  'json',
+  'html',
+  'css',
+  'diff',
+  'jsx',
+  'tsx',
+  'vue',
 ];
 
 export const POPULAR_LANGUAGES_MAP: Partial<Record<Lang, number>> =

--- a/packages/blocks/src/code-block/utils/consts.ts
+++ b/packages/blocks/src/code-block/utils/consts.ts
@@ -1,2 +1,20 @@
+import type { ILanguageRegistration } from 'shiki';
+
 export const DARK_THEME = 'gh/fisheva/Eva-Theme@master/themes/Eva-Dark';
 export const LIGHT_THEME = 'npm/shiki@0.14.1/themes/github-light';
+export const FALLBACK_LANG = 'Plain Text';
+
+/**
+ * Note: Use it carefully because it is not a valid language registration.
+ */
+export const PLAIN_TEXT_REGISTRATION = {
+  id: FALLBACK_LANG,
+  scopeName: 'source.plaintext',
+  /**
+   * Do not use this path. It is only used to match the type of `ILanguageRegistration`
+   *
+   * @deprecated
+   */
+  path: 'PLEASE-DO-NOT-USE-THIS' as const,
+  aliases: ['plaintext', 'txt', 'text'],
+} satisfies ILanguageRegistration;

--- a/tests/block-hub.spec.ts
+++ b/tests/block-hub.spec.ts
@@ -321,6 +321,10 @@ test.describe('Drag block hub can snap to the edge and function properly', () =>
   test('drag blank line to the bottom of editor should insert block', async ({
     page,
   }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/toeverything/AFFiNE/issues/2125',
+    });
     await enterPlaygroundRoom(page);
     const { frameId } = await initEmptyParagraphState(page);
 

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -128,7 +128,7 @@ test('support ```[lang] to add code block with language', async ({ page }) => {
   const languageButton = codeBlockController.languageButton;
   await expect(languageButton).toBeVisible();
   const languageText = await languageButton.innerText();
-  expect(languageText).toEqual('TypeScript');
+  expect(languageText).toEqual('Typescript');
 });
 
 test('use more than three backticks can not create code block', async ({
@@ -180,7 +180,7 @@ test('change code language can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
-  prop:language="Rust"
+  prop:language="rust"
 />`,
     codeBlockId
   );
@@ -650,7 +650,7 @@ test('should code block works in read only mode', async ({ page }) => {
   ).toHaveCount(2);
 });
 
-test('should code block lang input supports fuzzy search', async ({ page }) => {
+test('should code block lang input supports alias', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyCodeBlockState(page);
   await focusRichText(page);
@@ -660,9 +660,9 @@ test('should code block lang input supports fuzzy search', async ({ page }) => {
   await codeBlock.hover();
   await codeBlockController.clickLanguageButton();
   await expect(codeBlockController.langList).toBeVisible();
-  await type(page, 'jas');
+  await type(page, '文言');
   await pressEnter(page);
-  await expect(codeBlockController.languageButton).toHaveText('Javascript');
+  await expect(codeBlockController.languageButton).toHaveText('wenyan');
 });
 
 test('multi-line indent', async ({ page }) => {

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -662,7 +662,7 @@ test('should code block lang input supports alias', async ({ page }) => {
   await expect(codeBlockController.langList).toBeVisible();
   await type(page, '文言');
   await pressEnter(page);
-  await expect(codeBlockController.languageButton).toHaveText('wenyan');
+  await expect(codeBlockController.languageButton).toHaveText('Wenyan');
 });
 
 test('multi-line indent', async ({ page }) => {


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2430

- Sort language by popularity
- Use `BUNDLED_LANGUAGES` from the `shiki`
- Query language alias from the `BUNDLED_LANGUAGES`


https://github.com/toeverything/blocksuite/assets/18554747/4b813e16-3739-47dc-adbb-7437eae5279e


