### PR TITLE
fix(edgeless): dragging a block from the middle of a note should not separate t…

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/create-drag-handle.ts
+++ b/packages/blocks/src/page-block/edgeless/components/create-drag-handle.ts
@@ -3,17 +3,15 @@ import { assertExists } from '@blocksuite/store';
 import type {
   BlockComponentElement,
   EditingState,
+  Point,
 } from '../../../__internal__/index.js';
 import {
-  getBlockElementByModel,
   getBlockElementsExcludeSubtrees,
   getClosestBlockElementByPoint,
   getClosestNoteBlockElementById,
   getHoveringNote,
   getModelByBlockElement,
-  getRectByBlockElement,
   isInSamePath,
-  Point,
   Rect,
 } from '../../../__internal__/index.js';
 import { DragHandle } from '../../../components/index.js';
@@ -68,39 +66,6 @@ export function createDragHandle(pageBlock: EdgelessPageBlockComponent) {
       }
       // blank area
       page.captureSync();
-
-      const parent = page.getParent(models[0]);
-      assertExists(parent);
-
-      const firstModelIndex = parent.children.findIndex(
-        m => m.id === models[0].id
-      );
-      const lastModelIndex = parent.children.findIndex(
-        m => m.id === models[models.length - 1].id
-      );
-
-      pageBlock.moveBlocksWithNewNote(models, point, {
-        rect: getRectByBlockElement(blockElementsExcludeSubtrees[0]),
-        focus: true,
-        noteIndex: firstModelIndex === 0 ? 0 : undefined,
-      });
-
-      if (
-        firstModelIndex !== 0 &&
-        lastModelIndex !== parent.children.length - 1
-      ) {
-        const nextFirstBlockElement = getBlockElementByModel(
-          parent?.children[lastModelIndex]
-        );
-
-        assertExists(nextFirstBlockElement);
-        const nextFirstBlockRect = getRectByBlockElement(nextFirstBlockElement);
-        pageBlock.moveBlocksWithNewNote(
-          parent?.children.slice(lastModelIndex),
-          new Point(nextFirstBlockRect.x, nextFirstBlockRect.y),
-          { rect: nextFirstBlockRect }
-        );
-      }
     },
     setDragType(dragging: boolean) {
       const { selection } = pageBlock;

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -899,39 +899,6 @@ export class EdgelessPageBlockComponent
     };
   }
 
-  /** Moves selected blocks into a new note at the given point. */
-  moveBlocksWithNewNote(
-    blocks: BaseBlockModel[],
-    point: Point,
-    {
-      rect,
-      focus,
-      parentId,
-      noteIndex,
-    }: {
-      rect?: DOMRect;
-      focus?: boolean;
-      parentId?: string;
-      noteIndex?: number;
-    } = {}
-  ) {
-    const { left, top, zoom } = this.surface.viewport;
-    const width = rect?.width
-      ? rect.width / zoom + EDGELESS_BLOCK_CHILD_PADDING * 2
-      : DEFAULT_NOTE_WIDTH;
-    point.x -= left;
-    point.y -= top;
-    const noteId = this.addNoteWithPoint(point, {
-      width,
-      parentId,
-      noteIndex,
-    });
-    const noteModel = this.page.getBlockById(noteId) as NoteBlockModel;
-    this.page.moveBlocks(blocks, noteModel);
-
-    focus && this.setSelection(noteId, true, blocks[0].id, point);
-  }
-
   addImage(
     model: Partial<ImageBlockModel>,
     point?: Point

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -317,28 +317,6 @@ test('drag handle should work across multiple notes', async ({ page }) => {
   await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
 });
 
-test('drag handle should add new note when dragged outside note', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyEdgelessState(page);
-  await initThreeParagraphs(page);
-  await assertRichTexts(page, ['123', '456', '789']);
-
-  await switchEditorMode(page);
-
-  await expect(page.locator('.affine-edgeless-child-note')).toHaveCount(1);
-
-  await page.mouse.dblclick(CENTER_X, CENTER_Y);
-  await dragBlockToPoint(page, '3', { x: 30, y: 40 });
-  await waitNextFrame(page);
-  await expect(page.locator('affine-drag-handle')).toBeHidden();
-  await assertRichTexts(page, ['123', '456', '789']);
-
-  await expect(page.locator('.affine-edgeless-child-note')).toHaveCount(2);
-  await expect(page.locator('affine-selected-blocks > *')).toHaveCount(0);
-});
-
 test('format quick bar should show up when double-clicking on text', async ({
   page,
 }) => {


### PR DESCRIPTION
close #3084

Code has changed so much. It's hard to resolve conflicts if revert the commit directly.