### PR TITLE
fix: inaccurate markdown convert patterns

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
+++ b/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
@@ -29,7 +29,7 @@ type Match = {
 const matches: Match[] = [
   {
     name: 'bolditalic',
-    pattern: /(?:\*){3}(.+?)(?:\*){3}$/g,
+    pattern: /(?:\*){3}([^* \n](.+?[^* \n])?)(?:\*){3}$/g,
     action: (
       model: BaseBlockModel,
       vEditor: AffineVEditor,
@@ -44,10 +44,6 @@ const matches: Match[] = [
 
       const annotatedText = match[0];
       const startIndex = selection.index - annotatedText.length;
-
-      if (text.match(/^([* \n]+)$/g)) {
-        return false;
-      }
 
       vEditor.insertText(
         {
@@ -93,7 +89,7 @@ const matches: Match[] = [
   },
   {
     name: 'bold',
-    pattern: /(?:\*){2}(.+?)(?:\*){2}$/g,
+    pattern: /(?:\*){2}([^* \n](.+?[^* \n])?)(?:\*){2}$/g,
     action: (
       model: BaseBlockModel,
       vEditor: AffineVEditor,
@@ -107,10 +103,6 @@ const matches: Match[] = [
       }
       const annotatedText = match[0];
       const startIndex = selection.index - annotatedText.length;
-
-      if (text.match(/^([* \n]+)$/g)) {
-        return false;
-      }
 
       vEditor.insertText(
         {
@@ -153,7 +145,7 @@ const matches: Match[] = [
   },
   {
     name: 'italic',
-    pattern: /(?:\*){1}(.+?)(?:\*){1}$/g,
+    pattern: /(?:\*){1}([^* \n](.+?[^* \n])?)(?:\*){1}$/g,
     action: (
       model: BaseBlockModel,
       vEditor: AffineVEditor,
@@ -167,10 +159,6 @@ const matches: Match[] = [
       }
       const annotatedText = match[0];
       const startIndex = selection.index - annotatedText.length;
-
-      if (text.match(/^([* \n]+)$/g)) {
-        return false;
-      }
 
       vEditor.insertText(
         {
@@ -213,7 +201,7 @@ const matches: Match[] = [
   },
   {
     name: 'strikethrough',
-    pattern: /(?:~~)(.+?)(?:~~)$/g,
+    pattern: /(?:~~)([^~ \n](.+?[^~ \n])?)(?:~~)$/g,
     action: (
       model: BaseBlockModel,
       vEditor: AffineVEditor,
@@ -227,10 +215,6 @@ const matches: Match[] = [
       }
       const annotatedText = match[0];
       const startIndex = selection.index - annotatedText.length;
-
-      if (text.match(/^([* \n]+)$/g)) {
-        return false;
-      }
 
       vEditor.insertText(
         {
@@ -273,7 +257,7 @@ const matches: Match[] = [
   },
   {
     name: 'underthrough',
-    pattern: /(?:~)(.+?)(?:~)$/g,
+    pattern: /(?:~)([^~ \n](.+?[^~ \n])?)(?:~)$/g,
     action: (
       model: BaseBlockModel,
       vEditor: AffineVEditor,
@@ -287,10 +271,6 @@ const matches: Match[] = [
       }
       const annotatedText = match[0];
       const startIndex = selection.index - annotatedText.length;
-
-      if (text.match(/^([* \n]+)$/g)) {
-        return false;
-      }
 
       vEditor.insertText(
         {

--- a/tests/markdown.spec.ts
+++ b/tests/markdown.spec.ts
@@ -187,74 +187,152 @@ test('markdown shortcut', async ({ page }) => {
   await assertRichTexts(page, ['']);
 });
 
-test('markdown inline-text', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
-  await focusRichText(page);
-  await resetHistory(page);
+test.describe('markdown inline-text', async () => {
+  test.beforeEach(async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+    await resetHistory(page);
+  });
 
-  await type(page, '***test*** ');
-  await assertTextFormat(page, 0, 0, { bold: true, italic: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, { bold: true, italic: true });
-  await undoByKeyboard(page);
-  await assertRichTexts(page, ['***test*** ']);
-  await undoByKeyboard(page);
-  await assertRichTexts(page, ['']);
+  test('bolditalic', async ({ page }) => {
+    await type(page, '***test*** ');
+    await assertTextFormat(page, 0, 0, { bold: true, italic: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, { bold: true, italic: true });
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['***test*** ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
 
-  await waitNextFrame(page);
-  await type(page, '**test** ');
-  await assertTextFormat(page, 0, 0, { bold: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, { bold: true });
-  await undoByClick(page);
-  await assertRichTexts(page, ['**test** ']);
-  await undoByClick(page);
-  await assertRichTexts(page, ['']);
+    // '*** ' will be converted to divider, so needn't test this case here
 
-  await waitNextFrame(page);
-  await type(page, '*test* ');
-  await assertTextFormat(page, 0, 0, { italic: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, { italic: true });
-  await undoByClick(page);
-  await assertRichTexts(page, ['*test* ']);
-  await undoByClick(page);
-  await assertRichTexts(page, ['']);
+    await waitNextFrame(page);
+    await type(page, '***test *** ');
+    await assertRichTexts(page, ['***test *** ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
+  });
 
-  await waitNextFrame(page);
-  await type(page, '~~test~~ ');
-  await assertTextFormat(page, 0, 0, { strike: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, { strike: true });
-  await undoByClick(page);
-  await waitNextFrame(page);
-  await assertRichTexts(page, ['~~test~~ ']);
-  await undoByClick(page);
-  await assertRichTexts(page, ['']);
+  test('bold', async ({ page }) => {
+    await type(page, '**test** ');
+    await assertTextFormat(page, 0, 0, { bold: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, { bold: true });
+    await undoByClick(page);
+    await assertRichTexts(page, ['**test** ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
 
-  await waitNextFrame(page);
-  await type(page, '~test~ ');
-  await assertTextFormat(page, 0, 0, { underline: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, { underline: true });
-  await undoByClick(page);
-  await assertRichTexts(page, ['~test~ ']);
-  await undoByClick(page);
-  await assertRichTexts(page, ['']);
+    await waitNextFrame(page);
+    await type(page, '** test** ');
+    await assertRichTexts(page, ['** test** ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
 
-  await waitNextFrame(page);
-  await type(page, '`test` ');
-  await assertTextFormat(page, 0, 0, { code: true });
-  await type(page, 'test');
-  await assertTextFormat(page, 0, 6, {});
-  await undoByClick(page);
-  await assertRichTexts(page, ['`test` ']);
-  await undoByClick(page);
-  await assertRichTexts(page, ['']);
+    await waitNextFrame(page);
+    await type(page, '**test ** ');
+    await assertRichTexts(page, ['**test ** ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
 
-  // TODO
-  // await assertRichTexts(page, ['\n']);
+    await waitNextFrame(page);
+    await type(page, '** test ** ');
+    await assertRichTexts(page, ['** test ** ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
+  });
+
+  test('italic', async ({ page }) => {
+    await type(page, '*test* ');
+    await assertTextFormat(page, 0, 0, { italic: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, { italic: true });
+    await undoByClick(page);
+    await assertRichTexts(page, ['*test* ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    // '* ' will be converted to bulleted list, so needn't test this case here
+
+    await waitNextFrame(page);
+    await type(page, '*test * ');
+    await assertRichTexts(page, ['*test * ']);
+    await undoByKeyboard(page);
+    await assertRichTexts(page, ['']);
+  });
+
+  test('strike', async ({ page }) => {
+    await type(page, '~~test~~ ');
+    await assertTextFormat(page, 0, 0, { strike: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, { strike: true });
+    await undoByClick(page);
+    await waitNextFrame(page);
+    await assertRichTexts(page, ['~~test~~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~~ test~~ ');
+    await assertRichTexts(page, ['~~ test~~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~~test ~~ ');
+    await assertRichTexts(page, ['~~test ~~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~~ test ~~ ');
+    await assertRichTexts(page, ['~~ test ~~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+  });
+
+  test('underline', async ({ page }) => {
+    await type(page, '~test~ ');
+    await assertTextFormat(page, 0, 0, { underline: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, { underline: true });
+    await undoByClick(page);
+    await waitNextFrame(page);
+    await assertRichTexts(page, ['~test~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~ test~ ');
+    await assertRichTexts(page, ['~ test~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~test ~ ');
+    await assertRichTexts(page, ['~test ~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+
+    await waitNextFrame(page);
+    await type(page, '~ test ~ ');
+    await assertRichTexts(page, ['~ test ~ ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+  });
+
+  test('code', async ({ page }) => {
+    await waitNextFrame(page);
+    await type(page, '`test` ');
+    await assertTextFormat(page, 0, 0, { code: true });
+    await type(page, 'test');
+    await assertTextFormat(page, 0, 6, {});
+    await undoByClick(page);
+    await assertRichTexts(page, ['`test` ']);
+    await undoByClick(page);
+    await assertRichTexts(page, ['']);
+  });
 });
 
 test('inline code should work when pressing Enter followed by Backspace twice', async ({


### PR DESCRIPTION
Close #3505 

If there are whitespace characters immediately before or after the formatting symbols (including `*`, `**`, `***`, `~`, and `~~`), they shouldn't be converted, just like how this page's comment box works.


https://github.com/toeverything/blocksuite/assets/17249775/ffc82b7e-d3f2-43f7-a686-d9eb6c4bba54


https://github.com/toeverything/blocksuite/assets/17249775/47d1edf5-1690-4de8-9362-558b10c204fe

