### PR TITLE
feat(edgeless): toast message after copying to clipboard

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -56,6 +56,7 @@ import {
   getThemePropertyValue,
   listenToThemeChange,
 } from '../../__internal__/theme/utils.js';
+import { toast } from '../../components/toast.js';
 import type {
   BlockHost,
   DragHandle,
@@ -600,9 +601,10 @@ export class EdgelessPageBlockComponent
       slots.copyAsPng.on(({ notes, shapes }) => {
         if (!canCopyAsPng) return;
         canCopyAsPng = false;
-        this.clipboard
-          .copyAsPng(notes, shapes)
-          .finally(() => (canCopyAsPng = true));
+        this.clipboard.copyAsPng(notes, shapes).finally(() => {
+          canCopyAsPng = true;
+          toast('Copied to clipboard');
+        });
       })
     );
   }


### PR DESCRIPTION
closes: #3329

When running `toast` multiple times, an exception will be reported

```
toast.ts:80 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'animate')
    at toast (toast.ts:80:11)
toast @ toast.ts:80
await in toast (async)
(anonymous) @ edgeless-page-block.ts:606
Promise.finally (async)
(anonymous) @ edgeless-page-block.ts:604
(anonymous) @ slot.ts:106
emit @ slot.ts:104
EdgelessMoreButton._runAction @ more-button.ts:170
(anonymous) @ more-button.ts:46
handleEvent @ lit-html.ts:2010
Show 1 more frame
toast.ts:80 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'animate')
    at toast (toast.ts:80:11)
```
