### PR TITLE
feat(edgeless): add view layer for surface element

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/surface-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/surface-text-editor.ts
@@ -74,7 +74,10 @@ export class SurfaceTextEditor extends WithDisposable(ShadowlessElement) {
     this.requestUpdate();
     requestAnimationFrame(() => {
       assertExists(this._vEditor);
-      this._element?.setDisplay(false);
+      this._element &&
+        this._edgeless?.surface.updateElementView(this._element.id, {
+          display: false,
+        });
       this._vEditor.mount(this._virgoContainer);
 
       this._virgoContainer.addEventListener(
@@ -92,7 +95,10 @@ export class SurfaceTextEditor extends WithDisposable(ShadowlessElement) {
 
   private _unmount() {
     this.vEditor?.unmount();
-    this._element?.setDisplay(true);
+    this._element &&
+      this._edgeless?.surface.updateElementView(this._element.id, {
+        display: true,
+      });
 
     if (this._element?.text.length === 0) {
       this._edgeless?.surface.removeElement(this._element?.id);

--- a/packages/phasor/src/elements/brush/types.ts
+++ b/packages/phasor/src/elements/brush/types.ts
@@ -1,4 +1,5 @@
 import type { SerializedXYWH } from '../../utils/xywh.js';
+import type { ISurfaceElementView } from '../surface-element.js';
 
 export interface IBrush {
   id: string;
@@ -12,3 +13,5 @@ export interface IBrush {
   color: string;
   lineWidth: number;
 }
+
+export interface IBrushView extends Omit<ISurfaceElementView, 'type'>, IBrush {}

--- a/packages/phasor/src/elements/connector/types.ts
+++ b/packages/phasor/src/elements/connector/types.ts
@@ -1,5 +1,6 @@
 import type { StrokeStyle } from '../../consts.js';
 import type { SerializedXYWH } from '../../utils/xywh.js';
+import type { ISurfaceElementView } from '../surface-element.js';
 
 export enum ConnectorMode {
   Straight,
@@ -46,3 +47,7 @@ export interface IConnector {
   // relative to element x,y.
   controllers: Controller[];
 }
+
+export interface IConnectorView
+  extends Omit<ISurfaceElementView, 'type'>,
+    IConnector {}

--- a/packages/phasor/src/elements/debug/debug-element.ts
+++ b/packages/phasor/src/elements/debug/debug-element.ts
@@ -1,6 +1,9 @@
 import { type SerializedXYWH } from '../../utils/xywh.js';
 import type { IElementDefaultProps } from '../index.js';
-import { SurfaceElement } from '../surface-element.js';
+import {
+  type ISurfaceElementView,
+  SurfaceElement,
+} from '../surface-element.js';
 
 export interface IDebug {
   id: string;
@@ -12,10 +15,11 @@ export interface IDebug {
   color: string;
 }
 
+export interface IDebugView extends Omit<ISurfaceElementView, 'type'>, IDebug {}
+
 export const DebugElementDefaultProps: IElementDefaultProps<'debug'> = {
   type: 'debug',
   xywh: '[0,0,0,0]',
-
   color: '#000000',
 };
 

--- a/packages/phasor/src/elements/index.ts
+++ b/packages/phasor/src/elements/index.ts
@@ -1,21 +1,22 @@
 import type { SurfaceElement } from '../index.js';
 import { BrushElement } from './brush/brush-element.js';
 import { BrushElementDefaultProps } from './brush/constants.js';
-import type { IBrush } from './brush/types.js';
+import type { IBrush, IBrushView } from './brush/types.js';
 import { ConnectorElement } from './connector/connector-element.js';
 import { ConnectorElementDefaultProps } from './connector/constants.js';
-import type { IConnector } from './connector/types.js';
+import type { IConnector, IConnectorView } from './connector/types.js';
 import {
   DebugElement,
   DebugElementDefaultProps,
   type IDebug,
+  type IDebugView,
 } from './debug/debug-element.js';
 import { ShapeElementDefaultProps } from './shape/constants.js';
 import { ShapeElement } from './shape/shape-element.js';
-import type { IShape } from './shape/types.js';
+import type { IShape, IShapeView } from './shape/types.js';
 import { TextElementDefaultProps } from './text/constants.js';
 import { TextElement } from './text/text-element.js';
-import type { IText } from './text/types.js';
+import type { IText, ITextView } from './text/types.js';
 
 export { BrushElement } from './brush/brush-element.js';
 export { ConnectorElement } from './connector/connector-element.js';
@@ -48,6 +49,14 @@ export type IPhasorElementType = {
   text: IText;
 };
 
+export type IPhasorElementViewType = {
+  shape: IShapeView;
+  debug: IDebugView;
+  brush: IBrushView;
+  connector: IConnectorView;
+  text: ITextView;
+};
+
 export const ElementCtors = {
   debug: DebugElement,
   brush: BrushElement,
@@ -69,6 +78,9 @@ export const ElementDefaultProps: Record<
 
 export type IElementCreateProps<T extends keyof IPhasorElementType> = Partial<
   Omit<IPhasorElementType[T], 'id' | 'index' | 'seed'>
+>;
+export type IElementViewProps<T extends keyof IPhasorElementViewType> = Partial<
+  Omit<IPhasorElementViewType[T], 'id' | 'index' | 'seed'>
 >;
 
 export type IElementDefaultProps<T extends keyof IPhasorElementType> = Omit<

--- a/packages/phasor/src/elements/shape/types.ts
+++ b/packages/phasor/src/elements/shape/types.ts
@@ -1,19 +1,17 @@
 import type { RoughCanvas } from 'roughjs/bin/canvas.js';
 
 import type { IBound, StrokeStyle } from '../../consts.js';
-import type { SerializedXYWH } from '../../utils/xywh.js';
-import type { HitTestOptions } from '../surface-element.js';
+import type {
+  HitTestOptions,
+  ISurfaceElement,
+  ISurfaceElementView,
+} from '../surface-element.js';
 import type { ShapeElement } from './shape-element.js';
 
 export type ShapeType = 'rect' | 'triangle' | 'ellipse' | 'diamond';
 
-export interface IShape {
-  id: string;
+export interface IShape extends ISurfaceElement {
   type: 'shape';
-  xywh: SerializedXYWH;
-  index: string;
-  seed: number;
-
   shapeType: ShapeType;
   radius: number;
   filled: boolean;
@@ -24,6 +22,8 @@ export interface IShape {
   // https://github.com/rough-stuff/rough/wiki#roughness
   roughness?: number;
 }
+
+export interface IShapeView extends Omit<ISurfaceElementView, 'type'>, IShape {}
 
 export interface ShapeMethods {
   render: (

--- a/packages/phasor/src/elements/surface-element.ts
+++ b/packages/phasor/src/elements/surface-element.ts
@@ -123,7 +123,6 @@ export class SurfaceElement<
     for (const key in updates) {
       this.yMap.set(key, updates[key] as T[keyof T]);
     }
-    this.applyViewUpdate(updates as Partial<K>);
   }
 
   applyViewUpdate(updates: Partial<K>) {

--- a/packages/phasor/src/elements/text/types.ts
+++ b/packages/phasor/src/elements/text/types.ts
@@ -1,6 +1,7 @@
 import type * as Y from 'yjs';
 
 import type { SerializedXYWH } from '../../utils/xywh.js';
+import type { ISurfaceElementView } from '../surface-element.js';
 
 export interface IText {
   id: string;
@@ -22,3 +23,5 @@ export interface ITextDelta {
     [k: string]: unknown;
   };
 }
+
+export interface ITextView extends Omit<ISurfaceElementView, 'type'>, IText {}

--- a/packages/phasor/src/renderer.ts
+++ b/packages/phasor/src/renderer.ts
@@ -271,7 +271,10 @@ export class Renderer implements SurfaceViewport {
       ctx.save();
       ctx.translate(dx, dy);
 
-      if (intersects(element, viewportBounds) && element.display) {
+      if (intersects(element, viewportBounds) && element.view.display) {
+        if (element.view.opacity !== undefined) {
+          ctx.globalAlpha = element.view.opacity;
+        }
         element.render(ctx, rc);
       }
 

--- a/packages/phasor/src/surface.ts
+++ b/packages/phasor/src/surface.ts
@@ -8,7 +8,9 @@ import {
   ElementCtors,
   ElementDefaultProps,
   type IElementCreateProps,
+  type IElementViewProps,
   type IPhasorElementType,
+  type IPhasorElementViewType,
   type PhasorElement,
   type PhasorElementType,
   type SurfaceElement,
@@ -223,6 +225,15 @@ export class SurfaceManager {
       assertExists(element);
       element.applyUpdate(properties);
     });
+  }
+
+  updateElementView<T extends keyof IPhasorElementViewType>(
+    id: string,
+    properties: IElementViewProps<T>
+  ) {
+    const element = this._elements.get(id);
+    assertExists(element);
+    element.applyViewUpdate(properties);
   }
 
   setElementBound(id: string, bound: IBound) {

--- a/packages/phasor/src/surface.ts
+++ b/packages/phasor/src/surface.ts
@@ -224,6 +224,7 @@ export class SurfaceManager {
       const element = this._elements.get(id);
       assertExists(element);
       element.applyUpdate(properties);
+      this.updateElementView(id, properties as IElementViewProps<T>);
     });
   }
 


### PR DESCRIPTION
add a view layer for surface element.
we can alter the render result without changing the crdt model.
all crdt change will be reflected on view.
and view change will result in re-render.