### PR TITLE
fix: ignore arrow key when select is composing

### DIFF
--- a/packages/blocks/src/components/utils.ts
+++ b/packages/blocks/src/components/utils.ts
@@ -135,6 +135,9 @@ export const createKeydownObserver = ({
           return;
         }
         case 'ArrowUp': {
+          if (e.isComposing) {
+            return;
+          }
           if (e.shiftKey) {
             abortController.abort();
             return;
@@ -144,6 +147,9 @@ export const createKeydownObserver = ({
           return;
         }
         case 'ArrowDown': {
+          if (e.isComposing) {
+            return;
+          }
           if (e.shiftKey) {
             abortController.abort();
             return;
@@ -154,6 +160,9 @@ export const createKeydownObserver = ({
         }
         case 'ArrowLeft':
         case 'ArrowRight': {
+          if (e.isComposing) {
+            return;
+          }
           abortController.abort();
           return;
         }


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2673