### PR TITLE
fix(edgeless): change image caption background to transparent

### DIFF
--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -38,7 +38,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
       text-align: center;
       color: var(--affine-icon-color);
       display: none;
-      background: var(--affine-background-primary-color);
+      background: transparent;
     }
     .affine-embed-wrapper-caption::placeholder {
       color: var(--affine-placeholder-color);


### PR DESCRIPTION
To close #3472 

<img width="551" alt="Screenshot 2023-07-12 at 00 30 51" src="https://github.com/toeverything/blocksuite/assets/99816898/89d91754-df0e-4e09-a3ff-4c75c210052e">
