### PR TITLE
fix(store): broadcast channel

### DIFF
--- a/packages/store/src/providers/broadcast-channel.ts
+++ b/packages/store/src/providers/broadcast-channel.ts
@@ -1,18 +1,28 @@
+import type { EventBasedChannel } from 'async-call-rpc';
+
 import { createAsyncCallRPCProviderCreator } from './async-call-rpc.js';
 import type { DocProviderCreator } from './type.js';
 
+class BroadcastMessageChannel
+  extends BroadcastChannel
+  implements EventBasedChannel
+{
+  on(eventListener: (data: unknown) => void) {
+    const f = (e: MessageEvent): void => eventListener(e.data);
+    this.addEventListener('message', f);
+    return () => this.removeEventListener('message', f);
+  }
+  send(data: unknown) {
+    super.postMessage(data);
+  }
+}
+
 export const createBroadcastChannelProvider: DocProviderCreator = (...args) => {
   const id: string = args[0];
-  const channelPromise = import(
-    'async-call-rpc/utils/web/broadcast.channel.js'
-  ).then(({ BroadcastMessageChannel }) => new BroadcastMessageChannel(id));
-  return createAsyncCallRPCProviderCreator(
-    'broadcast-channel',
-    channelPromise,
-    {
-      cleanup: () => {
-        channelPromise.then(channel => channel.close());
-      },
-    }
-  )(...args);
+  const channel = new BroadcastMessageChannel(id);
+  return createAsyncCallRPCProviderCreator('broadcast-channel', channel, {
+    cleanup: () => {
+      channel.close();
+    },
+  })(...args);
 };


### PR DESCRIPTION
```
(node:24310) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/himself65/Code/AFFiNE/node_modules/async-call-rpc/utils/web/broadcast.channel.js:6
export class BroadcastMessageChannel extends BroadcastChannel {
^^^^^^
SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
    at Module._compile (node:internal/modules/cjs/loader:1218:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
/Users/himself65/Code/AFFiNE/node_modules/async-call-rpc/utils/web/broadcast.channel.js:6
export class BroadcastMessageChannel extends BroadcastChannel {
^^^^^^
SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
    at Module._compile (node:internal/modules/cjs/loader:1218:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)

```