### PR TITLE
feat(block-std): add scoped event

### DIFF
--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -1,5 +1,7 @@
 import { DisposableGroup } from '@blocksuite/global/utils';
+import type { Page } from '@blocksuite/store';
 
+import type { SelectionManager } from '../selection/index.js';
 import type { UIEventHandler } from './base.js';
 import { UIEventStateContext } from './base.js';
 import { UIEventState } from './base.js';
@@ -47,18 +49,29 @@ const eventNames = [
 ] as const;
 
 export type EventName = (typeof eventNames)[number];
+export type EventOptions = {
+  flavour?: string;
+};
+export type EventHandlerRunner = {
+  fn: UIEventHandler;
+  flavour?: string;
+};
 
 export class UIEventDispatcher {
   disposables = new DisposableGroup();
 
   private _handlersMap = Object.fromEntries(
-    eventNames.map((name): [EventName, Array<UIEventHandler>] => [name, []])
-  ) as Record<EventName, Array<UIEventHandler>>;
+    eventNames.map((name): [EventName, Array<EventHandlerRunner>] => [name, []])
+  ) as Record<EventName, Array<EventHandlerRunner>>;
 
   private _pointerControl: PointerControl;
   private _keyboardControl: KeyboardControl;
 
-  constructor(public root: HTMLElement) {
+  constructor(
+    public root: HTMLElement,
+    private selection: SelectionManager,
+    private page: Page
+  ) {
     this._pointerControl = new PointerControl(this);
     this._keyboardControl = new KeyboardControl(this);
   }
@@ -75,23 +88,30 @@ export class UIEventDispatcher {
   }
 
   run(name: EventName, context: UIEventStateContext) {
-    const handlers = this._handlersMap[name];
-    if (!handlers) return;
+    const runners = this._buildEventRunner(name);
+    if (!runners) {
+      return;
+    }
 
-    for (const handler of handlers) {
-      const result = handler(context);
+    for (const runner of runners) {
+      const { fn } = runner;
+      const result = fn(context);
       if (result) {
         return;
       }
     }
   }
 
-  add(name: EventName, handler: UIEventHandler) {
-    this._handlersMap[name].unshift(handler);
+  add(name: EventName, handler: UIEventHandler, options?: EventOptions) {
+    const runner: EventHandlerRunner = {
+      fn: handler,
+      flavour: options?.flavour,
+    };
+    this._handlersMap[name].unshift(runner);
     return () => {
-      if (this._handlersMap[name].includes(handler)) {
+      if (this._handlersMap[name].includes(runner)) {
         this._handlersMap[name] = this._handlersMap[name].filter(
-          f => f !== handler
+          x => x !== runner
         );
       }
     };
@@ -99,6 +119,42 @@ export class UIEventDispatcher {
 
   bindHotkey(keymap: Record<string, UIEventHandler>) {
     return this.add('keyDown', bindKeymap(keymap));
+  }
+
+  private get _currentSelections() {
+    return this.selection.value;
+  }
+
+  private _buildEventRunner(name: EventName) {
+    const handlers = this._handlersMap[name];
+    if (!handlers) return;
+
+    const selections = this._currentSelections;
+    const seen: Record<string, boolean> = {};
+
+    const paths = selections
+      .flatMap(selection => {
+        return selection.path.map(blockId => {
+          return this.page.getBlockById(blockId)?.flavour;
+        });
+      })
+      .filter((flavour): flavour is string => {
+        if (!flavour) return false;
+        if (seen[flavour]) return false;
+        seen[flavour] = true;
+        return true;
+      })
+      .reverse();
+
+    const globalEvents = handlers.filter(
+      handler => handler.flavour === undefined
+    );
+
+    const pathEvents = paths.flatMap(flavour => {
+      return handlers.filter(handler => handler.flavour === flavour);
+    });
+
+    return pathEvents.concat(globalEvents);
   }
 
   private _bindEvents() {

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -117,8 +117,8 @@ export class UIEventDispatcher {
     };
   }
 
-  bindHotkey(keymap: Record<string, UIEventHandler>) {
-    return this.add('keyDown', bindKeymap(keymap));
+  bindHotkey(keymap: Record<string, UIEventHandler>, options?: EventOptions) {
+    return this.add('keyDown', bindKeymap(keymap), options);
   }
 
   private get _currentSelections() {

--- a/packages/block-std/src/selection/base.ts
+++ b/packages/block-std/src/selection/base.ts
@@ -3,11 +3,18 @@ type SelectionConstructor<T = unknown> = {
   type: string;
 };
 
+export type BaseSelectionOptions = {
+  blockId: string;
+  path: readonly string[];
+};
+
 export abstract class BaseSelection {
   static readonly type: string;
   readonly blockId: string;
-  constructor(blockId: string) {
+  readonly path: readonly string[];
+  constructor({ blockId, path }: BaseSelectionOptions) {
     this.blockId = blockId;
+    this.path = path;
   }
 
   is<T extends BlockSuiteSelectionType>(

--- a/packages/block-std/src/selection/variants/block.ts
+++ b/packages/block-std/src/selection/variants/block.ts
@@ -14,11 +14,15 @@ export class BlockSelection extends BaseSelection {
     return {
       type: 'block',
       blockId: this.blockId,
+      path: this.path,
     };
   }
 
   static override fromJSON(json: Record<string, unknown>): BlockSelection {
-    return new BlockSelection(json.blockId as string);
+    return new BlockSelection({
+      blockId: json.blockId as string,
+      path: json.path as readonly string[],
+    });
   }
 }
 

--- a/packages/block-std/src/selection/variants/text.ts
+++ b/packages/block-std/src/selection/variants/text.ts
@@ -20,7 +20,10 @@ export class TextSelection extends BaseSelection {
   to: TextRangePoint | null;
 
   constructor({ from, to }: TextSelectionProps) {
-    super(from.blockId);
+    super({
+      blockId: from.blockId,
+      path: from.path,
+    });
     this.from = from;
     this.to = to;
   }

--- a/packages/block-std/src/service/index.ts
+++ b/packages/block-std/src/service/index.ts
@@ -61,6 +61,17 @@ export class BlockService<Model extends BaseBlockModel = BaseBlockModel> {
       })
     );
   }
+
+  bindHotKey(
+    keymap: Record<string, UIEventHandler>,
+    options?: { global: boolean }
+  ) {
+    this.disposables.add(
+      this.uiEventDispatcher.bindHotkey(keymap, {
+        flavour: options?.global ? undefined : this.flavour,
+      })
+    );
+  }
   // event handlers end
 }
 

--- a/packages/block-std/src/service/index.ts
+++ b/packages/block-std/src/service/index.ts
@@ -5,14 +5,17 @@ import type { EventName, UIEventHandler } from '../event/index.js';
 import type { BlockStore } from '../store/index.js';
 
 export interface BlockServiceOptions {
+  flavour: string;
   store: BlockStore;
 }
 
 export class BlockService<Model extends BaseBlockModel = BaseBlockModel> {
   readonly store: BlockStore;
+  readonly flavour: string;
   readonly disposables = new DisposableGroup();
 
   constructor(options: BlockServiceOptions) {
+    this.flavour = options.flavour;
     this.store = options.store;
   }
 
@@ -47,8 +50,16 @@ export class BlockService<Model extends BaseBlockModel = BaseBlockModel> {
   // life cycle end
 
   // event handlers start
-  handleEvent(name: EventName, fn: UIEventHandler) {
-    this.disposables.add(this.uiEventDispatcher.add(name, fn));
+  handleEvent(
+    name: EventName,
+    fn: UIEventHandler,
+    options?: { global: boolean }
+  ) {
+    this.disposables.add(
+      this.uiEventDispatcher.add(name, fn, {
+        flavour: options?.global ? undefined : this.flavour,
+      })
+    );
   }
   // event handlers end
 }

--- a/packages/block-std/src/store/index.ts
+++ b/packages/block-std/src/store/index.ts
@@ -2,7 +2,7 @@ import type { Page, Workspace } from '@blocksuite/store';
 
 import type { UIEventDispatcher } from '../event/index.js';
 import type { SelectionManager } from '../selection/index.js';
-import type { BlockService, BlockServiceOptions } from '../service/index.js';
+import type { BlockService } from '../service/index.js';
 import type { BlockSpec } from '../spec/index.js';
 
 export interface BlockStoreOptions {
@@ -86,16 +86,13 @@ export class BlockStore<ComponentType = unknown> {
         return;
       }
 
-      const service = new newSpec.service(this._serviceOptions);
+      const service = new newSpec.service({
+        flavour,
+        store: this,
+      });
       this._services.set(flavour, service);
       service.mounted();
     });
-  }
-
-  private get _serviceOptions(): BlockServiceOptions {
-    return {
-      store: this,
-    };
   }
 
   private _buildSpecMap(specs: Array<BlockSpec<ComponentType>>) {

--- a/packages/blocks/src/page-block/default/default-page-service.ts
+++ b/packages/blocks/src/page-block/default/default-page-service.ts
@@ -1,6 +1,5 @@
 import type {
   BaseSelection,
-  EventName,
   PointerEventState,
   TextSelection,
   UIEventHandler,
@@ -101,10 +100,6 @@ export class DefaultPageService extends BlockService<PageBlockModel> {
       scrollLeft,
       scrollTop,
     };
-  }
-
-  private _addEvent(name: EventName, handler: UIEventHandler) {
-    this.disposables.add(this.uiEventDispatcher.add(name, handler));
   }
 
   private _dragStartHandler: UIEventHandler = ctx => {
@@ -364,22 +359,26 @@ export class DefaultPageService extends BlockService<PageBlockModel> {
   override mounted() {
     super.mounted();
 
-    this._addEvent('dragStart', this._dragStartHandler);
-    this._addEvent('dragMove', this._dragMoveHandler);
-    this._addEvent('dragEnd', this._dragEndHandler);
-    this._addEvent('pointerMove', this._pointerMoveHandler);
-    this._addEvent('click', this._clickHandler);
-    this._addEvent('doubleClick', this._doubleClickHandler);
-    this._addEvent('tripleClick', this._tripleClickHandler);
+    this.handleEvent('dragStart', this._dragStartHandler, { global: true });
+    this.handleEvent('dragMove', this._dragMoveHandler, { global: true });
+    this.handleEvent('dragEnd', this._dragEndHandler, { global: true });
+    this.handleEvent('pointerMove', this._pointerMoveHandler, { global: true });
+    this.handleEvent('click', this._clickHandler, { global: true });
+    this.handleEvent('doubleClick', this._doubleClickHandler, { global: true });
+    this.handleEvent('tripleClick', this._tripleClickHandler, { global: true });
 
-    this._addEvent('selectionChange', () => {
-      const selection = window.getSelection();
-      if (!selection) {
-        return;
-      }
-      const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
-      this._prevSelection = this.rangeController.writeRange(range);
-    });
+    this.handleEvent(
+      'selectionChange',
+      () => {
+        const selection = window.getSelection();
+        if (!selection) {
+          return;
+        }
+        const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+        this._prevSelection = this.rangeController.writeRange(range);
+      },
+      { global: true }
+    );
 
     this.disposables.add(
       this.selectionManager.slots.changed.on(selections => {

--- a/packages/blocks/src/widgets/doc-dragging-area/index.ts
+++ b/packages/blocks/src/widgets/doc-dragging-area/index.ts
@@ -137,74 +137,94 @@ export class DocDraggingAreaWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.handleEvent('dragStart', ctx => {
-      const state = ctx.get('pointerState');
-      if (isBlankArea(state)) {
-        this._dragging = true;
-        const viewportElement = this._viewportElement;
-        this._offset = {
-          left: viewportElement.scrollLeft,
-          top: viewportElement.scrollTop,
-        };
-        return true;
-      }
-      return;
-    });
-
-    this.handleEvent('dragMove', ctx => {
-      this._clearRaf();
-      if (!this._dragging) {
-        return;
-      }
-
-      const runner = () => {
+    this.handleEvent(
+      'dragStart',
+      ctx => {
         const state = ctx.get('pointerState');
-        const { x, y } = state;
+        if (isBlankArea(state)) {
+          this._dragging = true;
+          const viewportElement = this._viewportElement;
+          this._offset = {
+            left: viewportElement.scrollLeft,
+            top: viewportElement.scrollTop,
+          };
+          return true;
+        }
+        return;
+      },
+      { global: true }
+    );
 
-        const { scrollTop, scrollLeft } = this._viewportElement;
-        const { x: startX, y: startY } = state.start;
-        const left = Math.min(this._offset.left + startX, scrollLeft + x);
-        const top = Math.min(this._offset.top + startY, scrollTop + y);
-        const right = Math.max(this._offset.left + startX, scrollLeft + x);
-        const bottom = Math.max(this._offset.top + startY, scrollTop + y);
-        const userRect = {
-          left,
-          top,
-          width: right - left,
-          height: bottom - top,
-        };
-        this.rect = userRect;
-        this._selectBlocksByRect(userRect);
-
-        const result = this._autoScroll(y);
-        if (!result) {
-          this._clearRaf();
+    this.handleEvent(
+      'dragMove',
+      ctx => {
+        this._clearRaf();
+        if (!this._dragging) {
           return;
         }
+
+        const runner = () => {
+          const state = ctx.get('pointerState');
+          const { x, y } = state;
+
+          const { scrollTop, scrollLeft } = this._viewportElement;
+          const { x: startX, y: startY } = state.start;
+          const left = Math.min(this._offset.left + startX, scrollLeft + x);
+          const top = Math.min(this._offset.top + startY, scrollTop + y);
+          const right = Math.max(this._offset.left + startX, scrollLeft + x);
+          const bottom = Math.max(this._offset.top + startY, scrollTop + y);
+          const userRect = {
+            left,
+            top,
+            width: right - left,
+            height: bottom - top,
+          };
+          this.rect = userRect;
+          this._selectBlocksByRect(userRect);
+
+          const result = this._autoScroll(y);
+          if (!result) {
+            this._clearRaf();
+            return;
+          }
+          this._rafID = requestAnimationFrame(runner);
+        };
+
         this._rafID = requestAnimationFrame(runner);
-      };
 
-      this._rafID = requestAnimationFrame(runner);
+        return true;
+      },
+      { global: true }
+    );
 
-      return true;
-    });
-
-    this.handleEvent('dragEnd', () => {
-      this._clearRaf();
-      this._dragging = false;
-      this.rect = null;
-      this._offset = {
-        top: 0,
-        left: 0,
-      };
-    });
-
-    this.handleEvent('pointerMove', ctx => {
-      if (this._dragging) {
-        const state = ctx.get('pointerState');
-        state.raw.preventDefault();
+    this.handleEvent(
+      'dragEnd',
+      () => {
+        this._clearRaf();
+        this._dragging = false;
+        this.rect = null;
+        this._offset = {
+          top: 0,
+          left: 0,
+        };
+      },
+      {
+        global: true,
       }
-    });
+    );
+
+    this.handleEvent(
+      'pointerMove',
+      ctx => {
+        if (this._dragging) {
+          const state = ctx.get('pointerState');
+          state.raw.preventDefault();
+        }
+      },
+      {
+        global: true,
+      }
+    );
   }
 
   override render() {

--- a/packages/blocks/src/widgets/doc-dragging-area/index.ts
+++ b/packages/blocks/src/widgets/doc-dragging-area/index.ts
@@ -65,6 +65,7 @@ export class DocDraggingAreaWidget extends WidgetElement {
         const bounding = element.getBoundingClientRect();
         return {
           id: element.model.id,
+          path: element.path,
           rect: {
             left: bounding.left + viewportElement.scrollLeft,
             top: bounding.top + viewportElement.scrollTop,
@@ -89,9 +90,11 @@ export class DocDraggingAreaWidget extends WidgetElement {
         ({ rect }) =>
           rectIntersects(rect, userRect) && !rectIncludes(rect, userRect)
       )
-      .map(rectWithId => rectWithId.id)
-      .map(blockId => {
-        return this.root.selectionManager.getInstance('block', blockId);
+      .map(rectWithId => {
+        return this.root.selectionManager.getInstance('block', {
+          blockId: rectWithId.id,
+          path: rectWithId.path,
+        });
       });
 
     this.root.selectionManager.set(selections);

--- a/packages/blocks/src/widgets/doc-dragging-area/index.ts
+++ b/packages/blocks/src/widgets/doc-dragging-area/index.ts
@@ -137,7 +137,7 @@ export class DocDraggingAreaWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._addEvent('dragStart', ctx => {
+    this.handleEvent('dragStart', ctx => {
       const state = ctx.get('pointerState');
       if (isBlankArea(state)) {
         this._dragging = true;
@@ -151,7 +151,7 @@ export class DocDraggingAreaWidget extends WidgetElement {
       return;
     });
 
-    this._addEvent('dragMove', ctx => {
+    this.handleEvent('dragMove', ctx => {
       this._clearRaf();
       if (!this._dragging) {
         return;
@@ -189,7 +189,7 @@ export class DocDraggingAreaWidget extends WidgetElement {
       return true;
     });
 
-    this._addEvent('dragEnd', () => {
+    this.handleEvent('dragEnd', () => {
       this._clearRaf();
       this._dragging = false;
       this.rect = null;
@@ -199,7 +199,7 @@ export class DocDraggingAreaWidget extends WidgetElement {
       };
     });
 
-    this._addEvent('pointerMove', ctx => {
+    this.handleEvent('pointerMove', ctx => {
       if (this._dragging) {
         const state = ctx.get('pointerState');
         state.raw.preventDefault();

--- a/packages/blocks/src/widgets/linked-page/index.ts
+++ b/packages/blocks/src/widgets/linked-page/index.ts
@@ -93,7 +93,7 @@ export class LinkedPageWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._addEvent('keyDown', this._onKeyDown);
+    this.handleEvent('keyDown', this._onKeyDown);
   }
 
   public showLinkedPage(model: BaseBlockModel) {

--- a/packages/blocks/src/widgets/linked-page/index.ts
+++ b/packages/blocks/src/widgets/linked-page/index.ts
@@ -93,7 +93,7 @@ export class LinkedPageWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.handleEvent('keyDown', this._onKeyDown);
+    this.handleEvent('keyDown', this._onKeyDown, { global: true });
   }
 
   public showLinkedPage(model: BaseBlockModel) {

--- a/packages/blocks/src/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/widgets/slash-menu/index.ts
@@ -99,7 +99,7 @@ export class SlashMenuWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.handleEvent('keyDown', this._onKeyDown);
+    this.handleEvent('keyDown', this._onKeyDown, { global: true });
   }
 
   private _onKeyDown = (ctx: UIEventStateContext) => {

--- a/packages/blocks/src/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/widgets/slash-menu/index.ts
@@ -99,7 +99,7 @@ export class SlashMenuWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._addEvent('keyDown', this._onKeyDown);
+    this.handleEvent('keyDown', this._onKeyDown);
   }
 
   private _onKeyDown = (ctx: UIEventStateContext) => {

--- a/packages/lit/src/element/lit-root.ts
+++ b/packages/lit/src/element/lit-root.ts
@@ -105,8 +105,12 @@ export class BlockSuiteRoot extends ShadowlessElement {
   override connectedCallback() {
     super.connectedCallback();
 
-    this.uiEventDispatcher = new UIEventDispatcher(this);
     this.selectionManager = new SelectionManager(this, this.page.workspace);
+    this.uiEventDispatcher = new UIEventDispatcher(
+      this,
+      this.selectionManager,
+      this.page
+    );
     this.blockStore = new BlockStore<StaticValue>({
       root: this,
       uiEventDispatcher: this.uiEventDispatcher,
@@ -115,8 +119,8 @@ export class BlockSuiteRoot extends ShadowlessElement {
       page: this.page,
     });
 
-    this.uiEventDispatcher.mount();
     this.selectionManager.mount(this.page);
+    this.uiEventDispatcher.mount();
 
     this.blockStore.applySpecs(this.blocks);
   }

--- a/packages/lit/src/element/widget-element.ts
+++ b/packages/lit/src/element/widget-element.ts
@@ -1,5 +1,6 @@
 import type { EventName, UIEventHandler } from '@blocksuite/block-std';
 import type { Page } from '@blocksuite/store';
+import { assertExists } from '@blocksuite/store';
 import { property } from 'lit/decorators.js';
 
 import { WithDisposable } from '../with-disposable.js';
@@ -38,8 +39,18 @@ export class WidgetElement extends WithDisposable(ShadowlessElement) {
     super.disconnectedCallback();
   }
 
-  protected _addEvent = (name: EventName, handler: UIEventHandler) =>
-    this._disposables.add(this.root.uiEventDispatcher.add(name, handler));
+  protected _addEvent = (
+    name: EventName,
+    handler: UIEventHandler,
+    options?: { global?: boolean }
+  ) => {
+    assertExists(this.hostElement);
+    this._disposables.add(
+      this.root.uiEventDispatcher.add(name, handler, {
+        flavour: options?.global ? undefined : this.hostElement.model.flavour,
+      })
+    );
+  };
 
   override render(): unknown {
     return null;

--- a/packages/lit/src/element/widget-element.ts
+++ b/packages/lit/src/element/widget-element.ts
@@ -29,6 +29,11 @@ export class WidgetElement extends WithDisposable(ShadowlessElement) {
     return this.root.blockViewMap.get(this.hostPath);
   }
 
+  get flavour(): string {
+    assertExists(this.hostElement);
+    return this.hostElement.model.flavour;
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     this.root.widgetViewMap.set(this.path, this);
@@ -39,18 +44,28 @@ export class WidgetElement extends WithDisposable(ShadowlessElement) {
     super.disconnectedCallback();
   }
 
-  protected _addEvent = (
+  handleEvent = (
     name: EventName,
     handler: UIEventHandler,
     options?: { global?: boolean }
   ) => {
-    assertExists(this.hostElement);
     this._disposables.add(
       this.root.uiEventDispatcher.add(name, handler, {
-        flavour: options?.global ? undefined : this.hostElement.model.flavour,
+        flavour: options?.global ? undefined : this.flavour,
       })
     );
   };
+
+  bindHotKey(
+    keymap: Record<string, UIEventHandler>,
+    options?: { global: boolean }
+  ) {
+    this._disposables.add(
+      this.root.uiEventDispatcher.bindHotkey(keymap, {
+        flavour: options?.global ? undefined : this.flavour,
+      })
+    );
+  }
 
   override render(): unknown {
     return null;


### PR DESCRIPTION
Previously, developers can only add global event handlers on event dispatcher. Since we have selection model for now, we can now which block should be involved when handling events.

For example, if current selection is on a `paragraph block`, it may have a path like `page -> note -> paragraph`. The event handlers will be called in a sequence like: `paragraph -> note -> page -> global`. In this chain, you can always `return true` to prevent later handlers if you want.

```ts
// in service

// this event will only be called if selection path contains current block's flavour
this.handleEvent('click', fn)

// this event will be added as global handler
this.handleEvent('click', fn, { global: true })
```