### PR TITLE
feat: support pressing esc to select blocks

### DIFF
--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -7,8 +7,11 @@ import {
 import type { Page } from '@blocksuite/store';
 
 import {
+  type BlockComponentElement,
   blockRangeToNativeRange,
   focusBlockByModel,
+  focusRichText,
+  getBlockElementByModel,
   getDefaultPage,
   hotkey,
   isMultiBlockRange,
@@ -334,6 +337,81 @@ function handleTab(
   }
 }
 
+function handleEscape(
+  e: KeyboardEvent,
+  page: Page,
+  selection: DefaultSelectionManager
+) {
+  const blockRange = getCurrentBlockRange(page);
+  if (!blockRange) return;
+  // Get the current range block models
+  const blockModels = blockRange.models;
+  assertExists(blockModels);
+  // If the selection type is block
+  // Clear the selection and foucs the last text block
+  if (selection.state.type === 'block') {
+    // TODO: need to confirm
+    // There are how many types of text blocks?
+    const textFlavours = [
+      'affine:paragraph',
+      'affine:code',
+      'affine:quote',
+      'affine:list',
+    ];
+
+    const lastTextIndex = blockModels.findLastIndex(blockModel =>
+      matchFlavours(blockModel, textFlavours)
+    );
+    let lastTextBlockModel;
+    if (lastTextIndex !== -1) {
+      // If there is a text block in current range, set it as the last text block
+      lastTextBlockModel = blockModels[lastTextIndex];
+    } else {
+      // TODO: need to confirm
+      // Should focus on which block if there is no text block in current range?
+      const lastBlockModel = blockModels.at(-1);
+      assertExists(lastBlockModel);
+      // To find the nearest text block from next siblings
+      const nextSiblings = lastBlockModel.page.getNextSiblings(lastBlockModel);
+      lastTextBlockModel = nextSiblings.find(blockModel =>
+        matchFlavours(blockModel, textFlavours)
+      );
+      // If no text block in next siblings, find it from previous siblings
+      if (!lastTextBlockModel) {
+        const previousSiblings =
+          lastBlockModel.page.getPreviousSiblings(lastBlockModel);
+        lastTextBlockModel = previousSiblings.findLast(blockModel =>
+          matchFlavours(blockModel, textFlavours)
+        );
+      }
+    }
+
+    selection.clear();
+    selection.state.type = 'native';
+
+    assertExists(lastTextBlockModel);
+    const lastTextBlockElement = getBlockElementByModel(lastTextBlockModel);
+    focusRichText(lastTextBlockElement as Element, 'end');
+  } else if (
+    selection.state.type === 'native' ||
+    selection.state.type === 'none'
+  ) {
+    // If the selection type is native or none
+    // Select the current range blocks
+    const blockElements = blockModels.map(blockModel =>
+      getBlockElementByModel(blockModel)
+    );
+    // Clear the selection
+    // To make sure clear the highlight when select multiple blocks
+    selection.clear();
+    selection.state.blur();
+    selection.state.type = 'block';
+    selection.setSelectedBlocks(blockElements as BlockComponentElement[]);
+  }
+
+  e.stopPropagation();
+}
+
 export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
   const {
     BACKSPACE,
@@ -349,6 +427,7 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
     ENTER,
     TAB,
     SPACE,
+    ESC,
   } = HOTKEYS;
 
   bindCommonHotkey(page);
@@ -493,6 +572,11 @@ export function bindHotkeys(page: Page, selection: DefaultSelectionManager) {
     }
   });
 
+  hotkey.addListener(ESC, e => {
+    e.preventDefault();
+    handleEscape(e, page, selection);
+  });
+
   // !!!
   // Don't forget to remove hotkeys at `removeHotkeys`
 }
@@ -513,5 +597,6 @@ export function removeHotkeys() {
     HOTKEYS.ENTER,
     HOTKEYS.TAB,
     HOTKEYS.SPACE,
+    HOTKEYS.ESC,
   ]);
 }

--- a/packages/blocks/src/page-block/utils/bind-hotkey.ts
+++ b/packages/blocks/src/page-block/utils/bind-hotkey.ts
@@ -351,7 +351,7 @@ function handleEscape(
   // Clear the selection and foucs the last text block
   if (selection.state.type === 'block') {
     // TODO: need to confirm
-    // There are how many types of text blocks?
+    // How many types of text blocks are there?
     const textFlavours = [
       'affine:paragraph',
       'affine:code',

--- a/tests/selection/block.spec.ts
+++ b/tests/selection/block.spec.ts
@@ -21,6 +21,8 @@ import {
   pasteByKeyboard,
   pressBackspace,
   pressEnter,
+  pressEscape,
+  pressSpace,
   pressTab,
   redoByKeyboard,
   resetHistory,
@@ -1227,4 +1229,57 @@ test('click bottom of page and if the last is embed block, editor should insert 
   </affine:page>
 </affine:page>`
   );
+});
+
+test('should select blocks when pressing escape', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+
+  await focusRichText(page, 2);
+  await page.keyboard.press('Escape');
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(1);
+  await page.keyboard.press('Escape');
+
+  const cords = await getIndexCoordinate(page, [1, 2]);
+  await page.mouse.move(cords.x + 10, cords.y + 10, { steps: 20 });
+  await page.mouse.down();
+  await page.mouse.move(cords.x + 20, cords.y + 30, { steps: 20 });
+  await page.mouse.up();
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(2);
+});
+
+test('should un-select blocks when pressing escape', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+
+  await focusRichText(page, 2);
+  await pressEscape(page);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(1);
+
+  await pressEscape(page);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
+
+  await page.keyboard.press(`${SHORT_KEY}+a`);
+  await page.keyboard.press(`${SHORT_KEY}+a`);
+  await shamefullyBlurActiveElement(page);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(3);
+
+  await pressEscape(page);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
+
+  await focusRichText(page, 2);
+  await pressEnter(page);
+  await type(page, '-');
+  await pressSpace(page);
+  await clickListIcon(page, 0);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(1);
+
+  await pressEscape(page);
+  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
 });

--- a/tests/selection/block.spec.ts
+++ b/tests/selection/block.spec.ts
@@ -1265,14 +1265,6 @@ test('should un-select blocks when pressing escape', async ({ page }) => {
   await pressEscape(page);
   await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
 
-  await page.keyboard.press(`${SHORT_KEY}+a`);
-  await page.keyboard.press(`${SHORT_KEY}+a`);
-  await shamefullyBlurActiveElement(page);
-  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(3);
-
-  await pressEscape(page);
-  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
-
   await focusRichText(page, 2);
   await pressEnter(page);
   await type(page, '-');


### PR DESCRIPTION
To close #2893 
Feat:
1. Press esc to select single block.
2. Press esc to select multiple blocks when having multiple native range block selection.
3. Press esc to unselect blocks when block is selected.

https://github.com/toeverything/blocksuite/assets/99816898/1aa54e69-6d0c-4d77-859f-c497ae0fa7ed

