### PR TITLE
refactor(phasor): prevent `SurfaceElement` export

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -3,7 +3,7 @@ import '../../toolbar/shape-tool/shape-menu.js';
 
 import { MoreHorizontalIcon } from '@blocksuite/global/config';
 import { WithDisposable } from '@blocksuite/lit';
-import type { SurfaceElement, SurfaceManager } from '@blocksuite/phasor';
+import type { PhasorElement, SurfaceManager } from '@blocksuite/phasor';
 import type { Page } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -120,10 +120,10 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
 
   private _splitElements(): {
     notes: TopLevelBlockModel[];
-    shapes: SurfaceElement[];
+    shapes: PhasorElement[];
   } {
     const notes: TopLevelBlockModel[] = [];
-    const shapes: SurfaceElement[] = [];
+    const shapes: PhasorElement[] = [];
     this.elements.forEach(element => {
       if (isTopLevelBlock(element)) {
         notes.push(element);

--- a/packages/phasor/src/elements/index.ts
+++ b/packages/phasor/src/elements/index.ts
@@ -1,4 +1,3 @@
-import type { SurfaceElement } from '../index.js';
 import { BrushElement } from './brush/brush-element.js';
 import { BrushElementDefaultProps } from './brush/constants.js';
 import type { IBrush } from './brush/types.js';
@@ -13,6 +12,7 @@ import {
 import { ShapeElementDefaultProps } from './shape/constants.js';
 import { ShapeElement } from './shape/shape-element.js';
 import type { IShape } from './shape/types.js';
+import type { SurfaceElement } from './surface-element.js';
 import { TextElementDefaultProps } from './text/constants.js';
 import { TextElement } from './text/text-element.js';
 import type { IText } from './text/types.js';
@@ -22,7 +22,6 @@ export { ConnectorElement } from './connector/connector-element.js';
 export { DebugElement } from './debug/debug-element.js';
 export { ShapeElement } from './shape/shape-element.js';
 export type { ShapeType } from './shape/types.js';
-export type { SurfaceElement } from './surface-element.js';
 export { TextElement } from './text/text-element.js';
 
 export type PhasorElement =

--- a/packages/phasor/src/surface.ts
+++ b/packages/phasor/src/surface.ts
@@ -11,11 +11,11 @@ import {
   type IPhasorElementType,
   type PhasorElement,
   type PhasorElementType,
-  type SurfaceElement,
 } from './elements/index.js';
 import type {
   ComputedValue,
   HitTestOptions,
+  SurfaceElement,
 } from './elements/surface-element.js';
 import { compare } from './grid.js';
 import type { SurfaceViewport } from './renderer.js';


### PR DESCRIPTION
Prevent `SurfaceElement` export in phasor to avoid confusion between `SurfaceElement` and `PhasorElement`outside the phasor.