### PR TITLE
feat(virgo): support embed

### DIFF
--- a/packages/playground/examples/virgo/test-page.ts
+++ b/packages/playground/examples/virgo/test-page.ts
@@ -54,7 +54,7 @@ const attributeRenderer = (delta: DeltaInsert) => {
         'word-wrap': 'break-word',
       });
 
-  // just for test
+  // split it to test v-element with multiple v-text
   if (delta.insert.length > 4) {
     const leftStr = delta.insert.slice(0, 3);
     const rightStr = delta.insert.slice(3);
@@ -314,7 +314,9 @@ export class TestPage extends ShadowlessElement {
     });
 
     const textA = yDocA.getText(TEXT_ID);
-    const editorA = new VEditor(textA);
+    const editorA = new VEditor(textA, {
+      embed: delta => !!delta.attributes?.code,
+    });
     editorA.setAttributeRenderer(attributeRenderer);
 
     const textB = yDocB.getText(TEXT_ID);

--- a/packages/virgo/src/components/virgo-element.ts
+++ b/packages/virgo/src/components/virgo-element.ts
@@ -1,10 +1,11 @@
-import { html, LitElement, type TemplateResult } from 'lit';
+import { assertExists } from '@blocksuite/global/utils';
+import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { ZERO_WIDTH_SPACE } from '../consts.js';
 import type { DeltaInsert } from '../types.js';
-import { getDefaultAttributeRenderer } from '../utils/attribute-renderer.js';
 import type { BaseTextAttributes } from '../utils/base-attributes.js';
+import type { VirgoRootElement } from '../virgo.js';
 
 @customElement('v-element')
 export class VirgoElement<
@@ -15,15 +16,23 @@ export class VirgoElement<
     insert: ZERO_WIDTH_SPACE,
   };
 
-  @property({ type: Function, attribute: false })
-  attributeRenderer: (delta: DeltaInsert<T>) => TemplateResult<1> =
-    getDefaultAttributeRenderer<T>();
-
   override render() {
+    const rootElement = this.closest(
+      '[data-virgo-root="true"]'
+    ) as VirgoRootElement;
+    assertExists(rootElement, 'v-element must be inside a v-root');
+    const virgoEditor = rootElement.virgoEditor;
+    assertExists(
+      virgoEditor,
+      'v-element must be inside a v-root with virgo-editor'
+    );
+
+    const attributeRenderer = virgoEditor.attributeService.attributeRenderer;
+
     // we need to avoid \n appearing before and after the span element, which will
     // cause the unexpected space
     return html`<span data-virgo-element="true"
-      >${this.attributeRenderer(this.delta)}</span
+      >${attributeRenderer(this.delta)}</span
     >`;
   }
 

