### PR TITLE
refactor: support customize linked page

### DIFF
--- a/packages/blocks/src/components/index.ts
+++ b/packages/blocks/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './drag-handle.js';
 export * from './file-drop-manager.js';
 export { FormatQuickBar } from './format-quick-bar/format-bar-node.js';
 export * from './import-page/index.js';
+export { LinkedPageWidget } from './linked-page/index.js';
 export * from './menu-divider.js';
 export * from './remote-selection/remote-selection.js';
 export * from './selected-blocks.js';

--- a/packages/blocks/src/components/linked-page/config.ts
+++ b/packages/blocks/src/components/linked-page/config.ts
@@ -16,11 +16,16 @@ import { showImportModal } from '../import-page/index.js';
 export type LinkedPageItem = {
   key: string;
   name: string;
-  groupName: string;
   icon: TemplateResult<1>;
   suffix?: TemplateResult<1>;
   disabled?: boolean;
   action: () => void;
+};
+
+export type LinkedPageGroup = {
+  name: string;
+  styles?: string;
+  items: LinkedPageItem[];
 };
 
 const DEFAULT_PAGE_NAME = 'Untitled';
@@ -51,7 +56,7 @@ export const getMenus: (ctx: {
   page: Page;
   pageMetas: PageMeta[];
   model: BaseBlockModel;
-}) => LinkedPageItem[] = ({ query, page, model, pageMetas }) => {
+}) => LinkedPageGroup[] = ({ query, page, model, pageMetas }) => {
   const pageName = query || DEFAULT_PAGE_NAME;
   const displayPageName =
     pageName.slice(0, DISPLAY_NAME_LENGTH) +
@@ -61,12 +66,10 @@ export const getMenus: (ctx: {
     .filter(({ id }) => id !== page.id)
     .filter(({ title }) => isFuzzyMatch(title, query));
 
-  const menuGroups: {
-    name: string;
-    items: Omit<LinkedPageItem, 'groupName'>[];
-  }[] = [
+  return [
     {
       name: 'Link to Page',
+      styles: 'overflow-y: scroll; max-height: 224px;',
       items: filteredPageList.map(page => ({
         key: page.id,
         name: page.title || DEFAULT_PAGE_NAME,
@@ -120,8 +123,5 @@ export const getMenus: (ctx: {
         },
       ],
     },
-  ];
-  return menuGroups
-    .map(group => group.items.map(item => ({ ...item, groupName: group.name })))
-    .flat();
+  ] satisfies LinkedPageGroup[];
 };

--- a/packages/blocks/src/components/linked-page/config.ts
+++ b/packages/blocks/src/components/linked-page/config.ts
@@ -13,6 +13,18 @@ import { createPage } from '../../__internal__/utils/common-operations.js';
 import { getVirgoByModel } from '../../__internal__/utils/query.js';
 import { showImportModal } from '../import-page/index.js';
 
+export type LinkedPageOptions = {
+  triggerKeys: string[];
+  ignoreBlockTypes: string[];
+  convertTriggerKey: boolean;
+  getMenus: (ctx: {
+    query: string;
+    page: Page;
+    pageMetas: PageMeta[];
+    model: BaseBlockModel;
+  }) => LinkedPageGroup[];
+};
+
 export type LinkedPageItem = {
   key: string;
   name: string;

--- a/packages/blocks/src/components/linked-page/config.ts
+++ b/packages/blocks/src/components/linked-page/config.ts
@@ -17,8 +17,8 @@ export type LinkedPageItem = {
   key: string;
   name: string;
   icon: TemplateResult<1>;
-  suffix?: TemplateResult<1>;
-  disabled?: boolean;
+  // suffix?: TemplateResult<1>;
+  // disabled?: boolean;
   action: () => void;
 };
 

--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -1,4 +1,3 @@
-import { ImportIcon, NewPageIcon, PageIcon } from '@blocksuite/global/config';
 import { WithDisposable } from '@blocksuite/lit';
 import {
   assertExists,
@@ -9,18 +8,10 @@ import { html, LitElement } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { createPage } from '../../__internal__/index.js';
-import { REFERENCE_NODE } from '../../__internal__/rich-text/reference-node.js';
-import { isFuzzyMatch } from '../../__internal__/utils/common.js';
-import {
-  getRichTextByModel,
-  getVirgoByModel,
-} from '../../__internal__/utils/query.js';
-import { showImportModal } from '../import-page/index.js';
+import { getRichTextByModel } from '../../__internal__/utils/query.js';
 import { cleanSpecifiedTail, createKeydownObserver } from '../utils.js';
+import { getMenus, type LinkedPageItem } from './config.js';
 import { styles } from './styles.js';
-
-const DEFAULT_PAGE_NAME = 'Untitled';
 
 @customElement('affine-linked-page-popover')
 export class LinkedPagePopover extends WithDisposable(LitElement) {
@@ -37,53 +28,17 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
   private _query = '';
 
   @state()
-  private _pageList: PageMeta[] = [];
-
-  @state()
   private _activatedItemIndex = 0;
 
-  private get _actionList() {
-    const DISPLAY_LENGTH = 8;
-    const pageName = this._query || DEFAULT_PAGE_NAME;
-    const displayPageName =
-      pageName.slice(0, DISPLAY_LENGTH) +
-      (pageName.length > DISPLAY_LENGTH ? '..' : '');
-    const filteredPageList = this._pageList
-      .filter(({ id }) => id !== this._page.id)
-      .filter(({ title }) => isFuzzyMatch(title, this._query));
+  private _actionList: LinkedPageItem[] = [];
 
-    return [
-      ...filteredPageList.map((page, idx) => ({
-        key: page.id,
-        name: page.title || DEFAULT_PAGE_NAME,
-        active: idx === this._activatedItemIndex,
-        icon: PageIcon,
-        action: () => this._insertLinkedNode('LinkedPage', page.id),
-      })),
-
-      // XXX The active condition is a bit tricky here
-      {
-        key: 'create-linked-page',
-        name: `Create "${displayPageName}" page`,
-        active: filteredPageList.length === this._activatedItemIndex,
-        icon: NewPageIcon,
-        action: () => this._createPage(),
-      },
-      // {
-      //   key: 'create-subpage',
-      //   name: `Create "${displayPageName}" subpage`,
-      //   active: filteredPageList.length + 1 === this._activatedItemIndex,
-      //   icon: NewPageIcon,
-      //   action: () => this._createSubpage(),
-      // },
-      {
-        key: 'import-linked-page',
-        name: `Import`,
-        active: filteredPageList.length + 1 === this._activatedItemIndex,
-        icon: ImportIcon,
-        action: () => this._importPage(),
-      },
-    ];
+  private _updateActionList(pageMetas: PageMeta[]) {
+    this._actionList = getMenus({
+      query: this._query,
+      page: this._page,
+      model: this.model,
+      pageMetas,
+    });
   }
 
   @query('.linked-page-popover')
@@ -105,11 +60,23 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
     const richText = getRichTextByModel(this.model);
     assertExists(richText, 'RichText not found');
 
+    this._disposables.add(
+      this.model.page.workspace.slots.pagesUpdated.on(() => {
+        this._updateActionList(this._page.workspace.meta.pageMetas);
+      })
+    );
+    this._disposables.addFromEvent(this, 'mousedown', e => {
+      // Prevent input from losing focus
+      e.preventDefault();
+    });
+
+    this._updateActionList(this._page.workspace.meta.pageMetas);
     createKeydownObserver({
       target: richText,
       onUpdateQuery: str => {
         this._query = str;
         this._activatedItemIndex = 0;
+        this._updateActionList(this._page.workspace.meta.pageMetas);
       },
       abortController: this.abortController,
       onMove: step => {
@@ -119,12 +86,6 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
         // Scroll to the active item
         const item = this._actionList[this._activatedItemIndex];
-        if (
-          item.key === 'create-linked-page' ||
-          item.key === 'import-linked-page'
-        ) {
-          return;
-        }
         const shadowRoot = this.shadowRoot;
         if (!shadowRoot) {
           console.warn('Failed to find the shadow root!', this);
@@ -142,65 +103,18 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
         });
       },
       onConfirm: () => {
+        this.abortController.abort();
+        cleanSpecifiedTail(this.model, '@' + this._query);
         this._actionList[this._activatedItemIndex].action();
       },
       onEsc: () => {
         this.abortController.abort();
       },
     });
-    this._disposables.addFromEvent(this, 'mousedown', e => {
-      // Prevent input from losing focus
-      e.preventDefault();
-    });
-
-    this._pageList = this._page.workspace.meta.pageMetas;
-    this._disposables.add(
-      this.model.page.workspace.slots.pagesUpdated.on(() => {
-        this._pageList = this._page.workspace.meta.pageMetas;
-      })
-    );
   }
 
   updatePosition(position: { height: number; x: string; y: string }) {
     this._position = position;
-  }
-
-  private _insertLinkedNode(type: 'Subpage' | 'LinkedPage', pageId: string) {
-    this.abortController.abort();
-    const vEditor = getVirgoByModel(this.model);
-    assertExists(vEditor, 'Editor not found');
-    cleanSpecifiedTail(vEditor, '@' + this._query);
-    const vRange = vEditor.getVRange();
-    assertExists(vRange);
-    vEditor.insertText(vRange, REFERENCE_NODE, { reference: { type, pageId } });
-    vEditor.setVRange({
-      index: vRange.index + 1,
-      length: 0,
-    });
-  }
-
-  private async _createPage() {
-    const pageName = this._query;
-
-    const page = await createPage(this._page.workspace, { title: pageName });
-
-    this._insertLinkedNode('LinkedPage', page.id);
-  }
-
-  private _importPage() {
-    this.abortController.abort();
-    const onSuccess = (pageIds: string[]) => {
-      if (pageIds.length === 0) {
-        return;
-      }
-      const pageId = pageIds[0];
-      this._insertLinkedNode('LinkedPage', pageId);
-    };
-    showImportModal({
-      workspace: this._page.workspace,
-      multiple: false,
-      onSuccess,
-    });
   }
 
   override render() {
@@ -214,49 +128,34 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
           visibility: 'hidden',
         });
 
-    const pageList = this._actionList.slice(0, -2).map(
-      ({ key, name, action, active, icon }, index) => html`<icon-button
-        width="280px"
-        height="32px"
-        data-id=${key}
-        text=${name}
-        ?hover=${active}
-        @click=${action}
-        @mousemove=${() => {
-          // Use `mousemove` instead of `mouseover` to avoid navigate conflict with keyboard
-          this._activatedItemIndex = index;
-        }}
-        >${icon}</icon-button
-      >`
-    );
-
-    const createList = this._actionList.slice(-2).map(
-      ({ key, name, action, active, icon }, index) => html`<icon-button
-        width="280px"
-        height="32px"
-        data-id=${key}
-        text=${name}
-        ?hover=${active}
-        @click=${action}
-        @mousemove=${() => {
-          // Use `mousemove` instead of `mouseover` to avoid navigate conflict with keyboard
-          this._activatedItemIndex = this._actionList.length + index;
-        }}
-        >${icon}</icon-button
-      >`
-    );
-
     return html`<div class="linked-page-popover" style="${style}">
-      ${pageList.length
-        ? html`<div class="group-title">Link to page</div>
-            <div class="group" style="overflow-y: scroll; max-height: 224px;">
-              ${pageList}
+      ${this._actionList.map(
+        ({ key, name, icon, groupName, action }, index) => {
+          const showDivider =
+            index !== 0 && this._actionList[index - 1].groupName !== groupName;
+          return html`<div class="divider" ?hidden=${!showDivider}></div>
+            <div class="group-title" ?hidden=${!showDivider && index !== 0}>
+              ${groupName}
             </div>
-            <div class="divider"></div>`
-        : null}
-
-      <div class="group-title">New page</div>
-      ${createList}
+            <icon-button
+              width="280px"
+              height="32px"
+              data-id=${key}
+              text=${name}
+              ?hover=${this._activatedItemIndex === index}
+              @click=${() => {
+                this.abortController.abort();
+                cleanSpecifiedTail(this.model, '@' + this._query);
+                action();
+              }}
+              @mousemove=${() => {
+                // Use `mousemove` instead of `mouseover` to avoid navigate conflict with keyboard
+                this._activatedItemIndex = index;
+              }}
+              >${icon}</icon-button
+            >`;
+        }
+      )}
     </div>`;
   }
 }

--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -14,7 +14,7 @@ import { styles } from './styles.js';
 export class LinkedPagePopover extends WithDisposable(LitElement) {
   static override styles = styles;
 
-  @property()
+  @property({ attribute: false })
   options!: LinkedPageOptions;
 
   @state()

--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -142,7 +142,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
           return html`
             <div class="divider" ?hidden=${idx === 0}></div>
             <div class="group-title">${group.name}</div>
-            <div class="group" style=${group.styles}>
+            <div class="group" style=${group.styles ?? ''}>
               ${group.items.map(({ key, name, icon, action }) => {
                 accIdx++;
                 const curIdx = accIdx - 1;

--- a/packages/blocks/src/components/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/components/linked-page/linked-page-popover.ts
@@ -1,17 +1,21 @@
 import { WithDisposable } from '@blocksuite/lit';
 import { assertExists, type BaseBlockModel } from '@blocksuite/store';
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { getRichTextByModel } from '../../__internal__/utils/query.js';
 import { cleanSpecifiedTail, createKeydownObserver } from '../utils.js';
-import { getMenus, type LinkedPageGroup } from './config.js';
+import type { LinkedPageOptions } from './config.js';
+import { type LinkedPageGroup } from './config.js';
 import { styles } from './styles.js';
 
 @customElement('affine-linked-page-popover')
 export class LinkedPagePopover extends WithDisposable(LitElement) {
   static override styles = styles;
+
+  @property()
+  options!: LinkedPageOptions;
 
   @state()
   private _position: {
@@ -37,7 +41,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
   }
 
   private _updateActionList() {
-    this._actionGroup = getMenus({
+    this._actionGroup = this.options.getMenus({
       query: this._query,
       page: this._page,
       model: this.model,

--- a/packages/blocks/src/components/slash-menu/config.ts
+++ b/packages/blocks/src/components/slash-menu/config.ts
@@ -22,6 +22,7 @@ import { getServiceOrRegister } from '../../__internal__/service.js';
 import {
   createPage,
   getCurrentNativeRange,
+  getPageBlock,
   getVirgoByModel,
   resetNativeSelection,
   uploadImageFromLocal,
@@ -34,7 +35,7 @@ import {
   onModelTextUpdated,
   updateBlockType,
 } from '../../page-block/utils/index.js';
-import { showLinkedPagePopover } from '../linked-page/index.js';
+import type { LinkedPageWidget } from '../linked-page/index.js';
 import { toast } from '../toast.js';
 import {
   formatDate,
@@ -149,7 +150,15 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
           !!model.page.awarenessStore.getFlag('enable_linked_page'),
         action: ({ model }) => {
           insertContent(model, '@');
-          showLinkedPagePopover({ model, range: getCurrentNativeRange() });
+          const pageBlock = getPageBlock(model);
+          const linkedPageWidget = pageBlock?.querySelector<LinkedPageWidget>(
+            'affine-linked-page-widget'
+          );
+          assertExists(linkedPageWidget);
+          // Wait for range to be updated
+          setTimeout(() => {
+            linkedPageWidget.showLinkedPage(model);
+          });
         },
       },
     ],

--- a/packages/blocks/src/components/slash-menu/index.ts
+++ b/packages/blocks/src/components/slash-menu/index.ts
@@ -18,36 +18,11 @@ import {
   throttle,
 } from '../../__internal__/utils/index.js';
 import { getPopperPosition } from '../../page-block/utils/position.js';
-import { cleanSpecifiedTail } from '../utils.js';
 import { menuGroups } from './config.js';
 import { SlashMenu } from './slash-menu-popover.js';
 import type { SlashMenuOptions } from './utils.js';
 
 let globalAbortController = new AbortController();
-
-function cleanSlashTextAfterAbort(e: Event, model: BaseBlockModel) {
-  if (!e.target || !(e.target instanceof AbortSignal)) {
-    throw new Error('Failed to clean slash search text! Unknown abort event');
-  }
-  // If not explicitly set in those methods, it defaults to "AbortError" DOMException.
-  if (e.target.reason instanceof DOMException) {
-    // Should not clean slash text when click away or abort
-    return;
-  }
-  if (typeof e.target.reason !== 'string') {
-    throw new Error('Failed to clean slash search text! Unknown abort reason');
-  }
-  const searchStr = '/' + e.target.reason;
-  const vEditor = getVirgoByModel(model);
-  if (!vEditor) {
-    console.warn(
-      'Failed to clean slash search text! No vEditor found for model, model:',
-      model
-    );
-    return;
-  }
-  cleanSpecifiedTail(vEditor, searchStr);
-}
 
 function showSlashMenu({
   model,
@@ -91,12 +66,6 @@ function showSlashMenu({
   container.appendChild(slashMenu);
   // Wait for the Node to be mounted
   setTimeout(updatePosition);
-
-  // Handle dispose
-  abortController.signal.addEventListener('abort', e => {
-    cleanSlashTextAfterAbort(e, model);
-  });
-
   return slashMenu;
 }
 

--- a/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/components/slash-menu/slash-menu-popover.ts
@@ -9,7 +9,7 @@ import {
   isControlledKeyboardEvent,
   isFuzzyMatch,
 } from '../../__internal__/utils/index.js';
-import { createKeydownObserver } from '../utils.js';
+import { cleanSpecifiedTail, createKeydownObserver } from '../utils.js';
 import { styles } from './styles.js';
 import {
   collectGroupNames,
@@ -240,7 +240,8 @@ export class SlashMenu extends WithDisposable(LitElement) {
     // Need to remove the search string
     // We must to do clean the slash string before we do the action
     // Otherwise, the action may change the model and cause the slash string to be changed
-    this.abortController.abort(this._searchString);
+    cleanSpecifiedTail(this.model, '/' + this._searchString);
+    this.abortController.abort();
 
     const { action } = this._filterItems[index];
     action({ page: this.model.page, model: this.model });

--- a/packages/blocks/src/components/utils.ts
+++ b/packages/blocks/src/components/utils.ts
@@ -1,9 +1,11 @@
 import { assertExists, sleep } from '@blocksuite/global/utils';
+import { BaseBlockModel } from '@blocksuite/store';
 import { css } from 'lit';
 
 import type { RichText } from '../__internal__/rich-text/rich-text.js';
 import type { AffineVEditor } from '../__internal__/rich-text/virgo/types.js';
 import { isControlledKeyboardEvent } from '../__internal__/utils/common.js';
+import { getVirgoByModel } from '../__internal__/utils/query.js';
 import { getCurrentNativeRange } from '../__internal__/utils/selection.js';
 
 export const createKeydownObserver = ({
@@ -200,7 +202,20 @@ export const createKeydownObserver = ({
 /**
  * Remove specified text from the current range.
  */
-export function cleanSpecifiedTail(vEditor: AffineVEditor, str: string) {
+export function cleanSpecifiedTail(
+  vEditorOrModel: AffineVEditor | BaseBlockModel,
+  str: string
+) {
+  if (!str) {
+    console.warn('Failed to clean text! Unexpected empty string');
+    return;
+  }
+  const vEditor =
+    vEditorOrModel instanceof BaseBlockModel
+      ? getVirgoByModel(vEditorOrModel)
+      : vEditorOrModel;
+  assertExists(vEditor, 'Editor not found');
+
   const vRange = vEditor.getVRange();
   assertExists(vRange);
   const idx = vRange.index - str.length;

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -480,7 +480,7 @@ test.describe('linked page popover', () => {
     await focusRichText(page);
     await type(page, '@');
     await expect(linkedPagePopover).toBeVisible();
-    await expect(pageBtn).toHaveCount(2);
+    await expect(pageBtn).toHaveCount(4);
 
     await assertActivePageIdx(0);
     await page.keyboard.press('ArrowDown');
@@ -493,12 +493,17 @@ test.describe('linked page popover', () => {
     await page.keyboard.press('Shift+Tab');
     await assertActivePageIdx(0);
 
-    await expect(pageBtn).toHaveText(['page1', 'page2']);
+    await expect(pageBtn).toHaveText([
+      'page1',
+      'page2',
+      'Create "Untitled" page',
+      'Import',
+    ]);
     // page2
     //  ^  ^
     await type(page, 'a2');
-    await expect(pageBtn).toHaveCount(1);
-    await expect(pageBtn).toHaveText(['page2']);
+    await expect(pageBtn).toHaveCount(3);
+    await expect(pageBtn).toHaveText(['page2', 'Create "a2" page', 'Import']);
     await pressEnter(page);
     await expect(linkedPagePopover).toBeHidden();
     await assertExistRefText('page2');


### PR DESCRIPTION
Upstream of https://github.com/toeverything/blocksuite/issues/3316

## API

```ts
type LinkedPageOptions = {
  triggerKeys: string[];
  ignoreBlockTypes: string[];
  convertTriggerKey: boolean;
  getMenus: (ctx: {
    query: string;
    page: Page;
    pageMetas: PageMeta[];
    model: BaseBlockModel;
  }) => LinkedPageGroup[];
};

@customElement('affine-linked-page-widget')
export class LinkedPageWidget {
  static DEFAULT_OPTIONS: LinkedPageOptions = {
    /**
     * The first item of the trigger keys will be the primary key
     */
    triggerKeys: ['@', '[[', '【【'],
    ignoreBlockTypes: ['affine:code'],
    /**
     * Convert trigger key to primary key (the first item of the trigger keys)
     */
    convertTriggerKey: true,
    getMenus,
  };

  options = LinkedPageWidget.DEFAULT_OPTIONS;

  public showLinkedPage(model: BaseBlockModel): void
}
```