### PR TITLE
fix(edgeless): unable to get computed value after switching mode

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -235,10 +235,11 @@ export class EdgelessPageBlockComponent
 
   // just init surface, attach to dom later
   private _initSurface() {
-    const { page } = this;
+    const { page, parentElement } = this;
     const surfaceBlock = this.model.children.find(
       child => child.flavour === 'affine:surface'
     );
+    assertExists(parentElement);
     assertExists(surfaceBlock);
     const yBlock = page.getYBlockById(surfaceBlock.id);
     assertExists(yBlock);
@@ -249,7 +250,10 @@ export class EdgelessPageBlockComponent
     }
     this.surface = new SurfaceManager(yContainer, value => {
       if (isCssVariable(value)) {
-        const cssValue = getThemePropertyValue(this, value as CssVariableName);
+        const cssValue = getThemePropertyValue(
+          parentElement,
+          value as CssVariableName
+        );
         if (cssValue === undefined) {
           console.error(
             new Error(


### PR DESCRIPTION
Probably the first time the cache was used, `affine-edgeless-page` has been deleted.

https://github.com/toeverything/blocksuite/assets/27926/5c8df067-7b87-4bfe-8633-9e0ce545a979


<img width="1339" alt="Screenshot 2023-05-29 at 4 27 05 PM" src="https://github.com/toeverything/blocksuite/assets/27926/2bc4ca0b-6f27-4532-a250-933e1ad1a17f">

https://github.com/toeverything/blocksuite/blob/eb880a7f1f05e9e0b6765bb53ec090a458bcea30/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts#L250-L252

```ts
    this.surface = new SurfaceManager(yContainer, value => {
      if (isCssVariable(value)) {
        console.log(this.checkVisibility(), this.parentElement);
        const cssValue = getThemePropertyValue(this, value as CssVariableName);
        if (cssValue === undefined) {
          console.error(
            new Error(
              `All variables should have a value. Please check for any dirty data or variable renaming.Variable: ${value}`
            )
          );
        }
        return cssValue ?? value;
      }
      return value;
    });
```