### PR TITLE
fix: hide divider in balloon toolbar

### DIFF
--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -96,6 +96,7 @@ function ParagraphPanel(
     @mouseout="${onHoverEnd}"
   >
     ${paragraphConfig
+      .filter(({ flavour }) => flavour !== 'affine:divider')
       .filter(({ flavour }) => page.schema.flavourSchemaMap.has(flavour))
       .map(
         ({ flavour, type, name, icon }) => html`<format-bar-button

--- a/packages/global/src/config/consts/block-hub.ts
+++ b/packages/global/src/config/consts/block-hub.ts
@@ -4,7 +4,7 @@ import type { BlockModelProps } from '../../types.js';
 import {
   BulletedListIcon,
   CodeBlockIcon,
-  // DividerIcon,
+  DividerIcon,
   H1Icon,
   H2Icon,
   H3Icon,
@@ -118,15 +118,13 @@ export const paragraphConfig = [
     hotkey: null,
     icon: QuoteIcon,
   },
-  // Temporarily due to https://github.com/toeverything/blocksuite/issues/2577
-  // {
-  //   flavour: 'affine:divider',
-  //   type: 'divider',
-  //   name: 'Divider',
-  //   hotkey: `${SHORT_KEY}+option+d,${SHORT_KEY}+shift+d`,
-  //   icon: DividerIcon,
-  // },
-
+  {
+    flavour: 'affine:divider',
+    type: 'divider',
+    name: 'Divider',
+    hotkey: `${SHORT_KEY}+option+d,${SHORT_KEY}+shift+d`,
+    icon: DividerIcon,
+  },
   // {
   //   flavour: 'affine:',
   //   type: 'callout',
@@ -208,16 +206,14 @@ export const BLOCKHUB_TEXT_ITEMS = [
     icon: QuoteIcon,
     tooltip: 'Drag/Click to insert Quote',
   },
-
-  // Temporarily due to https://github.com/toeverything/blocksuite/issues/2577
-  // {
-  //   flavour: 'affine:divider',
-  //   type: null,
-  //   name: 'Divider',
-  //   description: 'A visual divider.',
-  //   icon: DividerIcon,
-  //   tooltip: 'A visual divider',
-  // },
+  {
+    flavour: 'affine:divider',
+    type: null,
+    name: 'Divider',
+    description: 'A visual divider.',
+    icon: DividerIcon,
+    tooltip: 'A visual divider',
+  },
 ];
 
 export const BLOCKHUB_LIST_ITEMS = [

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -735,8 +735,6 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  // Temporarily due to https://github.com/toeverything/blocksuite/issues/2577
-  /*
   await page.waitForTimeout(50);
   await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+d`);
   await assertStoreMatchJSX(
@@ -756,7 +754,6 @@ test('should hotkey work in paragraph', async ({ page }) => {
 </affine:frame>`,
     frameId
   );
-  */
 });
 
 test('format list to h1', async ({ page }) => {


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2577