### PR TITLE
fix(edgeless): fix intersects method

### DIFF
--- a/packages/phasor/src/utils/math-utils.ts
+++ b/packages/phasor/src/utils/math-utils.ts
@@ -178,7 +178,7 @@ export function lineIntersects(
     if (!infinite) {
       u1 = clamp(u1, 0, 1);
     }
-    return Vec.lrp(sp, v1, u1);
+    return Vec.lrp(sp, ep, u1);
   }
   return null;
 }

--- a/packages/phasor/src/utils/math-utils.unit.spec.ts
+++ b/packages/phasor/src/utils/math-utils.unit.spec.ts
@@ -4,9 +4,13 @@ import { lineIntersects } from './math-utils.js';
 
 describe('Line', () => {
   it('should intersect', () => {
-    const rst = lineIntersects([0, 0], [1, 1], [0, 1], [1, 0]);
+    let rst = lineIntersects([0, 0], [1, 1], [0, 1], [1, 0]);
     expect(rst).toBeDefined();
     expect(rst).toMatchObject([0.5, 0.5]);
+
+    rst = lineIntersects([5, 5], [15, 5], [10, 0], [10, 10]);
+    expect(rst).toBeDefined();
+    expect(rst).toMatchObject([10, 5]);
   });
 
   it('should not intersect', () => {


### PR DESCRIPTION
before I used the Point.lerp method.
after I used the Vec.lrp method.
they actually don't have same parameter definition.
but the test still passed. What a coincidence.