### PR TITLE
fix: display current lang first

### DIFF
--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -2,10 +2,15 @@ import { SearchIcon } from '@blocksuite/global/config';
 import { ShadowlessElement } from '@blocksuite/lit';
 import { css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { BUNDLED_LANGUAGES, type ILanguageRegistration } from 'shiki';
+import {
+  BUNDLED_LANGUAGES,
+  type ILanguageRegistration,
+  type Lang,
+} from 'shiki';
 
 import { createEvent } from '../../__internal__/index.js';
 import { scrollbarStyle } from '../../components/utils.js';
+import { POPULAR_LANGUAGES_MAP } from '../utils/code-languages.js';
 import { PLAIN_TEXT_REGISTRATION } from '../utils/consts.js';
 
 // TODO extract to a common list component
@@ -136,20 +141,23 @@ export class LangList extends ShadowlessElement {
   }
 
   override render() {
-    const filteredLanguages = [
-      PLAIN_TEXT_REGISTRATION,
-      ...BUNDLED_LANGUAGES,
-    ].filter(language => {
-      if (!this._filterText) {
-        return true;
-      }
-      return (
-        language.id.startsWith(this._filterText.toLowerCase()) ||
-        language.aliases?.some(alias =>
-          alias.startsWith(this._filterText.toLowerCase())
-        )
+    const filteredLanguages = [PLAIN_TEXT_REGISTRATION, ...BUNDLED_LANGUAGES]
+      .filter(language => {
+        if (!this._filterText) {
+          return true;
+        }
+        return (
+          language.id.startsWith(this._filterText.toLowerCase()) ||
+          language.aliases?.some(alias =>
+            alias.startsWith(this._filterText.toLowerCase())
+          )
+        );
+      })
+      .sort(
+        (a, b) =>
+          (POPULAR_LANGUAGES_MAP[a.id as Lang] ?? Infinity) -
+          (POPULAR_LANGUAGES_MAP[b.id as Lang] ?? Infinity)
       );
-    });
 
     const onLanguageSelect = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -10,7 +10,7 @@ import {
 
 import { createEvent } from '../../__internal__/index.js';
 import { scrollbarStyle } from '../../components/utils.js';
-import { POPULAR_LANGUAGES_MAP } from '../utils/code-languages.js';
+import { getLanguagePriority } from '../utils/code-languages.js';
 import { PLAIN_TEXT_REGISTRATION } from '../utils/consts.js';
 
 // TODO extract to a common list component
@@ -107,6 +107,9 @@ export class LangList extends ShadowlessElement {
   filterInput!: HTMLInputElement;
 
   @property({ attribute: false })
+  currentLanguageId!: Lang;
+
+  @property({ attribute: false })
   delay = 150;
 
   override async connectedCallback() {
@@ -155,8 +158,8 @@ export class LangList extends ShadowlessElement {
       })
       .sort(
         (a, b) =>
-          (POPULAR_LANGUAGES_MAP[a.id as Lang] ?? Infinity) -
-          (POPULAR_LANGUAGES_MAP[b.id as Lang] ?? Infinity)
+          getLanguagePriority(a.id as Lang, this.currentLanguageId === a.id) -
+          getLanguagePriority(b.id as Lang, this.currentLanguageId === b.id)
       );
 
     const onLanguageSelect = (e: KeyboardEvent) => {

--- a/packages/blocks/src/code-block/utils/code-languages.ts
+++ b/packages/blocks/src/code-block/utils/code-languages.ts
@@ -72,13 +72,21 @@ const PopularLanguages: Lang[] = [
   'vue',
 ];
 
-export const POPULAR_LANGUAGES_MAP: Partial<Record<Lang, number>> =
+const POPULAR_LANGUAGES_MAP: Partial<Record<Lang, number>> =
   PopularLanguages.reduce((acc, lang, i) => {
     return {
       [lang]: i,
       ...acc,
     };
   }, {});
+
+export function getLanguagePriority(lang: Lang, isCurrentLanguage = false) {
+  if (isCurrentLanguage) {
+    // Important to show the current language first
+    return -Infinity;
+  }
+  return POPULAR_LANGUAGES_MAP[lang] ?? Infinity;
+}
 
 function isPlaintext(lang: string) {
   return [


### PR DESCRIPTION
revert https://github.com/toeverything/blocksuite/pull/3419

The old PR has several problems:

- It lacks the prioritization of popular languages.
- There are still instances of language mismatch after switching the language.
