### PR TITLE
refactor: switch to block level image selection

### DIFF
--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -3,6 +3,7 @@ import {
   BLOCK_ID_ATTR as ATTR,
 } from '@blocksuite/global/config';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
+import type { BlockElement } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import { activeEditorManager } from '../../__internal__/utils/active-editor-manager.js';
@@ -24,7 +25,11 @@ const STEPS = MAX_SPACE / 2 / 2;
 
 type ElementTagName = keyof HTMLElementTagNameMap;
 
-export type BlockComponentElement =
+// Fix use unknown type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BlockComponentElement = BlockElement<any>;
+
+export type BlockCustomElement =
   HTMLElementTagNameMap[keyof HTMLElementTagNameMap] extends infer U
     ? U extends { model: infer M }
       ? M extends BaseBlockModel

--- a/packages/blocks/src/__internal__/utils/selection.ts
+++ b/packages/blocks/src/__internal__/utils/selection.ts
@@ -192,11 +192,12 @@ export function focusBlockByModel(
     return;
   }
   const element = getBlockElementByModel(model);
+  assertExists(element);
   const editableContainer = element?.querySelector('[contenteditable]');
   if (editableContainer) {
     if (isPageMode) {
       pageBlock.selection.state.clearSelection();
-      pageBlock.selection.setFocusedBlock(element as Element);
+      pageBlock.selection.setFocusedBlock(element, { type: 'UNKNOWN' });
     }
     focusRichText(editableContainer, position, zoom);
   }

--- a/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
@@ -6,7 +6,7 @@ import { WithDisposable } from '@blocksuite/lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { toast } from '../..//components/toast.js';
+import { toast } from '../../components/toast.js';
 import { CloseIcon } from '../images/icons.js';
 import { bookmarkModalStyles } from './bookmark-edit-modal.js';
 

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -355,7 +355,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
       loading: html`<affine-image-block-loading-card
         content="Loading content..."
       ></affine-image-block-loading-card>`,
-      ready: html`<img src=${this._source} />`,
+      ready: html`<img src=${this._source} draggable="false" />`,
       failed: html`<affine-image-block-not-found-card></affine-image-block-not-found-card>`,
     }[this._imageState];
 

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -241,6 +241,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     const ANCHOR_EL: HTMLElement = this.resizeImg;
 
     let hover = false;
