### PR TITLE
fix(page): image selection spacing

### DIFF
--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -49,7 +49,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     }
 
     .affine-image-wrapper {
-      padding: 8px 8px 0 8px;
+      padding: 8px;
       width: 100%;
       text-align: center;
       line-height: 0;
@@ -410,14 +410,18 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     }[this._imageState];
 
     return html`
-      <div>
+      <div style="position: relative;">
         <div class="affine-image-wrapper">
           <div class="resizable-img" style=${styleMap(resizeImgStyle)}>
             ${img} ${this._imageOptionsTemplate()}
             ${this._imageResizeBoardTemplate()}
           </div>
         </div>
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : null}
       </div>
+
       <div class="affine-embed-block-container">
         <div class="affine-embed-wrapper">
           <input


### PR DESCRIPTION
Same change with https://github.com/toeverything/blocksuite/pull/3741

I revert the spacing changed for the image since it is necessary for image selection, related to https://github.com/toeverything/blocksuite/pull/3675

cc @hwangdev97 


<img width="909" alt="Screenshot 2023-07-30 at 02 15 03" src="https://github.com/toeverything/blocksuite/assets/18554747/067cd33f-5202-4cbc-83b0-0946309cd24c">
