### PR TITLE
fix: register database in simple affine editor

### DIFF
--- a/packages/editor/src/components/simple-affine-editor.ts
+++ b/packages/editor/src/components/simple-affine-editor.ts
@@ -1,4 +1,4 @@
-import { AffineSchemas } from '@blocksuite/blocks/models';
+import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
 import type { Page } from '@blocksuite/store';
 import { Workspace } from '@blocksuite/store';
 import { LitElement } from 'lit';
@@ -20,7 +20,9 @@ export class SimpleAffineEditor extends LitElement {
 
   constructor() {
     super();
-    this.workspace = new Workspace({ id: 'test' }).register(AffineSchemas);
+    this.workspace = new Workspace({ id: 'test' })
+      .register(AffineSchemas)
+      .register(__unstableSchemas);
     this.page = this.workspace.createPage({ id: 'page0' });
     this.page.waitForLoaded().then(() => {
       const pageBlockId = this.page.addBlock('affine:page');


### PR DESCRIPTION
Fixes #2971 

Upon investigation, it appears that the issue originated from this [commit](https://github.com/toeverything/blocksuite/commit/1ad53ccbae9e08a294694204b8fcc5719f7b1d10) - [File -packages/blocks/src/models.ts]

The `DatabaseBlockModelSchema` was separated from `builtInSchemas` and introduced as `__unstableSchemas`. Although its registration was managed in other references, it appears to have been missed in `simple-affine-editor.ts`.

I've included some screenshots of the issue prior to the fix. You can observe the error "Val doesn't exist" being thrown, and the drop target not appearing. I've also attached a screenshot showing the state after the fix.

Before fix - 
![msedge_Loe1azlYEw](https://github.com/toeverything/blocksuite/assets/16215578/9e13e455-27ab-440f-9f9e-19e4ac636c30)

After Fix - 
![msedge_KyH7nZKECN](https://github.com/toeverything/blocksuite/assets/16215578/885de8f0-e1f9-4085-a3d1-65b7b4d1cbbe)

Please let me know if there are any adjustments or improvements that need to be made. Thank you!



