### PR TITLE
feat: rename bookmark property title to bookmarkTitle

### DIFF
--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -240,7 +240,7 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
     };
 
   override render() {
-    const { url, title, description, icon, image } = this.model;
+    const { url, bookmarkTitle, description, icon, image } = this.model;
     const mode = queryCurrentMode();
 
     const createModal = this._showCreateModal
@@ -301,7 +301,7 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
             ${icon ? html`<img src="${icon}" alt="icon" />` : DefaultIcon}
           </div>
           <div class="affine-bookmark-title-content">
-            ${title || 'Bookmark'}
+            ${bookmarkTitle || 'Bookmark'}
           </div>
         </div>
 

--- a/packages/blocks/src/bookmark-block/bookmark-model.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-model.ts
@@ -2,15 +2,10 @@ import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 
 // This type is declared in Affine, this block will move to Affine
 type MetaData = {
-  title?: string;
+  bookmarkTitle?: string;
   description?: string;
   icon?: string;
   image?: string;
-  // keywords?: string[];
-  // language?: string;
-  // type?: string;
-  // url?: string;
-  // provider?: string;
   [x: string]: string | string[] | undefined | boolean;
 };
 export type BookmarkProps = {
@@ -21,7 +16,7 @@ export type BookmarkProps = {
 
 export const defaultBookmarkProps: BookmarkProps = {
   url: '',
-  title: '',
+  bookmarkTitle: '',
   description: '',
   icon: '',
   image: '',

--- a/packages/blocks/src/bookmark-block/bookmark-service.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-service.ts
@@ -12,7 +12,7 @@ export class BookmarkBlockService extends BaseService<BookmarkBlockModel> {
     { childText = '', begin, end }: BlockTransformContext = {}
   ) {
     return `<p><a href="${block.url}">${
-      block.title ? block.title : 'Bookmark'
+      block.bookmarkTitle ? block.bookmarkTitle : 'Bookmark'
     }</a></p>`;
   }
   override block2Text(

--- a/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
@@ -152,7 +152,7 @@ export class BookmarkEditModal extends WithDisposable(LitElement) {
     ) as HTMLInputElement;
 
     this.model.page.updateBlock(this.model, {
-      title: titleInput.value,
+      bookmarkTitle: titleInput.value,
       description: descInput.value,
     });
     this.onConfirm?.();
@@ -183,7 +183,7 @@ export class BookmarkEditModal extends WithDisposable(LitElement) {
             type="text"
             class="bookmark-input title"
             placeholder="Title"
-            value=${this.model.title || 'Bookmark'}
+            value=${this.model.bookmarkTitle || 'Bookmark'}
             tabindex="1"
           />
           <input

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -41,7 +41,7 @@ const config: ConfigItem[] = [
       const index = parent?.children.indexOf(model);
 
       const yText = new Y.Text();
-      const insert = model.title || model.caption || model.url;
+      const insert = model.bookmarkTitle || model.caption || model.url;
       yText.insert(0, insert);
       yText.format(0, insert.length, { link: model.url });
       const text = new page.Text(yText);

--- a/packages/blocks/src/bookmark-block/utils.ts
+++ b/packages/blocks/src/bookmark-block/utils.ts
@@ -30,9 +30,14 @@ export async function reloadBookmarkBlock(
       return;
     }
 
+    const { title, description, icon, image } = metaData;
+
     model.page.withoutTransact(() => {
       model.page.updateBlock(model, {
-        ...metaData,
+        bookmarkTitle: title,
+        description,
+        icon,
+        image,
         url: model.url,
         crawled: true,
       });

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -44,12 +44,12 @@ test(scoped`create bookmark by slash menu`, async ({ page }) => {
       prop:type="text"
     />
     <affine:bookmark
+      prop:bookmarkTitle=""
       prop:caption=""
       prop:crawled={false}
       prop:description=""
       prop:icon=""
       prop:image=""
-      prop:bookmarkTitle=""
       prop:url="https://google.com"
     />
   </affine:note>
@@ -87,12 +87,12 @@ test(scoped`create bookmark by blockhub`, async ({ page }) => {
       prop:type="text"
     />
     <affine:bookmark
+      prop:bookmarkTitle=""
       prop:caption=""
       prop:crawled={false}
       prop:description=""
       prop:icon=""
       prop:image=""
-      prop:bookmarkTitle=""
       prop:url="https://google.com"
     />
   </affine:note>

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -49,7 +49,7 @@ test(scoped`create bookmark by slash menu`, async ({ page }) => {
       prop:description=""
       prop:icon=""
       prop:image=""
-      prop:title=""
+      prop:bookmarkTitle=""
       prop:url="https://google.com"
     />
   </affine:note>
@@ -92,7 +92,7 @@ test(scoped`create bookmark by blockhub`, async ({ page }) => {
       prop:description=""
       prop:icon=""
       prop:image=""
-      prop:title=""
+      prop:bookmarkTitle=""
       prop:url="https://google.com"
     />
   </affine:note>


### PR DESCRIPTION
In `importPageSnapshot` function, when importing external json data, property "props:title" is the key world that will convert to the `yText` data. but in bookmark, title is string type, so change "title" to "bookmarkTitle" to avoid to convert automatically