### PR TITLE
fix(edgeless): unexpected history record added when updating note height

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -1065,18 +1065,16 @@ export class EdgelessPageBlockComponent
     this._resizeObserver = resizeObserver;
   }
 
-  private _initNoteResize() {
-    let raqId = 0;
-
-    const resetNoteResizeObserver = () => {
-      if (raqId) return;
-
-      raqId = requestAnimationFrame(() => {
-        this._noteResizeObserver.resetListener(this.page);
-        raqId = 0;
-      });
-    };
-
+  private _initNoteHeightUpdate() {
+    const resetNoteResizeObserver = throttle(
+      () => {
+        requestAnimationFrame(() => {
+          this._noteResizeObserver.resetListener(this.page);
+        });
+      },
+      16,
+      { leading: true }
+    );
     const listenChildrenUpdate = (root: BaseBlockModel<object> | null) => {
       if (!root) return;
 
@@ -1093,7 +1091,7 @@ export class EdgelessPageBlockComponent
     this._initSlotEffects();
     this._initDragHandle();
     this._initResizeEffect();
-    this._initNoteResize();
+    this._initNoteHeightUpdate();
     this.clipboard.init(this.page);
     tryUpdateNoteSize(this.page, this.surface.viewport.zoom);
 

--- a/packages/blocks/src/page-block/edgeless/utils/note-resize-observer.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/note-resize-observer.ts
@@ -1,6 +1,6 @@
 import { BLOCK_ID_ATTR } from '@blocksuite/global/config';
 import type { Page } from '@blocksuite/store';
-import { Slot } from '@blocksuite/store';
+import { matchFlavours, Slot } from '@blocksuite/store';
 
 import { almostEqual, throttle } from '../../../__internal__/utils/common.js';
 import { getBlockElementByModel } from '../../../__internal__/utils/query.js';
@@ -59,6 +59,7 @@ export class NoteResizeObserver {
   resetListener(page: Page) {
     const unCachedKeys = new Set(this._cachedElements.keys());
     page.root?.children.forEach(model => {
+      if (!matchFlavours(model, ['affine:note'])) return;
       const blockId = model.id;
       unCachedKeys.delete(blockId);
       const blockElement = getBlockElementByModel(model);

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -945,3 +945,16 @@ export async function createConnectorElement(
     { x: end[0], y: end[1] }
   );
 }
+
+export async function hoverOnNote(
+  page: Page,
+  id: string,
+  point?: { x: number; y: number }
+) {
+  const blockRect = await page.locator(`[data-block-id="${id}"]`).boundingBox();
+
+  assertExists(blockRect);
+
+  point = { x: blockRect.width / 2, y: blockRect.height / 2 };
+  await page.mouse.move(blockRect.x + point.x, blockRect.y + point.y);
+}

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -789,3 +789,9 @@ export async function assertConnectorPath(
   const actualPath = await getConnectorPath(page, index);
   actualPath.every((p, i) => assertPointAlmostEqual(p, path[i]));
 }
+
+export function assertRectExist(
+  rect: { x: number; y: number; width: number; height: number } | null
+): asserts rect is { x: number; y: number; width: number; height: number } {
+  expect(rect).not.toBe(null);
+}


### PR DESCRIPTION
close #3385

### Idea behined the solution
Note height is updated every time its related DOM element's rect changes. However, we cannot tell what triggers the change in the DOM rect (it could be triggered by local updates or undo/redo operations). Therefore, I have decided to make the undoManager not track updates to the note height.
If you think this solution is feasible, then I'll add some unit tests in the next days. Please let me know if you have any suggestions, thanks.