### PR TITLE
fix(edgeless): connectors cannot be activated using letter shortcuts

### DIFF
--- a/packages/blocks/src/page-block/edgeless/hotkey.ts
+++ b/packages/blocks/src/page-block/edgeless/hotkey.ts
@@ -1,4 +1,5 @@
 import { HOTKEYS, SHORT_KEY } from '@blocksuite/global/config';
+import { ConnectorMode } from '@blocksuite/phasor';
 
 import { activeEditorManager } from '../../__internal__/utils/active-editor-manager.js';
 import { hotkey, HOTKEY_SCOPE_TYPE } from '../../__internal__/utils/hotkey.js';
@@ -135,6 +136,20 @@ export function bindEdgelessHotkeys(edgeless: EdgelessPageBlockComponent) {
 
     hotkey.addListener('v', () => setMouseMode(edgeless, { type: 'default' }));
     hotkey.addListener('t', () => setMouseMode(edgeless, { type: 'text' }));
+    hotkey.addListener('l', () =>
+      setMouseMode(edgeless, {
+        type: 'connector',
+        mode: ConnectorMode.Straight,
+        color: GET_DEFAULT_LINE_COLOR(),
+      })
+    );
+    hotkey.addListener('x', () =>
+      setMouseMode(edgeless, {
+        type: 'connector',
+        mode: ConnectorMode.Orthogonal,
+        color: GET_DEFAULT_LINE_COLOR(),
+      })
+    );
     hotkey.addListener('h', () =>
       setMouseMode(edgeless, { type: 'pan', panning: false })
     );

--- a/tests/edgeless/shortcut.spec.ts
+++ b/tests/edgeless/shortcut.spec.ts
@@ -52,6 +52,14 @@ test('shortcut', async ({ page }) => {
   await page.keyboard.press('h');
   const panButton = locatorEdgelessToolButton(page, 'pan');
   await expect(panButton).toHaveAttribute('active', '');
+
+  await page.keyboard.press('l');
+  const connectorButton = locatorEdgelessToolButton(page, 'connector');
+  await expect(connectorButton).toHaveAttribute('active', '');
+
+  await page.mouse.click(100, 100);
+  await page.keyboard.press('x');
+  await expect(connectorButton).toHaveAttribute('active', '');
 });
 
 test('pressing the ESC key will return to the default state', async ({


### PR DESCRIPTION
To fix #3085 

https://github.com/toeverything/blocksuite/assets/99816898/741c573d-beeb-4e1a-8c69-0d4073906a5d

