### PR TITLE
fix(page):  paste in image caption

### DIFF
--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -175,6 +175,10 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     this._input.addEventListener('pointerup', (e: Event) => {
       e.stopPropagation();
     });
+
+    this._input.addEventListener('paste', (e: Event) => {
+      e.stopPropagation();
+    });
   }
 
   override focusBlock(ctx: FocusContext) {


### PR DESCRIPTION
fix #2663 

"I attempted to add test cases, but I encountered some difficulties when it came to triggering the paste event on the input. Can you please provide some guidance on how to proceed?"