### PR TITLE
fix(edgeless): connector's start/end handler not consider zoom

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
@@ -50,8 +50,9 @@ function capPointerdown(
     const { clientX, clientY } = mousePointerEvent;
     const deltaX = clientX - startX;
     const deltaY = clientY - startY;
-    const modelX = elementX + deltaX;
-    const modelY = elementY + deltaY;
+    const { zoom } = surface.viewport;
+    const modelX = elementX + deltaX / zoom;
+    const modelY = elementY + deltaY / zoom;
     const [x, y] = surface.toViewCoord(modelX, modelY);
 
     const { start, end } = getConnectorAttachedInfo(element, surface, page);


### PR DESCRIPTION
before

https://github.com/toeverything/blocksuite/assets/50226652/cd889b83-c381-4cd6-b0d7-202c383ca655


after

https://github.com/toeverything/blocksuite/assets/50226652/659feda8-4626-495c-8998-51f318a2a624

