### PR TITLE
fix: hide unregister flavour

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -5,7 +5,11 @@ import {
   type BlockConfig,
   paragraphConfig,
 } from '@blocksuite/global/config';
-import { type BaseBlockModel, type Page } from '@blocksuite/store';
+import {
+  assertExists,
+  type BaseBlockModel,
+  type Page,
+} from '@blocksuite/store';
 import { Slot } from '@blocksuite/store';
 import { html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -48,6 +52,8 @@ function ParagraphPanel(
   if (showParagraphPanel === 'hidden') {
     return html``;
   }
+  const page = models[0].page;
+  assertExists(page);
   const styles = styleMap({
     left: '0',
     top: showParagraphPanel === 'bottom' ? 'calc(100% + 4px)' : null,
@@ -91,17 +97,19 @@ function ParagraphPanel(
     @mouseover="${onHover}"
     @mouseout="${onHoverEnd}"
   >
-    ${paragraphConfig.map(
-      ({ flavour, type, name, icon }) => html`<format-bar-button
-        width="100%"
-        style="padding-left: 12px; justify-content: flex-start;"
-        text="${name}"
-        data-testid="${flavour}/${type}"
-        @click="${() => updateParagraphType(flavour, type)}"
-      >
-        ${icon}
-      </format-bar-button>`
-    )}
+    ${paragraphConfig
+      .filter(({ flavour }) => page.schema.flavourSchemaMap.has(flavour))
+      .map(
+        ({ flavour, type, name, icon }) => html`<format-bar-button
+          width="100%"
+          style="padding-left: 12px; justify-content: flex-start;"
+          text="${name}"
+          data-testid="${flavour}/${type}"
+          @click="${() => updateParagraphType(flavour, type)}"
+        >
+          ${icon}
+        </format-bar-button>`
+      )}
   </div>`;
 }
 

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -92,6 +92,10 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = (
               name,
               icon,
               showWhen: model => {
+                if (!model.page.schema.flavourSchemaMap.has(flavour)) {
+                  return false;
+                }
+
                 if (['Quote', 'Code Block', 'Divider'].includes(name)) {
                   return !insideDatabase(model);
                 }
@@ -155,6 +159,12 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = (
         .map(({ name, icon, flavour, type }) => ({
           name,
           icon,
+          showWhen: model => {
+            if (!model.page.schema.flavourSchemaMap.has(flavour)) {
+              return false;
+            }
+            return true;
+          },
           action: ({ model }) => updateBlockType([model], flavour, type),
         })),
     },
@@ -164,7 +174,15 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = (
         {
           name: 'Image',
           icon: ImageIcon20,
-          showWhen: model => !insideDatabase(model),
+          showWhen: model => {
+            if (!model.page.schema.flavourSchemaMap.has('affine:embed')) {
+              return false;
+            }
+            if (!insideDatabase(model)) {
+              return false;
+            }
+            return true;
+          },
           async action({ page, model }) {
             const parent = page.getParent(model);
             if (!parent) {
@@ -237,6 +255,9 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = (
             if (!model.page.awarenessStore.getFlag('enable_database')) {
               return false;
             }
+            if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
+              return false;
+            }
             if (insideDatabase(model)) {
               // You can't add a database block inside another database block
               return false;
@@ -265,6 +286,9 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = (
           icon: DatabaseKanbanViewIcon,
           showWhen: model => {
             if (!model.page.awarenessStore.getFlag('enable_database')) {
+              return false;
+            }
+            if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
               return false;
             }
             if (insideDatabase(model)) {

--- a/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
@@ -159,8 +159,17 @@ export class SlashMenu extends WithDisposable(LitElement) {
           this._handleClickCategory(targetGroup);
           return;
         }
-        this._activatedItemIndex =
-          (this._activatedItemIndex + step + configLen) % configLen;
+        let ejectedCnt = configLen;
+        do {
+          this._activatedItemIndex =
+            (this._activatedItemIndex + step + configLen) % configLen;
+          // Skip disabled items
+        } while (
+          this._filterItems[this._activatedItemIndex].disabled &&
+          // If all items are disabled, the loop will never end
+          ejectedCnt--
+        );
+
         this._scrollToItem(this._filterItems[this._activatedItemIndex], false);
       },
       onConfirm: () => {

--- a/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
@@ -1,4 +1,4 @@
-import { type BaseBlockModel, Utils } from '@blocksuite/store';
+import { type BaseBlockModel } from '@blocksuite/store';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -57,10 +57,6 @@ export class SlashMenu extends WithDisposable(LitElement) {
    * Does not include the slash character
    */
   private _searchString = '';
-
-  get enabledDatabase() {
-    return !!this.model.page.awarenessStore.getFlag('enable_database');
-  }
 
   get menuGroups() {
     return menuGroups;
@@ -203,25 +199,9 @@ export class SlashMenu extends WithDisposable(LitElement) {
     const searchStr = this._searchString.toLowerCase();
     let allMenus = this.menuGroups.flatMap(group => group.items);
 
-    if (!this.enabledDatabase) {
-      allMenus.filter(group => group.groupName !== 'Database');
-    }
-    // This is a temporary solution for the database menu
-    // If there are more menus that need to be filtered by flavours,
-    // we should refactor this by adding a `showWhen` property to the menu
-    if (
-      Utils.isInsideBlockByFlavour(
-        this.model.page,
-        this.model,
-        'affine:database'
-      )
-    ) {
-      allMenus = allMenus.filter(
-        item =>
-          item.groupName !== 'Database' &&
-          !['Image', 'Quote', 'Code Block', 'Divider'].includes(item.name)
-      );
-    }
+    allMenus = allMenus.filter(({ showWhen = () => true }) =>
+      showWhen(this.model)
+    );
     if (!searchStr) {
       return allMenus;
     }


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2528

- Hide unregister flavour in the slash menu and the format bar