### PR TITLE
fix(edgeless): inserted image size should be consistent in different viewport zoom level

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -937,8 +937,6 @@ export class EdgelessPageBlockComponent
       }
     }
 
-    const { zoom } = this.surface.viewport;
-
     if (!point) point = new Point(0, 0);
 
     if (point.x === 0 && point.y === 0) {
@@ -950,17 +948,8 @@ export class EdgelessPageBlockComponent
     const cx = point.x;
     const cy = point.y;
 
-    let x = 0;
-    let y = 0;
-    if (zoom > 1) {
-      x = cx - options.width / 2;
-      y = cy - options.height / 2;
-      options.width /= zoom;
-      options.height /= zoom;
-    } else {
-      x = cx - (options.width * zoom) / 2;
-      y = cy - (options.height * zoom) / 2;
-    }
+    const x = cx - options.width / 2;
+    const y = cy - options.height / 2;
 
     return this.addNewNote([model], new Point(x, y), options);
   }


### PR DESCRIPTION
To close #3499 

https://github.com/toeverything/blocksuite/assets/99816898/656cc898-cf54-4406-8376-16f57684ece2

