### PR TITLE
fix(page): add selection indicator for embed block

### DIFF
--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -71,6 +71,9 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
           : // TODO dark mode
             AttachmentBanner}
       </div>
+      ${this.selected?.is('block')
+        ? html`<affine-block-selection></affine-block-selection>`
+        : null}
     </div>`;
   }
 }

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -379,6 +379,9 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
           @blur=${this._onInputBlur}
           @click=${stopPropagation}
         />
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : null}
       </div>
     `;
   }

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -433,6 +433,9 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
           </rich-text>
         </div>
         ${this.content}
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : null}
       </div>
       ${this._codeOptionTemplate()}`;
   }

--- a/packages/blocks/src/components/block-selection.ts
+++ b/packages/blocks/src/components/block-selection.ts
@@ -1,0 +1,43 @@
+import { css, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * Renders a the block selection.
+ *
+ * @example
+ * ```ts
+ * class Block extends LitElement {
+ *   state override styles = css`
+ *     :host {
+ *       position: relative;
+ *     }
+ *   `
+ *   render() {
+ *     return html`${this.selected?.is('block')
+ *       ? html`<affine-block-selection></affine-block-selection>`
+ *       : null}`;
+ *   };
+ * }
+ * ```
+ */
+@customElement('affine-block-selection')
+export class BlockSelection extends LitElement {
+  static override styles = css`
+    :host {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      background-color: var(--affine-hover-color);
+      border-radius: 5px;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'affine-block-selection': BlockSelection;
+  }
+}

--- a/packages/blocks/src/components/index.ts
+++ b/packages/blocks/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './block-hub.js';
+export * from './block-selection.js';
 export * from './drag-handle.js';
 export * from './file-drop-manager.js';
 export { FormatQuickBar } from './format-quick-bar/format-bar-node.js';

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -47,7 +47,7 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
     </div>`;
 
     return html`
-      <div class="affine-divider-block-container" }>
+      <div class="affine-divider-block-container">
         <hr />
         ${children}
         ${this.selected?.is('block')

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -12,6 +12,7 @@ import { DividerBlockService } from './divider-service.js';
 export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
   static override styles = css`
     .affine-divider-block-container {
+      position: relative;
       width: 100%;
       height: 1px;
       display: flex;
@@ -46,9 +47,12 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
     </div>`;
 
     return html`
-      <div class=${`affine-divider-block-container`}>
+      <div class="affine-divider-block-container" }>
         <hr />
         ${children}
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : null}
       </div>
     `;
   }

--- a/packages/blocks/src/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/widgets/slash-menu/config.ts
@@ -273,7 +273,7 @@ export const menuGroups: { name: string; items: SlashItem[] }[] = [
               flavour: 'affine:attachment',
               name: file.name,
               size: file.size,
-              loadingKey: loadingKey,
+              loadingKey,
             };
             const [newBlockId] = page.addSiblingBlocks(model, [props]);
             assertExists(newBlockId);


### PR DESCRIPTION
## New component

```ts
@customElement('affine-block-selection')
export class BlockSelection extends LitElement
```

## Usage

 ```ts
 class Block extends LitElement {
   state override styles = css`
     :host {
       position: relative;
     }
   `
   render() {
     return html`${this.selected?.is('block')
       ? html`<affine-block-selection></affine-block-selection>`
       : null}`;
   };
 }
 ```

https://github.com/toeverything/blocksuite/assets/18554747/2751fed3-c611-4eaa-8ec9-32aaa18d82dc


