### PR TITLE
fix(phasor): curveFitting should be enabled on ellipse

### DIFF
--- a/packages/phasor/src/elements/shape/shapes/ellipse.ts
+++ b/packages/phasor/src/elements/shape/shapes/ellipse.ts
@@ -43,6 +43,7 @@ export const EllipseMethods: ShapeMethods = {
       stroke: realStrokeColor,
       strokeWidth,
       fill: filled ? realFillColor : undefined,
+      curveFitting: 1,
     });
   },
 


### PR DESCRIPTION
## before
<img width="873" alt="Screenshot 2023-06-27 at 5 13 00 PM" src="https://github.com/toeverything/blocksuite/assets/27926/c2cd2c34-2314-4f25-af73-9d9e94483c05">

## after
<img width="885" alt="Screenshot 2023-06-27 at 5 13 22 PM" src="https://github.com/toeverything/blocksuite/assets/27926/c35da63b-f1a1-4bd0-b7fd-46f5ead487ca">
