### PR TITLE
fix: bookmark block title style if overflow

### DIFF
--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -58,6 +58,11 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
       font-size: var(--affine-font-sm);
       font-weight: 600;
     }
+    .affine-bookmark-titletext {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
     .affine-bookmark-icon {
       width: 18px;
       height: 18px;
@@ -223,7 +228,9 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
               <div class="affine-bookmark-icon">
                 ${icon ? html`<img src="${icon}" alt="icon" />` : DefaultIcon}
               </div>
-              ${title || 'Bookmark'}
+              <span class="affine-bookmark-titletext">
+                ${title || 'Bookmark'}
+              </span>
             </div>
 
             <div class="affine-bookmark-description">${description || url}</div>


### PR DESCRIPTION
To fix #2823

<img width="1127" alt="CleanShot 2023-05-29 at 4 01 49@2x" src="https://github.com/toeverything/blocksuite/assets/41265413/415727f8-b18a-48b1-82da-e1f409d44d8d">
