### PR TITLE
feat(edgeless): support drag canvas with middle button of mouse

### DIFF
--- a/packages/blocks/src/__internal__/utils/event.ts
+++ b/packages/blocks/src/__internal__/utils/event.ts
@@ -1,4 +1,4 @@
-import { IS_IOS, IS_MAC } from '@blocksuite/global/config';
+import { IS_IOS, IS_MAC, MOUSE_BUTTONS } from '@blocksuite/global/config';
 
 export function isPinchEvent(e: WheelEvent) {
   // two finger pinches on touch pad, ctrlKey is always true.
@@ -26,4 +26,8 @@ export function createDragEvent(type: string, event?: MouseEvent) {
     });
   }
   return new DragEvent(type, options);
+}
+
+export function isMiddleButtonPressed(e: MouseEvent) {
+  return (MOUSE_BUTTONS.AUXILIARY & e.buttons) === MOUSE_BUTTONS.AUXILIARY;
 }

--- a/packages/blocks/src/page-block/edgeless/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/selection-manager.ts
@@ -14,6 +14,7 @@ import {
   isDatabaseInput,
   isInsideEdgelessTextEditor,
   isInsidePageTitle,
+  isMiddleButtonPressed,
   isPinchEvent,
   type MouseMode,
   Point,
@@ -246,6 +247,10 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
       }
       this._onContainerPointerMove(event);
     });
+    this._add('pointerDown', ctx => {
+      const event = ctx.get('pointerState');
+      this._onContainerPointerDown(event);
+    });
     this._add('pointerUp', ctx => {
       const event = ctx.get('pointerState');
       this._onContainerPointerUp(event);
@@ -357,6 +362,32 @@ export class EdgelessSelectionManager extends AbstractSelectionManager<EdgelessP
         }, 233),
       };
     }
+  };
+
+  private _onContainerPointerDown = (e: PointerEventState) => {
+    if (!isMiddleButtonPressed(e.raw)) return;
+
+    const prevMouseMode = this._mouseMode;
+    const switchToPreMode = (_e: MouseEvent) => {
+      if (!isMiddleButtonPressed(_e)) {
+        this.setMouseMode(prevMouseMode);
+        document.removeEventListener('pointerup', switchToPreMode, false);
+        document.removeEventListener('pointerover', switchToPreMode, false);
+      }
+    };
+
+    this._dispatcher.disposables.addFromEvent(
+      document,
+      'pointerover',
+      switchToPreMode
+    );
+    this._dispatcher.disposables.addFromEvent(
+      document,
+      'pointerup',
+      switchToPreMode
+    );
+
+    this.setMouseMode({ type: 'pan', panning: true });
   };
 
   private _onContainerPointerUp = (e: PointerEventState) => {

--- a/packages/global/src/config/consts.ts
+++ b/packages/global/src/config/consts.ts
@@ -1,6 +1,7 @@
 import { SHORT_KEY } from './consts/platform.js';
 
 export * from './consts/block-hub.js';
+export * from './consts/event.js';
 export * from './consts/platform.js';
 
 export const BLOCK_ID_ATTR = 'data-block-id';

--- a/packages/global/src/config/consts/event.ts
+++ b/packages/global/src/config/consts/event.ts
@@ -1,0 +1,9 @@
+// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+export enum MOUSE_BUTTONS {
+  NO_BUTTON = 0,
+  PRIMARY = 1,
+  SECONDARY = 2,
+  AUXILIARY = 4,
+  FORTH = 8,
+  FIFTH = 16,
+}


### PR DESCRIPTION
Closes #3033 

There're two things worth sharing:

1. Unlike pressing the primary mouse button, when the middle button is pressed and the mouse moves outside the document, it does not trigger the `pointermove` event.
2. After switching back to the current tab, the `pointermove` event won't be triggered if the middle button is pressed without first clicking on the page.