--- a/packages/virgo/src/services/delta.ts
+++ b/packages/virgo/src/services/delta.ts
@@ -165,8 +165,7 @@ export class VirgoDeltaService<TextAttributes extends BaseTextAttributes> {
         chunk.forEach(delta => {
           const element = renderElement(
             delta,
-            this._editor.attributeService.normalizeAttributes,
-            this._editor.attributeService.attributeRenderer
+            this._editor.attributeService.normalizeAttributes
           );
 
           elementTs.push(element);

--- a/packages/virgo/src/services/range.ts
+++ b/packages/virgo/src/services/range.ts
@@ -107,7 +107,7 @@ export class VirgoRangeService<TextAttributes extends BaseTextAttributes> {
   };
 
   private _applyVRange = (vRange: VRange): void => {
-    if (!this._editor.isActive) {
+    if (!this._editor.isActive()) {
       return;
     }
     const selectionRoot = findDocumentOrShadowRoot(this._editor);

--- a/packages/virgo/src/services/range.ts
+++ b/packages/virgo/src/services/range.ts
@@ -102,15 +102,6 @@ export class VirgoRangeService<TextAttributes extends BaseTextAttributes> {
     return domRangeToVirgoRange(selection, rootElement, yText);
   };
 
-  mergeRanges = (range1: VRange, range2: VRange): VRange => {
-    return {
-      index: Math.max(range1.index, range2.index),
-      length:
-        Math.min(range1.index + range1.length, range2.index + range2.length) -
-        Math.max(range1.index, range2.index),
-    };
-  };
-
   onScrollUpdated = (scrollLeft: number) => {
     this._lastScrollLeft = scrollLeft;
   };

--- a/packages/virgo/src/tests/utils/misc.ts
+++ b/packages/virgo/src/tests/utils/misc.ts
@@ -52,6 +52,26 @@ export async function getDeltaFromVirgoRichText(
   }, index);
 }
 
+export async function getVRangeFromVirgoRichText(
+  page: Page,
+  index = 0
+): Promise<VRange | null> {
+  await page.waitForTimeout(100);
+  return await page.evaluate(index => {
+    const richTexts = document
+      .querySelector('test-page')
+      ?.querySelectorAll('virgo-test-rich-text');
+
+    if (!richTexts) {
+      throw new Error('Cannot find virgo-test-rich-text');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const editor = (richTexts[index] as any).vEditor as VEditor;
+    return editor.getVRange();
+  }, index);
+}
+
 export async function setVirgoRichTextRange(
   page: Page,
   vRange: VRange,

--- a/packages/virgo/src/tests/v-range.unit.spec.ts
+++ b/packages/virgo/src/tests/v-range.unit.spec.ts
@@ -1,0 +1,347 @@
+import { expect, test } from 'vitest';
+
+import {
+  intersectVRange,
+  isPoint,
+  isVRangeAfter,
+  isVRangeBefore,
+  isVRangeContain,
+  isVRangeEdge,
+  isVRangeEdgeAfter,
+  isVRangeEdgeBefore,
+  isVRangeEqual,
+  isVRangeIntersect,
+  mergeVRange,
+} from '../utils/v-range.js';
+
+test('isVRangeContain', () => {
+  expect(
+    isVRangeContain({ index: 0, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 0, length: 0 }, { index: 0, length: 2 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeContain({ index: 0, length: 2 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 0, length: 2 }, { index: 0, length: 1 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 0, length: 2 }, { index: 0, length: 2 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 1, length: 3 }, { index: 0, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeContain({ index: 1, length: 3 }, { index: 0, length: 1 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeContain({ index: 1, length: 3 }, { index: 0, length: 2 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeContain({ index: 1, length: 4 }, { index: 2, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 1, length: 4 }, { index: 2, length: 3 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeContain({ index: 1, length: 4 }, { index: 2, length: 4 })
+  ).toEqual(false);
+});
+
+test('isVRangeEqual', () => {
+  expect(
+    isVRangeEqual({ index: 0, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeEqual({ index: 0, length: 2 }, { index: 0, length: 1 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeEqual({ index: 1, length: 3 }, { index: 1, length: 3 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeEqual({ index: 0, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeEqual({ index: 2, length: 0 }, { index: 2, length: 0 })
+  ).toEqual(true);
+});
+
+test('isVRangeIntersect', () => {
+  expect(
+    isVRangeIntersect({ index: 0, length: 2 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeIntersect({ index: 0, length: 2 }, { index: 2, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeIntersect({ index: 0, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeIntersect({ index: 1, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeIntersect({ index: 1, length: 0 }, { index: 0, length: 1 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeIntersect({ index: 1, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeIntersect({ index: 1, length: 0 }, { index: 2, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeIntersect({ index: 1, length: 0 }, { index: 0, length: 2 })
+  ).toEqual(true);
+});
+
+test('isVRangeBefore', () => {
+  expect(
+    isVRangeBefore({ index: 0, length: 1 }, { index: 2, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeBefore({ index: 2, length: 0 }, { index: 0, length: 1 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeBefore({ index: 0, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeBefore({ index: 1, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeBefore({ index: 0, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeBefore({ index: 0, length: 0 }, { index: 0, length: 1 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeBefore({ index: 0, length: 1 }, { index: 0, length: 0 })
+  ).toEqual(false);
+});
+
+test('isVRangeAfter', () => {
+  expect(
+    isVRangeAfter({ index: 2, length: 0 }, { index: 0, length: 1 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeAfter({ index: 0, length: 1 }, { index: 2, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeAfter({ index: 1, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeAfter({ index: 0, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeAfter({ index: 0, length: 0 }, { index: 0, length: 0 })
+  ).toEqual(true);
+
+  expect(
+    isVRangeAfter({ index: 0, length: 0 }, { index: 0, length: 1 })
+  ).toEqual(false);
+
+  expect(
+    isVRangeAfter({ index: 0, length: 1 }, { index: 0, length: 0 })
+  ).toEqual(true);
+});
+
+test('isVRangeEdge', () => {
+  expect(isVRangeEdge(1, { index: 1, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdge(1, { index: 0, length: 1 })).toEqual(true);
+
+  expect(isVRangeEdge(0, { index: 0, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdge(1, { index: 0, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdge(0, { index: 1, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdge(0, { index: 0, length: 1 })).toEqual(true);
+});
+
+test('isVRangeEdgeBefore', () => {
+  expect(isVRangeEdgeBefore(1, { index: 1, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdgeBefore(1, { index: 0, length: 1 })).toEqual(false);
+
+  expect(isVRangeEdgeBefore(0, { index: 0, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdgeBefore(1, { index: 0, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdgeBefore(0, { index: 1, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdgeBefore(0, { index: 0, length: 1 })).toEqual(true);
+});
+
+test('isVRangeEdgeAfter', () => {
+  expect(isVRangeEdgeAfter(1, { index: 0, length: 1 })).toEqual(true);
+
+  expect(isVRangeEdgeAfter(1, { index: 1, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdgeAfter(0, { index: 0, length: 0 })).toEqual(true);
+
+  expect(isVRangeEdgeAfter(0, { index: 1, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdgeAfter(1, { index: 0, length: 0 })).toEqual(false);
+
+  expect(isVRangeEdgeAfter(0, { index: 0, length: 1 })).toEqual(false);
+
+  expect(isVRangeEdgeAfter(0, { index: 0, length: 0 })).toEqual(true);
+});
+
+test('isPoint', () => {
+  expect(isPoint({ index: 1, length: 0 })).toEqual(true);
+
+  expect(isPoint({ index: 0, length: 2 })).toEqual(false);
+
+  expect(isPoint({ index: 0, length: 0 })).toEqual(true);
+
+  expect(isPoint({ index: 2, length: 0 })).toEqual(true);
+
+  expect(isPoint({ index: 2, length: 2 })).toEqual(false);
+});
+
+test('mergeVRange', () => {
+  expect(mergeVRange({ index: 0, length: 0 }, { index: 1, length: 0 })).toEqual(
+    {
+      index: 0,
+      length: 1,
+    }
+  );
+
+  expect(mergeVRange({ index: 0, length: 0 }, { index: 0, length: 0 })).toEqual(
+    {
+      index: 0,
+      length: 0,
+    }
+  );
+
+  expect(mergeVRange({ index: 1, length: 0 }, { index: 2, length: 0 })).toEqual(
+    {
+      index: 1,
+      length: 1,
+    }
+  );
+
+  expect(mergeVRange({ index: 2, length: 0 }, { index: 1, length: 0 })).toEqual(
+    {
+      index: 1,
+      length: 1,
+    }
+  );
+
+  expect(mergeVRange({ index: 1, length: 3 }, { index: 2, length: 2 })).toEqual(
+    {
+      index: 1,
+      length: 3,
+    }
+  );
+
+  expect(mergeVRange({ index: 2, length: 2 }, { index: 1, length: 1 })).toEqual(
+    {
+      index: 1,
+      length: 3,
+    }
+  );
+
+  expect(mergeVRange({ index: 3, length: 2 }, { index: 2, length: 1 })).toEqual(
+    {
+      index: 2,
+      length: 3,
+    }
+  );
+
+  expect(mergeVRange({ index: 0, length: 4 }, { index: 1, length: 1 })).toEqual(
+    {
+      index: 0,
+      length: 4,
+    }
+  );
+
+  expect(mergeVRange({ index: 1, length: 1 }, { index: 0, length: 4 })).toEqual(
+    {
+      index: 0,
+      length: 4,
+    }
+  );
+
+  expect(mergeVRange({ index: 0, length: 2 }, { index: 1, length: 3 })).toEqual(
+    {
+      index: 0,
+      length: 4,
+    }
+  );
+});
+
+test('intersectVRange', () => {
+  expect(
+    intersectVRange({ index: 0, length: 0 }, { index: 1, length: 0 })
+  ).toEqual(null);
+
+  expect(
+    intersectVRange({ index: 0, length: 2 }, { index: 1, length: 1 })
+  ).toEqual({ index: 1, length: 1 });
+
+  expect(
+    intersectVRange({ index: 0, length: 2 }, { index: 2, length: 0 })
+  ).toEqual({ index: 2, length: 0 });
+
+  expect(
+    intersectVRange({ index: 1, length: 0 }, { index: 1, length: 0 })
+  ).toEqual({ index: 1, length: 0 });
+
+  expect(
+    intersectVRange({ index: 1, length: 3 }, { index: 2, length: 2 })
+  ).toEqual({ index: 2, length: 2 });
+
+  expect(
+    intersectVRange({ index: 1, length: 2 }, { index: 0, length: 3 })
+  ).toEqual({ index: 1, length: 2 });
+
+  expect(
+    intersectVRange({ index: 1, length: 1 }, { index: 2, length: 2 })
+  ).toEqual({ index: 2, length: 0 });
+
+  expect(
+    intersectVRange({ index: 2, length: 2 }, { index: 1, length: 3 })
+  ).toEqual({ index: 2, length: 2 });
+
+  expect(
+    intersectVRange({ index: 2, length: 1 }, { index: 1, length: 1 })
+  ).toEqual({ index: 2, length: 0 });
+
+  expect(
+    intersectVRange({ index: 0, length: 4 }, { index: 1, length: 2 })
+  ).toEqual({ index: 1, length: 2 });
+});

--- a/packages/virgo/src/tests/virgo.spec.ts
+++ b/packages/virgo/src/tests/virgo.spec.ts
@@ -7,6 +7,7 @@ import {
   focusVirgoRichText,
   getDeltaFromVirgoRichText,
   getVirgoRichTextLine,
+  getVRangeFromVirgoRichText,
   press,
   setVirgoRichTextRange,
   type,
@@ -802,4 +803,45 @@ test('yText should not contain \r', async ({ page }) => {
   expect(message).toBe(
     'yText must not contain \r because it will break the range synchronization'
   );
+});
+
+test('embed element in virgo', async ({ page }) => {
+  await enterVirgoPlayground(page);
+  await focusVirgoRichText(page);
+
+  const editorA = page.locator('[data-virgo-root="true"]').nth(0);
+
+  const editorACode = page.getByText('code').nth(0);
+
+  expect(await editorA.innerText()).toBe(ZERO_WIDTH_SPACE);
+
+  await page.waitForTimeout(100);
+
+  await type(page, 'abcdefg');
+
+  expect(await editorA.innerText()).toBe('abcdefg');
+
+  await setVirgoRichTextRange(page, { index: 2, length: 3 });
+
+  editorACode.click();
+  await page.waitForTimeout(100);
+
+  await page.keyboard.press('ArrowLeft');
+  let vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 2, length: 0 });
+  await page.keyboard.press('ArrowLeft');
+  vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 1, length: 0 });
+  await page.keyboard.press('ArrowRight');
+  vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 2, length: 0 });
+  await page.keyboard.press('ArrowRight');
+  vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 2, length: 3 });
+  await page.keyboard.press('ArrowRight');
+  vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 5, length: 0 });
+  await page.keyboard.press('ArrowRight');
+  vRange = await getVRangeFromVirgoRichText(page);
+  expect(vRange).toEqual({ index: 6, length: 0 });
 });

--- a/packages/virgo/src/utils/renderer.ts
+++ b/packages/virgo/src/utils/renderer.ts
@@ -1,20 +1,18 @@
 import { html, type TemplateResult } from 'lit';
 
-import type { AttributeRenderer, DeltaInsert } from '../types.js';
+import type { DeltaInsert } from '../types.js';
 import type { BaseTextAttributes } from './base-attributes.js';
 
 export function renderElement<TextAttributes extends BaseTextAttributes>(
   delta: DeltaInsert<TextAttributes>,
   parseAttributes: (
     textAttributes?: TextAttributes
-  ) => TextAttributes | undefined,
-  attributeRenderer: AttributeRenderer<TextAttributes>
+  ) => TextAttributes | undefined
 ): TemplateResult<1> {
   return html`<v-element
     .delta=${{
       insert: delta.insert,
       attributes: parseAttributes(delta.attributes),
     }}
-    .attributeRenderer=${attributeRenderer}
   ></v-element>`;
 }

--- a/packages/virgo/src/utils/v-range.ts
+++ b/packages/virgo/src/utils/v-range.ts
@@ -1,0 +1,58 @@
+import type { VRange } from '../types.js';
+
+export function isVRangeContain(a: VRange, b: VRange): boolean {
+  return a.index <= b.index && a.index + a.length >= b.index + b.length;
+}
+
+export function isVRangeEqual(a: VRange, b: VRange): boolean {
+  return a.index === b.index && a.length === b.length;
+}
+
+export function isVRangeIntersect(a: VRange, b: VRange): boolean {
+  return a.index <= b.index + b.length && a.index + a.length >= b.index;
+}
+
+export function isVRangeBefore(a: VRange, b: VRange): boolean {
+  return a.index + a.length <= b.index;
+}
+
+export function isVRangeAfter(a: VRange, b: VRange): boolean {
+  return a.index >= b.index + b.length;
+}
+
+export function isVRangeEdge(index: VRange['index'], range: VRange): boolean {
+  return index === range.index || index === range.index + range.length;
+}
+
+export function isVRangeEdgeBefore(
+  index: VRange['index'],
+  range: VRange
+): boolean {
+  return index === range.index;
+}
+
+export function isVRangeEdgeAfter(
+  index: VRange['index'],
+  range: VRange
+): boolean {
+  return index === range.index + range.length;
+}
+
+export function isPoint(range: VRange): boolean {
+  return range.length === 0;
+}
+
+export function mergeVRange(a: VRange, b: VRange): VRange {
+  const index = Math.min(a.index, b.index);
+  const length = Math.max(a.index + a.length, b.index + b.length) - index;
+  return { index, length };
+}
+
+export function intersectVRange(a: VRange, b: VRange): VRange | null {
+  if (!isVRangeIntersect(a, b)) {
+    return null;
+  }
+  const index = Math.max(a.index, b.index);
+  const length = Math.min(a.index + a.length, b.index + b.length) - index;
+  return { index, length };
+}


### PR DESCRIPTION
Make Virgo support making a specific `v-element` only selectable as a whole, by passing a function to Virgo when initing it.

For example, if you want to make a `v-element` of type `code` only selectable as a whole, you can pass a function to Virgo like this.

```ts
const vEditor = new VEditor(yText, {
    embed: delta => !!delta.attributes?.code,
});
```

The effect is as follows.

https://github.com/toeverything/blocksuite/assets/50035259/95f6323a-48ab-4d9f-a0de-bb0466aae596
