### PR TITLE
feat: supports customizing the slash menu

### DIFF
--- a/packages/blocks/src/components/index.ts
+++ b/packages/blocks/src/components/index.ts
@@ -6,5 +6,5 @@ export * from './import-page/index.js';
 export * from './menu-divider.js';
 export * from './remote-selection/remote-selection.js';
 export * from './selected-blocks.js';
-export { SlashMenu } from './slash-menu/index.js';
+export { SlashMenuWidget } from './slash-menu/index.js';
 export * from './tooltip/index.js';

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -15,17 +15,9 @@ import {
   TomorrowIcon,
   YesterdayIcon,
 } from '@blocksuite/global/config';
-import {
-  assertExists,
-  type BaseBlockModel,
-  type Page,
-  Text,
-  Utils,
-} from '@blocksuite/store';
-import type { TemplateResult } from 'lit';
+import { assertExists, Text } from '@blocksuite/store';
 
 import { REFERENCE_NODE } from '../../__internal__/rich-text/reference-node.js';
-import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';
 import { getServiceOrRegister } from '../../__internal__/service.js';
 import { restoreSelection } from '../../__internal__/utils/block-range.js';
 import {
@@ -45,392 +37,344 @@ import {
 } from '../../page-block/utils/index.js';
 import { showLinkedPagePopover } from '../linked-page/index.js';
 import { toast } from '../toast.js';
+import {
+  formatDate,
+  insertContent,
+  insideDatabase,
+  type SlashItem,
+} from './utils.js';
 
-export type SlashItem = {
-  name: string;
-  groupName: string;
-  alias?: string[];
-  icon: TemplateResult<1>;
-  showWhen?: (model: BaseBlockModel) => boolean;
-  disabled?: boolean;
-  action: ({ page, model }: { page: Page; model: BaseBlockModel }) => void;
-};
-
-function insertContent(
-  model: BaseBlockModel,
-  text: string,
-  attributes?: AffineTextAttributes
-) {
-  if (!model.text) {
-    throw new Error("Can't insert text! Text not found");
-  }
-  const vEditor = getVirgoByModel(model);
-  if (!vEditor) {
-    throw new Error("Can't insert text! vEditor not found");
-  }
-  const vRange = vEditor.getVRange();
-  const index = vRange ? vRange.index : model.text.length;
-  model.text.insert(text, index, attributes);
-  // Update the caret to the end of the inserted text
-  vEditor.setVRange({
-    index: index + text.length,
-    length: 0,
-  });
-}
-
-function formatDate(date: Date) {
-  // yyyy-mm-dd
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-  const strTime = `${year}-${month}-${day}`;
-  return strTime;
-}
-
-function insideDatabase(model: BaseBlockModel) {
-  return Utils.isInsideBlockByFlavour(model.page, model, 'affine:database');
-}
-
-export const menuGroups: { name: string; items: SlashItem[] }[] = (
-  [
-    {
-      name: 'Text',
-      items: [
-        ...paragraphConfig
-          .filter(i => i.flavour !== 'affine:list')
-          .map<Omit<SlashItem, 'groupName'>>(
-            ({ name, icon, flavour, type }) => ({
-              name,
-              icon,
-              showWhen: model => {
-                if (!model.page.schema.flavourSchemaMap.has(flavour)) {
-                  return false;
-                }
-
-                if (['Quote', 'Code Block', 'Divider'].includes(name)) {
-                  return !insideDatabase(model);
-                }
-                return true;
-              },
-              action: ({ model }) => {
-                const newModels = updateBlockType([model], flavour, type);
-                // Reset selection if the target is code block
-                if (flavour === 'affine:code') {
-                  if (newModels.length !== 1) {
-                    throw new Error(
-                      "Failed to reset selection! New model length isn't 1"
-                    );
-                  }
-                  const codeModel = newModels[0];
-                  onModelTextUpdated(codeModel, () => {
-                    restoreSelection({
-                      type: 'Native',
-                      startOffset: 0,
-                      endOffset: 0,
-                      models: [codeModel],
-                    });
-                  });
-                }
-              },
-            })
-          ),
-      ],
-    },
-    {
-      name: 'Style',
-      items: formatConfig
-        .filter(i => !['Link', 'Code'].includes(i.name))
-        .map(({ name, icon, id }) => ({
-          name,
-          icon,
-          action: ({ model }) => {
-            if (!model.text) {
-              return;
-            }
-            const len = model.text.length;
-            if (!len) {
-              const vEditor = getVirgoByModel(model);
-              assertExists(vEditor, "Can't set style mark! vEditor not found");
-              vEditor.setMarks({
-                [id]: true,
-              });
-              clearMarksOnDiscontinuousInput(vEditor);
-              return;
-            }
-            model.text.format(0, len, {
-              [id]: true,
-            });
-          },
-        })),
-    },
-    {
-      name: 'List',
-      items: paragraphConfig
-        .filter(i => i.flavour === 'affine:list')
-        .map(({ name, icon, flavour, type }) => ({
+export const menuGroups: { name: string; items: SlashItem[] }[] = [
+  {
+    name: 'Text',
+    items: [
+      ...paragraphConfig
+        .filter(i => i.flavour !== 'affine:list')
+        .map<Omit<SlashItem, 'groupName'>>(({ name, icon, flavour, type }) => ({
           name,
           icon,
           showWhen: model => {
             if (!model.page.schema.flavourSchemaMap.has(flavour)) {
               return false;
             }
+
+            if (['Quote', 'Code Block', 'Divider'].includes(name)) {
+              return !insideDatabase(model);
+            }
             return true;
           },
-          action: ({ model }) => updateBlockType([model], flavour, type),
+          action: ({ model }) => {
+            const newModels = updateBlockType([model], flavour, type);
+            // Reset selection if the target is code block
+            if (flavour === 'affine:code') {
+              if (newModels.length !== 1) {
+                throw new Error(
+                  "Failed to reset selection! New model length isn't 1"
+                );
+              }
+              const codeModel = newModels[0];
+              onModelTextUpdated(codeModel, () => {
+                restoreSelection({
+                  type: 'Native',
+                  startOffset: 0,
+                  endOffset: 0,
+                  models: [codeModel],
+                });
+              });
+            }
+          },
         })),
-    },
-
-    {
-      name: 'Pages',
-      items: [
-        {
-          name: 'New Page',
-          icon: NewPageIcon,
-          showWhen: model =>
-            !!model.page.awarenessStore.getFlag('enable_linked_page'),
-          action: async ({ page, model }) => {
-            const newPage = await createPage(page.workspace);
-            insertContent(model, REFERENCE_NODE, {
-              reference: { type: 'LinkedPage', pageId: newPage.id },
+    ],
+  },
+  {
+    name: 'Style',
+    items: formatConfig
+      .filter(i => !['Link', 'Code'].includes(i.name))
+      .map(({ name, icon, id }) => ({
+        name,
+        icon,
+        action: ({ model }) => {
+          if (!model.text) {
+            return;
+          }
+          const len = model.text.length;
+          if (!len) {
+            const vEditor = getVirgoByModel(model);
+            assertExists(vEditor, "Can't set style mark! vEditor not found");
+            vEditor.setMarks({
+              [id]: true,
             });
-          },
+            clearMarksOnDiscontinuousInput(vEditor);
+            return;
+          }
+          model.text.format(0, len, {
+            [id]: true,
+          });
         },
-        {
-          name: 'Link Page',
-          alias: ['dual link'],
-          icon: DualLinkIcon,
-          showWhen: model =>
-            !!model.page.awarenessStore.getFlag('enable_linked_page'),
-          action: ({ model }) => {
-            insertContent(model, '@');
-            showLinkedPagePopover({ model, range: getCurrentNativeRange() });
-          },
+      })),
+  },
+  {
+    name: 'List',
+    items: paragraphConfig
+      .filter(i => i.flavour === 'affine:list')
+      .map(({ name, icon, flavour, type }) => ({
+        name,
+        icon,
+        showWhen: model => {
+          if (!model.page.schema.flavourSchemaMap.has(flavour)) {
+            return false;
+          }
+          return true;
         },
-      ],
-    },
-    {
-      name: 'Content & Media',
-      items: [
-        {
-          name: 'Image',
-          icon: ImageIcon20,
-          showWhen: model => {
-            if (!model.page.schema.flavourSchemaMap.has('affine:image')) {
-              return false;
-            }
-            if (insideDatabase(model)) {
-              return false;
-            }
-            return true;
-          },
-          async action({ page, model }) {
-            const parent = page.getParent(model);
-            if (!parent) {
-              return;
-            }
-            parent.children.indexOf(model);
-            const props = (await uploadImageFromLocal(page.blobs)).map(
-              ({ sourceId }) => ({ flavour: 'affine:image', sourceId })
-            );
-            page.addSiblingBlocks(model, props);
-          },
-        },
-        {
-          name: 'Bookmark',
-          icon: BookmarkIcon,
-          showWhen: model => {
-            if (
-              !model.page.awarenessStore.getFlag('enable_bookmark_operation')
-            ) {
-              return false;
-            }
-            if (!model.page.schema.flavourSchemaMap.has('affine:image')) {
-              return false;
-            }
-            return !insideDatabase(model);
-          },
-          async action({ page, model }) {
-            const parent = page.getParent(model);
-            if (!parent) {
-              return;
-            }
-            const url = await getBookmarkInitialProps();
-            if (!url) return;
-            const props = {
-              flavour: 'affine:bookmark',
-              url,
-            } as const;
-            page.addSiblingBlocks(model, [props]);
-          },
-        },
-      ],
-    },
-    {
-      name: 'Date & Time',
-      items: [
-        {
-          name: 'Today',
-          icon: TodayIcon,
-          action: ({ model }) => {
-            const date = new Date();
-            insertContent(model, formatDate(date));
-          },
-        },
-        {
-          name: 'Tomorrow',
-          icon: TomorrowIcon,
-          action: ({ model }) => {
-            // yyyy-mm-dd
-            const date = new Date();
-            date.setDate(date.getDate() + 1);
-            insertContent(model, formatDate(date));
-          },
-        },
-        {
-          name: 'Yesterday',
-          icon: YesterdayIcon,
-          action: ({ model }) => {
-            const date = new Date();
-            date.setDate(date.getDate() - 1);
-            insertContent(model, formatDate(date));
-          },
-        },
-        {
-          name: 'Now',
-          icon: NowIcon,
-          action: ({ model }) => {
-            // For example 7:13 pm
-            // https://stackoverflow.com/questions/8888491/how-do-you-display-javascript-datetime-in-12-hour-am-pm-format
-            const date = new Date();
-            let hours = date.getHours();
-            const minutes = date.getMinutes().toString().padStart(2, '0');
-            const amOrPm = hours >= 12 ? 'pm' : 'am';
-            hours = hours % 12;
-            hours = hours ? hours : 12; // the hour '0' should be '12'
-            const strTime = hours + ':' + minutes + ' ' + amOrPm;
-            insertContent(model, strTime);
-          },
-        },
-      ],
-    },
-    {
-      name: 'Database',
-      items: [
-        {
-          name: 'Table View',
-          alias: ['database'],
-          icon: DatabaseTableViewIcon,
-          showWhen: model => {
-            if (!model.page.awarenessStore.getFlag('enable_database')) {
-              return false;
-            }
-            if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
-              return false;
-            }
-            if (insideDatabase(model)) {
-              // You can't add a database block inside another database block
-              return false;
-            }
-            return true;
-          },
-          action: async ({ page, model }) => {
-            const parent = page.getParent(model);
-            assertExists(parent);
-            const index = parent.children.indexOf(model);
+        action: ({ model }) => updateBlockType([model], flavour, type),
+      })),
+  },
 
-            const id = page.addBlock(
-              'affine:database',
-              {},
-              page.getParent(model),
-              index + 1
-            );
-            const service = await getServiceOrRegister('affine:database');
-            service.initDatabaseBlock(page, model, id, false);
-          },
+  {
+    name: 'Pages',
+    items: [
+      {
+        name: 'New Page',
+        icon: NewPageIcon,
+        showWhen: model =>
+          !!model.page.awarenessStore.getFlag('enable_linked_page'),
+        action: async ({ page, model }) => {
+          const newPage = await createPage(page.workspace);
+          insertContent(model, REFERENCE_NODE, {
+            reference: { type: 'LinkedPage', pageId: newPage.id },
+          });
         },
-        {
-          name: 'Kanban View',
-          alias: ['database'],
-          disabled: true,
-          icon: DatabaseKanbanViewIcon,
-          showWhen: model => {
-            if (!model.page.awarenessStore.getFlag('enable_database')) {
-              return false;
-            }
-            if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
-              return false;
-            }
-            if (insideDatabase(model)) {
-              // You can't add a database block inside another database block
-              return false;
-            }
-            return true;
-          },
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          action: ({ model }) => {},
+      },
+      {
+        name: 'Link Page',
+        alias: ['dual link'],
+        icon: DualLinkIcon,
+        showWhen: model =>
+          !!model.page.awarenessStore.getFlag('enable_linked_page'),
+        action: ({ model }) => {
+          insertContent(model, '@');
+          showLinkedPagePopover({ model, range: getCurrentNativeRange() });
         },
-      ],
-    },
-    {
-      name: 'Actions',
-      items: [
-        {
-          name: 'Copy',
-          icon: CopyIcon,
-          action: async ({ model }) => {
-            const curRange = getCurrentNativeRange();
-            await copyBlock(model);
-            resetNativeSelection(curRange);
-            toast('Copied to clipboard');
-          },
+      },
+    ],
+  },
+  {
+    name: 'Content & Media',
+    items: [
+      {
+        name: 'Image',
+        icon: ImageIcon20,
+        showWhen: model => {
+          if (!model.page.schema.flavourSchemaMap.has('affine:image')) {
+            return false;
+          }
+          if (insideDatabase(model)) {
+            return false;
+          }
+          return true;
         },
-        // {
-        //   name: 'Paste',
-        //   icon: PasteIcon,
-        //   action: async ({ model }) => {
-        //     const copiedText = await navigator.clipboard.readText();
-        //     console.log('copiedText', copiedText);
-        //     insertContent(model, copiedText);
-        //   },
-        // },
-        {
-          name: 'Duplicate',
-          icon: DuplicateIcon,
-          action: ({ page, model }) => {
-            if (!model.text || !(model.text instanceof Text)) {
-              throw new Error("Can't duplicate a block without text");
-            }
-            const parent = page.getParent(model);
-            if (!parent) {
-              throw new Error('Failed to duplicate block! Parent not found');
-            }
-            const index = parent.children.indexOf(model);
+        async action({ page, model }) {
+          const parent = page.getParent(model);
+          if (!parent) {
+            return;
+          }
+          parent.children.indexOf(model);
+          const props = (await uploadImageFromLocal(page.blobs)).map(
+            ({ sourceId }) => ({ flavour: 'affine:image', sourceId })
+          );
+          page.addSiblingBlocks(model, props);
+        },
+      },
+      {
+        name: 'Bookmark',
+        icon: BookmarkIcon,
+        showWhen: model => {
+          if (!model.page.awarenessStore.getFlag('enable_bookmark_operation')) {
+            return false;
+          }
+          if (!model.page.schema.flavourSchemaMap.has('affine:image')) {
+            return false;
+          }
+          return !insideDatabase(model);
+        },
+        async action({ page, model }) {
+          const parent = page.getParent(model);
+          if (!parent) {
+            return;
+          }
+          const url = await getBookmarkInitialProps();
+          if (!url) return;
+          const props = {
+            flavour: 'affine:bookmark',
+            url,
+          } as const;
+          page.addSiblingBlocks(model, [props]);
+        },
+      },
+    ],
+  },
+  {
+    name: 'Date & Time',
+    items: [
+      {
+        name: 'Today',
+        icon: TodayIcon,
+        action: ({ model }) => {
+          const date = new Date();
+          insertContent(model, formatDate(date));
+        },
+      },
+      {
+        name: 'Tomorrow',
+        icon: TomorrowIcon,
+        action: ({ model }) => {
+          // yyyy-mm-dd
+          const date = new Date();
+          date.setDate(date.getDate() + 1);
+          insertContent(model, formatDate(date));
+        },
+      },
+      {
+        name: 'Yesterday',
+        icon: YesterdayIcon,
+        action: ({ model }) => {
+          const date = new Date();
+          date.setDate(date.getDate() - 1);
+          insertContent(model, formatDate(date));
+        },
+      },
+      {
+        name: 'Now',
+        icon: NowIcon,
+        action: ({ model }) => {
+          // For example 7:13 pm
+          // https://stackoverflow.com/questions/8888491/how-do-you-display-javascript-datetime-in-12-hour-am-pm-format
+          const date = new Date();
+          let hours = date.getHours();
+          const minutes = date.getMinutes().toString().padStart(2, '0');
+          const amOrPm = hours >= 12 ? 'pm' : 'am';
+          hours = hours % 12;
+          hours = hours ? hours : 12; // the hour '0' should be '12'
+          const strTime = hours + ':' + minutes + ' ' + amOrPm;
+          insertContent(model, strTime);
+        },
+      },
+    ],
+  },
+  {
+    name: 'Database',
+    items: [
+      {
+        name: 'Table View',
+        alias: ['database'],
+        icon: DatabaseTableViewIcon,
+        showWhen: model => {
+          if (!model.page.awarenessStore.getFlag('enable_database')) {
+            return false;
+          }
+          if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
+            return false;
+          }
+          if (insideDatabase(model)) {
+            // You can't add a database block inside another database block
+            return false;
+          }
+          return true;
+        },
+        action: async ({ page, model }) => {
+          const parent = page.getParent(model);
+          assertExists(parent);
+          const index = parent.children.indexOf(model);
 
-            // TODO add clone model util
-            page.addBlock(
-              model.flavour,
-              {
-                type: model.type,
-                text: page.Text.fromDelta(model.text.toDelta()),
-                // @ts-expect-error
-                checked: model.checked,
-              },
-              page.getParent(model),
-              index
-            );
-          },
+          const id = page.addBlock(
+            'affine:database',
+            {},
+            page.getParent(model),
+            index + 1
+          );
+          const service = await getServiceOrRegister('affine:database');
+          service.initDatabaseBlock(page, model, id, false);
         },
-        {
-          name: 'Delete',
-          icon: DeleteIcon,
-          action: ({ page, model }) => {
-            page.deleteBlock(model);
-          },
+      },
+      {
+        name: 'Kanban View',
+        alias: ['database'],
+        disabled: true,
+        icon: DatabaseKanbanViewIcon,
+        showWhen: model => {
+          if (!model.page.awarenessStore.getFlag('enable_database')) {
+            return false;
+          }
+          if (!model.page.schema.flavourSchemaMap.has('affine:database')) {
+            return false;
+          }
+          if (insideDatabase(model)) {
+            // You can't add a database block inside another database block
+            return false;
+          }
+          return true;
         },
-      ],
-    },
-  ] satisfies { name: string; items: Omit<SlashItem, 'groupName'>[] }[]
-).map(group => ({
-  name: group.name,
-  items: group.items.map(item => ({ ...item, groupName: group.name })),
-}));
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        action: ({ model }) => {},
+      },
+    ],
+  },
+  {
+    name: 'Actions',
+    items: [
+      {
+        name: 'Copy',
+        icon: CopyIcon,
+        action: async ({ model }) => {
+          const curRange = getCurrentNativeRange();
+          await copyBlock(model);
+          resetNativeSelection(curRange);
+          toast('Copied to clipboard');
+        },
+      },
+      // {
+      //   name: 'Paste',
+      //   icon: PasteIcon,
+      //   action: async ({ model }) => {
+      //     const copiedText = await navigator.clipboard.readText();
+      //     console.log('copiedText', copiedText);
+      //     insertContent(model, copiedText);
+      //   },
+      // },
+      {
+        name: 'Duplicate',
+        icon: DuplicateIcon,
+        action: ({ page, model }) => {
+          if (!model.text || !(model.text instanceof Text)) {
+            throw new Error("Can't duplicate a block without text");
+          }
+          const parent = page.getParent(model);
+          if (!parent) {
+            throw new Error('Failed to duplicate block! Parent not found');
+          }
+          const index = parent.children.indexOf(model);
+
+          // TODO add clone model util
+          page.addBlock(
+            model.flavour,
+            {
+              type: model.type,
+              text: page.Text.fromDelta(model.text.toDelta()),
+              // @ts-expect-error
+              checked: model.checked,
+            },
+            page.getParent(model),
+            index
+          );
+        },
+      },
+      {
+        name: 'Delete',
+        icon: DeleteIcon,
+        action: ({ page, model }) => {
+          page.deleteBlock(model);
+        },
+      },
+    ],
+  },
+] satisfies { name: string; items: SlashItem[] }[];

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -2,7 +2,11 @@ import type { UIEventStateContext } from '@blocksuite/block-std';
 import type { BlockSuiteRoot } from '@blocksuite/lit';
 import { WithDisposable } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
-import { assertExists, matchFlavours } from '@blocksuite/store';
+import {
+  assertExists,
+  DisposableGroup,
+  matchFlavours,
+} from '@blocksuite/store';
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -13,23 +17,13 @@ import {
   throttle,
 } from '../../__internal__/utils/index.js';
 import { getPopperPosition } from '../../page-block/utils/position.js';
+import { menuGroups } from './config.js';
 import { SlashMenu } from './slash-menu-popover.js';
-
-export { SlashMenu } from './slash-menu-popover.js';
+import type { SlashMenuOptions } from './utils.js';
 
 let globalAbortController = new AbortController();
 
-function onAbort(
-  e: Event,
-  slashMenu: SlashMenu,
-  positionCallback: () => void,
-  model: BaseBlockModel
-) {
-  slashMenu.remove();
-  window.removeEventListener('resize', positionCallback);
-
-  // Clean slash text
-
+function cleanSlashTextAfterAbort(e: Event, model: BaseBlockModel) {
   if (!e.target || !(e.target instanceof AbortSignal)) {
     throw new Error('Failed to clean slash search text! Unknown abort event');
   }
@@ -77,24 +71,30 @@ function onAbort(
   });
 }
 
-export function showSlashMenu({
+function showSlashMenu({
   model,
   range,
   container = document.body,
   abortController = new AbortController(),
+  options,
 }: {
   model: BaseBlockModel;
   range: Range;
   container?: HTMLElement;
   abortController?: AbortController;
+  options: SlashMenuOptions;
 }) {
   // Abort previous format quick bar
   globalAbortController.abort();
   globalAbortController = abortController;
+  const disposables = new DisposableGroup();
+  abortController.signal.addEventListener('abort', () => disposables.dispose());
 
   const slashMenu = new SlashMenu();
+  disposables.add(() => slashMenu.remove());
   slashMenu.model = model;
   slashMenu.abortController = abortController;
+  slashMenu.options = options;
 
   // Handle position
   const updatePosition = throttle(() => {
@@ -107,7 +107,7 @@ export function showSlashMenu({
     slashMenu.updatePosition(position);
   }, 10);
 
-  window.addEventListener('resize', updatePosition);
+  disposables.addFromEvent(window, 'resize', updatePosition);
 
   // Mount
   container.appendChild(slashMenu);
@@ -116,7 +116,7 @@ export function showSlashMenu({
 
   // Handle dispose
   abortController.signal.addEventListener('abort', e => {
-    onAbort(e, slashMenu, updatePosition, model);
+    cleanSlashTextAfterAbort(e, model);
   });
 
   return slashMenu;
@@ -124,14 +124,22 @@ export function showSlashMenu({
 
 @customElement('affine-slash-menu-widget')
 export class SlashMenuWidget extends WithDisposable(LitElement) {
+  static DEFAULT_OPTIONS: SlashMenuOptions = {
+    triggerKeys: [
+      '/',
+      // Compatible with CJK IME
+      '、',
+    ],
+    menus: menuGroups,
+  };
+
+  options = SlashMenuWidget.DEFAULT_OPTIONS;
+
   @property({ attribute: false })
   root!: BlockSuiteRoot;
 
-  abortController = new AbortController();
-
-  override connectedCallback(): void {
+  override connectedCallback() {
     super.connectedCallback();
-
     this._disposables.add(
       this.root.uiEventDispatcher.add('keyDown', this._onKeyDown)
     );
@@ -142,13 +150,8 @@ export class SlashMenuWidget extends WithDisposable(LitElement) {
     if (!flag) return;
 
     const eventState = ctx.get('keyboardState');
-    const event = eventState.event as KeyboardEvent;
-    if (
-      event.key !== '/' &&
-      // Compatible with CJK IME
-      event.key !== '、'
-    )
-      return;
+    const event = eventState.raw;
+    if (!this.options.triggerKeys.includes(event.key)) return;
 
     // Fixme @Saul-Mirone get model from getCurrentSelection
     const target = event.target;
@@ -162,7 +165,11 @@ export class SlashMenuWidget extends WithDisposable(LitElement) {
       // Wait for dom update, see this case https://github.com/toeverything/blocksuite/issues/2611
       requestAnimationFrame(() => {
         const curRange = getCurrentNativeRange();
-        showSlashMenu({ model, range: curRange });
+        showSlashMenu({
+          model,
+          range: curRange,
+          options: this.options,
+        });
       });
     });
   };

--- a/packages/blocks/src/components/slash-menu/utils.ts
+++ b/packages/blocks/src/components/slash-menu/utils.ts
@@ -1,6 +1,6 @@
 import type { BaseBlockModel } from '@blocksuite/store';
-import type { Page } from '@blocksuite/store/index.js';
-import { Utils } from '@blocksuite/store/index.js';
+import type { Page } from '@blocksuite/store';
+import { Utils } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
 import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';

--- a/packages/blocks/src/components/slash-menu/utils.ts
+++ b/packages/blocks/src/components/slash-menu/utils.ts
@@ -1,0 +1,70 @@
+import type { BaseBlockModel } from '@blocksuite/store';
+import type { Page } from '@blocksuite/store/index.js';
+import { Utils } from '@blocksuite/store/index.js';
+import type { TemplateResult } from 'lit';
+
+import type { AffineTextAttributes } from '../../__internal__/rich-text/virgo/types.js';
+import { getVirgoByModel } from '../../__internal__/utils/query.js';
+
+export type SlashMenuOptions = {
+  triggerKeys: string[];
+  menus: {
+    name: string;
+    items: SlashItem[];
+  }[];
+};
+
+export type SlashItem = {
+  name: string;
+  alias?: string[];
+  icon: TemplateResult<1>;
+  showWhen?: (model: BaseBlockModel) => boolean;
+  disabled?: boolean;
+  action: ({ page, model }: { page: Page; model: BaseBlockModel }) => void;
+};
+
+export type InternSlashItem = SlashItem & { groupName: string };
+
+export function collectGroupNames(menuItem: InternSlashItem[]) {
+  return menuItem.reduce((acc, item) => {
+    if (!acc.length || acc[acc.length - 1] !== item.groupName) {
+      acc.push(item.groupName);
+    }
+    return acc;
+  }, [] as string[]);
+}
+
+export function insertContent(
+  model: BaseBlockModel,
+  text: string,
+  attributes?: AffineTextAttributes
+) {
+  if (!model.text) {
+    throw new Error("Can't insert text! Text not found");
+  }
+  const vEditor = getVirgoByModel(model);
+  if (!vEditor) {
+    throw new Error("Can't insert text! vEditor not found");
+  }
+  const vRange = vEditor.getVRange();
+  const index = vRange ? vRange.index : model.text.length;
+  model.text.insert(text, index, attributes);
+  // Update the caret to the end of the inserted text
+  vEditor.setVRange({
+    index: index + text.length,
+    length: 0,
+  });
+}
+
+export function formatDate(date: Date) {
+  // yyyy-mm-dd
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const strTime = `${year}-${month}-${day}`;
+  return strTime;
+}
+
+export function insideDatabase(model: BaseBlockModel) {
+  return Utils.isInsideBlockByFlavour(model.page, model, 'affine:database');
+}

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -53,6 +53,12 @@ export class EditorContainer
   mode: 'page' | 'edgeless' = 'page';
 
   @property({ attribute: false })
+  pagePreset = pagePreset;
+
+  @property({ attribute: false })
+  edgelessPreset = edgelessPreset;
+
+  @property({ attribute: false })
   override autofocus = false;
 
   @query('affine-default-page')

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -568,28 +568,44 @@ test.skip('should compatible CJK IME', async ({ page }) => {
   await expect(slashItems).toHaveText(['Heading 2']);
 });
 
-test.describe.skip('slash menu with customize menu', () => {
+test.describe('slash menu with customize menu', () => {
   test('can remove specified menus', async ({ page }) => {
     await enterPlaygroundRoom(page);
-    await initEmptyParagraphState(page);
-    await focusRichText(page);
-
     await page.evaluate(async () => {
+      // https://github.com/lit/lit/blob/84df6ef8c73fffec92384891b4b031d7efc01a64/packages/lit-html/src/static.ts#L93
+      const fakeLiteral = (strings: TemplateStringsArray) =>
+        ({
+          ['_$litStatic$']: strings[0],
+          r: Symbol.for(''),
+        } as const);
+
       const editor = document.querySelector('editor-container');
       if (!editor) throw new Error("Can't find editor-container");
-      const defaultPage = editor.querySelector('affine-default-page');
-      if (!defaultPage) throw new Error("Can't find affine-default-page");
-      const SlashMenu = (await import('@blocksuite/blocks')).SlashMenu;
-      if (!SlashMenu) throw new Error("Can't find SlashMenu");
-      class CustomSlashMenu extends SlashMenu {
-        override get menuGroups() {
-          return super.menuGroups.slice(0, 1);
-        }
+
+      const SlashMenuWidget = window.$blocksuite.blocks.SlashMenuWidget;
+      class CustomSlashMenu extends SlashMenuWidget {
+        override options = {
+          ...SlashMenuWidget.DEFAULT_OPTIONS,
+          menus: SlashMenuWidget.DEFAULT_OPTIONS.menus.slice(0, 1),
+        };
       }
       // Fix `Illegal constructor` error
       // see https://stackoverflow.com/questions/41521812/illegal-constructor-with-ecmascript-6
-      customElements.define('custom-slash-menu', CustomSlashMenu);
+      customElements.define('affine-custom-slash-menu', CustomSlashMenu);
+
+      const pagePreset = window.$blocksuite.blocks.pagePreset;
+      const pageBlockSpec = pagePreset.shift();
+      if (!pageBlockSpec) throw new Error("Can't find pageBlockSpec");
+      pageBlockSpec.view.widgets = [
+        fakeLiteral`affine-custom-slash-menu`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any;
+      pagePreset.unshift(pageBlockSpec);
+      editor.pagePreset = pagePreset;
     });
+
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
 
     const slashMenu = page.locator(`.slash-menu`);
     const slashItems = slashMenu.locator('format-bar-button');
@@ -601,20 +617,23 @@ test.describe.skip('slash menu with customize menu', () => {
 
   test('can add some menus', async ({ page }) => {
     await enterPlaygroundRoom(page);
-    await initEmptyParagraphState(page);
-    await focusRichText(page);
 
     await page.evaluate(async () => {
+      // https://github.com/lit/lit/blob/84df6ef8c73fffec92384891b4b031d7efc01a64/packages/lit-html/src/static.ts#L93
+      const fakeLiteral = (strings: TemplateStringsArray) =>
+        ({
+          ['_$litStatic$']: strings[0],
+          r: Symbol.for(''),
+        } as const);
+
       const editor = document.querySelector('editor-container');
       if (!editor) throw new Error("Can't find editor-container");
-      const defaultPage = editor.querySelector('affine-default-page');
-      if (!defaultPage) throw new Error("Can't find affine-default-page");
-      const SlashMenu = (await import('@blocksuite/blocks')).SlashMenu;
-      if (!SlashMenu) throw new Error("Can't find SlashMenu");
-      class CustomSlashMenu extends SlashMenu {
-        override get menuGroups() {
-          const defaultMenuGroups = super.menuGroups;
-          return [
+      const SlashMenuWidget = window.$blocksuite.blocks.SlashMenuWidget;
+
+      class CustomSlashMenu extends SlashMenuWidget {
+        override options = {
+          ...SlashMenuWidget.DEFAULT_OPTIONS,
+          menus: [
             {
               name: 'Custom Menu',
               items: [
@@ -629,13 +648,26 @@ test.describe.skip('slash menu with customize menu', () => {
                 },
               ],
             },
-          ] satisfies typeof defaultMenuGroups;
-        }
+          ],
+        };
       }
       // Fix `Illegal constructor` error
       // see https://stackoverflow.com/questions/41521812/illegal-constructor-with-ecmascript-6
-      customElements.define('custom-slash-menu', CustomSlashMenu);
+      customElements.define('affine-custom-slash-menu', CustomSlashMenu);
+
+      const pagePreset = window.$blocksuite.blocks.pagePreset;
+      const pageBlockSpec = pagePreset.shift();
+      if (!pageBlockSpec) throw new Error("Can't find pageBlockSpec");
+      pageBlockSpec.view.widgets = [
+        fakeLiteral`affine-custom-slash-menu`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ] as any;
+      pagePreset.unshift(pageBlockSpec);
+      editor.pagePreset = pagePreset;
     });
+
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
 
     const slashMenu = page.locator(`.slash-menu`);
     const slashItems = slashMenu.locator('format-bar-button');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -78,12 +78,17 @@ export const getSelectionRect = async (page: Page): Promise<DOMRect> => {
  * await initEmptyEditor(page, { enable_some_flag: true });
  * ```
  */
-async function initEmptyEditor(
-  page: Page,
-  flags: Partial<BlockSuiteFlags> = {},
+async function initEmptyEditor({
+  page,
+  flags = {},
   noInit = false,
-  multiEditor = false
-) {
+  multiEditor = false,
+}: {
+  page: Page;
+  flags?: Partial<BlockSuiteFlags>;
+  noInit?: boolean;
+  multiEditor?: boolean;
+}) {
   await page.evaluate(
     ([flags, noInit, multiEditor]) => {
       const { workspace } = window;
@@ -208,7 +213,12 @@ export async function enterPlaygroundRoom(
     throw new Error(`Uncaught exception: "${exception}"\n${exception.stack}`);
   });
 
-  await initEmptyEditor(page, ops?.flags, ops?.noInit, multiEditor);
+  await initEmptyEditor({
+    page,
+    flags: ops?.flags,
+    noInit: ops?.noInit,
+    multiEditor,
+  });
 
   await readyPromise;
 
@@ -271,7 +281,7 @@ export async function enterPlaygroundWithList(
 ) {
   const room = generateRandomRoomId();
   await page.goto(`${DEFAULT_PLAYGROUND}?room=${room}`);
-  await initEmptyEditor(page);
+  await initEmptyEditor({ page });
 
   await page.evaluate(
     async ({ contents, type }: { contents: string[]; type: ListType }) => {


### PR DESCRIPTION
Upstream https://github.com/toeverything/blocksuite/pull/3128

## Design

```ts
import { SlashMenuWidget, pagePreset, edgelessPreset } from '@blocksuite/blocks'

class CustomSlashMenu extends SlashMenuWidget {
  override options = {
    ...SlashMenuWidget.DEFAULT_OPTIONS,
    menus: [
      {
        name: "Custom Menu",
        items: [
          {
            name: "Custom Menu Item",
            groupName: "Custom Menu",
            icon: "" as any,
            action: () => {
              // do nothing
            },
          },
        ],
      },
    ],
  };
}
// Fix `Illegal constructor` error
// see https://stackoverflow.com/questions/41521812/illegal-constructor-with-ecmascript-6
customElements.define("affine-custom-slash-menu", CustomSlashMenu);

const pageBlockSpec = pagePreset.shift();
if (!pageBlockSpec) throw new Error("Can't find pageBlockSpec");
pageBlockSpec.view.widgets = [literal`affine-custom-slash-menu`];
pagePreset.unshift(pageBlockSpec);
editor.pagePreset = pagePreset;

const edgelessBlockSpec = edgelessPreset.shift();
edgelessBlockSpec.view.widgets = [literal`affine-custom-slash-menu`];
edgelessPreset.unshift(edgelessBlockSpec);
editor.edgelessPreset = edgelessPreset;
```