### PR TITLE
[WIP] feat: add forward delete keybinding at the end of block

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -546,6 +546,10 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
   handleUnknownBlockBackspace(model);
 }
 
+export function handleLineEndDelete(page: Page, model: ExtendedModel) {
+  // TODO: implement delete actions for line end
+}
+
 export function handleKeyUp(event: KeyboardEvent, editableContainer: Element) {
   const range = getCurrentNativeRange();
   if (!range.collapsed) {

--- a/packages/blocks/src/__internal__/service/index.ts
+++ b/packages/blocks/src/__internal__/service/index.ts
@@ -22,6 +22,7 @@ import {
   enterMarkdownMatch,
   hardEnter,
   onBackspace,
+  onDelete,
   onKeyLeft,
   onKeyRight,
   onSoftEnter,
@@ -216,6 +217,13 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
         key: 'Backspace',
         handler(range, context) {
           return onBackspace(block, context.event, this.vEditor);
+        },
+      },
+      delete: {
+        key: 'Delete',
+        handler(range, context) {
+          // TODO: support macos ctrl + d
+          return onDelete(block, context.event, this.vEditor);
         },
       },
       up: {

--- a/packages/blocks/src/__internal__/service/keymap.ts
+++ b/packages/blocks/src/__internal__/service/keymap.ts
@@ -11,12 +11,16 @@ import {
 import {
   handleBlockEndEnter,
   handleBlockSplit,
+  handleLineEndDelete,
   handleLineStartBackspace,
   handleSoftEnter,
   handleUnindent,
 } from '../rich-text/rich-text-operations.js';
 import type { AffineVEditor } from '../rich-text/virgo/types.js';
-import { isCollapsedAtBlockStart } from '../utils/index.js';
+import {
+  isCollapsedAtBlockEnd,
+  isCollapsedAtBlockStart,
+} from '../utils/index.js';
 
 export function onSoftEnter(
   model: BaseBlockModel,
@@ -172,6 +176,19 @@ export function onBackspace(
   e.stopPropagation();
   if (isCollapsedAtBlockStart(vEditor)) {
     handleLineStartBackspace(model.page, model);
+    return PREVENT_DEFAULT;
+  }
+  return ALLOW_DEFAULT;
+}
+
+export function onDelete(
+  model: BaseBlockModel,
+  e: KeyboardEvent,
+  vEditor: AffineVEditor
+) {
+  e.stopPropagation();
+  if (isCollapsedAtBlockEnd(vEditor)) {
+    handleLineEndDelete(model.page, model);
     return PREVENT_DEFAULT;
   }
   return ALLOW_DEFAULT;

--- a/packages/blocks/src/__internal__/utils/common-operations.ts
+++ b/packages/blocks/src/__internal__/utils/common-operations.ts
@@ -42,6 +42,11 @@ export function isCollapsedAtBlockStart(vEditor: VEditor) {
   return vRange?.index === 0 && vRange?.length === 0;
 }
 
+export function isCollapsedAtBlockEnd(vEditor: VEditor) {
+  const vRange = vEditor.getVRange();
+  return vRange?.index === vEditor.yText.length && vRange?.length === 0;
+}
+
 export function isInSamePath(
   page: Page,
   children: BaseBlockModel,


### PR DESCRIPTION
I saw an issue (#2921) on [BlockSuite Project](https://github.com/orgs/toeverything/projects/22/views/10) regarding the unresponsiveness of forward delete at the end of a block, so I tried to solve this problem.

I didn't have a thorough understanding of the implementation details of this project, so I found the solution by tracing breakpoints through DevTools. As shown in the TODO in the code, should I implement corresponding functions such as `handleParagraphBlockDelete`/`handleCodeBlockDelete` for `handleLineEndDelete`? 

If implementing it in this way is feasible or if there are better solutions available, please let me know.