### PR TITLE
fix(database): hotkeys do not work

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text.ts
@@ -165,7 +165,7 @@ export class RichText extends ShadowlessElement {
     this._vEditor = new VEditor(this.model.text.yText, {
       active: () => activeEditorManager.isActive(this),
     });
-    setupVirgoScroll(this.model.page, this._vEditor);
+    setupVirgoScroll(this, this._vEditor);
     const textSchema = this.textSchema;
     assertExists(
       textSchema,

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -1,9 +1,9 @@
 import type { KeyHandler } from 'hotkeys-js';
 import hotkeys from 'hotkeys-js';
 
-import { DatabaseCellContainer } from '../../database-block/table/components/cell-container.js';
 import {
   isCaptionElement,
+  isDatabaseCell,
   isDatabaseInput,
   isInsideDatabaseTitle,
   isInsideEdgelessTextEditor,
@@ -52,17 +52,15 @@ function shouldFilterHotkey(event: KeyboardEvent) {
     }
     // undo/redo should work in database title or cell container
     if (
-      (isInsideDatabaseTitle(event.target) || isDatabaseInput(event.target)) &&
+      (isInsideDatabaseTitle(event.target) ||
+        isDatabaseInput(event.target) ||
+        isDatabaseCell(event.target)) &&
       isUndoRedo(event)
     ) {
       return false;
     }
     // undo/redo should work in edgeless text editor
     if (isInsideEdgelessTextEditor(event.target) && isUndoRedo(event)) {
-      return false;
-    }
-    // focus on database cell
-    if (event.target instanceof DatabaseCellContainer) {
       return false;
     }
     // Some event dispatch from body

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -50,11 +50,12 @@ function shouldFilterHotkey(event: KeyboardEvent) {
     if (isInsidePageTitle(event.target) && isUndoRedo(event)) {
       return false;
     }
+    if (isDatabaseCell(event.target)) {
+      return false;
+    }
     // undo/redo should work in database title or cell container
     if (
-      (isInsideDatabaseTitle(event.target) ||
-        isDatabaseInput(event.target) ||
-        isDatabaseCell(event.target)) &&
+      (isInsideDatabaseTitle(event.target) || isDatabaseInput(event.target)) &&
       isUndoRedo(event)
     ) {
       return false;

--- a/packages/blocks/src/__internal__/utils/hotkey.ts
+++ b/packages/blocks/src/__internal__/utils/hotkey.ts
@@ -1,6 +1,7 @@
 import type { KeyHandler } from 'hotkeys-js';
 import hotkeys from 'hotkeys-js';
 
+import { DatabaseCellContainer } from '../../database-block/table/components/cell-container.js';
 import {
   isCaptionElement,
   isDatabaseInput,
@@ -58,6 +59,10 @@ function shouldFilterHotkey(event: KeyboardEvent) {
     }
     // undo/redo should work in edgeless text editor
     if (isInsideEdgelessTextEditor(event.target) && isUndoRedo(event)) {
+      return false;
+    }
+    // focus on database cell
+    if (event.target instanceof DatabaseCellContainer) {
       return false;
     }
     // Some event dispatch from body

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -31,7 +31,9 @@ export type BlockComponentElement = BlockElement<any>;
 
 export type BlockCustomElement =
   HTMLElementTagNameMap[keyof HTMLElementTagNameMap] extends infer U
-    ? U extends { model: infer M }
+    ? U extends {
+        model: infer M;
+      }
       ? M extends BaseBlockModel
         ? U
         : never
@@ -219,6 +221,14 @@ export function getEditorContainerByElement(ele: Element) {
 export function isPageMode(page: Page) {
   const editor = getEditorContainer(page);
   if (!('mode' in editor)) {
+    throw new Error('Failed to check page mode! Editor mode is not exists!');
+  }
+  return editor.mode === 'page';
+}
+
+export function checkIsPageModeByDom(ele: Element) {
+  const editor = ele?.closest('editor-container');
+  if (!editor || !('mode' in editor)) {
     throw new Error('Failed to check page mode! Editor mode is not exists!');
   }
   return editor.mode === 'page';
@@ -686,7 +696,10 @@ export function getClosestBlockElementByPoint(
   state: {
     rect?: Rect;
     container?: Element;
-    snapToEdge?: { x: boolean; y: boolean };
+    snapToEdge?: {
+      x: boolean;
+      y: boolean;
+    };
   } | null = null,
   scale = 1
 ): Element | null {

--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -541,6 +541,13 @@ export function isDatabaseInput(element: unknown): boolean {
   );
 }
 
+export function isDatabaseCell(element: unknown): boolean {
+  return (
+    element instanceof HTMLElement &&
+    element.tagName === 'affine-database-cell-container'.toUpperCase()
+  );
+}
+
 export function isRawInput(element: unknown): boolean {
   return (
     element instanceof HTMLInputElement && !!element.closest('affine-database')

--- a/packages/blocks/src/__internal__/utils/virgo.ts
+++ b/packages/blocks/src/__internal__/utils/virgo.ts
@@ -1,7 +1,6 @@
-import type { Page } from '@blocksuite/store';
 import type { VEditor } from '@blocksuite/virgo';
 
-import { isPageMode } from './query.js';
+import { checkIsPageModeByDom } from './query.js';
 
 // When the user selects a range, check if it matches the previous selection.
 // If it does, apply the marks from the previous selection.
@@ -23,6 +22,6 @@ export function clearMarksOnDiscontinuousInput(vEditor: VEditor): void {
   });
 }
 
-export function setupVirgoScroll(page: Page, vEditor: VEditor): void {
-  vEditor.shouldLineScrollIntoView = isPageMode(page);
+export function setupVirgoScroll(ele: Element, vEditor: VEditor): void {
+  vEditor.shouldLineScrollIntoView = checkIsPageModeByDom(ele);
 }

--- a/packages/blocks/src/database-block/database-service.ts
+++ b/packages/blocks/src/database-block/database-service.ts
@@ -22,16 +22,11 @@ export class DatabaseBlockService extends BaseService<DatabaseBlockModel> {
   private _databaseSelection?: DatabaseSelection;
 
   slots = {
-    databaseSelectionUpdated: new Slot<DatabaseSelectionState>(),
+    databaseSelectionUpdated: new Slot<{
+      selection: DatabaseSelectionState;
+      old: DatabaseSelectionState;
+    }>(),
   };
-
-  constructor() {
-    super();
-
-    this.slots.databaseSelectionUpdated.on(selection => {
-      this._databaseSelection = selection;
-    });
-  }
 
   initDatabaseBlock(
     page: Page,
@@ -131,8 +126,12 @@ export class DatabaseBlockService extends BaseService<DatabaseBlockModel> {
   }
 
   select(state: DatabaseSelectionState) {
+    const old = this._databaseSelection;
     this._databaseSelection = state;
-    this.slots.databaseSelectionUpdated.emit(state);
+    this.slots.databaseSelectionUpdated.emit({
+      selection: state,
+      old,
+    });
   }
 
   getSelection() {

--- a/packages/blocks/src/database-block/database-service.ts
+++ b/packages/blocks/src/database-block/database-service.ts
@@ -125,8 +125,32 @@ export class DatabaseBlockService extends BaseService<DatabaseBlockModel> {
     });
   }
 
+  selectionEqual(a: DatabaseSelectionState, b: DatabaseSelectionState) {
+    if (a === undefined || b === undefined) return a === b;
+    if (a.databaseId !== b.databaseId) return false;
+    if (
+      a.rowsSelection?.start !== b.rowsSelection?.start ||
+      a.rowsSelection?.end !== b.rowsSelection?.end
+    )
+      return false;
+    if (
+      a.columnsSelection?.start !== b.columnsSelection?.start ||
+      a.columnsSelection?.end !== b.columnsSelection?.end
+    )
+      return false;
+    if (
+      a.focus.rowIndex !== b.focus.rowIndex ||
+      a.focus.columnIndex !== b.focus.columnIndex
+    )
+      return false;
+    return a.isEditing === b.isEditing;
+  }
+
   select(state: DatabaseSelectionState) {
     const old = this._databaseSelection;
+    if (this.selectionEqual(state, old)) {
+      return;
+    }
     this._databaseSelection = state;
     this.slots.databaseSelectionUpdated.emit({
       selection: state,

--- a/packages/blocks/src/database-block/table/components/cell-container.ts
+++ b/packages/blocks/src/database-block/table/components/cell-container.ts
@@ -54,13 +54,13 @@ export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
   private _selectCurrentCell = (editing: boolean) => {
     const selection = this.closest('affine-database-table')?.selection;
     if (selection) {
-      selection.forceSelect({
+      selection.selection = {
         focus: {
           rowIndex: this.rowIndex,
           columnIndex: this.columnIndex,
         },
         isEditing: editing,
-      });
+      };
     }
   };
 
@@ -76,7 +76,7 @@ export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
 
   private _cell = createRef<DatabaseCellElement<unknown>>();
 
-  public get cell() {
+  public get cell(): DatabaseCellElement<unknown> | undefined {
     return this._cell.value;
   }
 

--- a/packages/blocks/src/database-block/table/components/cell-container.ts
+++ b/packages/blocks/src/database-block/table/components/cell-container.ts
@@ -22,7 +22,9 @@ export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
       align-items: center;
       width: 100%;
       height: 100%;
-      border-right: 1px solid var(--affine-border-color);
+      border: none;
+      outline: none;
+      border-right: 1px solid var(--affine-border-color) !important;
     }
 
     affine-database-cell-container * {
@@ -70,12 +72,12 @@ export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
     const service = getService('affine:database');
     if (isEditing) {
       this.editingDisposable = service.slots.databaseSelectionUpdated.on(
-        state => {
+        ({ selection }) => {
           if (
-            !state ||
-            !state.isEditing ||
-            state.focus.rowIndex !== this.rowIndex ||
-            state.focus.columnIndex !== this.columnIndex
+            !selection ||
+            !selection.isEditing ||
+            selection.focus.rowIndex !== this.rowIndex ||
+            selection.focus.columnIndex !== this.columnIndex
           ) {
             this.editingDisposable?.dispose();
             this.editingDisposable = undefined;

--- a/packages/blocks/src/database-block/table/components/column-type/checkbox.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/checkbox.ts
@@ -65,9 +65,9 @@ class CheckboxCell extends DatabaseCellElement<boolean> {
     }
   `;
 
-  override _setEditing() {
+  override onEnterEditMode() {
     this.onChange(!this.value);
-    this.setEditing(false);
+    return false;
   }
 
   override render() {

--- a/packages/blocks/src/database-block/table/components/column-type/checkbox.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/checkbox.ts
@@ -65,7 +65,7 @@ class CheckboxCell extends DatabaseCellElement<boolean> {
     }
   `;
 
-  override onEnterEditMode() {
+  override beforeEnterEditMode() {
     this.onChange(!this.value);
     return false;
   }

--- a/packages/blocks/src/database-block/table/components/column-type/link.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/link.ts
@@ -51,17 +51,12 @@ export class LinkCell extends DatabaseCellElement<string> {
     }
   `;
 
-  override _setEditing(_: boolean) {
-    // override
-  }
-
   private _onClick = (event: Event) => {
     event.stopPropagation();
-
     const value = this.value ?? '';
 
     if (!value || !isValidLink(value)) {
-      this.setEditing(true);
+      this.selectCurrentCell(true);
       return;
     }
 
@@ -78,7 +73,7 @@ export class LinkCell extends DatabaseCellElement<string> {
 
   private _onEdit = (e: Event) => {
     e.stopPropagation();
-    this.setEditing(true);
+    this.selectCurrentCell(true);
   };
 
   override render() {
@@ -141,9 +136,8 @@ export class LinkCellEditing extends DatabaseCellElement<string> {
     this._container.setSelectionRange(end, end);
   };
 
-  override exitEditMode() {
+  override onExitEditMode() {
     this._setValue();
-    super.exitEditMode();
   }
 
   private _setValue = (value: string = this._container.value) => {
@@ -155,7 +149,7 @@ export class LinkCellEditing extends DatabaseCellElement<string> {
     if (e.key === 'Enter') {
       this._setValue();
       setTimeout(() => {
-        this.exitEditMode();
+        this.selectCurrentCell(false);
       });
     }
   };

--- a/packages/blocks/src/database-block/table/components/column-type/multi-select.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/multi-select.ts
@@ -40,7 +40,7 @@ class MultiSelectCellEditing extends DatabaseCellElement<
   };
 
   _editComplete = () => {
-    this._setEditing(false);
+    this.selectCurrentCell(false);
   };
 
   _onOptionsChange = (options: SelectTag[]) => {

--- a/packages/blocks/src/database-block/table/components/column-type/number.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/number.ts
@@ -77,9 +77,8 @@ export class NumberCellEditing extends DatabaseCellElement<number> {
     this._inputEle.setSelectionRange(end, end);
   };
 
-  override exitEditMode() {
+  override onExitEditMode() {
     this._setValue();
-    super.exitEditMode();
   }
 
   private _setValue = (str: string = this._inputEle.value) => {
@@ -100,7 +99,7 @@ export class NumberCellEditing extends DatabaseCellElement<number> {
     if (e.key === 'Enter') {
       this._setValue();
       setTimeout(() => {
-        this.exitEditMode();
+        this.selectCurrentCell(false);
       });
     }
   };

--- a/packages/blocks/src/database-block/table/components/column-type/rich-text.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/rich-text.ts
@@ -5,6 +5,7 @@ import { VEditor } from '@blocksuite/virgo';
 import { css } from 'lit';
 import { query } from 'lit/decorators.js';
 import { html, literal } from 'lit/static-html.js';
+import { Text as YText } from 'yjs';
 
 import type {
   AffineTextAttributes,
@@ -105,7 +106,7 @@ export class RichTextCell extends DatabaseCellElement<Y.Text> {
   }
 
   private _initYText = (text?: string) => {
-    const yText = new this.column.page.YText(text);
+    const yText = new YText(text);
 
     this.onChange(yText);
     return yText;
@@ -127,7 +128,7 @@ export class RichTextCell extends DatabaseCellElement<Y.Text> {
     this.vEditor = new VEditor(value, {
       active: () => activeEditorManager.isActive(this),
     });
-    setupVirgoScroll(this.column.page, this.vEditor);
+    setupVirgoScroll(this, this.vEditor);
     this.vEditor.mount(this._container);
     this.vEditor.setReadonly(true);
   }
@@ -181,7 +182,7 @@ export class RichTextCellEditing extends DatabaseCellElement<Y.Text> {
   }
 
   private _initYText = (text?: string) => {
-    const yText = new this.page.YText(text);
+    const yText = new YText(text);
 
     this.onChange(yText);
     return yText;
@@ -203,7 +204,7 @@ export class RichTextCellEditing extends DatabaseCellElement<Y.Text> {
     this.vEditor = new VEditor(value, {
       active: () => activeEditorManager.isActive(this),
     });
-    setupVirgoScroll(this.column.page, this.vEditor);
+    setupVirgoScroll(this, this.vEditor);
     this.vEditor.mount(this._container);
     this.vEditor.bindHandlers({
       keydown: this._handleKeyDown,

--- a/packages/blocks/src/database-block/table/components/column-type/rich-text.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/rich-text.ts
@@ -232,7 +232,7 @@ export class RichTextCellEditing extends DatabaseCellElement<Y.Text> {
         this._onSoftEnter();
       } else {
         // exit editing
-        this._setEditing(false);
+        this.selectCurrentCell(false);
         this._container.blur();
       }
       event.preventDefault();

--- a/packages/blocks/src/database-block/table/components/column-type/select.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/select.ts
@@ -42,7 +42,7 @@ export class SelectCellEditing extends DatabaseCellElement<
   };
 
   _editComplete = () => {
-    this._setEditing(false);
+    this.selectCurrentCell(false);
   };
   _onOptionsChange = (options: SelectTag[]) => {
     this.column.updateData(data => {

--- a/packages/blocks/src/database-block/table/components/column-type/title.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/title.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
 import { css } from 'lit';
 import { html, literal } from 'lit/static-html.js';
 
@@ -37,8 +37,32 @@ export class TitleCell extends DatabaseCellElement<TemplateResult> {
     }
   `;
 
+  protected override firstUpdated(_changedProperties: PropertyValues) {
+    this._disposables.addFromEvent(
+      this,
+      'keydown',
+      e => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          this.selectCurrentCell(false);
+        }
+      },
+      true
+    );
+    setTimeout(() => {
+      this.querySelector('rich-text')?.vEditor?.slots.vRangeUpdated.on(
+        range => {
+          this.selectCurrentCell(true);
+        }
+      );
+    });
+  }
+
   override focusCell() {
     this.querySelector('rich-text')?.vEditor?.focusEnd();
+  }
+  override blurCell() {
+    this.querySelector<HTMLDivElement>('.virgo-editor')?.blur();
   }
 
   override render() {

--- a/packages/blocks/src/database-block/table/components/column-type/title.ts
+++ b/packages/blocks/src/database-block/table/components/column-type/title.ts
@@ -11,6 +11,7 @@ export class TitleCell extends DatabaseCellElement<TemplateResult> {
     affine-database-title-cell {
       background-color: var(--affine-hover-color);
     }
+
     .affine-database-block-row-cell-content {
       display: flex;
       align-items: center;
@@ -35,6 +36,10 @@ export class TitleCell extends DatabaseCellElement<TemplateResult> {
       margin-top: unset;
     }
   `;
+
+  override focusCell() {
+    this.querySelector('rich-text')?.vEditor?.focusEnd();
+  }
 
   override render() {
     return html`

--- a/packages/blocks/src/database-block/table/components/database-title.ts
+++ b/packages/blocks/src/database-block/table/components/database-title.ts
@@ -88,7 +88,7 @@ export class DatabaseTitle extends WithDisposable(ShadowlessElement) {
       rootElement: this._titleContainer,
       maxLength: DATABASE_TITLE_LENGTH,
     });
-    setupVirgoScroll(this.targetModel.page, this._titleVInput.vEditor);
+    setupVirgoScroll(this, this._titleVInput.vEditor);
     this._titleVInput.vEditor.setReadonly(this.targetModel.page.readonly);
     this._titleContainer.addEventListener('keydown', this._handleKeyDown);
 

--- a/packages/blocks/src/database-block/table/components/row-container.ts
+++ b/packages/blocks/src/database-block/table/components/row-container.ts
@@ -77,6 +77,7 @@ export function DataBaseRowContainer(view: TableViewManager) {
                         data-column-id=${column.id}
                         .columnIndex="${i}"
                         data-column-index=${i}
+                        tabindex="0"
                       >
                       </affine-database-cell-container>
                     </div>

--- a/packages/blocks/src/database-block/table/components/selection/selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection/selection.ts
@@ -117,7 +117,6 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
           if (selection.isEditing) {
             container.isEditing = true;
             cell?.focusCell();
-            cell?.onEnterEditMode();
           } else {
             container.focus();
           }

--- a/packages/blocks/src/database-block/table/components/selection/selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection/selection.ts
@@ -6,6 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 
 import { getService } from '../../../../__internal__/service.js';
+import { activeEditorManager } from '../../../../__internal__/utils/active-editor-manager.js';
 import type {
   CellFocus,
   DatabaseSelection,
@@ -85,6 +86,9 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
   override firstUpdated() {
     this._disposables.add(
       this.service.slots.databaseSelectionUpdated.on(({ selection, old }) => {
+        if (!activeEditorManager.isActive(this)) {
+          return;
+        }
         if (selection?.databaseId !== this.databaseId) {
           selection = undefined;
         }
@@ -414,7 +418,10 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
         columnIndex,
       },
     };
-    this.focusRef.value?.scrollIntoView();
+    this.focusRef.value?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+    });
   }
 
   selectRange(

--- a/packages/blocks/src/database-block/table/components/selection/selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection/selection.ts
@@ -115,6 +115,7 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
           );
           const cell = container?.cell;
           if (selection.isEditing) {
+            cell?.onEnterEditMode();
             container.isEditing = true;
             cell?.focusCell();
           } else {
@@ -190,7 +191,7 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
         focus.columnIndex
       );
       const cell = container?.cell;
-      const isEditing = cell ? cell.onEnterEditMode() : true;
+      const isEditing = cell ? cell.beforeEnterEditMode() : true;
       this.service.select({
         ...selection,
         isEditing,
@@ -198,23 +199,6 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
       return;
     }
     this.service.select(selection);
-  }
-
-  forceSelect(data: Omit<DatabaseSelection, 'databaseId'> | undefined) {
-    const selection = data
-      ? { ...data, databaseId: this.databaseId }
-      : undefined;
-    this.service.select(selection);
-  }
-
-  setEditing(focus: CellFocus, editing: boolean) {
-    const cell = this.getCellContainer(focus.rowIndex, focus.columnIndex)?.cell;
-    if (cell && (editing ? cell.onEnterEditMode() : cell.onExitEditMode())) {
-      this.selection = {
-        focus,
-        isEditing: editing,
-      };
-    }
   }
 
   cellPosition(left: number, top: number) {
@@ -366,6 +350,8 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
     if (evt.key === hotkeys.Enter) {
       this.selection = {
         ...selection,
+        rowsSelection: undefined,
+        columnsSelection: undefined,
         isEditing: true,
       };
       return true;

--- a/packages/blocks/src/database-block/table/register.ts
+++ b/packages/blocks/src/database-block/table/register.ts
@@ -17,7 +17,7 @@ export abstract class DatabaseCellElement<
   @property({ attribute: false })
   isEditing!: boolean;
   @property({ attribute: false })
-  protected setEditing!: (editing: boolean) => void;
+  public selectCurrentCell!: (editing: boolean) => void;
 
   get readonly(): boolean {
     return this.column.readonly;
@@ -31,25 +31,24 @@ export abstract class DatabaseCellElement<
     this.column.setValue(this.rowId, value, ops);
   }
 
-  protected _setEditing(editing: boolean) {
-    this.setEditing(editing);
+  public onEnterEditMode(): boolean {
+    return true;
   }
 
-  public enterEditMode() {
-    this._setEditing(true);
-  }
-
-  public exitEditMode() {
-    this._setEditing(false);
+  public onExitEditMode() {
+    // do nothing
   }
 
   override connectedCallback() {
     super.connectedCallback();
     this.style.width = '100%';
     this.style.height = '100%';
+    this._disposables.addFromEvent(this, 'click', e => {
+      this.selectCurrentCell(true);
+    });
   }
+
   public focusCell() {
-    console.log('focus');
     this.parentElement?.focus();
   }
 

--- a/packages/blocks/src/database-block/table/register.ts
+++ b/packages/blocks/src/database-block/table/register.ts
@@ -31,8 +31,12 @@ export abstract class DatabaseCellElement<
     this.column.setValue(this.rowId, value, ops);
   }
 
-  public onEnterEditMode(): boolean {
+  public beforeEnterEditMode(): boolean {
     return true;
+  }
+
+  public onEnterEditMode(): void {
+    // do nothing
   }
 
   public onExitEditMode() {

--- a/packages/blocks/src/database-block/table/register.ts
+++ b/packages/blocks/src/database-block/table/register.ts
@@ -19,10 +19,6 @@ export abstract class DatabaseCellElement<
   @property({ attribute: false })
   protected setEditing!: (editing: boolean) => void;
 
-  get page() {
-    return this.column.page;
-  }
-
   get readonly(): boolean {
     return this.column.readonly;
   }
@@ -51,6 +47,14 @@ export abstract class DatabaseCellElement<
     super.connectedCallback();
     this.style.width = '100%';
     this.style.height = '100%';
+  }
+  public focusCell() {
+    console.log('focus');
+    this.parentElement?.focus();
+  }
+
+  public blurCell() {
+    this.parentElement?.blur();
   }
 }
 

--- a/packages/blocks/src/database-block/table/table-view-manager.ts
+++ b/packages/blocks/src/database-block/table/table-view-manager.ts
@@ -100,11 +100,6 @@ export interface ColumnManager<
    * @deprecated
    */
   captureSync(): void;
-
-  /**
-   * @deprecated
-   */
-  get page(): Page;
 }
 
 export class DatabaseTableViewManager implements TableViewManager {
@@ -364,11 +359,11 @@ export class DatabaseColumnManager implements ColumnManager {
   }
 
   get readonly(): boolean {
-    return this.page.readonly;
+    return this._model.page.readonly;
   }
 
   captureSync(): void {
-    this.page.captureSync();
+    this._model.page.captureSync();
   }
 
   get page(): Page {
@@ -450,7 +445,7 @@ export class DatabaseTitleColumnManager implements ColumnManager {
   }
 
   captureSync(): void {
-    this.page.captureSync();
+    this._model.page.captureSync();
   }
 
   get hide(): boolean {
@@ -470,7 +465,7 @@ export class DatabaseTitleColumnManager implements ColumnManager {
   }
 
   get readonly(): boolean {
-    return this.page.readonly;
+    return this._model.page.readonly;
   }
 
   get renderer(): ColumnRenderer {
@@ -490,6 +485,6 @@ export class DatabaseTitleColumnManager implements ColumnManager {
   }
 
   getStringValue(rowId: string): string {
-    return this.page.getBlockById(rowId)?.text?.toString() ?? '';
+    return this._model.page.getBlockById(rowId)?.text?.toString() ?? '';
   }
 }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -56,6 +56,7 @@ import {
   getThemePropertyValue,
   listenToThemeChange,
 } from '../../__internal__/theme/utils.js';
+import { toast } from '../../components/toast.js';
 import type {
   BlockHost,
   DragHandle,
@@ -600,9 +601,10 @@ export class EdgelessPageBlockComponent
       slots.copyAsPng.on(({ notes, shapes }) => {
         if (!canCopyAsPng) return;
         canCopyAsPng = false;
-        this.clipboard
-          .copyAsPng(notes, shapes)
-          .finally(() => (canCopyAsPng = true));
+        this.clipboard.copyAsPng(notes, shapes).finally(() => {
+          canCopyAsPng = true;
+          toast('Copied to clipboard');
+        });
       })
     );
   }

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -41,6 +41,7 @@ import {
   triggerComponentToolbarAction,
   type,
   undoByClick,
+  undoByKeyboard,
   waitForVirgoStateUpdated,
   waitNextFrame,
 } from './utils/actions/index.js';
@@ -609,7 +610,7 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
 </affine:page>`
   );
 
-  await undoByClick(page);
+  await undoByKeyboard(page);
   await assertStoreMatchJSX(
     page,
     /*xml*/ `

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -563,12 +563,8 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
   await initDatabaseDynamicRowWithData(page, 'abc', true);
   await pressEscape(page);
   await selectAllByKeyboard(page);
-  await waitNextFrame(page);
-  await selectAllByKeyboard(page);
   await copyByKeyboard(page);
-  await waitNextFrame(page);
-
-  await focusRichText(page, 1);
+  await pressEnter(page);
   await pasteByKeyboard(page);
   await page.waitForTimeout(100);
 
@@ -592,6 +588,9 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
         prop:type="text"
       />
     </affine:database>
+    <affine:paragraph
+      prop:type="text"
+    />
     <affine:database
       prop:columns="Array [1]"
       prop:title="Database 1"
@@ -631,6 +630,9 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
         prop:type="text"
       />
     </affine:database>
+    <affine:paragraph
+      prop:type="text"
+    />
     <affine:paragraph
       prop:type="text"
     />

--- a/tests/database/actions.ts
+++ b/tests/database/actions.ts
@@ -15,7 +15,6 @@ import {
   getEditorLocator,
   waitNextFrame,
 } from '../utils/actions/misc.js';
-import { assertClassName } from '../utils/asserts.js';
 export async function initDatabaseColumn(page: Page, title = '') {
   await focusDatabaseHeader(page);
   const editor = getEditorLocator(page);

--- a/tests/database/database.spec.ts
+++ b/tests/database/database.spec.ts
@@ -27,11 +27,7 @@ import {
   undoByKeyboard,
   waitNextFrame,
 } from '../utils/actions/index.js';
-import {
-  assertBlockCount,
-  assertBlockProps,
-  assertLocatorVisible,
-} from '../utils/asserts.js';
+import { assertBlockCount, assertBlockProps } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 import {
   assertColumnWidth,
@@ -272,7 +268,6 @@ test('should database title and rich-text support undo/redo', async ({
   await initDatabaseColumn(page);
   await switchColumnType(page, 'Text');
   await initDatabaseDynamicRowWithData(page, '123', true);
-  await pressArrowLeft(page);
   await undoByKeyboard(page);
   await assertDatabaseCellRichTexts(page, { text: '' });
   await redoByKeyboard(page);

--- a/tests/database/selection.spec.ts
+++ b/tests/database/selection.spec.ts
@@ -16,35 +16,14 @@ import {
   switchColumnType,
 } from './actions.js';
 
-test.describe('row-level selection', () => {
-  test('should support pressing esc to trigger row selection', async ({
-    page,
-  }) => {
+test.describe('focus', () => {
+  test('should support move focus by arrow key', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyDatabaseState(page);
 
     await initDatabaseColumn(page);
     await initDatabaseDynamicRowWithData(page, '123', true);
     await pressEscape(page);
-    const titleColumn = getDatabaseBodyCell(page, {
-      rowIndex: 0,
-      columnIndex: 0,
-      cellClass: 'affine-rich-text',
-    });
-    const startBox = await getBoundingBox(titleColumn);
-    const startX = startBox.x + startBox.width / 2;
-    const startY = startBox.y + startBox.height / 2;
-
-    const selectColumn = getFirstColumnCell(page, 'select-selected');
-    const endBox = await getBoundingBox(selectColumn);
-    const endX = endBox.x + endBox.width / 2;
-    const endY = endBox.y + endBox.height / 2;
-
-    await dragBetweenCoords(
-      page,
-      { x: endX, y: endY },
-      { x: startX, y: startY }
-    );
     await waitNextFrame(page, 100);
     await pressEscape(page);
     await assertRowsSelection(page, [0, 0]);
@@ -60,15 +39,6 @@ test.describe('row-level selection', () => {
     await switchColumnType(page, 'Number');
     await initDatabaseDynamicRowWithData(page, '123', true);
 
-    const titleColumn = getDatabaseBodyCell(page, {
-      rowIndex: 0,
-      columnIndex: 0,
-      cellClass: 'affine-rich-text',
-    });
-    const startBox = await getBoundingBox(titleColumn);
-    const startX = startBox.x + startBox.width / 2;
-    const startY = startBox.y + startBox.height / 2;
-
     const selectColumn = getDatabaseBodyCell(page, {
       rowIndex: 1,
       columnIndex: 1,
@@ -81,10 +51,10 @@ test.describe('row-level selection', () => {
 
     await dragBetweenCoords(
       page,
-      { x: startX, y: startY },
-      { x: endX, y: endY }
+      { x: endX, y: endBox.y },
+      { x: endX, y: endBox.y + endBox.height }
     );
-
+    await pressEscape(page);
     await assertRowsSelection(page, [0, 1]);
   });
 
@@ -101,26 +71,71 @@ test.describe('row-level selection', () => {
     await type(page, 'defdef');
     await pressEnter(page);
     await pressEscape(page);
-    const titleColumn = getDatabaseBodyCell(page, {
-      rowIndex: 0,
-      columnIndex: 0,
-      cellClass: 'affine-rich-text',
-    });
-    const startBox = await getBoundingBox(titleColumn);
-    const startX = startBox.x + startBox.width / 2;
-    const startY = startBox.y + startBox.height / 2;
 
-    const selectColumn = getFirstColumnCell(page, 'select-selected').nth(3);
+    await pressEscape(page);
+    await assertRowsSelection(page, [0, 0]);
+  });
+});
+
+test.describe('row-level selection', () => {
+  test('should support pressing esc to trigger row selection', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyDatabaseState(page);
+
+    await initDatabaseColumn(page);
+    await initDatabaseDynamicRowWithData(page, '123', true);
+    await pressEscape(page);
+    await waitNextFrame(page, 100);
+    await pressEscape(page);
+    await assertRowsSelection(page, [0, 0]);
+  });
+
+  test('should support multi row selection', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyDatabaseState(page);
+
+    await initDatabaseColumn(page);
+    await initDatabaseDynamicRowWithData(page, '', true);
+    await pressEscape(page);
+    await switchColumnType(page, 'Number');
+    await initDatabaseDynamicRowWithData(page, '123', true);
+
+    const selectColumn = getDatabaseBodyCell(page, {
+      rowIndex: 1,
+      columnIndex: 1,
+      cellClass: 'number',
+    });
+
     const endBox = await getBoundingBox(selectColumn);
     const endX = endBox.x + endBox.width / 2;
     const endY = endBox.y + endBox.height / 2;
 
     await dragBetweenCoords(
       page,
-      { x: startX, y: startY },
-      { x: endX, y: endY }
+      { x: endX, y: endBox.y },
+      { x: endX, y: endBox.y + endBox.height }
     );
+    await pressEscape(page);
+    await assertRowsSelection(page, [0, 1]);
+  });
 
+  test('should support row selection with dynamic height', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyDatabaseState(page);
+
+    await initDatabaseColumn(page);
+    await initDatabaseDynamicRowWithData(page, '123123', true);
+    await type(page, '456456');
+    await pressEnter(page);
+    await type(page, 'abcabc');
+    await pressEnter(page);
+    await type(page, 'defdef');
+    await pressEnter(page);
+    await pressEscape(page);
+
+    await pressEscape(page);
     await assertRowsSelection(page, [0, 0]);
   });
 });

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -420,10 +420,11 @@ export async function initDatabaseDynamicRowWithData(
   addRow = false,
   index = 0
 ) {
+  const editor = getEditorLocator(page);
   if (addRow) {
     await initDatabaseRow(page);
   }
-  const lastRow = page.locator('.affine-database-block-row').last();
+  const lastRow = editor.locator('.affine-database-block-row').last();
   const cell = lastRow.locator('.database-cell').nth(index + 1);
   await cell.click();
   await type(page, data);


### PR DESCRIPTION
1. Add `tabindex` for `affine-database-cell-container`.
2. When the cell is selected but not in the editing state, the focus on `affine-database-cell-container`.
3. Call `focusCell` when a cell is selected and enters the edit state.
4. Provide `beforeEnterEditMode` to prevent entering edit mode or to do something before entering edit mode.
5. Remove the deprecated `page` method from `ColumnManager`