### PR TITLE
fix: handling backspace key press for cursor transition from paragraph to page title

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -78,3 +78,4 @@ Example:
 - Till, @tillkwl, 2023/06/04
 - Yuexun Jiang, @ahonn, 2023/06/06
 - Hyden Liu, @HydenLiu, 2023/06/11
+- zhengjitf, @zhengjitf, 2023/06/17

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -559,7 +559,10 @@ function handleParagraphDeleteActions(page: Page, model: ExtendedModel) {
     const text = model.text;
     const titleElement = document.querySelector(
       '.affine-default-page-block-title'
-    ) as HTMLTextAreaElement;
+    ) as HTMLTextAreaElement | null;
+    // Probably no title, e.g. in edgeless mode
+    if (!titleElement) return false;
+
     const pageModel = getModelByElement(titleElement) as PageBlockModel;
     const title = pageModel.title;
 

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -572,7 +572,13 @@ function handleParagraphDeleteActions(page: Page, model: ExtendedModel) {
       textLength = text.length;
       title.join(text);
     }
-    page.deleteBlock(model);
+
+    // Preserve at least one block to be able to focus on container click
+    if (page.getNextSibling(model)) {
+      page.deleteBlock(model);
+    } else {
+      text?.clear();
+    }
     focusTitle(page, title.length - textLength);
     return true;
   }

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -148,6 +148,11 @@ export function getPreviousBlock(
     // Assume children is not possible to be `affine:note` or `affine:page`
     return lastChild;
   }
+
+  if (matchFlavours(previousBlock, ['affine:surface'])) {
+    return getPreviousBlock(previousBlock);
+  }
+
   return previousBlock;
 }
 

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -156,18 +156,18 @@ for (const { initState, desc } of [
 
     await pressEnter(page);
     await assertTitle(page, 'hello');
-    await assertRichTexts(page, ['abc']);
+    await assertRichTexts(page, ['abc', '']);
 
     await pressBackspace(page);
     await assertTitle(page, 'helloabc');
-    await assertRichTexts(page, []);
+    await assertRichTexts(page, ['']);
     await undoByClick(page);
     await assertTitle(page, 'hello');
-    await assertRichTexts(page, ['abc']);
+    await assertRichTexts(page, ['abc', '']);
 
     await redoByClick(page);
     await assertTitle(page, 'helloabc');
-    await assertRichTexts(page, []);
+    await assertRichTexts(page, ['']);
   });
 
   test(`backspace on line start of the first empty block (${desc})`, async ({
@@ -179,7 +179,7 @@ for (const { initState, desc } of [
 
     await pressArrowDown(page);
     await pressBackspace(page);
-    await assertBlockCount(page, 'paragraph', 0);
+    await assertBlockCount(page, 'paragraph', 1);
 
     await pressArrowDown(page);
     await assertSelection(page, 0, 0, 0);

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -136,10 +136,6 @@ for (const { initState, desc } of [
   test(`backspace on line start of the first block (${desc})`, async ({
     page,
   }) => {
-    if (desc === 'with surface') {
-      test.fail();
-    }
-
     await enterPlaygroundRoom(page);
     await initState(page);
     await waitDefaultPageLoaded(page);
@@ -177,10 +173,6 @@ for (const { initState, desc } of [
   test(`backspace on line start of the first empty block (${desc})`, async ({
     page,
   }) => {
-    if (desc === 'with surface') {
-      test.fail();
-    }
-
     await enterPlaygroundRoom(page);
     await initState(page);
     await focusTitle(page);

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -6,6 +6,7 @@ import {
   enterPlaygroundRoom,
   focusRichText,
   focusTitle,
+  initEmptyEdgelessState,
   initEmptyParagraphState,
   initThreeParagraphs,
   pressArrowDown,
@@ -28,6 +29,7 @@ import {
 import {
   assertBlockChildrenFlavours,
   assertBlockChildrenIds,
+  assertBlockCount,
   assertBlockType,
   assertClassName,
   assertPageTitleFocus,
@@ -121,52 +123,76 @@ test('backspace and arrow on title', async ({ page }) => {
   await assertTitle(page, 'hll');
 });
 
-test('backspace on line start of the first block', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
-  await waitDefaultPageLoaded(page);
-  await focusTitle(page);
-  await type(page, 'hello');
-  await assertTitle(page, 'hello');
-  await resetHistory(page);
+for (const { initState, desc } of [
+  {
+    initState: initEmptyParagraphState,
+    desc: 'without surface',
+  },
+  {
+    initState: initEmptyEdgelessState,
+    desc: 'with surface',
+  },
+]) {
+  test(`backspace on line start of the first block (${desc})`, async ({
+    page,
+  }) => {
+    if (desc === 'with surface') {
+      test.fail();
+    }
 
-  await focusRichText(page, 0);
-  await type(page, 'abc');
-  await page.keyboard.press('ArrowLeft');
-  await page.keyboard.press('ArrowLeft');
-  await page.keyboard.press('ArrowLeft');
-  await assertSelection(page, 0, 0, 0);
+    await enterPlaygroundRoom(page);
+    await initState(page);
+    await waitDefaultPageLoaded(page);
+    await focusTitle(page);
+    await type(page, 'hello');
+    await assertTitle(page, 'hello');
+    await resetHistory(page);
 
-  await pressBackspace(page);
-  await assertTitle(page, 'helloabc');
+    await focusRichText(page, 0);
+    await type(page, 'abc');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowLeft');
+    await assertSelection(page, 0, 0, 0);
 
-  await pressEnter(page);
-  await assertTitle(page, 'hello');
-  await assertRichTexts(page, ['abc']);
+    await pressBackspace(page);
+    await assertTitle(page, 'helloabc');
 
-  await pressBackspace(page);
-  await assertTitle(page, 'helloabc');
-  await assertRichTexts(page, []);
-  await undoByClick(page);
-  await assertTitle(page, 'hello');
-  await assertRichTexts(page, ['abc']);
+    await pressEnter(page);
+    await assertTitle(page, 'hello');
+    await assertRichTexts(page, ['abc']);
 
-  await redoByClick(page);
-  await assertTitle(page, 'helloabc');
-  await assertRichTexts(page, []);
-});
+    await pressBackspace(page);
+    await assertTitle(page, 'helloabc');
+    await assertRichTexts(page, []);
+    await undoByClick(page);
+    await assertTitle(page, 'hello');
+    await assertRichTexts(page, ['abc']);
 
-test('backspace on line start of the first empty block', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
-  await focusTitle(page);
+    await redoByClick(page);
+    await assertTitle(page, 'helloabc');
+    await assertRichTexts(page, []);
+  });
 
-  await pressArrowDown(page);
-  await pressBackspace(page);
+  test(`backspace on line start of the first empty block (${desc})`, async ({
+    page,
+  }) => {
+    if (desc === 'with surface') {
+      test.fail();
+    }
 
-  await pressArrowDown(page);
-  await assertSelection(page, 0, 0, 0);
-});
+    await enterPlaygroundRoom(page);
+    await initState(page);
+    await focusTitle(page);
+
+    await pressArrowDown(page);
+    await pressBackspace(page);
+    await assertBlockCount(page, 'paragraph', 0);
+
+    await pressArrowDown(page);
+    await assertSelection(page, 0, 0, 0);
+  });
+}
 
 test('append new paragraph block by enter', async ({ page }) => {
   await enterPlaygroundRoom(page);


### PR DESCRIPTION
Fix #2976, about the delete action. (For forward-delete fixed by https://github.com/toeverything/blocksuite/pull/2552)