### PR TITLE
refactor: `@property()` -> `@property({ attribute: false })`

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/link-node/affine-link.ts
+++ b/packages/blocks/src/__internal__/rich-text/link-node/affine-link.ts
@@ -26,7 +26,7 @@ export class AffineLink extends ShadowlessElement {
     return link;
   }
 
-  @property()
+  @property({ attribute: false })
   popoverHoverOpenDelay = 150;
 
   @state()

--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -118,10 +118,10 @@ export class RichText extends ShadowlessElement {
     return this._virgoContainer;
   }
 
-  @property()
+  @property({ attribute: false })
   model!: BaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   textSchema?: AffineTextSchema;
 
   private _vEditor: AffineVEditor | null = null;

--- a/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
@@ -12,10 +12,10 @@ import { bookmarkModalStyles } from './bookmark-edit-modal.js';
 
 @customElement('bookmark-create-modal')
 export class BookmarkCreateModal extends WithDisposable(LitElement) {
-  @property()
+  @property({ attribute: false })
   onCancel?: () => void;
 
-  @property()
+  @property({ attribute: false })
   onConfirm?: (props: { url: string }) => void;
 
   override get id() {

--- a/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
@@ -105,11 +105,11 @@ export const bookmarkModalStyles = html`
 `;
 @customElement('bookmark-edit-modal')
 export class BookmarkEditModal extends WithDisposable(LitElement) {
-  @property()
+  @property({ attribute: false })
   model!: BaseBlockModel<BookmarkBlockModel>;
-  @property()
+  @property({ attribute: false })
   onCancel?: () => void;
-  @property()
+  @property({ attribute: false })
   onConfirm?: () => void;
 
   override get id() {

--- a/packages/blocks/src/bookmark-block/components/bookmark-operation-popper.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-operation-popper.ts
@@ -156,13 +156,13 @@ export class BookmarkOperationMenu extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   model!: BaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   root!: BookmarkBlockComponent;
 
-  @property()
+  @property({ attribute: false })
   onSelected?: MenuActionCallback;
 
   @query('.bookmark-bar')

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -106,10 +106,10 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   model!: BaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   onSelected?: ToolbarActionCallback & MenuActionCallback;
 
   @query('.bookmark-bar')

--- a/packages/blocks/src/bookmark-block/components/loader.ts
+++ b/packages/blocks/src/bookmark-block/components/loader.ts
@@ -42,10 +42,10 @@ export class Loader extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   size: string | number = '50px';
 
-  @property()
+  @property({ attribute: false })
   color = 'blue';
 
   override firstUpdated() {

--- a/packages/blocks/src/code-block/affine-code-line.ts
+++ b/packages/blocks/src/code-block/affine-code-line.ts
@@ -21,7 +21,7 @@ export class AffineCodeLine extends ShadowlessElement {
     insert: ZERO_WIDTH_SPACE,
   };
 
-  @property()
+  @property({ attribute: false })
   highlightOptionsGetter:
     | (() => {
         lang: Lang;

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -110,7 +110,7 @@ export class LangList extends ShadowlessElement {
   @query('#filter-input')
   filterInput!: HTMLInputElement;
 
-  @property()
+  @property({ attribute: false })
   delay = 150;
 
   override async connectedCallback() {

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -459,10 +459,10 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
   /**
    * A function that returns all blocks that are allowed to be moved to
    */
-  @property()
+  @property({ attribute: false })
   public getAllowedBlocks: () => BaseBlockModel[];
 
-  @property()
+  @property({ attribute: false })
   public getHoveringNoteState: (point: Point) => {
     container?: Element;
     rect?: Rect;

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -76,19 +76,19 @@ export class IconButton extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   size: string | number | null = null;
 
-  @property()
+  @property({ attribute: false })
   width: string | number = '28px';
 
-  @property()
+  @property({ attribute: false })
   height: string | number = '28px';
 
-  @property()
+  @property({ attribute: false })
   text: string | null = null;
 
-  @property()
+  @property({ attribute: false })
   disabled: false | '' = false;
 
   constructor() {

--- a/packages/blocks/src/components/database-modal/database-modal.ts
+++ b/packages/blocks/src/components/database-modal/database-modal.ts
@@ -45,13 +45,13 @@ const databaseViews: DatabaseView[] = [
 export class DatabaseModal extends LitElement {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
   @state()
   private _selectedView: DatabaseViewName = 'table';
 
-  @property()
+  @property({ attribute: false })
   abortController!: AbortController;
 
   private _convertToDatabase(viewType: DatabaseViewName) {

--- a/packages/blocks/src/components/drag-handle.ts
+++ b/packages/blocks/src/components/drag-handle.ts
@@ -47,7 +47,7 @@ export class DragIndicator extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   rect: Rect | null = null;
 
   override render() {
@@ -66,7 +66,7 @@ export class DragIndicator extends LitElement {
 
 @customElement('affine-drag-preview')
 export class DragPreview extends ShadowlessElement {
-  @property()
+  @property({ attribute: false })
   offset = { x: 0, y: 0 };
 
   override render() {

--- a/packages/blocks/src/components/format-quick-bar/button.ts
+++ b/packages/blocks/src/components/format-quick-bar/button.ts
@@ -21,14 +21,14 @@ export class FormatBarButton extends IconButton {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   override width: string | number = '32px';
 
-  @property()
+  @property({ attribute: false })
   override height: string | number = '32px';
 
   // TODO update color when active
-  @property()
+  @property({ attribute: false })
   active = false;
 
   private readonly _mousedown = (e: MouseEvent) => {

--- a/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
+++ b/packages/blocks/src/components/format-quick-bar/format-bar-node.ts
@@ -125,23 +125,23 @@ export class FormatQuickBar extends WithDisposable(LitElement) {
   static override styles = formatQuickBarStyle;
   static customElements: CustomElementCreator[] = [];
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   left: string | null = null;
 
-  @property()
+  @property({ attribute: false })
   top: string | null = null;
 
-  @property()
+  @property({ attribute: false })
   abortController = new AbortController();
 
   // Sometimes the quick bar need to update position
-  @property()
+  @property({ attribute: false })
   positionUpdated = new Slot();
 
-  @property()
+  @property({ attribute: false })
   models: BaseBlockModel[] = [];
 
   @state()

--- a/packages/blocks/src/components/link-popover/link-popover.ts
+++ b/packages/blocks/src/components/link-popover/link-popover.ts
@@ -102,25 +102,25 @@ const isValidLink = (str: string) => {
 export class LinkPopover extends LitElement {
   static override styles = linkPopoverStyle;
 
-  @property()
+  @property({ attribute: false })
   left = '0';
 
-  @property()
+  @property({ attribute: false })
   top = '0';
 
-  @property()
+  @property({ attribute: false })
   type: 'create' | 'edit' = 'create';
 
-  @property()
+  @property({ attribute: false })
   showMask = true;
 
-  @property()
+  @property({ attribute: false })
   text = '';
 
-  @property()
+  @property({ attribute: false })
   previewLink = '';
 
-  @property()
+  @property({ attribute: false })
   showBookmarkOperation = false;
 
   @state()

--- a/packages/blocks/src/components/loader.ts
+++ b/packages/blocks/src/components/loader.ts
@@ -62,13 +62,13 @@ export class Loader extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   hostModel: BaseBlockModel | null = null;
 
-  @property()
+  @property({ attribute: false })
   radius: string | number = '8px';
 
-  @property()
+  @property({ attribute: false })
   width: string | number = '150px';
 
   constructor() {

--- a/packages/blocks/src/components/menu-divider.ts
+++ b/packages/blocks/src/components/menu-divider.ts
@@ -26,7 +26,7 @@ export class MenuDivider extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   vertical = false;
 
   override render() {

--- a/packages/blocks/src/components/portal.ts
+++ b/packages/blocks/src/components/portal.ts
@@ -15,10 +15,10 @@ import { customElement, property } from 'lit/decorators.js';
  */
 @customElement('affine-portal')
 export class Portal extends LitElement {
-  @property()
+  @property({ attribute: false })
   public container = document.body;
 
-  @property()
+  @property({ attribute: false })
   public template = html``;
 
   private _portalRoot: HTMLElement | null = null;

--- a/packages/blocks/src/components/remote-selection/remote-selection.ts
+++ b/packages/blocks/src/components/remote-selection/remote-selection.ts
@@ -65,7 +65,7 @@ export class RemoteSelection extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   page: Page | null = null;
 
   private _ranges: Array<{

--- a/packages/blocks/src/components/selected-blocks.ts
+++ b/packages/blocks/src/components/selected-blocks.ts
@@ -45,13 +45,13 @@ export class AffineSelectedBlocks extends WithDisposable(LitElement) {
     );
   }
 
-  @property()
+  @property({ attribute: false })
   mouseRoot!: HTMLElement;
 
-  @property()
+  @property({ attribute: false })
   offset: IPoint = { x: 0, y: 0 };
 
-  @property()
+  @property({ attribute: false })
   state: { rects: DOMRect[]; grab: boolean } = { rects: [], grab: false };
 
   override connectedCallback() {

--- a/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
@@ -26,7 +26,7 @@ function collectGroupNames(menuItem: SlashItem[]) {
 export class SlashMenu extends WithDisposable(LitElement) {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   model!: BaseBlockModel;
 
   @query('.slash-menu')

--- a/packages/blocks/src/counter-block/counter-block.ts
+++ b/packages/blocks/src/counter-block/counter-block.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 @customElement('counter-block')
 export class CounterBlock extends LitElement {
-  @property()
+  @property({ attribute: false })
   count: number;
 
   constructor() {

--- a/packages/blocks/src/database-block/common/database-view-header.ts
+++ b/packages/blocks/src/database-block/common/database-view-header.ts
@@ -40,13 +40,13 @@ export class DatabaseViewHeader extends WithDisposable(ShadowlessElement) {
       background-color: #e0e0e0;
     }
   `;
-  @property()
+  @property({ attribute: false })
   model!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   currentView?: string;
 
-  @property()
+  @property({ attribute: false })
   setViewId!: (id: string) => void;
 
   @query('.database-view-header')

--- a/packages/blocks/src/database-block/common/filter/condition.ts
+++ b/packages/blocks/src/database-block/common/filter/condition.ts
@@ -17,13 +17,13 @@ import { createDatabasePopup } from '../popup.js';
 @customElement('filter-condition-view')
 export class FilterConditionView extends WithDisposable(ShadowlessElement) {
   static override styles = css``;
-  @property()
+  @property({ attribute: false })
   data!: SingleFilter;
 
-  @property()
+  @property({ attribute: false })
   setData!: (filter: SingleFilter) => void;
 
-  @property()
+  @property({ attribute: false })
   vars!: Variable[];
   @query('.filter-select')
   filterSelect!: HTMLElement;

--- a/packages/blocks/src/database-block/common/filter/filter-group.ts
+++ b/packages/blocks/src/database-block/common/filter/filter-group.ts
@@ -18,16 +18,16 @@ export class FilterGroupView extends WithDisposable(ShadowlessElement) {
       background-color: white;
     }
   `;
-  @property()
+  @property({ attribute: false })
   data!: FilterGroup;
 
-  @property()
+  @property({ attribute: false })
   vars!: Variable[];
 
   @query('.add-new')
   addNew!: HTMLElement;
 
-  @property()
+  @property({ attribute: false })
   setData!: (filter: FilterGroup) => void;
 
   private opMap = {

--- a/packages/blocks/src/database-block/common/literal/literal-element.ts
+++ b/packages/blocks/src/database-block/common/literal/literal-element.ts
@@ -10,16 +10,16 @@ export abstract class LiteralElement<
   T = unknown,
   Type extends TType = TType
 > extends WithDisposable(ShadowlessElement) {
-  @property()
+  @property({ attribute: false })
   type!: Type;
 
-  @property()
+  @property({ attribute: false })
   value!: T;
 
-  @property()
+  @property({ attribute: false })
   onChange!: (value: T) => void;
 
-  @property()
+  @property({ attribute: false })
   mode: 'show' | 'edit' = 'show';
 
   showValue(): string {

--- a/packages/blocks/src/database-block/common/menu.ts
+++ b/packages/blocks/src/database-block/common/menu.ts
@@ -43,7 +43,7 @@ export class DatabaseMenuComponent extends WithDisposable(ShadowlessElement) {
       background-color: rgba(0, 0, 0, 0.1);
     }
   `;
-  @property()
+  @property({ attribute: false })
   menuGroup!: MenuGroup;
 
   override render() {

--- a/packages/blocks/src/database-block/common/ref/ref.ts
+++ b/packages/blocks/src/database-block/common/ref/ref.ts
@@ -19,13 +19,13 @@ export class VariableRefView extends WithDisposable(ShadowlessElement) {
       padding: 0 2px;
     }
   `;
-  @property()
+  @property({ attribute: false })
   data?: VariableOrProperty;
 
-  @property()
+  @property({ attribute: false })
   setData!: (filter: VariableOrProperty) => void;
 
-  @property()
+  @property({ attribute: false })
   vars!: Variable[];
 
   get field() {

--- a/packages/blocks/src/database-block/kanban/kanban-view.ts
+++ b/packages/blocks/src/database-block/kanban/kanban-view.ts
@@ -37,10 +37,10 @@ export class DatabaseKanban
     return this.host.getService;
   }
 
-  @property()
+  @property({ attribute: false })
   model!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   host!: BlockHost;
 
   override connectedCallback() {

--- a/packages/blocks/src/database-block/table/components/cell-container.ts
+++ b/packages/blocks/src/database-block/table/components/cell-container.ts
@@ -41,18 +41,18 @@ export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
   @state()
   private _isEditing = false;
 
-  @property()
+  @property({ attribute: false })
   columnRenderer!: ColumnRendererHelper;
 
-  @property()
+  @property({ attribute: false })
   rowModel!: BaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   column!: TableMixColumn;
 
-  @property()
+  @property({ attribute: false })
   databaseModel!: DatabaseBlockModel;
-  @property()
+  @property({ attribute: false })
   root!: BlockSuiteRoot;
 
   private get readonly() {

--- a/packages/blocks/src/database-block/table/components/column-header/column-header.ts
+++ b/packages/blocks/src/database-block/table/components/column-header/column-header.ts
@@ -49,16 +49,16 @@ const columnTypeIconMap: ColumnTypeIcon = {
 export class DatabaseColumnHeader extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   targetModel!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   view!: DatabaseViewDataMap['table'];
 
-  @property()
+  @property({ attribute: false })
   columns!: TableMixColumn[];
 
-  @property()
+  @property({ attribute: false })
   addColumn!: (index: number) => string;
 
   get tableContainer(): HTMLElement {

--- a/packages/blocks/src/database-block/table/components/column-header/column-move/column-drag-indicator.ts
+++ b/packages/blocks/src/database-block/table/components/column-header/column-move/column-drag-indicator.ts
@@ -19,10 +19,10 @@ export class ColumnDragIndicator extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   targetRect: DOMRect | null = null;
 
-  @property()
+  @property({ attribute: false })
   scale = 1;
 
   override render() {

--- a/packages/blocks/src/database-block/table/components/column-type/components/multi-tag-select.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/components/multi-tag-select.ts
@@ -223,30 +223,30 @@ export class SelectCellEditing extends WithDisposable(ShadowlessElement) {
 
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   mode: SelectMode = SelectMode.Single;
 
-  @property()
+  @property({ attribute: false })
   options: SelectTag[] = [];
 
-  @property()
+  @property({ attribute: false })
   value: string[] = [];
-  @property()
+  @property({ attribute: false })
   container!: HTMLElement;
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   onChange!: (value: string[]) => void;
 
-  @property()
+  @property({ attribute: false })
   editComplete!: () => void;
 
-  @property()
+  @property({ attribute: false })
   newTag!: (tag: SelectTag) => void;
-  @property()
+  @property({ attribute: false })
   deleteTag!: (id: string) => void;
-  @property()
+  @property({ attribute: false })
   changeTag!: (tag: SelectTag) => void;
 
   @query('.select-input')

--- a/packages/blocks/src/database-block/table/components/column-type/components/multi-tag-view.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/components/multi-tag-view.ts
@@ -43,13 +43,13 @@ export class MultiTagView extends WithDisposable(ShadowlessElement) {
   @query('.affine-database-select-cell-container')
   selectContainer!: HTMLElement;
 
-  @property()
+  @property({ attribute: false })
   value: string[] = [];
 
-  @property()
+  @property({ attribute: false })
   options: SelectTag[] = [];
 
-  @property()
+  @property({ attribute: false })
   setHeight?: (height: number) => void;
 
   protected override updated(_changedProperties: Map<string, unknown>) {

--- a/packages/blocks/src/database-block/table/components/column-type/components/select-option-color.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/components/select-option-color.ts
@@ -55,7 +55,7 @@ export class SelectOptionColor extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   onChange!: (color: string) => void;
 
   protected override render() {

--- a/packages/blocks/src/database-block/table/components/column-type/components/select-option-popup.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/components/select-option-popup.ts
@@ -74,13 +74,13 @@ export class SelectActionPopup extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   tagId!: string;
 
-  @property()
+  @property({ attribute: false })
   onAction!: (type: SelectTagActionType, id: string) => void;
 
-  @property()
+  @property({ attribute: false })
   onClosePopup!: () => void;
 
   private _onAction = (e: Event, type: SelectTagActionType) => {

--- a/packages/blocks/src/database-block/table/components/column-type/components/select-option.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/components/select-option.ts
@@ -41,22 +41,22 @@ export class SelectOption extends WithDisposable(ShadowlessElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   select!: SelectTag;
 
-  @property()
+  @property({ attribute: false })
   editing!: boolean;
 
-  @property()
+  @property({ attribute: false })
   tagId!: string;
 
-  @property()
+  @property({ attribute: false })
   saveSelectionName!: (id?: string) => void;
 
-  @property()
+  @property({ attribute: false })
   setEditingId!: (id?: string) => void;
 
   @query('.select-option-text')

--- a/packages/blocks/src/database-block/table/components/database-title.ts
+++ b/packages/blocks/src/database-block/table/components/database-title.ts
@@ -58,10 +58,10 @@ export class DatabaseTitle extends WithDisposable(ShadowlessElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   targetModel!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   addRow!: (rowIndex?: number) => void;
 
   @query('.database-title')

--- a/packages/blocks/src/database-block/table/components/edit-column-popup/column-type-popup.ts
+++ b/packages/blocks/src/database-block/table/components/edit-column-popup/column-type-popup.ts
@@ -97,13 +97,13 @@ const styles = css`
 export class ColumnTypePopup extends LitElement {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   columnType: ColumnType | undefined;
 
-  @property()
+  @property({ attribute: false })
   columnId!: string;
 
-  @property()
+  @property({ attribute: false })
   changeColumnType!: (columnId: string, type: ColumnType) => void;
 
   override render() {

--- a/packages/blocks/src/database-block/table/components/edit-column-popup/edit-column-popup.ts
+++ b/packages/blocks/src/database-block/table/components/edit-column-popup/edit-column-popup.ts
@@ -93,23 +93,23 @@ const titleColumnActions: TitleColumnAction[] = [
 export class EditColumnPopup extends LitElement {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   targetModel!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   targetColumn!: Column | string;
 
   /** base on database column index */
-  @property()
+  @property({ attribute: false })
   columnIndex!: number;
 
-  @property()
+  @property({ attribute: false })
   closePopup!: () => void;
 
-  @property()
+  @property({ attribute: false })
   setTitleColumnEditId!: (columnId: string) => void;
 
-  @property()
+  @property({ attribute: false })
   insertColumn!: (position: ColumnInsertPosition) => void;
 
   @query('input')

--- a/packages/blocks/src/database-block/table/components/selection/cell-selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection/cell-selection.ts
@@ -22,7 +22,7 @@ export class CellLevelSelection extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   cell!: HTMLElement;
 
   @state()

--- a/packages/blocks/src/database-block/table/components/selection/row-selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection/row-selection.ts
@@ -21,7 +21,7 @@ export class RowLevelSelection extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   container!: HTMLElement;
 
   @state()

--- a/packages/blocks/src/database-block/table/components/toolbar/index.ts
+++ b/packages/blocks/src/database-block/table/components/toolbar/index.ts
@@ -10,7 +10,7 @@ import { Point, Rect } from '../../../../std.js';
 
 @customElement('affine-database-new-record-preview')
 class NewRecordPreview extends ShadowlessElement {
-  @property()
+  @property({ attribute: false })
   offset = { x: 0, y: 0 };
 
   override render() {

--- a/packages/blocks/src/database-block/table/components/toolbar/toolbar-action-popup.ts
+++ b/packages/blocks/src/database-block/table/components/toolbar/toolbar-action-popup.ts
@@ -105,7 +105,7 @@ class DatabaseTypePopup extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   dbType!: SwitchViewActionType;
 
   override render() {
@@ -172,7 +172,7 @@ export class ToolbarActionPopup extends LitElement {
 
   targetModel!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   close!: () => void;
 
   @query('.affine-database-toolbar-action-popup')

--- a/packages/blocks/src/database-block/table/components/toolbar/toolbar.ts
+++ b/packages/blocks/src/database-block/table/components/toolbar/toolbar.ts
@@ -166,30 +166,30 @@ const styles = css`
 export class DatabaseToolbar extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   targetModel!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   hoverState!: boolean;
 
-  @property()
+  @property({ attribute: false })
   searchState!: SearchState;
 
-  @property()
+  @property({ attribute: false })
   columns!: TableMixColumn[];
 
-  @property()
+  @property({ attribute: false })
   view!: DatabaseViewDataMap['table'];
 
-  @property()
+  @property({ attribute: false })
   addRow!: (index?: number) => void;
 
-  @property()
+  @property({ attribute: false })
   setSearchState!: (state: SearchState) => void;
 
-  @property()
+  @property({ attribute: false })
   setSearchString!: (search: string) => void;
-  @property()
+  @property({ attribute: false })
   setFilteredRowIds!: (rowIds: string[]) => void;
 
   @query('.affine-database-search-input')

--- a/packages/blocks/src/database-block/table/register.ts
+++ b/packages/blocks/src/database-block/table/register.ts
@@ -13,29 +13,29 @@ export abstract class DatabaseCellElement<
 > extends WithDisposable(ShadowlessElement) {
   static tag: ReturnType<typeof literal>;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
-  @property()
+  @property({ attribute: false })
   root!: BlockSuiteRoot;
 
-  @property()
+  @property({ attribute: false })
   readonly!: boolean;
-  @property()
+  @property({ attribute: false })
   setHeight!: (height: number) => void;
 
-  @property()
+  @property({ attribute: false })
   updateColumnData!: (apply: (oldProperty: Data) => Partial<Data>) => void;
-  @property()
+  @property({ attribute: false })
   columnData!: Data;
-  @property()
+  @property({ attribute: false })
   value: Value | null = null;
-  @property()
+  @property({ attribute: false })
   onChange!: (value: Value | null, ops?: SetValueOption) => void;
 
-  @property()
+  @property({ attribute: false })
   isEditing!: boolean;
 
-  @property()
+  @property({ attribute: false })
   protected setEditing!: (editing: boolean) => void;
 
   protected _setEditing(editing: boolean) {

--- a/packages/blocks/src/database-block/table/table-view.ts
+++ b/packages/blocks/src/database-block/table/table-view.ts
@@ -151,13 +151,13 @@ export class DatabaseTable extends WithDisposable(ShadowlessElement) {
 
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   model!: DatabaseBlockModel;
 
-  @property()
+  @property({ attribute: false })
   view!: DatabaseViewDataMap['table'];
 
-  @property()
+  @property({ attribute: false })
   root!: BlockSuiteRoot;
 
   @query('.affine-database-table-container')

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -358,10 +358,10 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
 
     const img = {
       waitUploaded: html`<affine-image-block-loading-card
-        content="Delivering content..."
+        .content=${'Delivering content...'}
       ></affine-image-block-loading-card>`,
       loading: html`<affine-image-block-loading-card
-        content="Loading content..."
+        .content=${'Loading content...'}
       ></affine-image-block-loading-card>`,
       ready: html`<img src=${this._source} />`,
       failed: html`<affine-image-block-not-found-card></affine-image-block-not-found-card>`,

--- a/packages/blocks/src/image-block/image/placeholder/loading-card.ts
+++ b/packages/blocks/src/image-block/image/placeholder/loading-card.ts
@@ -32,7 +32,7 @@ export class AffineImageBlockLoadingCard extends ShadowlessElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   content = 'Loading content...';
 
   override render() {

--- a/packages/blocks/src/page-block/default/backlink-popover.ts
+++ b/packages/blocks/src/page-block/default/backlink-popover.ts
@@ -95,10 +95,10 @@ export type BackLink = {
 export class BacklinkButton extends WithDisposable(LitElement) {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   page?: Page;
 
-  @property()
+  @property({ attribute: false })
   host!: BlockHost;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/align-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/align-panel.ts
@@ -25,7 +25,7 @@ export class EdgelessAlignPanel extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   value: 'left' | 'center' | 'right' = 'left';
 
   private _onSelect(value: EdgelessAlignPanel['value']) {
@@ -34,7 +34,7 @@ export class EdgelessAlignPanel extends LitElement {
       this.onSelect(value);
     }
   }
-  @property()
+  @property({ attribute: false })
   onSelect?: (value: EdgelessAlignPanel['value']) => void;
 
   override render() {

--- a/packages/blocks/src/page-block/edgeless/components/color-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/color-panel.ts
@@ -190,16 +190,16 @@ export class EdgelessColorPanel extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   value?: CssVariableName;
 
-  @property()
+  @property({ attribute: false })
   options: CssVariableName[] = LINE_COLORS;
 
-  @property()
+  @property({ attribute: false })
   showLetterMark = false;
 
-  @property()
+  @property({ attribute: false })
   hollowCircle = false;
 
   private _onSelect(value: CssVariableName) {

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-brush-button.ts
@@ -20,7 +20,7 @@ import {
 } from '../color-panel.js';
 import { createButtonPopper } from '../utils.js';
 
-function getMostCommonColor(elements: BrushElement[]): CssVariableName | null {
+function getMostCommonColor(elements: BrushElement[]): CssVariableName {
   const shapeTypes = countBy(elements, (ele: BrushElement) => ele.color);
   const max = maxBy(Object.entries(shapeTypes), ([k, count]) => count);
   return max ? (max[0] as CssVariableName) : GET_DEFAULT_LINE_COLOR();
@@ -93,19 +93,19 @@ export class EdgelessChangeBrushButton extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   elements: BrushElement[] = [];
 
   @property({ type: Object })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-connector-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-connector-button.ts
@@ -146,19 +146,19 @@ export class EdgelessChangeConnectorButton extends LitElement {
     `,
   ];
 
-  @property()
+  @property({ attribute: false })
   elements: ConnectorElement[] = [];
 
   @property({ type: Object })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @query('.connector-color-button')

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
@@ -71,16 +71,16 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   notes: TopLevelBlockModel[] = [];
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
@@ -201,19 +201,19 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     `,
   ];
 
-  @property()
+  @property({ attribute: false })
   elements: ShapeElement[] = [];
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-text-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-text-button.ts
@@ -66,19 +66,19 @@ export class EdgelessChangeTextButton extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   texts: TextElement[] = [];
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -59,19 +59,19 @@ export class EdgelessComponentToolbar extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   selected: Selectable[] = [];
 
   @property({ type: Object })
   selectionState!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   private _groupSelected(): CategorizedElements {

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -97,16 +97,16 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   elements: Selectable[] = [];
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   surface!: SurfaceManager;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-selected-rect.ts
@@ -162,7 +162,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   @property({ type: Object })
   state!: EdgelessSelectionState;
 
-  @property()
+  @property({ attribute: false })
   slots!: EdgelessSelectionSlots;
 
   @query('.affine-edgeless-selected-rect')

--- a/packages/blocks/src/page-block/edgeless/components/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/tool-icon-button.ts
@@ -47,22 +47,22 @@ export class EdgelessToolIconButton extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   disabled = false;
 
-  @property()
+  @property({ attribute: false })
   coming = false;
 
-  @property()
+  @property({ attribute: false })
   tooltip!: string | TemplateResult<1>;
 
-  @property()
+  @property({ attribute: false })
   tipPosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
 
-  @property()
+  @property({ attribute: false })
   active = false;
 
-  @property()
+  @property({ attribute: false })
   activeMode: 'color' | 'background' = 'color';
 
   constructor() {

--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-menu.ts
@@ -112,10 +112,10 @@ export class EdgelessBrushMenu extends LitElement {
     ${tooltipStyle}
   `;
 
-  @property()
+  @property({ attribute: false })
   mouseMode!: MouseMode;
 
-  @property()
+  @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
   private _setBrushColor = (color: CssVariableName) => {

--- a/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/brush-tool/brush-tool-button.ts
@@ -53,13 +53,13 @@ export class EdgelessBrushToolButton extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   mouseMode!: MouseMode;
 
-  @property()
+  @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
-  @property()
+  @property({ attribute: false })
   setMouseMode!: (mouseMode: MouseMode) => void;
 
   @state()

--- a/packages/blocks/src/page-block/edgeless/toolbar/connector-tool/connector-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/connector-tool/connector-menu.ts
@@ -108,10 +108,10 @@ export class EdgelessConnectorMenu extends LitElement {
     ${tooltipStyle}
   `;
 
-  @property()
+  @property({ attribute: false })
   mouseMode!: MouseMode;
 
-  @property()
+  @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
   private _setConnectorColor = (color: CssVariableName) => {

--- a/packages/blocks/src/page-block/edgeless/toolbar/connector-tool/connector-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/connector-tool/connector-tool-button.ts
@@ -54,13 +54,13 @@ export class EdgelessConnectorToolButton extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   mouseMode!: MouseMode;
 
-  @property()
+  @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
-  @property()
+  @property({ attribute: false })
   setMouseMode!: (mouseMode: MouseMode) => void;
 
   private _menu: ConnectorMenuPopper | null = null;

--- a/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-menu.ts
@@ -27,7 +27,7 @@ export class EdgelessShapeMenu extends LitElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   selectedShape?: ShapeMouseMode['shape'] | null;
 
   slots = {

--- a/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/toolbar/shape-tool/shape-tool-button.ts
@@ -32,13 +32,13 @@ export class EdgelessShapeToolButton extends WithDisposable(LitElement) {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   mouseMode!: MouseMode;
 
-  @property()
+  @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
-  @property()
+  @property({ attribute: false })
   setMouseMode!: (mouseMode: MouseMode) => void;
 
   @state()

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -43,13 +43,13 @@ export class EditorContainer
   extends WithDisposable(ShadowlessElement)
   implements AbstractEditor
 {
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   mode: 'page' | 'edgeless' = 'page';
 
-  @property()
+  @property({ attribute: false })
   override autofocus = false;
 
   @query('affine-default-page')

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -10,15 +10,15 @@ import { ShadowlessElement } from './shadowless-element.js';
 export class BlockElement<Model extends BaseBlockModel> extends WithDisposable(
   ShadowlessElement
 ) {
-  @property()
+  @property({ attribute: false })
   root!: BlockSuiteRoot;
 
-  @property()
+  @property({ attribute: false })
   model!: Model;
 
-  @property()
+  @property({ attribute: false })
   content!: TemplateResult;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 }

--- a/packages/lit/src/element/lit-root.ts
+++ b/packages/lit/src/element/lit-root.ts
@@ -13,13 +13,13 @@ import { ShadowlessElement } from './shadowless-element.js';
 
 @customElement('block-suite-root')
 export class BlockSuiteRoot extends ShadowlessElement {
-  @property()
+  @property({ attribute: false })
   componentMap!: Map<BlockSchemaType, StaticValue>;
 
-  @property()
+  @property({ attribute: false })
   page!: Page;
 
-  @property()
+  @property({ attribute: false })
   blockIdAttr = 'data-block-id';
 
   modelSubscribed = new Set<string>();

--- a/packages/playground/src/components/debug-menu.ts
+++ b/packages/playground/src/components/debug-menu.ts
@@ -132,13 +132,13 @@ export class DebugMenu extends ShadowlessElement {
     }
   `;
 
-  @property()
+  @property({ attribute: false })
   workspace!: Workspace;
 
-  @property()
+  @property({ attribute: false })
   editor!: EditorContainer;
 
-  @property()
+  @property({ attribute: false })
   contentParser!: ContentParser;
 
   @state()
@@ -150,10 +150,10 @@ export class DebugMenu extends ShadowlessElement {
   @state()
   private _canRedo = false;
 
-  @property()
+  @property({ attribute: false })
   mode: 'page' | 'edgeless' = 'page';
 
-  @property()
+  @property({ attribute: false })
   readonly = false;
 
   @state()

--- a/packages/store/src/workspace/__tests__/test-app.ts
+++ b/packages/store/src/workspace/__tests__/test-app.ts
@@ -14,7 +14,7 @@ declare module '../../workspace/meta.js' {
 export class TestApp extends LitElement {
   workspace!: Workspace;
 
-  @property()
+  @property({ attribute: false })
   pages: Pick<PageMeta, 'title' | 'favorite'>[] = [];
 
   @query('input[name="page"]')
@@ -58,7 +58,7 @@ export class TestApp extends LitElement {
             <li>
               <input
                 type="checkbox"
-                .checked=${todo.favorite}
+                .checked=${todo.favorite ?? false}
                 @change=${() => this._toggleFavorite(index)}
               />
               ${todo.title}

--- a/packages/virgo/src/components/virgo-text.ts
+++ b/packages/virgo/src/components/virgo-text.ts
@@ -7,10 +7,10 @@ import { ZERO_WIDTH_SPACE } from '../consts.js';
 
 @customElement('v-text')
 export class VText extends LitElement {
-  @property()
+  @property({ attribute: false })
   str: string = ZERO_WIDTH_SPACE;
 
-  @property()
+  @property({ attribute: false })
   styles: DirectiveResult<typeof StyleMapDirective> = styleMap({
     'word-wrap': 'break-word',
     'white-space': 'break-spaces',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,16 @@
       "@blocksuite/virgo/*": ["./packages/virgo/src/*"],
       "@blocksuite/connector": ["./packages/connector/src"],
       "@blocksuite/connector/*": ["./packages/connector/src/*"]
-    }
+    },
+    "plugins": [
+      {
+        "name": "ts-lit-plugin",
+        "strict": true,
+        "rules": {
+          "no-unknown-event": "warning"
+        }
+      }
+    ]
   },
   "files": [],
   "references": [


### PR DESCRIPTION
Fix warning from [lit-plugin](https://marketplace.visualstudio.com/items?itemName=runem.lit-plugin)

Not all modifications are necessary, but considering that we don't need to use [attributes](https://lit.dev/docs/components/properties/#attributes), I have replaced them all.