### PR TITLE
feat: edgeless mode upload multiple images

### DIFF
--- a/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/edgeless-toolbar.ts
@@ -251,12 +251,11 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       const sh = height > 100 ? height - 100 : height;
       const p = options.width / options.height;
       if (s >= 1) {
-        options.height =
-          options.height > sh ? sh : Math.min(options.height, sh);
+        options.height = Math.min(options.height, sh);
         options.width = p * options.height;
       } else {
         const sw = sh * s;
-        options.width = options.width > sw ? sw : Math.min(options.width, sw);
+        options.width = Math.min(options.width, sw);
         options.height = options.width / p;
       }
     }


### PR DESCRIPTION
To fix #3022 

I am not sure what the effect this feature is expected to achieve, give a simple try.

Currently, the logic is to add all the images embed blocks to a single frame.

Does this feature need to add each image embed block to a separate frame ?

The effect is as below now.

https://github.com/toeverything/blocksuite/assets/99816898/4ea22fc5-c756-4f4d-9fc9-0c41b3bd7b4a



