### PR TITLE
fix: exclude the current page from linked page popover

### DIFF
--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -70,9 +70,9 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
     const displayPageName =
       pageName.slice(0, DISPLAY_LENGTH) +
       (pageName.length > DISPLAY_LENGTH ? '..' : '');
-    const filteredPageList = this._pageList.filter(({ title }) =>
-      isFuzzyMatch(title, this._query)
-    );
+    const filteredPageList = this._pageList
+      .filter(({ id }) => id !== this._page.id)
+      .filter(({ title }) => isFuzzyMatch(title, this._query));
 
     return [
       ...filteredPageList.map((page, idx) => ({

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -183,6 +183,7 @@ test.describe('reference node', () => {
   test('should reference node attributes correctly', async ({ page }) => {
     await enterPlaygroundRoom(page);
     const { paragraphId } = await initEmptyParagraphState(page);
+    const { id } = await addNewPage(page);
     await focusRichText(page);
     await type(page, '[[');
     await pressEnter(page);
@@ -197,7 +198,7 @@ test.describe('reference node', () => {
         insert=" "
         reference={
           Object {
-            "pageId": "page0",
+            "pageId": "${id}",
             "type": "LinkedPage",
           }
         }
@@ -225,6 +226,7 @@ test.describe('reference node', () => {
   }) => {
     await enterPlaygroundRoom(page);
     const { paragraphId } = await initEmptyParagraphState(page);
+    const { id } = await addNewPage(page);
     await focusRichText(page);
 
     await type(page, '1');
@@ -254,7 +256,7 @@ test.describe('reference node', () => {
         insert=" "
         reference={
           Object {
-            "pageId": "page0",
+            "pageId": "${id}",
             "type": "LinkedPage",
           }
         }
@@ -297,8 +299,12 @@ test.describe('reference node', () => {
   test('should create reference node works', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyParagraphState(page);
+    const defaultPageId = 'page0';
+    const { id: newId } = await addNewPage(page);
+    await switchToPage(page, newId);
     await focusTitle(page);
     await type(page, 'title');
+    await switchToPage(page, defaultPageId);
 
     await focusRichText(page);
     await type(page, '@');
@@ -314,9 +320,12 @@ test.describe('reference node', () => {
     await expect(refNode).toBeVisible();
     await expect(refNode).toHaveCount(1);
     await assertReferenceText('title');
+
+    await switchToPage(page, newId);
     await focusTitle(page);
     await pressBackspace(page);
     await type(page, '1');
+    await switchToPage(page, defaultPageId);
     await assertReferenceText('titl1');
   });
 
@@ -467,7 +476,7 @@ test.describe('linked page popover', () => {
     await focusRichText(page);
     await type(page, '@');
     await expect(linkedPagePopover).toBeVisible();
-    await expect(pageBtn).toHaveCount(3);
+    await expect(pageBtn).toHaveCount(2);
 
     await assertActivePageIdx(0);
     await page.keyboard.press('ArrowDown');
@@ -480,7 +489,7 @@ test.describe('linked page popover', () => {
     await page.keyboard.press('Shift+Tab');
     await assertActivePageIdx(0);
 
-    await expect(pageBtn).toHaveText(['page0', 'page1', 'page2']);
+    await expect(pageBtn).toHaveText(['page1', 'page2']);
     // page2
     //  ^  ^
     await type(page, 'a2');


### PR DESCRIPTION
Fix part of https://github.com/toeverything/blocksuite/issues/3059

![Screenshot 2023-06-15 at 10 14 58 AM](https://github.com/toeverything/blocksuite/assets/18554747/358d6a91-39a6-48c9-9404-272cfca4b5a4)
