### PR TITLE
fix(edgeless): fix click delete empty block

### DIFF
--- a/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
+++ b/packages/blocks/src/page-block/edgeless/mode-controllers/default-mode.ts
@@ -300,8 +300,6 @@ export class DefaultModeController extends MouseModeController<DefaultMouseMode>
   }
 
   onContainerClick(e: PointerEventState) {
-    this._tryDeleteEmptyBlocks();
-
     const selected = this._pick(e.x, e.y);
 
     if (selected) {


### PR DESCRIPTION
closes #3094 
I think there is no reason to delete empty block automatically.
It does not meet the user's expectations.