+    let clicked = false;
     let timer: number;
     const updatePosition = () => {
       // Update option position when scrolling
@@ -257,6 +258,10 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     this.hoverState.on(newHover => {
       hover = newHover;
       clearTimeout(timer);
+      if (clicked) {
+        this._optionPosition = null;
+        return;
+      }
       if (hover) {
         updatePosition();
         return;
@@ -271,6 +276,16 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     this._disposables.addFromEvent(ANCHOR_EL, 'mouseleave', () =>
       this.hoverState.emit(false)
     );
+    this._disposables.addFromEvent(this, 'pointerdown', () => {
+      clicked = true;
+      this.hoverState.emit(false);
+    });
+    this._disposables.addFromEvent(
+      window,
+      'pointerup',
+      () => (clicked = false)
+    );
+
     this._disposables.add(
       this.model.propsUpdated.on(() => {
         if (!hover) return;
@@ -298,7 +313,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   }
 
   private _imageResizeBoardTemplate() {
-    if (!this.focused) return null;
+    if (!this.focused || this._imageState !== 'ready') return null;
     return ImageSelectedRectsContainer();
   }
 

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -2,7 +2,7 @@ import './image/placeholder/loading-card.js';
 import './image/placeholder/image-not-found.js';
 
 import { Slot } from '@blocksuite/global/utils';
-import { BlockElement } from '@blocksuite/lit';
+import { BlockElement, type FocusContext } from '@blocksuite/lit';
 import { css, html, type PropertyValues } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -11,6 +11,7 @@ import { registerService } from '../__internal__/service.js';
 import { getViewportElement } from '../__internal__/utils/query.js';
 import { stopPropagation } from '../page-block/edgeless/utils.js';
 import { ImageOptionsTemplate } from './image/image-options.js';
+import { ImageSelectedRectsContainer } from './image/image-selected-rects.js';
 import type { ImageBlockModel } from './image-model.js';
 import { ImageBlockService } from './image-service.js';
 
@@ -63,72 +64,9 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
       width: 100%;
     }
 
-    .resizable {
-      max-width: 100%;
-    }
-
-    .active .resizable {
-      border: 1px solid var(--affine-primary-color) !important;
-    }
-    .resizable .image-option-container {
-      display: none;
-      position: absolute;
-      top: 4px;
-      right: -52px;
-      margin: 0;
-      padding-left: 12px;
-    }
-
-    .resizable .resizes {
-      /* width: 100%; */
-      height: 100%;
-      box-sizing: border-box;
-      line-height: 0;
-    }
-
-    .resizable .resizes .resize {
-      /* display: none; */
-      width: 10px;
-      height: 10px;
-      border-radius: 50%; /*magic to turn square into circle*/
-      background: white;
-      border: 2px solid var(--affine-primary-color);
-      position: absolute;
-    }
-
-    .resizable:hover .resize {
-      display: block;
-    }
-    .active .resize {
-      display: block !important;
-    }
-    .resizable .resizes .resize.top-left {
-      left: -5px;
-      top: -5px;
-      cursor: nwse-resize; /*resizer cursor*/
-    }
-    .resizable .resizes .resize.top-right {
-      right: -5px;
-      top: -5px;
-      cursor: nesw-resize;
-    }
-    .resizable .resizes .resize.bottom-left {
-      left: -5px;
-      bottom: -5px;
-      cursor: nesw-resize;
-    }
-    .resizable .resizes .resize.bottom-right {
-      right: -5px;
-      bottom: -5px;
-      cursor: nwse-resize;
-    }
-
     .resizable-img {
       position: relative;
       border: 1px solid var(--affine-white-90);
-    }
-    .resizable-img:hover {
-      border: 1px solid var(--affine-primary-color);
     }
 
     .resizable-img img {
@@ -232,6 +170,20 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     });
   }
 
+  override focusBlock(ctx: FocusContext) {
+    super.focusBlock(ctx);
+    if (ctx.multi) {
+      return true;
+    }
+    // show selection rect
+    return false;
+  }
+
+  override blurBlock(ctx: FocusContext) {
+    super.blurBlock(ctx);
+    return true;
+  }
+
   private _onInputChange() {
     this._caption = this._input.value;
     this.model.page.updateBlock(this.model, { caption: this._caption });
@@ -297,7 +249,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
         // when image size is too large, the option popup should show inside
         x: rect.width > 680 ? rect.right - 50 : rect.right + 12,
         y: Math.min(
-          Math.max(rect.top, HEADER_HEIGHT + 12),
+          Math.max(rect.top + 10, HEADER_HEIGHT + 12),
           rect.bottom - OPTION_ELEMENT_HEIGHT
         ),
       };
@@ -345,6 +297,11 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     ></affine-portal>`;
   }
 
+  private _imageResizeBoardTemplate() {
+    if (!this.focused) return null;
+    return ImageSelectedRectsContainer();
+  }
+
   override render() {
     const resizeImgStyle = {
       width: 'unset',
@@ -372,6 +329,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
         <div class="affine-image-wrapper">
           <div class="resizable-img" style=${styleMap(resizeImgStyle)}>
             ${img} ${this._imageOptionsTemplate()}
+            ${this._imageResizeBoardTemplate()}
           </div>
         </div>
       </div>

--- a/packages/blocks/src/image-block/image/image-options.ts
+++ b/packages/blocks/src/image-block/image/image-options.ts
@@ -42,7 +42,7 @@ export function ImageOptionsTemplate({
 
       .embed-editing-state {
         box-shadow: var(--affine-shadow-2);
-        border-radius: 10px;
+        border-radius: 8px;
         list-style: none;
         padding: 4px;
         width: 40px;

--- a/packages/blocks/src/image-block/image/image-selected-rects.ts
+++ b/packages/blocks/src/image-block/image/image-selected-rects.ts
@@ -1,0 +1,58 @@
+import { html } from 'lit';
+
+export function ImageSelectedRectsContainer() {
+  return html`
+    <style>
+      .affine-page-selected-embed-rects-container {
+        position: absolute;
+        border: 2px solid var(--affine-primary-color);
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: calc(100% + 1px);
+        user-select: none;
+        pointer-events: none;
+        box-sizing: border-box;
+        line-height: 0;
+      }
+
+      .affine-page-selected-embed-rects-container .resize {
+        /* display: none; */
+        width: 10px;
+        height: 10px;
+        border-radius: 50%; /*magic to turn square into circle*/
+        background: white;
+        border: 2px solid var(--affine-primary-color);
+        position: absolute;
+        pointer-events: auto;
+      }
+
+      .resizable .resize.top-left {
+        left: -5px;
+        top: -5px;
+        cursor: nwse-resize; /*resizer cursor*/
+      }
+      .resizable .resize.top-right {
+        right: -5px;
+        top: -5px;
+        cursor: nesw-resize;
+      }
+      .resizable .resize.bottom-left {
+        left: -5px;
+        bottom: -5px;
+        cursor: nesw-resize;
+      }
+      .resizable .resize.bottom-right {
+        right: -5px;
+        bottom: -5px;
+        cursor: nwse-resize;
+      }
+    </style>
+    <div class="affine-page-selected-embed-rects-container resizable resizes">
+      <div class="resize top-left"></div>
+      <div class="resize top-right"></div>
+      <div class="resize bottom-left"></div>
+      <div class="resize bottom-right"></div>
+    </div>
+  `;
+}

--- a/packages/blocks/src/image-block/image/image-selected-rects.ts
+++ b/packages/blocks/src/image-block/image/image-selected-rects.ts
@@ -17,42 +17,59 @@ export function ImageSelectedRectsContainer() {
       }
 
       .affine-page-selected-embed-rects-container .resize {
-        /* display: none; */
-        width: 10px;
-        height: 10px;
-        border-radius: 50%; /*magic to turn square into circle*/
-        background: white;
-        border: 2px solid var(--affine-primary-color);
         position: absolute;
+        padding: 5px;
         pointer-events: auto;
+        z-index: 1;
       }
 
-      .resizable .resize.top-left {
-        left: -5px;
-        top: -5px;
+      .affine-page-selected-embed-rects-container .resize-inner {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: white;
+        border: 2px solid var(--affine-primary-color);
+        pointer-events: none;
+      }
+
+      .affine-page-selected-embed-rects-container .resize.top-left {
+        left: 0;
+        top: 0;
+        transform: translate(-50%, -50%);
         cursor: nwse-resize; /*resizer cursor*/
       }
-      .resizable .resize.top-right {
-        right: -5px;
-        top: -5px;
+      .affine-page-selected-embed-rects-container .resize.top-right {
+        right: 0;
+        top: 0;
+        transform: translate(50%, -50%);
         cursor: nesw-resize;
       }
-      .resizable .resize.bottom-left {
-        left: -5px;
-        bottom: -5px;
+      .affine-page-selected-embed-rects-container .resize.bottom-left {
+        left: 0;
+        bottom: 0;
+        transform: translate(-50%, 50%);
         cursor: nesw-resize;
       }
-      .resizable .resize.bottom-right {
-        right: -5px;
-        bottom: -5px;
+      .affine-page-selected-embed-rects-container .resize.bottom-right {
+        right: 0;
+        bottom: 0;
+        transform: translate(50%, 50%);
         cursor: nwse-resize;
       }
     </style>
     <div class="affine-page-selected-embed-rects-container resizable resizes">
-      <div class="resize top-left"></div>
-      <div class="resize top-right"></div>
-      <div class="resize bottom-left"></div>
-      <div class="resize bottom-right"></div>
+      <div class="resize top-left">
+        <div class="resize-inner"></div>
+      </div>
+      <div class="resize top-right">
+        <div class="resize-inner"></div>
+      </div>
+      <div class="resize bottom-left">
+        <div class="resize-inner"></div>
+      </div>
+      <div class="resize bottom-right">
+        <div class="resize-inner"></div>
+      </div>
     </div>
   `;
 }

--- a/packages/blocks/src/page-block/default/components.ts
+++ b/packages/blocks/src/page-block/default/components.ts
@@ -1,8 +1,6 @@
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { IPoint } from '../../__internal__/index.js';
-
 export function DraggingArea(rect: DOMRect | null) {
   if (rect === null) return null;
 
@@ -22,43 +20,5 @@ export function DraggingArea(rect: DOMRect | null) {
       }
     </style>
     <div class="affine-page-dragging-area" style=${styleMap(style)}></div>
-  `;
-}
-
-export function EmbedSelectedRectsContainer(
-  rects: DOMRect[],
-  viewportOffset: IPoint
-) {
-  return html`
-    <style>
-      .affine-page-selected-embed-rects-container > .resizes {
-        position: absolute;
-        display: block;
-        border: 2px solid var(--affine-primary-color);
-        user-select: none;
-      }
-      .affine-page-selected-embed-rects-container .resize {
-        pointer-events: auto;
-      }
-    </style>
-    <div class="affine-page-selected-embed-rects-container resizable">
-      ${rects.map(rect => {
-        const style = {
-          left: rect.left + viewportOffset.x + 'px',
-          top: rect.top + viewportOffset.y + 'px',
-          width: rect.width + 'px',
-          height: rect.height + 'px',
-          pointerEvents: 'none',
-        };
-        return html`
-          <div class="resizes" style=${styleMap(style)}>
-            <div class="resize top-left"></div>
-            <div class="resize top-right"></div>
-            <div class="resize bottom-left"></div>
-            <div class="resize bottom-right"></div>
-          </div>
-        `;
-      })}
-    </div>
   `;
 }

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -36,14 +36,20 @@ import { PageBlockService } from '../index.js';
 import type { PageBlockModel } from '../page-model.js';
 import { bindHotkeys, removeHotkeys } from '../utils/bind-hotkey.js';
 import { tryUpdateNoteSize } from '../utils/index.js';
-import { DraggingArea, EmbedSelectedRectsContainer } from './components.js';
+import { DraggingArea } from './components.js';
 import { DefaultSelectionManager } from './selection-manager/index.js';
 import { createDragHandle, getAllowSelectedBlocks } from './utils.js';
 
 export interface DefaultSelectionSlots {
   draggingAreaUpdated: Slot<DOMRect | null>;
   selectedRectsUpdated: Slot<DOMRect[]>;
+  /**
+   * @deprecated
+   */
   embedRectsUpdated: Slot<DOMRect[]>;
+  /**
+   * @deprecated
+   */
   embedEditingStateUpdated: Slot<EditingState | null>;
 }
 
@@ -138,12 +144,6 @@ export class DefaultPageBlockComponent
 
   @state()
   private _selectedRects: DOMRect[] = [];
-
-  @state()
-  private _selectedEmbedRects: DOMRect[] = [];
-
-  @state()
-  private _embedEditingState!: EditingState | null;
 
   @state()
   private _isComposing = false;
@@ -337,10 +337,10 @@ export class DefaultPageBlockComponent
       return;
     }
 
-    if (type === 'embed') {
-      selection.refreshEmbedRects(this._embedEditingState);
-      return;
-    }
+    // if (type === 'embed') {
+    //   selection.refreshEmbedRects(this._embedEditingState);
+    //   return;
+    // }
 
     let point;
 
@@ -430,16 +430,6 @@ export class DefaultPageBlockComponent
     slots.selectedRectsUpdated.on(rects => {
       this._selectedRects = rects;
     });
-    slots.embedRectsUpdated.on(rects => {
-      this._selectedEmbedRects = rects;
-      if (rects.length === 0) {
-        this._embedEditingState = null;
-      }
-    });
-    slots.embedEditingStateUpdated.on(embedEditingState => {
-      this._embedEditingState = embedEditingState;
-    });
-
     this.model.childrenUpdated.on(() => this.requestUpdate());
   }
 
@@ -538,10 +528,6 @@ export class DefaultPageBlockComponent
     const { viewportOffset } = selection.state;
 
     const draggingArea = DraggingArea(this._draggingArea);
-    const selectedEmbedContainer = EmbedSelectedRectsContainer(
-      this._selectedEmbedRects,
-      viewportOffset
-    );
     const isEmpty =
       (!this.model.title || !this.model.title.length) && !this._isComposing;
 
@@ -578,7 +564,7 @@ export class DefaultPageBlockComponent
           }}
           .offset=${viewportOffset}
         ></affine-selected-blocks>
-        ${this.widgets} ${draggingArea} ${selectedEmbedContainer}
+        ${this.widgets} ${draggingArea}
       </div>
     `;
   }

--- a/packages/blocks/src/page-block/default/default-page-block.ts
+++ b/packages/blocks/src/page-block/default/default-page-block.ts
@@ -337,11 +337,6 @@ export class DefaultPageBlockComponent
       return;
     }
 
-    // if (type === 'embed') {
-    //   selection.refreshEmbedRects(this._embedEditingState);
-    //   return;
-    // }
-
     let point;
 
     if (type === 'native') {

--- a/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/embed-resize-manager.ts
@@ -12,10 +12,9 @@ export class EmbedResizeManager {
   readonly slots: DefaultSelectionSlots;
   private _originPosition: IPoint = { x: 0, y: 0 };
   private _dropContainer: HTMLElement | null = null;
-  private _dropContainerSize: { w: number; h: number; left: number } = {
+  private _dropContainerSize = {
     w: 0,
     h: 0,
-    left: 0,
   };
   private _dragMoveTarget = 'right';
 
@@ -33,7 +32,6 @@ export class EmbedResizeManager {
     const rect = this._dropContainer?.getBoundingClientRect() as DOMRect;
     this._dropContainerSize.w = rect.width;
     this._dropContainerSize.h = rect.height;
-    this._dropContainerSize.left = rect.left;
     if ((e.raw.target as HTMLElement).className.includes('right')) {
       this._dragMoveTarget = 'right';
     } else {
@@ -53,10 +51,10 @@ export class EmbedResizeManager {
     let width = 0;
     if (this._dragMoveTarget === 'right') {
       width =
-        this._dropContainerSize.w + (e.raw.pageX - this._originPosition.x);
+        this._dropContainerSize.w + (e.raw.pageX - this._originPosition.x) * 2;
     } else {
       width =
-        this._dropContainerSize.w - (e.raw.pageX - this._originPosition.x);
+        this._dropContainerSize.w - (e.raw.pageX - this._originPosition.x) * 2;
     }
 
     const MIN_WIDTH = 50;

--- a/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
@@ -101,7 +101,7 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
 
     this.slots = slots;
 
-    this._embedResizeManager = new EmbedResizeManager(this.state, slots);
+    this._embedResizeManager = new EmbedResizeManager(this.state);
 
     let isDragging = false;
     this._add('dragStart', ctx => {

--- a/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
@@ -8,13 +8,13 @@ import type {
 } from '@blocksuite/block-std';
 import { PAGE_BLOCK_CHILD_PADDING } from '@blocksuite/global/config';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
+import type { FocusContext } from '@blocksuite/lit';
 import { type BaseBlockModel, type Page } from '@blocksuite/store';
 
 import {
   AbstractSelectionManager,
   type BlockComponentElement,
   debounce,
-  type EditingState,
   type EmbedBlockDoubleClickData,
   getBlockElementByModel,
   getBlockElementsByElement,
@@ -34,7 +34,6 @@ import {
   isDragHandle,
   isElement,
   isEmbed,
-  isImage,
   isInsidePageTitle,
   isSelectedBlocks,
   Point,
@@ -425,9 +424,11 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
       state.activeComponent = clickBlockInfo.element;
 
       assertExists(this.state.activeComponent);
-      if (clickBlockInfo.model.flavour === 'affine:image') {
+      const clickModel = clickBlockInfo.model;
+      const clickEle = clickBlockInfo.element;
+      if (matchFlavours(clickModel, ['affine:image'])) {
         state.type = 'embed';
-        this.slots.embedRectsUpdated.emit([clickBlockInfo.rect]);
+        this.setFocusedBlock(clickEle, { type: 'pointer', event: e.raw });
       } else {
         state.type = 'block';
         state.selectedBlocks.push(state.activeComponent);
@@ -664,8 +665,6 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
     const { type } = this.state;
     if (type === 'block') {
       this.refreshSelectedBlocksRects();
-    } else if (type === 'embed') {
-      this.refreshEmbedRects();
     }
   }
 
@@ -708,28 +707,6 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
       .map(getBlockElementByModel)
       .filter((block): block is BlockComponentElement => block !== null);
     this.refreshSelectedBlocksRects();
-  }
-
-  refreshEmbedRects(hoverEditingState: EditingState | null = null) {
-    const { activeComponent, viewport } = this.state;
-    if (activeComponent) {
-      const rect = getSelectedStateRectByBlockElement(activeComponent);
-      const embedRects = [
-        new DOMRect(rect.left, rect.top, rect.width, rect.height),
-      ];
-
-      // updates editing
-      if (hoverEditingState && isImage(activeComponent)) {
-        const isOutside =
-          rect.right + 60 < viewport.left + viewport.clientWidth;
-
-        // when image size is too large, the option popup should show inside
-        rect.x = rect.right + (isOutside ? 10 : -50);
-        hoverEditingState.rect = rect;
-      }
-
-      this.slots.embedRectsUpdated.emit(embedRects);
-    }
   }
 
   refreshRemoteSelection() {
@@ -915,8 +892,29 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
     setSelectedBlocks(this.state, this.slots, selectedBlocks, rects);
   }
 
-  setFocusedBlock(blockElement: Element) {
-    this.state.focusedBlock = blockElement as BlockComponentElement;
+  blurFocusedBlock(ctx: FocusContext, blockElement = this.state.focusedBlock) {
+    if (!blockElement) return;
+    const blurState = blockElement.blurBlock(ctx);
+    if (blurState === false) return;
+    this.state.activeComponent = null;
+    this.state.focusedBlock = null;
+  }
+
+  setFocusedBlock(
+    blockElement: BlockComponentElement,
+    ctx: FocusContext,
+    blurPrev = true
+  ) {
+    const focusedBlock = this.state.focusedBlock;
+    if (blurPrev && focusedBlock && blockElement !== focusedBlock) {
+      this.blurFocusedBlock(ctx, focusedBlock);
+    }
+
+    const focusState = blockElement.focusBlock(ctx);
+    if (focusState === false) return;
+
+    this.state.activeComponent = blockElement;
+    this.state.focusedBlock = blockElement;
   }
 
   // clear selection: `block`, `block:drag`, `embed`, `native`
@@ -940,9 +938,7 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
       // clear `format quick bar`
       this.container.querySelector('format-quick-bar')?.remove();
     } else if (type === 'embed') {
-      state.clearEmbedSelection();
-      slots.embedRectsUpdated.emit([]);
-      slots.embedEditingStateUpdated.emit(null);
+      this.blurFocusedBlock({ type: 'UNKNOWN' });
     } else if (type === 'native') {
       state.clearNativeSelection();
     }

--- a/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/selection-manager.ts
@@ -117,6 +117,7 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
       this._onContainerDragStart(ctx);
     });
     this._add('dragMove', ctx => {
+      if (!isDragging) return;
       const event = ctx.get('pointerState');
       if (shouldFilterMouseEvent(event.raw)) return;
       if (
@@ -128,6 +129,7 @@ export class DefaultSelectionManager extends AbstractSelectionManager<DefaultPag
       this._onContainerDragMove(ctx);
     });
     this._dispatcher.add('dragEnd', ctx => {
+      if (!isDragging) return;
       const event = ctx.get('pointerState');
       if (
         !isInsidePageTitle(event.raw.target) &&

--- a/packages/blocks/src/page-block/default/selection-manager/utils.ts
+++ b/packages/blocks/src/page-block/default/selection-manager/utils.ts
@@ -150,6 +150,9 @@ export function setSelectedBlocks(
 }
 
 export interface AutoScrollHooks {
+  /**
+   * @deprecated This hook is meaningless.
+   */
   init(): void;
   onMove(): void;
   onScroll(val: number): void;

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -7,6 +7,41 @@ import { WithDisposable } from '../width-disposable.js';
 import type { BlockSuiteRoot } from './lit-root.js';
 import { ShadowlessElement } from './shadowless-element.js';
 
+export type FocusContext = (
+  | {
+      multi?: false;
+    }
+  | {
+      /**
+       * Please note that this parameter only suggests that the operation is a multi-select operation,
+       * and does not mean that multiple blocks will be selected every time.
+       *
+       * For example, select all blocks by pressing `Ctrl+A` or clicking the drag handler.
+       */
+      multi: true;
+      /**
+       * Please check the length of the array before using it.
+       */
+      blocks: BlockElement<BaseBlockModel>;
+    }
+) &
+  (
+    | {
+        type: 'pointer';
+        event: PointerEvent;
+      }
+    | {
+        type: 'keyboard';
+        event: KeyboardEvent;
+      }
+    | {
+        // Please update the type name
+        // for example, 'api' or 'others'
+        type: 'UNKNOWN';
+        // TODO: add more information
+      }
+  );
+
 export class BlockElement<Model extends BaseBlockModel> extends WithDisposable(
   ShadowlessElement
 ) {
@@ -24,4 +59,25 @@ export class BlockElement<Model extends BaseBlockModel> extends WithDisposable(
 
   @property({ attribute: false })
   page!: Page;
+
+  /**
+   * This is different from `element.focus()`
+   */
+  @property({ attribute: false })
+  focused = false;
+
+  focusBlock(focusContext: FocusContext): void | boolean {
+    this.focused = true;
+    // Return false to prevent default focus behavior
+  }
+
+  blurBlock(focusContext: FocusContext): boolean {
+    this.focused = false;
+    // Return false to prevent default focus behavior
+    return true;
+  }
+
+  override render(): unknown {
+    return null;
+  }
 }

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -46,7 +46,7 @@ test('can drag resize image by left menu', async ({ page }) => {
 
   await dragEmbedResizeByTopLeft(page);
   await waitNextFrame(page);
-  await assertImageSize(page, { width: 536, height: 402 });
+  await assertImageSize(page, { width: 340, height: 255 });
 
   await undoByKeyboard(page);
   await waitNextFrame(page);
@@ -54,7 +54,7 @@ test('can drag resize image by left menu', async ({ page }) => {
 
   await redoByKeyboard(page);
   await waitNextFrame(page);
-  await assertImageSize(page, { width: 536, height: 402 });
+  await assertImageSize(page, { width: 340, height: 255 });
 });
 
 test('can drag resize image by right menu', async ({ page }) => {
@@ -67,13 +67,13 @@ test('can drag resize image by right menu', async ({ page }) => {
   await assertImageSize(page, { width: 736, height: 552 });
 
   await dragEmbedResizeByTopRight(page);
-  await assertImageSize(page, { width: 536, height: 402 });
+  await assertImageSize(page, { width: 320, height: 240 });
 
   await undoByKeyboard(page);
   await assertImageSize(page, { width: 736, height: 552 });
 
   await redoByKeyboard(page);
-  await assertImageSize(page, { width: 536, height: 402 });
+  await assertImageSize(page, { width: 320, height: 240 });
 });
 
 test('can click and delete image', async ({ page }) => {


### PR DESCRIPTION
- Remove `EmbedSelectedRectsContainer` from `defaultPageBlock`
- Add new API in `BlockElement`(WIP)

```ts

export type FocusContext = (
  | {
      multi?: false;
    }
  | {
      /**
       * Please note that this parameter only suggests that the operation is a multi-select operation,
       * and does not mean that multiple blocks will be selected every time.
       *
       * For example, select all blocks by pressing `Ctrl+A` or clicking the drag handler.
       */
      multi: true;
      /**
       * Please check the length of the array before using it.
       */
      blocks: BlockElement<BaseBlockModel>;
    }
) &
  (
    | {
        type: 'pointer';
        event: PointerEvent;
      }
    | {
        type: 'keyboard';
        event: KeyboardEvent;
      }
    | {
        // Please update the type name
        // for example, 'api' or 'others'
        type: 'UNKNOWN';
        // TODO: add more information
      }
  );


class BlockElement<Model extends BaseBlockModel> extends WithDisposable(
  ShadowlessElement
) {
  @property({ attribute: false })
  focused = false;

  focusBlock(focusContext: FocusContext): void | boolean {
    this.focused = true;
    // Return false to prevent default focus behavior
  }

  blurBlock(focusContext: FocusContext): boolean {
    this.focused = false;
    // Return false to prevent default focus behavior
    return true;
  }
}
```