### PR TITLE
fix: export two adjacent bookmarks produce one invalid url

### DIFF
--- a/packages/blocks/src/bookmark-block/bookmark-service.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-service.ts
@@ -11,7 +11,9 @@ export class BookmarkBlockService extends BaseService<BookmarkBlockModel> {
     block: BookmarkBlockModel,
     { childText = '', begin, end }: BlockTransformContext = {}
   ) {
-    return block.url;
+    return `<p><a href="${block.url}">${
+      block.title ? block.title : 'Bookmark'
+    }</a></p>`;
   }
   override block2Text(
     block: BookmarkBlockModel,


### PR DESCRIPTION
To fix #2938 

https://github.com/toeverything/blocksuite/assets/99816898/1f94bb5f-fba3-401f-b8c1-c4f66d19dee1

The previous Bookmark block2html service just return the url of bookmark block.
Can bookmarks be considered as links and return the link in bookmark service? 

