### PR TITLE
fix(edgeless): fix continuous undo redo lost frame

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -848,15 +848,20 @@ export class EdgelessPageBlockComponent
       }
 
       this._handleToolbarFlag();
+      this._frameResizeObserver.resetListener(this.page);
       this.requestUpdate();
     });
 
     // XXX: should be called after rich text components are mounted
     this._clearSelection();
+
+    // should be updated on any frame add and delete
+    this.page.root?.childrenUpdated.on(() => {
+      this._frameResizeObserver.resetListener(this.page);
+    });
   }
 
   override updated(changedProperties: Map<string, unknown>) {
-    this._frameResizeObserver.resetListener(this.page);
     super.updated(changedProperties);
   }
 

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -857,7 +857,9 @@ export class EdgelessPageBlockComponent
 
     // should be updated on any frame add and delete
     this.page.root?.childrenUpdated.on(() => {
-      this._frameResizeObserver.resetListener(this.page);
+      requestAnimationFrame(() => {
+        this._frameResizeObserver.resetListener(this.page);
+      });
     });
   }
 

--- a/packages/blocks/src/page-block/edgeless/frame-resize-observer.ts
+++ b/packages/blocks/src/page-block/edgeless/frame-resize-observer.ts
@@ -14,9 +14,10 @@ export class FrameResizeObserver {
    * So we need to cache observed element.
    */
   private _cachedElements = new Map<string, Element>();
+  private _lastRect = new Map<string, DOMRect>();
 
   slots = {
-    resize: new Slot<Map<string, DOMRect>>(),
+    resize: new Slot<Map<string, DOMRectReadOnly>>(),
   };
 
   constructor() {
@@ -35,6 +36,19 @@ export class FrameResizeObserver {
       const blockElement = entry.target.closest(`[${BLOCK_ID_ATTR}]`);
       const id = blockElement?.getAttribute(BLOCK_ID_ATTR);
       if (!id) return;
+      if (this._lastRect.has(id)) {
+        const rect = this._lastRect.get(id);
+        if (
+          rect &&
+          rect.x === entry.contentRect.x &&
+          rect.y === entry.contentRect.y &&
+          rect.width === entry.contentRect.width &&
+          rect.height === entry.contentRect.height
+        ) {
+          return;
+        }
+      }
+      this._lastRect.set(id, entry.contentRect);
       resizedFrames.set(id, entry.contentRect);
     });
 

--- a/packages/blocks/src/page-block/edgeless/frame-resize-observer.ts
+++ b/packages/blocks/src/page-block/edgeless/frame-resize-observer.ts
@@ -14,7 +14,7 @@ export class FrameResizeObserver {
    * So we need to cache observed element.
    */
   private _cachedElements = new Map<string, Element>();
-  private _lastRect = new Map<string, DOMRect>();
+  private _lastRect = new Map<string, DOMRectReadOnly>();
 
   slots = {
     resize: new Slot<Map<string, DOMRectReadOnly>>(),

--- a/tests/edgeless/frame.spec.ts
+++ b/tests/edgeless/frame.spec.ts
@@ -1,5 +1,4 @@
 import { EDITOR_WIDTH } from '@blocksuite/global/config';
-import { sleep } from '@blocksuite/store';
 import { expect } from '@playwright/test';
 
 import {
@@ -437,7 +436,7 @@ test('cursor for active and inactive state', async ({ page }) => {
   await assertNativeSelectionRangeCount(page, 1);
 });
 
-test.only('continuous undo and redo (frame blcok add operation) should work', async ({
+test('continuous undo and redo (frame blcok add operation) should work', async ({
   page,
 }) => {
   await enterPlaygroundRoom(page);

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -310,6 +310,15 @@ export async function getAllFrames(page: Page) {
   });
 }
 
+export async function countBlock(page: Page, flavour: string) {
+  return await page.evaluate(
+    ([flavour]) => {
+      return Array.from(document.querySelectorAll(flavour)).length;
+    },
+    [flavour]
+  );
+}
+
 export async function activeFrameInEdgeless(page: Page, frameId: string) {
   const bound = await getFrameBoundBoxInEdgeless(page, frameId);
   await page.mouse.dblclick(bound.x + 8, bound.y + 8);


### PR DESCRIPTION
Closes #2715 
after redo, will trigger once resizeObserver event which cause the history stack chaotic. 
So If there is no change in size, then there is no need to update the size of frame block