### PR TITLE
fix(edgeless): correct the connecotor's handle behavior

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
+++ b/packages/blocks/src/page-block/edgeless/components/single-connector-handles.ts
@@ -46,6 +46,8 @@ function capPointerdown(
   const elementX = anchorPoint.x;
   const elementY = anchorPoint.y;
 
+  let routes: Point[] = originControllers;
+
   const pointermove = (mousePointerEvent: PointerEvent) => {
     const { clientX, clientY } = mousePointerEvent;
     const deltaX = clientX - startX;
@@ -71,14 +73,13 @@ function capPointerdown(
     const { point: newPoint, position: attachedPointPosition } =
       getAttachedPoint(modelX, modelY, newRect);
 
-    let routes: Point[];
     if (position === 'start') {
       routes = generateConnectorPath(
         newRect,
         end.rect,
         newPoint,
         end.point,
-        originControllers,
+        routes,
         connectorMode,
         'end'
       );
@@ -88,7 +89,7 @@ function capPointerdown(
         newRect,
         start.point,
         newPoint,
-        originControllers,
+        routes,
         connectorMode,
         'start'
       );


### PR DESCRIPTION
The originController in closure is not updated, then it casued the incorrect calculation of connector path (especially `customized start/end`).
before:

https://github.com/toeverything/blocksuite/assets/50226652/3761d779-43d0-4ec7-b3d6-c6ac35446088

after:

https://github.com/toeverything/blocksuite/assets/50226652/b35eeda2-0f0b-41bb-8d92-6ca47db25a44

