### PR TITLE
feat(edgeless): support proportional scaling with shift key

### DIFF
--- a/packages/blocks/src/__internal__/clipboard/edgeless-clipboard.ts
+++ b/packages/blocks/src/__internal__/clipboard/edgeless-clipboard.ts
@@ -57,6 +57,14 @@ export class EdgelessClipboard implements Clipboard {
     return this._edgeless.selection;
   }
 
+  get slots() {
+    return this._edgeless.slots;
+  }
+
+  get surface() {
+    return this._edgeless.surface;
+  }
+
   public dispose() {
     document.body.removeEventListener('cut', this._onCut);
     document.body.removeEventListener('copy', this._onCopy);
@@ -81,11 +89,11 @@ export class EdgelessClipboard implements Clipboard {
         if (isTopLevelBlock(selected)) {
           this._page.deleteBlock(selected);
         } else {
-          this._edgeless.surface.removeElement(selected.id);
+          this.surface.removeElement(selected.id);
         }
       });
     });
-    this._edgeless.slots.selectionUpdated.emit({ active: false, selected: [] });
+    this.slots.selectionUpdated.emit({ active: false, selected: [] });
   };
 
   private _onCopy = (e: ClipboardEvent) => {
@@ -156,11 +164,11 @@ export class EdgelessClipboard implements Clipboard {
     const phasorElements =
       (elements
         ?.map(d => {
-          const id = this._edgeless.surface.addElement(
+          const id = this.surface.addElement(
             d.type as keyof PhasorElementType,
             d
           );
-          const element = this._edgeless.surface.pickById(id);
+          const element = this.surface.pickById(id);
           return element;
         })
         .filter(e => !!e) as PhasorElement[]) || [];
@@ -238,7 +246,7 @@ export class EdgelessClipboard implements Clipboard {
   ) {
     const newSelected = [
       ...(phasorElementIds
-        .map(id => this._edgeless.surface.pickById(id))
+        .map(id => this.surface.pickById(id))
         .filter(e => !!e) as PhasorElement[]),
       ...(frameIds
         .map(id => this._page.getBlockById(id))
@@ -247,7 +255,7 @@ export class EdgelessClipboard implements Clipboard {
         ) as TopLevelBlockModel[]),
     ];
 
-    this._edgeless.slots.selectionUpdated.emit({
+    this.slots.selectionUpdated.emit({
       active: false,
       selected: newSelected,
     });
@@ -271,7 +279,7 @@ export class EdgelessClipboard implements Clipboard {
     );
 
     const { lastMousePos } = this.selection;
-    const [modelX, modelY] = this._edgeless.surface.toModelCoord(
+    const [modelX, modelY] = this.surface.toModelCoord(
       lastMousePos.x,
       lastMousePos.y
     );
@@ -287,7 +295,7 @@ export class EdgelessClipboard implements Clipboard {
         ele.h
       );
 
-      this._edgeless.surface.updateElement(ele.id, {
+      this.surface.updateElement(ele.id, {
         xywh: newXYWH,
       });
     });

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -362,7 +362,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       <div class="affine-edgeless-selected-rect" style=${styleMap(style)}>
         ${resizeHandles} ${connectorHandles}
       </div>
-      ${resizeHandles} ${componentToolbar}
+      ${componentToolbar}
     `;
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -260,7 +260,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     const { _disposables, slots } = this;
     _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
     _disposables.add(
-      slots.pressShiftKey.on(pressed => this._resizeManager.onShift(pressed))
+      slots.pressShiftKeyUpdated.on(pressed =>
+        this._resizeManager.onPressShiftKey(pressed)
+      )
     );
 
     this._componentToolbarPopper = this._componentToolbar

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -160,9 +160,6 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   @property({ type: SurfaceManager })
   surface!: SurfaceManager;
 
-  @property()
-  shift!: boolean;
-
   @property({ type: Object })
   state!: EdgelessSelectionState;
 
@@ -302,14 +299,16 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   }
 
   override render() {
-    if (
-      this.state.selected.length === 0 ||
-      (this.state.selected[0] instanceof TextElement && this.state.active)
-    )
-      return null;
-
-    const { page, state, surface, resizeMode, _resizeManager } = this;
+    const { state } = this;
     const { active, selected } = state;
+    if (
+      selected.length === 0 ||
+      (active && selected[0] instanceof TextElement)
+    ) {
+      return nothing;
+    }
+
+    const { page , surface, resizeMode, _resizeManager } = this;
     const selectedRect = getSelectedRect(selected, surface.viewport);
 
     const style = getCommonRectStyle(selectedRect, active, true);
@@ -344,7 +343,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
           .page=${this.page}
           .surface=${this.surface}
           .slots=${this.slots}
-          .selectionState=${this.state}
+          .selectionState=${state}
         >
         </edgeless-component-toolbar>`;
 

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -259,6 +259,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   override firstUpdated() {
     const { _disposables, slots } = this;
     _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
+    _disposables.add(
+      slots.shiftUpdated.on(pressed => this._resizeManager.onShift(pressed))
+    );
 
     this._componentToolbarPopper = this._componentToolbar
       ? createPopper(this._selectedRect, this._componentToolbar, {
@@ -308,7 +311,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       return nothing;
     }
 
-    const { page , surface, resizeMode, _resizeManager } = this;
+    const { page, surface, resizeMode, _resizeManager } = this;
     const selectedRect = getSelectedRect(selected, surface.viewport);
 
     const style = getCommonRectStyle(selectedRect, active, true);
@@ -318,8 +321,14 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       ? ResizeHandles(
           resizeMode,
           (e: PointerEvent, direction: HandleDirection) => {
-            const bounds = getSelectableBounds(this.state.selected);
-            _resizeManager.onPointerDown(e, direction, bounds, this.zoom);
+            const bounds = getSelectableBounds(selected);
+            _resizeManager.onPointerDown(
+              e,
+              direction,
+              bounds,
+              resizeMode,
+              this.zoom
+            );
           }
         )
       : nothing;
@@ -351,7 +360,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       <div class="affine-edgeless-selected-rect" style=${styleMap(style)}>
         ${resizeHandles} ${connectorHandles}
       </div>
-      ${componentToolbar}
+      ${resizeHandles} ${componentToolbar}
     `;
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -260,7 +260,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     const { _disposables, slots } = this;
     _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
     _disposables.add(
-      slots.shiftUpdated.on(pressed => this._resizeManager.onShift(pressed))
+      slots.pressShift.on(pressed => this._resizeManager.onShift(pressed))
     );
 
     this._componentToolbarPopper = this._componentToolbar

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -260,7 +260,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     const { _disposables, slots } = this;
     _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
     _disposables.add(
-      slots.pressShift.on(pressed => this._resizeManager.onShift(pressed))
+      slots.pressShiftKey.on(pressed => this._resizeManager.onShift(pressed))
     );
 
     this._componentToolbarPopper = this._componentToolbar

--- a/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-handles.ts
@@ -60,7 +60,7 @@ export function ResizeHandles(
       const handleLeft = ResizeHandle(HandleDirection.Left, onPointerDown);
       const handleRight = ResizeHandle(HandleDirection.Right, onPointerDown);
 
-      return html` ${handleLeft} ${handleRight} `;
+      return html`${handleLeft} ${handleRight}`;
     }
     case 'none': {
       return nothing;

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -28,7 +28,7 @@ export class HandleResizeManager {
   private _resizeMode = 'none';
   private _zoom = 1;
 
-  private _shift = false;
+  private _shiftKey = false;
 
   constructor(onResizeMove: ResizeMoveHandler, onResizeEnd: ResizeEndHandler) {
     this._onResizeMove = onResizeMove;
@@ -231,10 +231,10 @@ export class HandleResizeManager {
     const _onPointerMove = (e: PointerEvent) => {
       if (resizeMode === 'none') return;
 
-      this._shift ||= e.shiftKey;
+      this._shiftKey ||= e.shiftKey;
       this._dragPos.end = { x: e.x, y: e.y };
 
-      this._resize(this._shift);
+      this._resize(this._shiftKey);
     };
 
     const _onPointerUp = (_: PointerEvent) => {
@@ -252,9 +252,9 @@ export class HandleResizeManager {
   };
 
   onShift(pressed: boolean) {
-    if (this._shift === pressed) return;
+    if (this._shiftKey === pressed) return;
 
-    this._shift = pressed;
+    this._shiftKey = pressed;
     this._resize(pressed);
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -49,7 +49,6 @@ export class HandleResizeManager {
     const isCorner = resizeMode === 'corner';
     const { x: startX, y: startY } = dragPos.start;
     const { x: endX, y: endY } = dragPos.end;
-    dragPos.end = { x: endX, y: endY };
 
     const deltaX = (endX - startX) / zoom;
 
@@ -224,7 +223,7 @@ export class HandleResizeManager {
 
     this._dragDirection = direction;
     this._dragPos.start = { x: e.x, y: e.y };
-    this._dragPos.end = { ...this._dragPos.start };
+    this._dragPos.end = { x: e.x, y: e.y };
     this._aspectRatio = w / h;
     this._resizeMode = resizeMode;
     this._zoom = zoom;

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -36,7 +36,7 @@ export class HandleResizeManager {
   }
 
   // TODO: add them to vec2
-  private _draw(shift = false) {
+  private _resize(shift = false) {
     const {
       _aspectRatio: aspectRatio,
       _dragDirection: direction,
@@ -235,7 +235,7 @@ export class HandleResizeManager {
       this._shift ||= e.shiftKey;
       this._dragPos.end = { x: e.x, y: e.y };
 
-      this._draw(this._shift);
+      this._resize(this._shift);
     };
 
     const _onPointerUp = (_: PointerEvent) => {
@@ -256,6 +256,6 @@ export class HandleResizeManager {
     if (this._shift === pressed) return;
 
     this._shift = pressed;
-    this._draw(pressed);
+    this._resize(pressed);
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -251,7 +251,7 @@ export class HandleResizeManager {
     window.addEventListener('pointerup', _onPointerUp);
   };
 
-  onShift(pressed: boolean) {
+  onPressShiftKey(pressed: boolean) {
     if (this._shiftKey === pressed) return;
 
     this._shiftKey = pressed;

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -223,10 +223,8 @@ export class HandleResizeManager {
     this._commonBound = [x, y, x + w, y + h];
 
     this._dragDirection = direction;
-    this._dragPos.start = {
-      x: e.x,
-      y: e.y,
-    };
+    this._dragPos.start = { x: e.x, y: e.y };
+    this._dragPos.end = { ...this._dragPos.start };
     this._aspectRatio = w / h;
     this._resizeMode = resizeMode;
     this._zoom = zoom;

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -27,7 +27,8 @@ export class HandleResizeManager {
     e: PointerEvent,
     direction: HandleDirection,
     bounds: Map<string, Bound>,
-    zoom: number
+    zoom: number,
+    shift: boolean
   ) => {
     // Prevent selection action from being triggered
     e.stopPropagation();
@@ -44,8 +45,11 @@ export class HandleResizeManager {
     };
 
     const _onPointerMove = (e: PointerEvent) => {
-      const direction = this._dragDirection;
-      const { x: startX, y: startY } = this._startDragPos;
+      shift ||= e.shiftKey;
+      const {
+        _dragDirection: direction,
+        _startDragPos: { x: startX, y: startY },
+      } = this;
 
       const [oldCommonMinX, oldCommonMinY, oldCommonMaxX, oldCommonMaxY] =
         this._commonBound;
@@ -56,7 +60,7 @@ export class HandleResizeManager {
 
       let deltaX = (e.clientX - startX) / zoom;
       let deltaY = (e.clientY - startY) / zoom;
-      if (e.shiftKey) {
+      if (shift) {
         const { w, h } = getCommonBound([...this._bounds.values()]) as Bound;
         const aspectRatio = w / h;
         deltaX = deltaX > deltaY ? deltaX : deltaY * aspectRatio;
@@ -140,8 +144,8 @@ export class HandleResizeManager {
     const _onPointerUp = (_: PointerEvent) => {
       this._onResizeEnd();
 
-      this._startDragPos = { x: 0, y: 0 };
       this._bounds.clear();
+      this._startDragPos = { x: 0, y: 0 };
       this._commonBound = [0, 0, 0, 0];
 
       window.removeEventListener('pointermove', _onPointerMove);

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -116,8 +116,8 @@ export class HandleResizeManager {
         const bw = Math.abs(dw);
         const bh = Math.abs(dh);
         const isTall = aspectRatio < bw / bh;
-        const th = (bw * (flipY ? 1 : -1)) / aspectRatio;
-        const tw = bh * (flipX ? 1 : -1) * aspectRatio;
+        const th = (bw / aspectRatio) * (flipY ? 1 : -1);
+        const tw = bh * aspectRatio * (flipX ? 1 : -1);
 
         switch (direction) {
           // TODO

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -35,7 +35,7 @@ export class HandleResizeManager {
     this._onResizeEnd = onResizeEnd;
   }
 
-  // TODO: add them to vec2
+  // TODO: move to vec2
   private _resize(shift = false) {
     const {
       _aspectRatio: aspectRatio,

--- a/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/components/resize-manager.ts
@@ -116,7 +116,7 @@ export class HandleResizeManager {
         const bw = Math.abs(dw);
         const bh = Math.abs(dh);
         const isTall = aspectRatio < bw / bh;
-        const th = bw * (flipY ? 1 : -1) * (1 / aspectRatio);
+        const th = (bw * (flipY ? 1 : -1)) / aspectRatio;
         const tw = bh * (flipX ? 1 : -1) * aspectRatio;
 
         switch (direction) {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -93,7 +93,7 @@ export interface EdgelessSelectionSlots {
   mouseModeUpdated: Slot<MouseMode>;
   reorderingFramesUpdated: Slot<ReorderingAction<Selectable>>;
   reorderingShapesUpdated: Slot<ReorderingAction<Selectable>>;
-  pressShift: Slot<boolean>;
+  pressShiftKey: Slot<boolean>;
 }
 
 export interface EdgelessContainer extends HTMLElement {
@@ -211,7 +211,7 @@ export class EdgelessPageBlockComponent
     reorderingFramesUpdated: new Slot<ReorderingAction<Selectable>>(),
     reorderingShapesUpdated: new Slot<ReorderingAction<Selectable>>(),
     zoomUpdated: new Slot<ZoomAction>(),
-    pressShift: new Slot<boolean>(),
+    pressShiftKey: new Slot<boolean>(),
 
     subpageLinked: new Slot<{ pageId: string }>(),
     subpageUnlinked: new Slot<{ pageId: string }>(),
@@ -451,7 +451,7 @@ export class EdgelessPageBlockComponent
       )
     );
     _disposables.add(
-      slots.pressShift.on(pressed => {
+      slots.pressShiftKey.on(pressed => {
         this.selection.shiftKey = pressed;
         this.requestUpdate();
       })

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -93,7 +93,7 @@ export interface EdgelessSelectionSlots {
   mouseModeUpdated: Slot<MouseMode>;
   reorderingFramesUpdated: Slot<ReorderingAction<Selectable>>;
   reorderingShapesUpdated: Slot<ReorderingAction<Selectable>>;
-  shiftUpdated: Slot<boolean>;
+  pressShift: Slot<boolean>;
 }
 
 export interface EdgelessContainer extends HTMLElement {
@@ -211,7 +211,7 @@ export class EdgelessPageBlockComponent
     reorderingFramesUpdated: new Slot<ReorderingAction<Selectable>>(),
     reorderingShapesUpdated: new Slot<ReorderingAction<Selectable>>(),
     zoomUpdated: new Slot<ZoomAction>(),
-    shiftUpdated: new Slot<boolean>(),
+    pressShift: new Slot<boolean>(),
 
     subpageLinked: new Slot<{ pageId: string }>(),
     subpageUnlinked: new Slot<{ pageId: string }>(),
@@ -451,8 +451,8 @@ export class EdgelessPageBlockComponent
       )
     );
     _disposables.add(
-      slots.shiftUpdated.on(shift => {
-        this.selection.shift = shift;
+      slots.pressShift.on(pressed => {
+        this.selection.shiftKey = pressed;
         this.requestUpdate();
       })
     );

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -192,6 +192,9 @@ export class EdgelessPageBlockComponent
   @state()
   private _rectsOfSelectedBlocks: DOMRect[] = [];
 
+  @state()
+  private _shift = false;
+
   @query('.affine-edgeless-surface-block-container')
   private _surfaceContainer!: HTMLDivElement;
 
@@ -210,6 +213,7 @@ export class EdgelessPageBlockComponent
     reorderingFramesUpdated: new Slot<ReorderingAction<Selectable>>(),
     reorderingShapesUpdated: new Slot<ReorderingAction<Selectable>>(),
     zoomUpdated: new Slot<ZoomAction>(),
+    shiftUpdated: new Slot<boolean>(),
 
     subpageLinked: new Slot<{ pageId: string }>(),
     subpageUnlinked: new Slot<{ pageId: string }>(),
@@ -408,6 +412,7 @@ export class EdgelessPageBlockComponent
     );
     _disposables.add(this.selection);
     _disposables.add(this.surface);
+    _disposables.add(slots.shiftUpdated.on(shift => (this._shift = shift)));
     _disposables.add(bindEdgelessHotkeys(this));
 
     _disposables.add(this._frameResizeObserver);

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -192,9 +192,6 @@ export class EdgelessPageBlockComponent
   @state()
   private _rectsOfSelectedBlocks: DOMRect[] = [];
 
-  @state()
-  private _shift = false;
-
   @query('.affine-edgeless-surface-block-container')
   private _surfaceContainer!: HTMLDivElement;
 
@@ -412,7 +409,6 @@ export class EdgelessPageBlockComponent
     );
     _disposables.add(this.selection);
     _disposables.add(this.surface);
-    _disposables.add(slots.shiftUpdated.on(shift => (this._shift = shift)));
     _disposables.add(bindEdgelessHotkeys(this));
 
     _disposables.add(this._frameResizeObserver);
@@ -452,6 +448,12 @@ export class EdgelessPageBlockComponent
       slots.zoomUpdated.on((action: ZoomAction) =>
         this.components.toolbar?.setZoomByAction(action)
       )
+    );
+    _disposables.add(
+      slots.shiftUpdated.on(shift => {
+        this.selection.shift = shift;
+        this.requestUpdate();
+      })
     );
   }
 

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -944,6 +944,7 @@ export class EdgelessPageBlockComponent
                 disabled=${mouseMode.type === 'pan'}
                 .page=${page}
                 .state=${state}
+                .shift=${selection.shift}
                 .slots=${this.slots}
                 .surface=${surface}
               ></edgeless-selected-rect>

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -93,6 +93,7 @@ export interface EdgelessSelectionSlots {
   mouseModeUpdated: Slot<MouseMode>;
   reorderingFramesUpdated: Slot<ReorderingAction<Selectable>>;
   reorderingShapesUpdated: Slot<ReorderingAction<Selectable>>;
+  shiftUpdated: Slot<boolean>;
 }
 
 export interface EdgelessContainer extends HTMLElement {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -93,7 +93,7 @@ export interface EdgelessSelectionSlots {
   mouseModeUpdated: Slot<MouseMode>;
   reorderingFramesUpdated: Slot<ReorderingAction<Selectable>>;
   reorderingShapesUpdated: Slot<ReorderingAction<Selectable>>;
-  pressShiftKey: Slot<boolean>;
+  pressShiftKeyUpdated: Slot<boolean>;
 }
 
 export interface EdgelessContainer extends HTMLElement {
@@ -211,7 +211,7 @@ export class EdgelessPageBlockComponent
     reorderingFramesUpdated: new Slot<ReorderingAction<Selectable>>(),
     reorderingShapesUpdated: new Slot<ReorderingAction<Selectable>>(),
     zoomUpdated: new Slot<ZoomAction>(),
-    pressShiftKey: new Slot<boolean>(),
+    pressShiftKeyUpdated: new Slot<boolean>(),
 
     subpageLinked: new Slot<{ pageId: string }>(),
     subpageUnlinked: new Slot<{ pageId: string }>(),
@@ -451,7 +451,7 @@ export class EdgelessPageBlockComponent
       )
     );
     _disposables.add(
-      slots.pressShiftKey.on(pressed => {
+      slots.pressShiftKeyUpdated.on(pressed => {
         this.selection.shiftKey = pressed;
         this.requestUpdate();
       })

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -945,7 +945,6 @@ export class EdgelessPageBlockComponent
                 disabled=${mouseMode.type === 'pan'}
                 .page=${page}
                 .state=${state}
-                .shift=${selection.shift}
                 .slots=${this.slots}
                 .surface=${surface}
               ></edgeless-selected-rect>

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -96,6 +96,26 @@ function bindDelete(edgeless: EdgelessPageBlockComponent) {
   hotkey.addListener(HOTKEYS.DELETE, backspace);
 }
 
+function bindShift(
+  edgeless: EdgelessPageBlockComponent,
+  key = 'shift',
+  pressed = false
+) {
+  hotkey.addListener(
+    HOTKEYS.ANY_KEY,
+    e => {
+      if (e.key.toLowerCase() === key && pressed !== e.shiftKey) {
+        pressed = e.shiftKey;
+        edgeless.slots.pressShiftKey.emit(pressed);
+      }
+    },
+    {
+      keydown: true,
+      keyup: true,
+    }
+  );
+}
+
 export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
   const scope = hotkey.newScope(HOTKEY_SCOPE_TYPE.AFFINE_EDGELESS);
   if (activeEditorManager.isActive(edgeless)) {
@@ -175,12 +195,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
 
     bindSpace(edgeless);
     bindDelete(edgeless);
-    bindCommonHotkey(edgeless.page, {
-      filter: (e: KeyboardEvent) =>
-        e.shiftKey && e.key.toLowerCase() === 'shift',
-      keydown: _ => edgeless.slots.pressShiftKey.emit(true),
-      keyup: _ => edgeless.slots.pressShiftKey.emit(false),
-    });
+    bindShift(edgeless);
+    bindCommonHotkey(edgeless.page);
   });
   return () => {
     hotkey.deleteScope(scope);

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -178,8 +178,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
     bindCommonHotkey(edgeless.page, {
       filter: (e: KeyboardEvent) =>
         e.shiftKey && e.key.toLowerCase() === 'shift',
-      keydown: _ => edgeless.slots.pressShift.emit(true),
-      keyup: _ => edgeless.slots.pressShift.emit(false),
+      keydown: _ => edgeless.slots.pressShiftKey.emit(true),
+      keyup: _ => edgeless.slots.pressShiftKey.emit(false),
     });
   });
   return () => {

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -176,7 +176,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
     bindSpace(edgeless);
     bindDelete(edgeless);
     bindCommonHotkey(edgeless.page, {
-      filter: (e: KeyboardEvent) => e.shiftKey && e.key === 'Shift',
+      filter: (e: KeyboardEvent) =>
+        e.shiftKey && e.key.toLowerCase() === 'shift',
       keydown: _ => {
         edgeless.slots.shiftUpdated.emit(true);
       },

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -175,7 +175,15 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
 
     bindSpace(edgeless);
     bindDelete(edgeless);
-    bindCommonHotkey(edgeless.page);
+    bindCommonHotkey(edgeless.page, {
+      filter: (e: KeyboardEvent) => e.shiftKey && e.key === 'Shift',
+      keydown: _ => {
+        edgeless.slots.shiftUpdated.emit(true);
+      },
+      keyup: _ => {
+        edgeless.slots.shiftUpdated.emit(false);
+      },
+    });
   });
   return () => {
     hotkey.deleteScope(scope);

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -106,7 +106,7 @@ function bindShift(
     e => {
       if (e.key.toLowerCase() === key && pressed !== e.shiftKey) {
         pressed = e.shiftKey;
-        edgeless.slots.pressShiftKey.emit(pressed);
+        edgeless.slots.pressShiftKeyUpdated.emit(pressed);
       }
     },
     {

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -178,12 +178,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
     bindCommonHotkey(edgeless.page, {
       filter: (e: KeyboardEvent) =>
         e.shiftKey && e.key.toLowerCase() === 'shift',
-      keydown: _ => {
-        edgeless.slots.shiftUpdated.emit(true);
-      },
-      keyup: _ => {
-        edgeless.slots.shiftUpdated.emit(false);
-      },
+      keydown: _ => edgeless.slots.shiftUpdated.emit(true),
+      keyup: _ => edgeless.slots.shiftUpdated.emit(false),
     });
   });
   return () => {

--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -178,8 +178,8 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
     bindCommonHotkey(edgeless.page, {
       filter: (e: KeyboardEvent) =>
         e.shiftKey && e.key.toLowerCase() === 'shift',
-      keydown: _ => edgeless.slots.shiftUpdated.emit(true),
-      keyup: _ => edgeless.slots.shiftUpdated.emit(false),
+      keydown: _ => edgeless.slots.pressShift.emit(true),
+      keyup: _ => edgeless.slots.pressShift.emit(false),
     });
   });
   return () => {

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
@@ -96,7 +96,7 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
@@ -96,7 +96,7 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/brush-mode.ts
@@ -95,4 +95,8 @@ export class BrushModeController extends MouseModeController<BrushMouseMode> {
   onContainerMouseOut(e: PointerEventState) {
     noop();
   }
+
+  onShift(_: boolean) {
+    noop();
+  }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
@@ -180,4 +180,8 @@ export class ConnectorModeController extends MouseModeController<ConnectorMouseM
   onContainerMouseOut(e: PointerEventState) {
     noop();
   }
+
+  onShift(_: boolean) {
+    noop();
+  }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
@@ -181,7 +181,7 @@ export class ConnectorModeController extends MouseModeController<ConnectorMouseM
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/connector-mode.ts
@@ -181,7 +181,7 @@ export class ConnectorModeController extends MouseModeController<ConnectorMouseM
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -507,7 +507,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -506,4 +506,8 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   onContainerMouseOut(_: PointerEventState) {
     noop();
   }
+
+  onShift(_: boolean) {
+    noop();
+  }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -507,7 +507,7 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
@@ -44,4 +44,5 @@ export abstract class MouseModeController<Mode extends MouseMode = MouseMode> {
   abstract onContainerMouseMove(e: PointerEventState): void;
   abstract onContainerMouseOut(e: PointerEventState): void;
   abstract onContainerContextMenu(e: PointerEventState): void;
+  abstract onShift(pressed: boolean): void;
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
@@ -44,5 +44,5 @@ export abstract class MouseModeController<Mode extends MouseMode = MouseMode> {
   abstract onContainerMouseMove(e: PointerEventState): void;
   abstract onContainerMouseOut(e: PointerEventState): void;
   abstract onContainerContextMenu(e: PointerEventState): void;
-  abstract onShift(pressed: boolean): void;
+  abstract onPressShift(pressed: boolean): void;
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/index.ts
@@ -44,5 +44,5 @@ export abstract class MouseModeController<Mode extends MouseMode = MouseMode> {
   abstract onContainerMouseMove(e: PointerEventState): void;
   abstract onContainerMouseOut(e: PointerEventState): void;
   abstract onContainerContextMenu(e: PointerEventState): void;
-  abstract onPressShift(pressed: boolean): void;
+  abstract onPressShiftKey(pressed: boolean): void;
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
@@ -69,7 +69,7 @@ export class NoteModeController extends MouseModeController<NoteMouseMode> {
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
@@ -69,7 +69,7 @@ export class NoteModeController extends MouseModeController<NoteMouseMode> {
     noop();
   }
 
-  syncDraggingArea() {
+  onShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/note-mode.ts
@@ -69,7 +69,7 @@ export class NoteModeController extends MouseModeController<NoteMouseMode> {
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
@@ -65,7 +65,7 @@ export class PanModeController extends MouseModeController<PanMouseMode> {
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
@@ -65,7 +65,7 @@ export class PanModeController extends MouseModeController<PanMouseMode> {
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/pan-mode.ts
@@ -64,4 +64,8 @@ export class PanModeController extends MouseModeController<PanMouseMode> {
   onContainerMouseOut(e: PointerEventState) {
     noop();
   }
+
+  onShift(_: boolean) {
+    noop();
+  }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -81,7 +81,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
 
     this._draggingArea.end = new DOMPoint(e.x, e.y);
 
-    this._draw(e.keys.shift || this._edgeless.selection.shift);
+    this._resize(e.keys.shift || this._edgeless.selection.shift);
   }
 
   onContainerDragEnd(e: PointerEventState) {
@@ -105,10 +105,10 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     const id = this._draggingElementId;
     if (!id) return;
 
-    this._draw(pressed);
+    this._resize(pressed);
   }
 
-  private _draw(shift = false) {
+  private _resize(shift = false) {
     const { _draggingElementId: id, _draggingArea, _edgeless } = this;
     assertExists(id);
     assertExists(_draggingArea);

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -81,7 +81,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
 
     this._draggingArea.end = new DOMPoint(e.x, e.y);
 
-    this._draw(e.keys.shift);
+    this._draw(e.keys.shift || this._edgeless.selection.shift);
   }
 
   onContainerDragEnd(e: PointerEventState) {
@@ -113,8 +113,6 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     assertExists(id);
     assertExists(_draggingArea);
 
-    shift ||= _edgeless.selection.shift;
-
     const { slots, surface } = _edgeless;
     const { viewport } = surface;
     const { zoom } = viewport;
@@ -125,11 +123,11 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     let { x: endX, y: endY } = end;
 
     if (shift) {
-      const w = Math.abs(endX - startX) / zoom;
-      const h = Math.abs(endY - startY) / zoom;
-      const max = Math.max(w, h);
-      endX = endX > startX ? startX + max : startX - max;
-      endY = endY > startY ? startY + max : startY - max;
+      const w = Math.abs(endX - startX);
+      const h = Math.abs(endY - startY);
+      const m = Math.max(w, h);
+      endX = startX + (endX > startX ? m : -m);
+      endY = startY + (endY > startY ? m : -m);
     }
 
     const [x, y] = viewport.toModelCoord(

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -101,7 +101,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     });
   }
 
-  onPressShift(pressed: boolean) {
+  onPressShiftKey(pressed: boolean) {
     const id = this._draggingElementId;
     if (!id) return;
 

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -81,7 +81,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
 
     this._draggingArea.end = new DOMPoint(e.x, e.y);
 
-    this._resize(e.keys.shift || this._edgeless.selection.shift);
+    this._resize(e.keys.shift || this._edgeless.selection.shiftKey);
   }
 
   onContainerDragEnd(e: PointerEventState) {
@@ -101,7 +101,7 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
     });
   }
 
-  onShift(pressed: boolean) {
+  onPressShift(pressed: boolean) {
     const id = this._draggingElementId;
     if (!id) return;
 

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/shape-mode.ts
@@ -109,34 +109,37 @@ export class ShapeModeController extends MouseModeController<ShapeMouseMode> {
   }
 
   private _draw(shift = false) {
-    assertExists(this._draggingElementId);
-    assertExists(this._draggingArea);
+    const { _draggingElementId: id, _draggingArea, _edgeless } = this;
+    assertExists(id);
+    assertExists(_draggingArea);
 
-    const { slots, surface } = this._edgeless;
+    shift ||= _edgeless.selection.shift;
+
+    const { slots, surface } = _edgeless;
     const { viewport } = surface;
-
-    shift = shift || this._edgeless.selection.shift;
-
-    const { x: startX, y: startY } = this._draggingArea.start;
-    let { x: endX, y: endY } = this._draggingArea.end;
+    const { zoom } = viewport;
+    const {
+      start: { x: startX, y: startY },
+      end,
+    } = _draggingArea;
+    let { x: endX, y: endY } = end;
 
     if (shift) {
-      const w = Math.abs(endX - startX) / viewport.zoom;
-      const h = Math.abs(endY - startY) / viewport.zoom;
-      const maxLength = Math.max(w, h);
-      endX = endX > startX ? startX + maxLength : startX - maxLength;
-      endY = endY > startY ? startY + maxLength : startY - maxLength;
+      const w = Math.abs(endX - startX) / zoom;
+      const h = Math.abs(endY - startY) / zoom;
+      const max = Math.max(w, h);
+      endX = endX > startX ? startX + max : startX - max;
+      endY = endY > startY ? startY + max : startY - max;
     }
 
     const [x, y] = viewport.toModelCoord(
       Math.min(startX, endX),
       Math.min(startY, endY)
     );
-    const w = Math.abs(startX - endX) / viewport.zoom;
-    const h = Math.abs(startY - endY) / viewport.zoom;
+    const w = Math.abs(startX - endX) / zoom;
+    const h = Math.abs(startY - endY) / zoom;
 
     const bound = new Bound(x, y, w, h);
-    const id = this._draggingElementId;
     surface.setElementBound(id, bound);
     slots.surfaceUpdated.emit();
   }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
@@ -46,7 +46,7 @@ export class TextModeController extends MouseModeController<TextMouseMode> {
     noop();
   }
 
-  onShift(_: boolean) {
+  onPressShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
@@ -46,7 +46,7 @@ export class TextModeController extends MouseModeController<TextMouseMode> {
     noop();
   }
 
-  syncDraggingArea() {
+  onShift(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/text-mode.ts
@@ -46,7 +46,7 @@ export class TextModeController extends MouseModeController<TextMouseMode> {
     noop();
   }
 
-  onPressShift(_: boolean) {
+  onPressShiftKey(_: boolean) {
     noop();
   }
 }

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -140,7 +140,7 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
 
   set shiftKey(pressed: boolean) {
     this._shiftKey = pressed;
-    this.currentController.onPressShift(pressed);
+    this.currentController.onPressShiftKey(pressed);
   }
 
   constructor(

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -87,7 +87,7 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
   } | null = null;
 
   // pressed shift key
-  private _shift = false;
+  private _shiftKey = false;
 
   // selected blocks
   selectedBlocks: BlockComponentElement[] = [];
@@ -134,13 +134,13 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
     return new DOMRect(minX, minY, maxX - minX, maxY - minY);
   }
 
-  get shift() {
-    return this._shift;
+  get shiftKey() {
+    return this._shiftKey;
   }
 
-  set shift(pressed: boolean) {
-    this._shift = pressed;
-    this.currentController.onShift(pressed);
+  set shiftKey(pressed: boolean) {
+    this._shiftKey = pressed;
+    this.currentController.onPressShift(pressed);
   }
 
   constructor(

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -86,7 +86,10 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
     timeStamp: number;
   } | null = null;
 
-  // The selected blocks on then frame.
+  // pressed shift key
+  private _shift = false;
+
+  // selected blocks
   selectedBlocks: BlockComponentElement[] = [];
 
   // Cache the last edited elements.
@@ -129,6 +132,15 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
     const maxX = Math.max(start.x, end.x);
     const maxY = Math.max(start.y, end.y);
     return new DOMRect(minX, minY, maxX - minX, maxY - minY);
+  }
+
+  get shift() {
+    return this._shift;
+  }
+
+  set shift(pressed: boolean) {
+    this._shift = pressed;
+    this.currentController.onShift(pressed);
   }
 
   constructor(

--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -311,12 +311,12 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
   }
 
   override firstUpdated() {
-    this._disposables.add(
-      this.edgeless.slots.mouseModeUpdated.on(() => this.requestUpdate())
-    );
-    this._disposables.add(
-      this.edgeless.slots.viewportUpdated.on(() => this.requestUpdate())
-    );
+    const {
+      _disposables,
+      edgeless: { slots },
+    } = this;
+    _disposables.add(slots.mouseModeUpdated.on(() => this.requestUpdate()));
+    _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
   }
 
   override render() {

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -83,9 +83,8 @@ export function bindCommonHotkey(
   });
 
   paragraphConfig.forEach(({ flavour, type, hotkey: hotkeyStr }) => {
-    if (!hotkeyStr) {
-      return;
-    }
+    if (!hotkeyStr) return;
+
     hotkey.addListener(hotkeyStr, () => {
       const blockRange = getCurrentBlockRange(page);
       if (!blockRange) {
@@ -126,11 +125,12 @@ export function bindCommonHotkey(
           return;
         }
       }
+
+      if (e.type === 'keyup') return;
+
       if (!isPrintableKeyEvent(e) || page.readonly) return;
       const blockRange = getCurrentBlockRange(page);
-      if (!blockRange) {
-        return;
-      }
+      if (!blockRange) return;
       if (blockRange.type === 'Block') {
         handleKeydownAfterSelectBlocks({
           page,
@@ -177,9 +177,8 @@ export function handleUp(
   }
 ) {
   const blockRange = getCurrentBlockRange(page);
-  if (!blockRange) {
-    return;
-  }
+  if (!blockRange) return;
+
   if (blockRange.type === 'Block') {
     if (!selection) {
       console.error(
@@ -247,7 +246,6 @@ export function handleUp(
       return;
     }
     focusPreviousBlock(model, new Point(left, top), zoom);
-    return;
   }
 }
 
@@ -262,9 +260,8 @@ export function handleDown(
   }
 ) {
   const blockRange = getCurrentBlockRange(page);
-  if (!blockRange) {
-    return;
-  }
+  if (!blockRange) return;
+
   if (blockRange.type === 'Block') {
     if (!selection) {
       console.error(
@@ -344,9 +341,7 @@ export function handleDown(
       return;
     }
     focusNextBlock(model, new Point(left, bottom), zoom);
-    return;
   }
-  return;
 }
 
 function handleTab(
@@ -355,9 +350,8 @@ function handleTab(
   selection: DefaultSelectionManager
 ) {
   const blockRange = getCurrentBlockRange(page);
-  if (!blockRange) {
-    return;
-  }
+  if (!blockRange) return;
+
   e.preventDefault();
   const models = blockRange.models;
   handleMultiBlockIndent(page, models);
@@ -399,9 +393,8 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
 
   hotkey.addListener(ENTER, e => {
     const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
+    if (!blockRange) return;
+
     if (blockRange.type === 'Block') {
       e.preventDefault();
 
@@ -440,21 +433,18 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
     vEditor?.slots.updated.once(() => {
       focusBlockByModel(endModel, 'start');
     });
-    return;
   });
 
   hotkey.addListener(BACKSPACE, e => {
     // delete blocks
     deleteModelsByRange(page);
     e.preventDefault();
-    return;
   });
 
   hotkey.addListener(UP, e => {
     const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
+    if (!blockRange) return;
+
     const parent = page.getParent(blockRange.models[0]);
     if (parent && matchFlavours(parent, ['affine:database'])) {
       const service = getService('affine:database');
@@ -464,9 +454,8 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
   });
   hotkey.addListener(DOWN, e => {
     const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
+    if (!blockRange) return;
+
     const parent = page.getParent(blockRange.models[0]);
     if (parent && matchFlavours(parent, ['affine:database'])) {
       const service = getService('affine:database');
@@ -476,13 +465,10 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
   });
   hotkey.addListener(LEFT, e => {
     const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
-    if (blockRange.type === 'Block') {
-      // Do nothing
-      return;
-    }
+    if (!blockRange) return;
+
+    // Do nothing
+    if (blockRange.type === 'Block') return;
     // See https://github.com/toeverything/blocksuite/issues/2260
     if (blockRange.models.length > 1) {
       e.preventDefault();
@@ -496,21 +482,17 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
       return;
     }
     focusPreviousBlock(blockRange.models[0], 'end');
-    return;
   });
   hotkey.addListener(RIGHT, e => {
     const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
+    if (!blockRange) return;
+
     if (matchFlavours(blockRange.models[0], ['affine:database'])) {
       const service = getService('affine:database');
       if (service.getLastCellSelection()) return;
     }
-    if (blockRange.type === 'Block') {
-      // Do nothing
-      return;
-    }
+    // Do nothing
+    if (blockRange.type === 'Block') return;
     // See https://github.com/toeverything/blocksuite/issues/2260
     if (blockRange.models.length > 1) {
       e.preventDefault();
@@ -524,7 +506,6 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
       return;
     }
     focusNextBlock(blockRange.models[0], 'start');
-    return;
   });
 
   hotkey.addListener(TAB, e => handleTab(e, page, selection));

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -51,9 +51,8 @@ export function bindCommonHotkey(page: Page) {
     hotkey.addListener(hotkeyStr, e => {
       // Prevent default behavior
       e.preventDefault();
-      if (page.awarenessStore.isReadonly(page)) {
-        return;
-      }
+
+      if (page.awarenessStore.isReadonly(page)) return;
 
       action({ page });
     });
@@ -66,10 +65,10 @@ export function bindCommonHotkey(page: Page) {
     hotkey.addListener(hotkeyStr, e => {
       // Prevent default behavior
       e.preventDefault();
+
       if (!enabledWhen(page)) return;
-      if (page.awarenessStore.isReadonly(page)) {
-        return;
-      }
+      if (page.awarenessStore.isReadonly(page)) return;
+
       action({ page });
     });
   });
@@ -79,9 +78,8 @@ export function bindCommonHotkey(page: Page) {
 
     hotkey.addListener(hotkeyStr, () => {
       const blockRange = getCurrentBlockRange(page);
-      if (!blockRange) {
-        return;
-      }
+      if (!blockRange) return;
+
       updateBlockType(blockRange.models, flavour, type);
     });
   });
@@ -104,8 +102,10 @@ export function bindCommonHotkey(page: Page) {
   // So we could just hook on the keydown event and detect whether user input a new character.
   hotkey.addListener(HOTKEYS.ANY_KEY, e => {
     if (!isPrintableKeyEvent(e) || page.readonly) return;
+
     const blockRange = getCurrentBlockRange(page);
     if (!blockRange) return;
+
     if (blockRange.type === 'Block') {
       handleKeydownAfterSelectBlocks({
         page,

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -44,7 +44,15 @@ import {
 } from './container-operations.js';
 import { formatConfig } from './format-config.js';
 
-export function bindCommonHotkey(page: Page) {
+export function bindCommonHotkey(
+  page: Page,
+  anyKeyOptions?: {
+    pressed?: string;
+    filter: (e: KeyboardEvent) => boolean;
+    keydown: (e: KeyboardEvent) => void;
+    keyup: (e: KeyboardEvent) => void;
+  }
+) {
   if (page.readonly) return;
 
   formatConfig.forEach(({ hotkey: hotkeyStr, action }) => {
@@ -103,25 +111,44 @@ export function bindCommonHotkey(page: Page) {
   // We shouldn't prevent user input, because there could have CN/JP/KR... input,
   // that have pop-up for selecting local characters.
   // So we could just hook on the keydown event and detect whether user input a new character.
-  hotkey.addListener(HOTKEYS.ANY_KEY, e => {
-    if (!isPrintableKeyEvent(e) || page.readonly) return;
-    const blockRange = getCurrentBlockRange(page);
-    if (!blockRange) {
-      return;
-    }
-    if (blockRange.type === 'Block') {
-      handleKeydownAfterSelectBlocks({
-        page,
-        keyboardEvent: e,
-        selectedBlocks: blockRange.models,
-      });
-      return;
-    }
+  hotkey.addListener(
+    HOTKEYS.ANY_KEY,
+    e => {
+      if (anyKeyOptions) {
+        if (anyKeyOptions.pressed === e.key && e.type === 'keyup') {
+          anyKeyOptions.keyup(e);
+          anyKeyOptions.pressed = undefined;
+          return;
+        }
+        if (anyKeyOptions.filter(e)) {
+          anyKeyOptions.pressed = e.key;
+          anyKeyOptions.keydown(e);
+          return;
+        }
+      }
+      if (!isPrintableKeyEvent(e) || page.readonly) return;
+      const blockRange = getCurrentBlockRange(page);
+      if (!blockRange) {
+        return;
+      }
+      if (blockRange.type === 'Block') {
+        handleKeydownAfterSelectBlocks({
+          page,
+          keyboardEvent: e,
+          selectedBlocks: blockRange.models,
+        });
+        return;
+      }
 
-    const range = blockRangeToNativeRange(blockRange);
-    if (!range || !isMultiBlockRange(range)) return;
-    deleteModelsByRange(page);
-  });
+      const range = blockRangeToNativeRange(blockRange);
+      if (!range || !isMultiBlockRange(range)) return;
+      deleteModelsByRange(page);
+    },
+    {
+      keyup: true,
+      keydown: true,
+    }
+  );
 
   // !!!
   // Don't forget to remove hotkeys at `removeCommonHotKey`

--- a/tests/edgeless/frame.spec.ts
+++ b/tests/edgeless/frame.spec.ts
@@ -6,7 +6,6 @@ import {
   addNote,
   assertMouseMode,
   changeEdgelessFrameBackground,
-  getFrameBoundBoxInEdgeless,
   getFrameRect,
   locatorComponentToolbar,
   locatorEdgelessToolButton,
@@ -43,7 +42,6 @@ import {
   assertRectEqual,
   assertRichTexts,
   assertSelection,
-  assertSelectionInFrame,
 } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
@@ -333,34 +331,6 @@ test('drag handle should add new frame when dragged outside frame', async ({
 
   await expect(page.locator('.affine-edgeless-block-child')).toHaveCount(2);
   await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
-});
-
-test('when the selection is always a frame, it should remain in an active state', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  const ids = await initEmptyEdgelessState(page);
-  await initThreeParagraphs(page);
-
-  await switchEditorMode(page);
-  const bound = await getFrameBoundBoxInEdgeless(page, ids.frameId);
-
-  await setMouseMode(page, 'note');
-
-  const newFrameX = bound.x;
-  const newFrameY = bound.y + bound.height + 100;
-  // add text
-  await page.mouse.click(newFrameX, newFrameY);
-  await waitForVirgoStateUpdated(page);
-  await page.keyboard.type('hello');
-  await pressEnter(page);
-  // should wait for virgo update and resizeObserver callback
-  await waitNextFrame(page);
-  // assert add text success
-  await assertEdgelessSelectedRect(page, [46, 410, 448, 112]);
-
-  await page.mouse.click(bound.x + 10, bound.y + 10);
-  await assertSelectionInFrame(page, ids.frameId);
 });
 
 test('format quick bar should show up when double-clicking on text', async ({

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -1,14 +1,28 @@
 import * as actions from '../utils/actions/edgeless.js';
 import {
+  getFrameBoundBoxInEdgeless,
+  setMouseMode,
+  switchEditorMode,
+} from '../utils/actions/edgeless.js';
+import {
+  addBasicBrushElement,
   addBasicRectShapeElement,
   clickInCenter,
   dragBetweenCoords,
   enterPlaygroundRoom,
   getBoundingRect,
   initEmptyEdgelessState,
+  initThreeParagraphs,
+  pressEnter,
+  resizeElementByTopLeftHandle,
+  waitForVirgoStateUpdated,
   waitNextFrame,
 } from '../utils/actions/index.js';
-import { assertEdgelessSelectedRect } from '../utils/asserts.js';
+import {
+  assertEdgelessHoverRect,
+  assertEdgelessSelectedRect,
+  assertSelectionInFrame,
+} from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
 test('should update rect of selection when resizing viewport', async ({
@@ -64,4 +78,133 @@ test('should update rect of selection when resizing viewport', async ({
   await actions.increaseZoomLevel(page);
   await waitNextFrame(page);
   await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+});
+
+test('select multiple shapes and resize', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+
+  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
+  await page.mouse.move(110, 110);
+  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
+
+  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
+  await page.mouse.move(220, 120);
+  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
+
+  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
+  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
+
+  await resizeElementByTopLeftHandle(page, { x: 50, y: 50 });
+  await assertEdgelessSelectedRect(page, [148, 148, 162, 62]);
+
+  await page.mouse.move(160, 160);
+  await assertEdgelessHoverRect(page, [148, 148, 79, 57.5]);
+
+  await page.mouse.move(260, 160);
+  await assertEdgelessHoverRect(page, [234, 155, 76, 55]);
+});
+
+test('select multiple shapes and resize to negative', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+
+  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
+  await page.mouse.move(110, 110);
+  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
+
+  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
+  await page.mouse.move(220, 120);
+  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
+
+  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
+  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
+
+  await resizeElementByTopLeftHandle(page, { x: 400, y: 300 }, 30);
+  await assertEdgelessSelectedRect(page, [310, 210, 188, 188]);
+
+  await page.mouse.move(450, 300);
+  await assertEdgelessHoverRect(page, [406, 223, 92, 174.5]);
+
+  await page.mouse.move(320, 220);
+  await assertEdgelessHoverRect(page, [310, 210, 88.6, 167.8]);
+});
+
+test('select multiple shapes and translate', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+
+  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
+  await page.mouse.move(110, 110);
+  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
+
+  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
+  await page.mouse.move(220, 120);
+  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
+
+  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
+  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
+
+  await dragBetweenCoords(page, { x: 120, y: 120 }, { x: 150, y: 150 });
+  await assertEdgelessSelectedRect(page, [128, 128, 212, 112]);
+
+  await page.mouse.move(160, 160);
+  await assertEdgelessHoverRect(page, [128, 128, 104, 104]);
+
+  await page.mouse.move(260, 160);
+  await assertEdgelessHoverRect(page, [240, 140, 100, 100]);
+});
+
+test('selection box of shape element sync on fast dragging', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  await setMouseMode(page, 'shape');
+  await dragBetweenCoords(page, { x: 100, y: 100 }, { x: 200, y: 200 });
+  await setMouseMode(page, 'default');
+  await dragBetweenCoords(
+    page,
+    { x: 150, y: 150 },
+    { x: 700, y: 500 },
+    { click: true }
+  );
+
+  await assertEdgelessHoverRect(page, [650, 450, 100, 100]);
+});
+
+test('when the selection is always a frame, it should remain in an active state', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  const ids = await initEmptyEdgelessState(page);
+  await initThreeParagraphs(page);
+
+  await switchEditorMode(page);
+  const bound = await getFrameBoundBoxInEdgeless(page, ids.frameId);
+
+  await setMouseMode(page, 'note');
+
+  const newFrameX = bound.x;
+  const newFrameY = bound.y + bound.height + 100;
+  // add text
+  await page.mouse.click(newFrameX, newFrameY);
+  await waitForVirgoStateUpdated(page);
+  await page.keyboard.type('hello');
+  await pressEnter(page);
+  // should wait for virgo update and resizeObserver callback
+  await waitNextFrame(page);
+  // assert add text success
+  await assertEdgelessSelectedRect(page, [46, 410, 448, 112]);
+
+  await page.mouse.click(bound.x + 10, bound.y + 10);
+  await assertSelectionInFrame(page, ids.frameId);
 });

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -24,7 +24,6 @@ import {
   enterPlaygroundRoom,
   focusRichText,
   initEmptyEdgelessState,
-  resizeElementByTopLeftHandle,
   type,
   waitNextFrame,
 } from '../utils/actions/index.js';
@@ -49,87 +48,6 @@ test('add shape element', async ({ page }) => {
 
   await assertMouseMode(page, 'default');
   await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
-});
-
-test('select multiple shapes and resize', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-
-  await switchEditorMode(page);
-
-  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
-  await page.mouse.move(110, 110);
-  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
-
-  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
-  await page.mouse.move(220, 120);
-  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
-
-  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
-  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
-
-  await resizeElementByTopLeftHandle(page, { x: 50, y: 50 });
-  await assertEdgelessSelectedRect(page, [148, 148, 162, 62]);
-
-  await page.mouse.move(160, 160);
-  await assertEdgelessHoverRect(page, [148, 148, 79, 57.5]);
-
-  await page.mouse.move(260, 160);
-  await assertEdgelessHoverRect(page, [234, 155, 76, 55]);
-});
-
-test('select multiple shapes and resize to negative', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-
-  await switchEditorMode(page);
-
-  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
-  await page.mouse.move(110, 110);
-  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
-
-  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
-  await page.mouse.move(220, 120);
-  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
-
-  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
-  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
-
-  await resizeElementByTopLeftHandle(page, { x: 400, y: 300 }, 30);
-  await assertEdgelessSelectedRect(page, [310, 210, 188, 188]);
-
-  await page.mouse.move(450, 300);
-  await assertEdgelessHoverRect(page, [406, 223, 92, 174.5]);
-
-  await page.mouse.move(320, 220);
-  await assertEdgelessHoverRect(page, [310, 210, 88.6, 167.8]);
-});
-
-test('select multiple shapes and translate', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-
-  await switchEditorMode(page);
-
-  await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
-  await page.mouse.move(110, 110);
-  await assertEdgelessHoverRect(page, [98, 98, 104, 104]);
-
-  await addBasicRectShapeElement(page, { x: 210, y: 110 }, { x: 310, y: 210 });
-  await page.mouse.move(220, 120);
-  await assertEdgelessHoverRect(page, [210, 110, 100, 100]);
-
-  await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
-  await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
-
-  await dragBetweenCoords(page, { x: 120, y: 120 }, { x: 150, y: 150 });
-  await assertEdgelessSelectedRect(page, [128, 128, 212, 112]);
-
-  await page.mouse.move(160, 160);
-  await assertEdgelessHoverRect(page, [128, 128, 104, 104]);
-
-  await page.mouse.move(260, 160);
-  await assertEdgelessHoverRect(page, [240, 140, 100, 100]);
 });
 
 test('delete shape by component-toolbar', async ({ page }) => {
@@ -275,26 +193,6 @@ test('edgeless toolbar shape menu shows up and close normally', async ({
 
   await page.mouse.click(shapeToolBox.x + 10, shapeToolBox.y + 10);
   await expect(shapeMenu).toBeHidden();
-});
-
-test('selection box of shape element sync on fast dragging', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await switchEditorMode(page);
-
-  await setMouseMode(page, 'shape');
-  await dragBetweenCoords(page, { x: 100, y: 100 }, { x: 200, y: 200 });
-  await setMouseMode(page, 'default');
-  await dragBetweenCoords(
-    page,
-    { x: 150, y: 150 },
-    { x: 700, y: 500 },
-    { click: true }
-  );
-
-  await assertEdgelessHoverRect(page, [650, 450, 100, 100]);
 });
 
 test('hovering on shape should not have effect on underlying block', async ({

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -38,7 +38,7 @@ import {
 import { test } from '../utils/playwright.js';
 
 test.describe('add shape', () => {
-  test('without pressing shift shortcut', async ({ page }) => {
+  test('without holding shift key', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
@@ -58,7 +58,7 @@ test.describe('add shape', () => {
     await assertEdgelessSelectedRect(page, [100, 100, 100, 50]);
   });
 
-  test('with pressing shift shortcut', async ({ page }) => {
+  test('with holding shift key', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -37,17 +37,52 @@ import {
 } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
-test('add shape element', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await switchEditorMode(page);
+test.describe('add shape', () => {
+  test('without pressing shift shortcut', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
 
-  const start = { x: 100, y: 100 };
-  const end = { x: 200, y: 200 };
-  await addBasicRectShapeElement(page, start, end);
+    const start0 = { x: 100, y: 100 };
+    const end0 = { x: 150, y: 200 };
+    await addBasicRectShapeElement(page, start0, end0);
 
-  await assertMouseMode(page, 'default');
-  await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+    await assertMouseMode(page, 'default');
+    await assertEdgelessSelectedRect(page, [100, 100, 50, 100]);
+
+    const start1 = { x: 100, y: 100 };
+    const end1 = { x: 200, y: 150 };
+    await addBasicRectShapeElement(page, start1, end1);
+
+    await assertMouseMode(page, 'default');
+    await assertEdgelessSelectedRect(page, [100, 100, 100, 50]);
+  });
+
+  test('with pressing shift shortcut', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+
+    await page.keyboard.down('Shift');
+
+    const start0 = { x: 100, y: 100 };
+    const end0 = { x: 150, y: 200 };
+    await addBasicRectShapeElement(page, start0, end0);
+
+    await page.keyboard.up('Shift');
+
+    await assertMouseMode(page, 'default');
+    await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+
+    await page.keyboard.down('Shift');
+
+    const start1 = { x: 100, y: 100 };
+    const end1 = { x: 200, y: 150 };
+    await addBasicRectShapeElement(page, start1, end1);
+
+    await assertMouseMode(page, 'default');
+    await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+  });
 });
 
 test('delete shape by component-toolbar', async ({ page }) => {


### PR DESCRIPTION
Closes #1873

* [x] resize selected shapes with holding shift key
* [x] resize added shape  with holding shift key
* [x] tests

https://github.com/toeverything/blocksuite/assets/27926/d2b3e686-bfb8-48d3-b815-fc25dddd9159

