### PR TITLE
fix: press enter in the middle of parent also indent children list

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -141,12 +141,8 @@ export function handleBlockSplit(
   page.captureSync();
   const right = model.text.split(splitIndex, splitLength);
 
-  let newParent = parent;
-  let newBlockIndex = newParent.children.indexOf(model) + 1;
-  if (matchFlavours(model, ['affine:list']) && model.children.length > 0) {
-    newParent = model;
-    newBlockIndex = 0;
-  }
+  const newParent = parent;
+  const newBlockIndex = newParent.children.indexOf(model) + 1;
   const children = [...model.children];
   page.updateBlock(model, { children: [] });
   const id = page.addBlock(


### PR DESCRIPTION
To fix #2801 

https://github.com/toeverything/blocksuite/assets/99816898/d7651f80-e0f2-4709-85aa-4dd4104903a4

