### PR TITLE
fix: selection status with redo/undo

### DIFF
--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -122,8 +122,8 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
 
     const newSelections = selection.selected.reduce((res, cur) => {
       // update new selection rendering position
-      const el = this._surface.pickById(cur.id);
-      if (el) res.push(el);
+      const el = this._surface.pickById(cur.id) || cur;
+      res.push(el);
       return res;
     }, [] as Selectable[]);
 


### PR DESCRIPTION
close #1250 

add selection state to history stack meta info, for recreate selection rect when redo/undo