### PR TITLE
fix(edgeless): edgeless toolbar note-menu rounded border

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
@@ -18,14 +18,15 @@ export class EdgelessNoteMenu extends LitElement {
     :host {
       position: absolute;
       height: 76px;
-      display: flex;
       box-shadow: var(--affine-shadow-2);
+      border-radius: 8px 8px 0 0;
+      display: flex;
       z-index: -1;
     }
     .note-menu-container {
       display: flex;
       flex-direction: column;
-      background: var(--affine-background-overlay-panel-color);
+      background: transparent;
       fill: currentcolor;
       position: relative;
     }


### PR DESCRIPTION
To close #3381 

<img width="661" alt="Screenshot 2023-07-06 at 13 32 02" src="https://github.com/toeverything/blocksuite/assets/99816898/dba50c38-f150-4796-847e-89f07fc83008">
