### PR TITLE
fix(database): accidentally triggered row selection

### DIFF
--- a/packages/blocks/src/database-block/table/selection-manager/row.ts
+++ b/packages/blocks/src/database-block/table/selection-manager/row.ts
@@ -138,6 +138,7 @@ export class RowSelectionManager {
   };
 
   private _onPointerUp = (ctx: UIEventStateContext) => {
+    this._startCell = null;
     this._startRange = null;
     this._setColumnWidthHandleDisplay('block');
     return true;


### PR DESCRIPTION
Unexpected situation:

1. Click the first cell
2. Move the mouse to select column
3. Press mouse and drag

https://github.com/toeverything/blocksuite/assets/15389209/7daba71a-20ea-4c6e-b606-871e35a90084

