### PR TITLE
fix(edgeless): scissors z-index bug after bump into AFFiNE

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/note-cut/cut-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-cut/cut-button.ts
@@ -139,7 +139,7 @@ export class NoteScissorsButton extends WithDisposable(LitElement) {
         position: absolute;
         left: 0;
         top: 0;
-        z-index: 1;
+        z-index: calc(var(--affine-z-index-popover, 0) + 2);
         transform-origin: top left;
       }
     `,


### PR DESCRIPTION

https://github.com/toeverything/blocksuite/assets/9301743/04382761-3825-4c36-bde3-7ad5dad81443

