### PR TITLE
fix: cursor pos when select multiple blocks and input

### DIFF
--- a/packages/virgo/src/services/range.ts
+++ b/packages/virgo/src/services/range.ts
@@ -28,10 +28,13 @@ export class VirgoRangeService<TextAttributes extends BaseTextAttributes> {
     }
 
     const fn = () => {
-      if (newVRange) {
+      // There may be multiple range update events in one frame,
+      // so we need to obtain the latest vRange.
+      // see https://github.com/toeverything/blocksuite/issues/2982
+      if (this._vRange) {
         // when using input method _vRange will return to the starting point,
         // so we need to re-sync
-        this._applyVRange(newVRange);
+        this._applyVRange(this._vRange);
       }
     };
 

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -1057,3 +1057,18 @@ test('should support ctrl/cmd+g convert to database', async ({ page }) => {
   const rows = page.locator('.affine-database-block-row');
   expect(await rows.count()).toBe(3);
 });
+
+test('should drag multiple block and input text works', async ({ page }) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/2982',
+  });
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await dragBetweenIndices(page, [0, 1], [2, 1]);
+  await type(page, 'ab');
+  await assertRichTexts(page, ['1ab89']);
+  await undoByKeyboard(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+});


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2982

Co-authored-by: @Flrande 


---

Event flow

```

press key
⬇️
hotkey.addListener(HOTKEYS.ANY_KEY)
  deleteModelsByRange
    vEditor.setVRange
      this._editor.slots.vRangeUpdated.emit([vRange, 'other'])
        onVRangeUpdated
          requestAnimationFrame
            _applyVRange  <- apply an expired range at the next tick
⬇️
_onBeforeInput
  transformInput
    handleInsertText
      editor.slots.vRangeUpdated.emit([correctRange, 'input'])
        onVRangeUpdated
          _applyVRange
         // ^ The correct range has been applied synchronously

```