### PR TITLE
feat(page): support universal list toggle

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -18,7 +18,7 @@
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
-    "@toeverything/theme": "^0.7.15",
+    "@toeverything/theme": "^0.7.16",
     "nanoid": "^4"
   },
   "dependencies": {
@@ -78,7 +78,7 @@
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
-    "@toeverything/theme": "^0.7.15",
+    "@toeverything/theme": "^0.7.16",
     "@types/marked": "^4.3.1",
     "@types/sortablejs": "^1.15.1"
   }

--- a/packages/blocks/src/__internal__/consts.ts
+++ b/packages/blocks/src/__internal__/consts.ts
@@ -5,7 +5,7 @@ export const SCROLL_THRESHOLD = 100;
 export const EDITOR_WIDTH = 800;
 export const BLOCK_CHILDREN_CONTAINER_PADDING_LEFT = 26;
 export const PAGE_BLOCK_CHILD_PADDING = 24;
-export const EDGELESS_BLOCK_CHILD_PADDING = 24;
+export const EDGELESS_BLOCK_CHILD_PADDING = 36;
 export const EDGELESS_BLOCK_CHILD_BORDER_WIDTH = 2;
 
 // The height of the header, which is used to calculate the scroll offset

--- a/packages/blocks/src/__internal__/consts.ts
+++ b/packages/blocks/src/__internal__/consts.ts
@@ -5,7 +5,7 @@ export const SCROLL_THRESHOLD = 100;
 export const EDITOR_WIDTH = 800;
 export const BLOCK_CHILDREN_CONTAINER_PADDING_LEFT = 26;
 export const PAGE_BLOCK_CHILD_PADDING = 24;
-export const EDGELESS_BLOCK_CHILD_PADDING = 36;
+export const EDGELESS_BLOCK_CHILD_PADDING = 24;
 export const EDGELESS_BLOCK_CHILD_BORDER_WIDTH = 2;
 
 // The height of the header, which is used to calculate the scroll offset

--- a/packages/blocks/src/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/components/rich-text/rich-text-operations.ts
@@ -331,7 +331,6 @@ export function handleOutdent(
     }
   }
 
-  assertExists(model);
   asyncSetVRange(model, { index: offset, length: 0 });
 }
 

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -93,19 +93,24 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
     const listIcon = ListIcon(model, index, deep, showChildren, _onClickIcon);
 
     const toggleChildren = () => (this.showChildren = !this.showChildren);
-    const toggleIcon =
-      this.model.children.length > 0
-        ? this.showChildren
-          ? html`<div class="toggle-icon" @click=${toggleChildren}>
-              ${toggleDown()}
-            </div>`
-          : html`<div
-              class="toggle-icon toggle-icon__collapsed"
-              @click=${toggleChildren}
-            >
-              ${toggleRight()}
-            </div>`
-        : nothing;
+    const noChildren = this.model.children.length === 0;
+    const toggleDownTemplate = html`<div
+      class="toggle-icon"
+      @click=${toggleChildren}
+    >
+      ${toggleDown()}
+    </div>`;
+    const toggleRightTemplate = html`<div
+      class="toggle-icon toggle-icon__collapsed"
+      @click=${toggleChildren}
+    >
+      ${toggleRight()}
+    </div>`;
+    const toggleIcon = noChildren
+      ? nothing
+      : this.showChildren
+      ? toggleDownTemplate
+      : toggleRightTemplate;
 
     // For the first list item, we need to add a margin-top to make it align with the text
     const shouldAddMarginTop = index === 0 && deep === 0;

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -87,30 +87,33 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
     this._vRangeProvider = getVRangeProvider(this);
   }
 
-  override render(): TemplateResult<1> {
-    const { deep, index } = getListInfo(this.model);
-    const { model, showChildren, _onClickIcon } = this;
-    const listIcon = ListIcon(model, index, deep, showChildren, _onClickIcon);
-
+  private _toggleTemplate() {
     const toggleChildren = () => (this.showChildren = !this.showChildren);
     const noChildren = this.model.children.length === 0;
     const toggleDownTemplate = html`<div
       class="toggle-icon"
       @click=${toggleChildren}
     >
-      ${toggleDown()}
+      ${toggleDown}
     </div>`;
     const toggleRightTemplate = html`<div
       class="toggle-icon toggle-icon__collapsed"
       @click=${toggleChildren}
     >
-      ${toggleRight()}
+      ${toggleRight}
     </div>`;
     const toggleIcon = noChildren
       ? nothing
       : this.showChildren
       ? toggleDownTemplate
       : toggleRightTemplate;
+    return toggleIcon;
+  }
+
+  override render(): TemplateResult<1> {
+    const { deep, index } = getListInfo(this.model);
+    const { model, showChildren, _onClickIcon } = this;
+    const listIcon = ListIcon(model, index, deep, showChildren, _onClickIcon);
 
     // For the first list item, we need to add a margin-top to make it align with the text
     const shouldAddMarginTop = index === 0 && deep === 0;
@@ -130,7 +133,7 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
     return html`
       <div class=${`affine-list-block-container ${top}`}>
         <div class=${`affine-list-rich-text-wrapper ${checked}`}>
-          ${listIcon} ${toggleIcon}
+          ${this._toggleTemplate()} ${listIcon}
           <rich-text
             .yText=${this.model.text.yText}
             .undoManager=${this.model.page.history}

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -21,6 +21,7 @@ import { styles } from './styles.js';
 import { ListIcon } from './utils/get-list-icon.js';
 import { getListInfo } from './utils/get-list-info.js';
 import { playCheckAnimation } from './utils/icons.js';
+import { toggleDown, toggleRight } from './utils/icons.js';
 
 @customElement('affine-list')
 export class ListBlockComponent extends BlockElement<ListBlockModel> {
@@ -91,6 +92,21 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
     const { model, showChildren, _onClickIcon } = this;
     const listIcon = ListIcon(model, index, deep, showChildren, _onClickIcon);
 
+    const toggleChildren = () => (this.showChildren = !this.showChildren);
+    const toggleIcon =
+      this.model.children.length > 0
+        ? this.showChildren
+          ? html`<div class="toggle-icon" @click=${toggleChildren}>
+              ${toggleDown()}
+            </div>`
+          : html`<div
+              class="toggle-icon toggle-icon__collapsed"
+              @click=${toggleChildren}
+            >
+              ${toggleRight()}
+            </div>`
+        : nothing;
+
     // For the first list item, we need to add a margin-top to make it align with the text
     const shouldAddMarginTop = index === 0 && deep === 0;
     const top = shouldAddMarginTop ? 'affine-list-block-container--first' : '';
@@ -109,7 +125,7 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
     return html`
       <div class=${`affine-list-block-container ${top}`}>
         <div class=${`affine-list-rich-text-wrapper ${checked}`}>
-          ${listIcon}
+          ${listIcon} ${toggleIcon}
           <rich-text
             .yText=${this.model.text.yText}
             .undoManager=${this.model.page.history}

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -30,6 +30,28 @@ const listPrefix = css`
   }
 `;
 
+const toggleStyles = css`
+  .toggle-icon {
+    display: flex;
+    position: absolute;
+    left: 0;
+    transform: translateX(-100%);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  }
+  .toggle-icon:hover {
+    background: var(--affine-hover-color);
+  }
+  .affine-list-block-container:hover .toggle-icon {
+    opacity: 1;
+  }
+  .toggle-icon__collapsed {
+    opacity: 1;
+  }
+`;
+
 export const styles = css`
   .affine-list-block-container {
     box-sizing: border-box;
@@ -56,4 +78,5 @@ export const styles = css`
   }
 
   ${listPrefix}
+  ${toggleStyles}
 `;

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -66,6 +66,7 @@ export const styles = css`
     margin-top: 0;
   }
   .affine-list-rich-text-wrapper {
+    position: relative;
     display: flex;
     position: relative;
   }

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -53,6 +53,10 @@ const toggleStyles = css`
   .toggle-icon__collapsed {
     opacity: 1;
   }
+
+  .with-drag-handle .toggle-icon {
+    opacity: 1;
+  }
 `;
 
 export const styles = css`

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -35,7 +35,8 @@ const toggleStyles = css`
     display: flex;
     position: absolute;
     left: 0;
-    transform: translateX(-100%);
+    top: 50%;
+    transform: translate(-100%, -50%);
     border-radius: 4px;
     cursor: pointer;
     opacity: 0;

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -33,10 +33,12 @@ const listPrefix = css`
 const toggleStyles = css`
   .toggle-icon {
     display: flex;
+    align-items: center;
+    height: 16px;
+    margin: 4px 0;
     position: absolute;
     left: 0;
-    top: 50%;
-    transform: translate(-100%, -50%);
+    transform: translateX(-100%);
     border-radius: 4px;
     cursor: pointer;
     opacity: 0;

--- a/packages/blocks/src/list-block/utils/get-list-icon.ts
+++ b/packages/blocks/src/list-block/utils/get-list-icon.ts
@@ -38,7 +38,7 @@ export function ListIcon(
       </div>`;
     case 'toggle':
       return html`<div class="affine-list-block__prefix" @click=${onClick}>
-        ${showChildren ? toggleDown() : toggleRight(model.children.length > 0)}
+        ${showChildren ? toggleDown : toggleRight}
       </div>`;
     default:
       console.error('Unknown list type', model.type, model);

--- a/packages/blocks/src/list-block/utils/icons.ts
+++ b/packages/blocks/src/list-block/utils/icons.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, svg } from 'lit';
 
 export const point1 = () => {
   return html`
@@ -69,39 +69,33 @@ export const point4 = () => {
   `;
 };
 
-export const toggleRight = (enabled = true) => {
-  return html`
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      data-is-toggle-icon="true"
-      width="1em"
-      height="1em"
-      viewBox="0 0 20 20"
-    >
-      <path
-        fill="currentColor"
-        opacity="${enabled ? '1' : '0.6'}"
-        d="m15.795 11.272l-8 5A1.5 1.5 0 0 1 5.5 15V5a1.5 1.5 0 0 1 2.295-1.272l8 5a1.5 1.5 0 0 1 0 2.544Z"
-      />
-    </svg>
-  `;
-};
-export const toggleDown = () => {
-  return html`
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      data-is-toggle-icon="true"
-      width="1em"
-      height="1em"
-      viewBox="0 0 20 20"
-    >
-      <path
-        fill="currentColor"
-        d="m8.728 15.795l-5-8A1.5 1.5 0 0 1 5 5.5h10a1.5 1.5 0 0 1 1.272 2.295l-5 8a1.5 1.5 0 0 1-2.544 0Z"
-      />
-    </svg>
-  `;
-};
+const toggleSVG = svg`<path
+d="M16.5 11.134C17.1667 11.5189 17.1667 12.4811 16.5 12.866L9 17.1962C8.33333 17.5811 7.5 17.0999 7.5 16.3301L7.5 7.66989C7.5 6.90009 8.33333 6.41896 9 6.80386L16.5 11.134Z"
+fill="#77757D"
+/>`;
+
+export const toggleRight = html`
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    ${toggleSVG}
+  </svg>
+`;
+
+export const toggleDown = html`
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    style="transform: rotate(90deg)"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    ${toggleSVG}
+  </svg>
+`;
 
 export const checkboxChecked = () => {
   return html`

--- a/packages/blocks/src/list-block/utils/icons.ts
+++ b/packages/blocks/src/list-block/utils/icons.ts
@@ -79,9 +79,8 @@ export const toggleRight = (enabled = true) => {
       viewBox="0 0 20 20"
     >
       <path
-        data-is-toggle-icon="true"
         fill="currentColor"
-        opacity="${!enabled ? '0.6' : '1'}"
+        opacity="${enabled ? '1' : '0.6'}"
         d="m15.795 11.272l-8 5A1.5 1.5 0 0 1 5.5 15V5a1.5 1.5 0 0 1 2.295-1.272l8 5a1.5 1.5 0 0 1 0 2.544Z"
       />
     </svg>
@@ -95,13 +94,8 @@ export const toggleDown = () => {
       width="1em"
       height="1em"
       viewBox="0 0 20 20"
-      @mousedown="${() => {
-        // console.log('preventing def svg');
-        // e.preventDefault();
-      }}"
     >
       <path
-        data-is-toggle-icon="true"
         fill="currentColor"
         d="m8.728 15.795l-5-8A1.5 1.5 0 0 1 5 5.5h10a1.5 1.5 0 0 1 1.272 2.295l-5 8a1.5 1.5 0 0 1-2.544 0Z"
       />

--- a/packages/blocks/src/list-block/utils/icons.ts
+++ b/packages/blocks/src/list-block/utils/icons.ts
@@ -76,8 +76,8 @@ fill="#77757D"
 
 export const toggleRight = html`
   <svg
-    width="20"
-    height="20"
+    width="16"
+    height="16"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
@@ -87,8 +87,8 @@ export const toggleRight = html`
 
 export const toggleDown = html`
   <svg
-    width="20"
-    height="20"
+    width="16"
+    height="16"
     viewBox="0 0 24 24"
     style="transform: rotate(90deg)"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -65,6 +65,14 @@ export class DocPageBlockComponent extends BlockElement<
       padding-right: var(--affine-editor-side-padding, ${PAGE_BLOCK_CHILD_PADDING}px);
     }
 
+    /* Extra small devices (phones, 640px and down) */
+    @media screen and (max-width: 640px) {
+      .affine-doc-page-block-container {
+        padding-left: ${PAGE_BLOCK_CHILD_PADDING}px;
+        padding-right: ${PAGE_BLOCK_CHILD_PADDING}px;
+      }
+    }
+
     .affine-doc-page-block-title {
       width: 100%;
       font-size: 40px;

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -63,9 +63,6 @@ export class DocPageBlockComponent extends BlockElement<
       padding-left: var(--affine-editor-side-padding, ${PAGE_BLOCK_CHILD_PADDING}px);
       /* prettier-ignore */
       padding-right: var(--affine-editor-side-padding, ${PAGE_BLOCK_CHILD_PADDING}px);
-      /* TODO update theme after pass test */
-      padding-left: 96px;
-      padding-right: 96px;
     }
 
     .affine-doc-page-block-title {

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -63,6 +63,9 @@ export class DocPageBlockComponent extends BlockElement<
       padding-left: var(--affine-editor-side-padding, ${PAGE_BLOCK_CHILD_PADDING}px);
       /* prettier-ignore */
       padding-right: var(--affine-editor-side-padding, ${PAGE_BLOCK_CHILD_PADDING}px);
+      /* TODO update theme after pass test */
+      padding-left: 96px;
+      padding-right: 96px;
     }
 
     .affine-doc-page-block-title {

--- a/packages/blocks/src/widgets/drag-handle/config.ts
+++ b/packages/blocks/src/widgets/drag-handle/config.ts
@@ -3,9 +3,11 @@ import type { Disposable } from '@blocksuite/global/utils';
 import type { BlockElement } from '@blocksuite/lit';
 
 import type { Rect } from '../../__internal__/index.js';
+import { matchFlavours } from '../../__internal__/utils/model.js';
 
 export const DEFAULT_DRAG_HANDLE_CONTAINER_HEIGHT = 24;
-export const DRAG_HANDLE_OFFSET_LEFT = 18;
+export const DRAG_HANDLE_OFFSET_LEFT = 2;
+export const LIST_DRAG_HANDLE_OFFSET_LEFT = 18;
 export const DRAG_HANDLE_GRABBER_HEIGHT = 12;
 export const DRAG_HANDLE_GRABBER_WIDTH = 4;
 export const DRAG_HANDLE_GRABBER_BORDER_RADIUS = 4;
@@ -75,4 +77,14 @@ export class DragHandleOptionsRunner {
       this.optionMap.delete(option);
     }
   }
+}
+
+export function getDragHandleLeftPadding(blockElement: BlockElement) {
+  const isToggleList =
+    matchFlavours(blockElement.model, ['affine:list']) &&
+    blockElement.model.children.length > 0;
+  const offsetLeft = isToggleList
+    ? LIST_DRAG_HANDLE_OFFSET_LEFT
+    : DRAG_HANDLE_OFFSET_LEFT;
+  return offsetLeft;
 }

--- a/packages/blocks/src/widgets/drag-handle/config.ts
+++ b/packages/blocks/src/widgets/drag-handle/config.ts
@@ -5,7 +5,7 @@ import type { BlockElement } from '@blocksuite/lit';
 import type { Rect } from '../../__internal__/index.js';
 
 export const DEFAULT_DRAG_HANDLE_CONTAINER_HEIGHT = 24;
-export const DRAG_HANDLE_OFFSET_LEFT = 2;
+export const DRAG_HANDLE_OFFSET_LEFT = 18;
 export const DRAG_HANDLE_GRABBER_HEIGHT = 12;
 export const DRAG_HANDLE_GRABBER_WIDTH = 4;
 export const DRAG_HANDLE_GRABBER_BORDER_RADIUS = 4;

--- a/packages/blocks/src/widgets/drag-handle/config.ts
+++ b/packages/blocks/src/widgets/drag-handle/config.ts
@@ -3,7 +3,6 @@ import type { Disposable } from '@blocksuite/global/utils';
 import type { BlockElement } from '@blocksuite/lit';
 
 import type { Rect } from '../../__internal__/index.js';
-import { matchFlavours } from '../../__internal__/utils/model.js';
 
 export const DEFAULT_DRAG_HANDLE_CONTAINER_HEIGHT = 24;
 export const DRAG_HANDLE_OFFSET_LEFT = 2;
@@ -77,14 +76,4 @@ export class DragHandleOptionsRunner {
       this.optionMap.delete(option);
     }
   }
-}
-
-export function getDragHandleLeftPadding(blockElement: BlockElement) {
-  const isToggleList =
-    matchFlavours(blockElement.model, ['affine:list']) &&
-    blockElement.model.children.length > 0;
-  const offsetLeft = isToggleList
-    ? LIST_DRAG_HANDLE_OFFSET_LEFT
-    : DRAG_HANDLE_OFFSET_LEFT;
-  return offsetLeft;
 }

--- a/packages/blocks/src/widgets/drag-handle/index.ts
+++ b/packages/blocks/src/widgets/drag-handle/index.ts
@@ -32,11 +32,11 @@ import {
   DRAG_HANDLE_GRABBER_BORDER_RADIUS,
   DRAG_HANDLE_GRABBER_HEIGHT,
   DRAG_HANDLE_GRABBER_WIDTH,
-  DRAG_HANDLE_OFFSET_LEFT,
   DRAG_HOVER_RECT_PADDING,
   type DragHandleOption,
   DragHandleOptionsRunner,
   type DropResult,
+  getDragHandleLeftPadding,
   HOVER_DRAG_HANDLE_GRABBER_WIDTH,
   NOTE_CONTAINER_PADDING,
 } from './config.js';
@@ -458,9 +458,12 @@ export class DragHandleWidget extends WidgetElement {
 
     const containerHeight = getDragHandleContainerHeight(blockElement.model);
 
+    // Ad-hoc solution for list with toggle icon
+    const offsetLeft = getDragHandleLeftPadding(blockElement);
+
     const posLeft =
       left -
-      (DRAG_HANDLE_WIDTH + DRAG_HANDLE_OFFSET_LEFT) * this.scale +
+      (DRAG_HANDLE_WIDTH + offsetLeft) * this.scale +
       this._viewportOffset.left;
     const posTop = this._getTopWithBlockElement(blockElement);
 
@@ -578,8 +581,10 @@ export class DragHandleWidget extends WidgetElement {
       });
     }
 
+    const offsetLeft = getDragHandleLeftPadding(blockElement);
+
     // Add padding to hover rect
-    left -= (DRAG_HANDLE_WIDTH + DRAG_HANDLE_OFFSET_LEFT) * this.scale;
+    left -= (DRAG_HANDLE_WIDTH + offsetLeft) * this.scale;
     top -= DRAG_HOVER_RECT_PADDING * this.scale;
     right += DRAG_HOVER_RECT_PADDING * this.scale;
     bottom += DRAG_HOVER_RECT_PADDING * this.scale;

--- a/packages/blocks/src/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/widgets/drag-handle/utils.ts
@@ -21,7 +21,9 @@ import type { BlockComponentElement } from '../../index.js';
 import type { ParagraphBlockModel } from '../../paragraph-block/index.js';
 import {
   DEFAULT_DRAG_HANDLE_CONTAINER_HEIGHT,
+  DRAG_HANDLE_OFFSET_LEFT,
   type DropResult,
+  LIST_DRAG_HANDLE_OFFSET_LEFT,
 } from './config.js';
 
 const heightMap: { [key: string]: number } = {
@@ -207,3 +209,23 @@ export const getDropResult = (
 
   return dropIndicator;
 };
+
+export function getDragHandleLeftPadding(blockElements: BlockElement[]) {
+  const hasToggleList = blockElements.some(
+    blockElement =>
+      matchFlavours(blockElement.model, ['affine:list']) &&
+      blockElement.model.children.length > 0
+  );
+  const offsetLeft = hasToggleList
+    ? LIST_DRAG_HANDLE_OFFSET_LEFT
+    : DRAG_HANDLE_OFFSET_LEFT;
+  return offsetLeft;
+}
+
+let previousEle: BlockElement[] = [];
+export function updateDragHandleClassName(blockElements: BlockElement[] = []) {
+  const className = 'with-drag-handle';
+  previousEle.forEach(blockElement => blockElement.classList.remove(className));
+  previousEle = blockElements;
+  blockElements.forEach(blockElement => blockElement.classList.add(className));
+}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,7 +15,7 @@
     "@blocksuite/blocks": "workspace:*",
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
-    "@toeverything/theme": "^0.7.15"
+    "@toeverything/theme": "^0.7.16"
   },
   "dependencies": {
     "@blocksuite/global": "workspace:*",
@@ -25,7 +25,7 @@
     "@blocksuite/blocks": "workspace:*",
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
-    "@toeverything/theme": "^0.7.15"
+    "@toeverything/theme": "^0.7.16"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/editor/themes/affine.css
+++ b/packages/editor/themes/affine.css
@@ -8,7 +8,7 @@
 }
 
 :root {
-  --affine-editor-width: 800px;
+  --affine-editor-width: 944px;
 }
 
 .dg > ul {

--- a/packages/editor/themes/affine.css
+++ b/packages/editor/themes/affine.css
@@ -7,10 +7,6 @@
   unicode-range: U+1F000-1F644, U+203C-3299;
 }
 
-:root {
-  --affine-editor-width: 944px;
-}
-
 .dg > ul {
   overflow: scroll;
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     browserName:
       (process.env.BROWSER as PlaywrightWorkerOptions['browserName']) ??
       'chromium',
-    viewport: { width: 900, height: 900 },
+    viewport: { width: 960, height: 900 },
     // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
     // You can open traces locally(`npx playwright show-trace trace.zip`)
     // or in your browser on [Playwright Trace Viewer](https://trace.playwright.dev/).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: workspace:*
         version: link:../store
       '@toeverything/theme':
-        specifier: ^0.7.15
-        version: 0.7.15
+        specifier: ^0.7.16
+        version: 0.7.16
       '@types/marked':
         specifier: ^4.3.1
         version: 4.3.1
@@ -271,8 +271,8 @@ importers:
         specifier: workspace:*
         version: link:../store
       '@toeverything/theme':
-        specifier: ^0.7.15
-        version: 0.7.15
+        specifier: ^0.7.16
+        version: 0.7.16
 
   packages/global:
     dependencies:
@@ -1541,8 +1541,8 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@toeverything/theme@0.7.15:
-    resolution: {integrity: sha512-aV64wpghK0tOOEVU5iI7AELY4qds+TJuNWHNVGjZbnZECXfo0+BSL0xAfLXD8kUHzoKcnw+IlwcmEl1ctwGOJg==}
+  /@toeverything/theme@0.7.16:
+    resolution: {integrity: sha512-39eJ4wW7Ht07nmNWEmpGq+zPmCSOE3nAwLOOv36HOSEb9FKFAR1n+1DDQsjVs7zjs+yX3+zU7gCveQV4UD9vBA==}
     dev: true
 
   /@toeverything/y-indexeddb@0.9.0-canary.0(yjs@13.6.7):

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -67,6 +67,7 @@ import {
   assertStoreMatchJSX,
   assertText,
   assertTextFormats,
+  assertZoomLevel,
 } from './utils/asserts.js';
 import { scoped, test } from './utils/playwright.js';
 
@@ -1020,13 +1021,20 @@ test(`copy phasor element and text note in edgeless mode`, async ({ page }) => {
     { x: 800, y: 800 },
     { steps: 10 }
   );
-  await assertEdgelessSelectedRect(page, [50, 100, EDITOR_WIDTH, 463.5]);
+  const zoom = 1.075;
+  await assertZoomLevel(page, zoom * 100);
+  await assertEdgelessSelectedRect(page, [50, 100, EDITOR_WIDTH * zoom, 472]);
 
   await copyByKeyboard(page);
   await page.mouse.move(800, 400);
   await page.waitForTimeout(300);
   await pasteByKeyboard(page, false);
-  await assertEdgelessSelectedRect(page, [400, 168.25, EDITOR_WIDTH, 463.5]);
+  await assertEdgelessSelectedRect(page, [
+    370,
+    163.99,
+    EDITOR_WIDTH * zoom,
+    472,
+  ]);
 });
 
 test(scoped`copy when text note active in edgeless`, async ({ page }) => {

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -77,20 +77,24 @@ test('can zoom viewport', async ({ page }) => {
   await assertNoteXYWH(page, [0, 0, EDITOR_WIDTH, 95]);
   await page.mouse.move(CENTER_X, CENTER_Y);
 
-  const original = [50, 402.5, EDITOR_WIDTH, 95];
+  const original = [80, 402.5, EDITOR_WIDTH, 95];
   await assertEdgelessHoverRect(page, original);
-  let box = await getEdgelessHoverRect(page);
+  await assertZoomLevel(page, 100);
 
   await decreaseZoomLevel(page);
+  await assertZoomLevel(page, 75);
   await decreaseZoomLevel(page);
+  await assertZoomLevel(page, 50);
   await page.mouse.move(CENTER_X, CENTER_Y);
 
-  box = await getEdgelessHoverRect(page);
+  const box = await getEdgelessHoverRect(page);
   const zoomed = [box.x, box.y, original[2] * 0.5, original[3] * 0.5];
   await assertEdgelessHoverRect(page, zoomed);
 
   await increaseZoomLevel(page);
+  await assertZoomLevel(page, 75);
   await increaseZoomLevel(page);
+  await assertZoomLevel(page, 100);
   await page.mouse.move(CENTER_X, CENTER_Y);
   await assertEdgelessHoverRect(page, original);
 });
@@ -100,16 +104,20 @@ test('zoom by mouse', async ({ page }) => {
   await initEmptyEdgelessState(page);
 
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+  await assertZoomLevel(page, 100);
+
   await assertNoteXYWH(page, [0, 0, EDITOR_WIDTH, 95]);
   await page.mouse.move(CENTER_X, CENTER_Y);
 
-  const original = [50, 402.5, EDITOR_WIDTH, 95];
+  const original = [80, 402.5, EDITOR_WIDTH, 95];
   await assertEdgelessHoverRect(page, original);
 
   await zoomByMouseWheel(page, 0, 125);
   await page.mouse.move(CENTER_X, CENTER_Y);
+  await assertZoomLevel(page, 75);
 
-  const zoomed = [150, 414.375, original[2] * 0.75, original[3] * 0.75];
+  const zoomed = [172.5, 414.375, original[2] * 0.75, original[3] * 0.75];
   await assertEdgelessHoverRect(page, zoomed);
 });
 
@@ -117,6 +125,7 @@ test('option/alt mouse drag duplicate a new element', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await deleteAll(page);
 
   const start = [0, 0];
@@ -138,6 +147,7 @@ test('should cancel select when the selected point is outside the current select
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   const firstStart = { x: 100, y: 100 };
   const firstEnd = { x: 200, y: 200 };
@@ -252,6 +262,7 @@ test('Before and after switching to Edgeless, the previous zoom ratio and positi
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await assertZoomLevel(page, 100);
   await increaseZoomLevel(page);
   await assertZoomLevel(page, 125);

--- a/tests/edgeless/block-hub.spec.ts
+++ b/tests/edgeless/block-hub.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from '@playwright/test';
 
-import { deleteAll, switchEditorMode } from '../utils/actions/edgeless.js';
+import {
+  deleteAll,
+  switchEditorMode,
+  zoomResetByKeyboard,
+} from '../utils/actions/edgeless.js';
 import {
   click,
   dragBetweenCoords,
@@ -23,6 +27,7 @@ test('block hub should drag and drop a card into existing note', async ({
   await assertRichTexts(page, ['123', '456', '789']);
 
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   await expect(page.locator('.affine-edgeless-child-note')).toHaveCount(1);
 
@@ -55,6 +60,7 @@ test('block hub should add new note when dragged to blank area', async ({
   await assertRichTexts(page, ['123', '456', '789']);
 
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   await expect(page.locator('.affine-edgeless-child-note')).toHaveCount(1);
 

--- a/tests/edgeless/brush.spec.ts
+++ b/tests/edgeless/brush.spec.ts
@@ -9,6 +9,7 @@ import {
   setEdgelessTool,
   switchEditorMode,
   updateExistedBrushElementSize,
+  zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
   addBasicBrushElement,
@@ -151,6 +152,7 @@ test('change brush element size by component-toolbar', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   const start = { x: 100, y: 100 };
   const end = { x: 200, y: 200 };

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -18,6 +18,7 @@ import {
   setEdgelessTool,
   switchEditorMode,
   triggerComponentToolbarAction,
+  zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
   click,
@@ -509,6 +510,7 @@ test('undo/redo should work correctly after resizing', async ({ page }) => {
   await enterPlaygroundRoom(page);
   const ids = await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await activeNoteInEdgeless(page, ids.noteId);
   await waitNextFrame(page, 400);
   // current implementation may be a little inefficient

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -69,6 +69,7 @@ test('can drag selected non-active note', async ({ page }) => {
   await assertRichTexts(page, ['hello']);
 
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await assertNoteXYWH(page, [0, 0, EDITOR_WIDTH, 95]);
 
   // selected, non-active
@@ -85,6 +86,7 @@ test('resize note in edgeless mode', async ({ page }) => {
   await enterPlaygroundRoom(page);
   const ids = await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await activeNoteInEdgeless(page, ids.noteId);
   await waitNextFrame(page, 400);
   await type(page, 'hello');
@@ -125,7 +127,7 @@ test('add Note', async ({ page }) => {
   await initEmptyEdgelessState(page);
 
   await switchEditorMode(page);
-
+  await zoomResetByKeyboard(page);
   await addNote(page, 'hello', 300, 300);
 
   await assertEdgelessTool(page, 'default');
@@ -138,6 +140,7 @@ test('add empty Note', async ({ page }) => {
   await initEmptyEdgelessState(page);
 
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
   await setEdgelessTool(page, 'note');
 
   // add note at 300,300

--- a/tests/edgeless/reordering.spec.ts
+++ b/tests/edgeless/reordering.spec.ts
@@ -5,6 +5,7 @@ import {
   initThreeOverlapNotes,
   switchEditorMode,
   triggerComponentToolbarAction,
+  zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
   enterPlaygroundRoom,
@@ -122,6 +123,7 @@ test.describe('reordering notes', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
     await initThreeOverlapNotes(page);
     await waitNextFrame(page);
     await page.mouse.click(0, 0);

--- a/tests/edgeless/resizing.spec.ts
+++ b/tests/edgeless/resizing.spec.ts
@@ -1,4 +1,7 @@
-import { switchEditorMode } from '../utils/actions/edgeless.js';
+import {
+  switchEditorMode,
+  zoomResetByKeyboard,
+} from '../utils/actions/edgeless.js';
 import {
   addBasicBrushElement,
   addBasicRectShapeElement,
@@ -18,6 +21,7 @@ test.describe('resizing shapes and aspect ratio will be maintained', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
 
     await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
     await page.mouse.move(110, 110);
@@ -57,6 +61,7 @@ test.describe('resizing shapes and aspect ratio will be maintained', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
 
     await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
     await page.mouse.move(110, 110);

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -36,6 +36,7 @@ test('should update rect of selection when resizing viewport', async ({
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await actions.switchEditorMode(page);
+  await actions.zoomResetByKeyboard(page);
 
   await addBasicRectShapeElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
   await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
@@ -81,6 +82,7 @@ test('select multiple shapes and translate', async ({ page }) => {
   await initEmptyEdgelessState(page);
 
   await switchEditorMode(page);
+  await actions.zoomResetByKeyboard(page);
 
   await addBasicBrushElement(page, { x: 100, y: 100 }, { x: 200, y: 200 });
   await page.mouse.move(110, 110);
@@ -109,6 +111,7 @@ test('selection box of shape element sync on fast dragging', async ({
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await actions.zoomResetByKeyboard(page);
 
   await setEdgelessTool(page, 'shape');
   await dragBetweenCoords(page, { x: 100, y: 100 }, { x: 200, y: 200 });
@@ -131,6 +134,7 @@ test('when the selection is always a note, it should remain in an active state',
   await initThreeParagraphs(page);
 
   await switchEditorMode(page);
+  await actions.zoomResetByKeyboard(page);
   const bound = await getNoteBoundBoxInEdgeless(page, ids.noteId);
 
   await setEdgelessTool(page, 'note');
@@ -145,7 +149,7 @@ test('when the selection is always a note, it should remain in an active state',
   // should wait for virgo update and resizeObserver callback
   await waitNextFrame(page);
   // assert add text success
-  await assertEdgelessSelectedRect(page, [46, 597.5, 448, 128]);
+  await assertEdgelessSelectedRect(page, [76, 597.5, 448, 128]);
 
   await clickInCenter(page, bound);
   await clickInCenter(page, bound);

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -16,6 +16,7 @@ import {
   setEdgelessTool,
   switchEditorMode,
   triggerComponentToolbarAction,
+  zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
   addBasicBrushElement,
@@ -334,6 +335,7 @@ test('click to add shape', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   await setEdgelessTool(page, 'shape');
   await waitNextFrame(page, 500);
@@ -350,6 +352,7 @@ test('dbclick to add text in shape', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   await setEdgelessTool(page, 'shape');
   await waitNextFrame(page, 500);
@@ -397,6 +400,7 @@ test('auto wrap text in shape', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
 
   await setEdgelessTool(page, 'shape');
   await waitNextFrame(page, 500);

--- a/tests/edgeless/shortcut.spec.ts
+++ b/tests/edgeless/shortcut.spec.ts
@@ -85,6 +85,7 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
 
     const start = { x: 0, y: 0 };
     const end = { x: 200, y: 200 };
@@ -100,6 +101,7 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
 
     await zoomOutByKeyboard(page);
 
@@ -115,10 +117,13 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
+    let zoom = await getZoomLevel(page);
+    expect(zoom).toBe(100);
 
     await zoomOutByKeyboard(page);
 
-    let zoom = await getZoomLevel(page);
+    zoom = await getZoomLevel(page);
     expect(zoom).toBe(75);
 
     await zoomResetByKeyboard(page);
@@ -130,6 +135,7 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
 
     await zoomInByKeyboard(page);
 

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -161,7 +161,7 @@ test('normalize text element rect after change its font', async ({ page }) => {
 
   await page.mouse.click(140, 210);
   await waitNextFrame(page);
-  await assertEdgelessSelectedRect(page, [130, 200, 113.9, 163.3]);
+  await assertEdgelessSelectedRect(page, [130, 200, 113.9, 167.6]);
   const fontButton = page.locator('.text-font-family-button');
   await fontButton.click();
 
@@ -174,5 +174,5 @@ test('normalize text element rect after change its font', async ({ page }) => {
   await assertTextFont(page, 'General');
   const scribbledTextFont = page.getByText('Scribbled');
   await scribbledTextFont.click();
-  await assertEdgelessSelectedRect(page, [130, 200, 108.3, 163.3]);
+  await assertEdgelessSelectedRect(page, [130, 200, 108.3, 167.6]);
 });

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import {
   assertEdgelessTool,
@@ -17,6 +17,32 @@ import {
   assertEdgelessSelectedRect,
 } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
+
+async function assertTextFont(page: Page, font: 'General' | 'Scribbled') {
+  const fontButton = page.locator('.text-font-family-button');
+  const fontPanel = page.locator('edgeless-font-family-panel');
+  const isFontPanelShow = await fontPanel.isVisible();
+  if (!isFontPanelShow) {
+    if (!fontButton.isVisible())
+      throw new Error('edgeless change text toolbar is not visible');
+
+    await fontButton.click();
+  }
+
+  const generalButton = fontPanel.locator('.general-button');
+  const scibbledButton = fontPanel.locator('.scibbled-button');
+  if (font === 'General') {
+    await expect(
+      generalButton.locator('.active-mode-background[active]')
+    ).toBeVisible();
+    return;
+  }
+  if (font === 'Scribbled') {
+    await expect(
+      scibbledButton.locator('.active-mode-background[active]')
+    ).toBeVisible();
+  }
+}
 
 // it's flaky
 test('add text element in default mode', async ({ page }) => {
@@ -135,13 +161,17 @@ test('normalize text element rect after change its font', async ({ page }) => {
 
   await page.mouse.click(140, 210);
   await waitNextFrame(page);
-  await assertEdgelessSelectedRect(page, [130, 200, 110.7, 163.3]);
+  await assertEdgelessSelectedRect(page, [130, 200, 113.9, 163.3]);
   const fontButton = page.locator('.text-font-family-button');
   await fontButton.click();
+
+  // Default is Scribbled
+  await assertTextFont(page, 'Scribbled');
   const generalTextFont = page.getByText('General');
   await generalTextFont.click();
   await assertEdgelessSelectedRect(page, [130, 200, 114.7, 118.2]);
   await fontButton.click();
+  await assertTextFont(page, 'General');
   const scribbledTextFont = page.getByText('Scribbled');
   await scribbledTextFont.click();
   await assertEdgelessSelectedRect(page, [130, 200, 108.3, 163.3]);

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -101,7 +101,7 @@ test('copy and paste', async ({ page }) => {
 
   await page.mouse.move(145, 155);
   await page.mouse.down();
-  await page.mouse.move(165, 155, {
+  await page.mouse.move(170, 155, {
     steps: 10,
   });
   await page.mouse.up();
@@ -134,14 +134,15 @@ test('normalize text element rect after change its font', async ({ page }) => {
   await page.mouse.click(10, 100);
 
   await page.mouse.click(140, 210);
-  await assertEdgelessSelectedRect(page, [130, 200, 106, 156]);
+  await waitNextFrame(page);
+  await assertEdgelessSelectedRect(page, [130, 200, 110.7, 163.3]);
   const fontButton = page.locator('.text-font-family-button');
   await fontButton.click();
   const generalTextFont = page.getByText('General');
   await generalTextFont.click();
-  await assertEdgelessSelectedRect(page, [130, 200, 106.7, 108]);
+  await assertEdgelessSelectedRect(page, [130, 200, 114.7, 118.2]);
   await fontButton.click();
   const scribbledTextFont = page.getByText('Scribbled');
   await scribbledTextFont.click();
-  await assertEdgelessSelectedRect(page, [130, 200, 104, 156]);
+  await assertEdgelessSelectedRect(page, [130, 200, 108.3, 163.3]);
 });

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -169,10 +169,12 @@ test('normalize text element rect after change its font', async ({ page }) => {
   await assertTextFont(page, 'Scribbled');
   const generalTextFont = page.getByText('General');
   await generalTextFont.click();
-  await assertEdgelessSelectedRect(page, [130, 200, 114.7, 118.2]);
+  await waitNextFrame(page);
+  await assertEdgelessSelectedRect(page, [130, 200, 114.7, 116]);
   await fontButton.click();
   await assertTextFont(page, 'General');
   const scribbledTextFont = page.getByText('Scribbled');
   await scribbledTextFont.click();
-  await assertEdgelessSelectedRect(page, [130, 200, 108.3, 167.6]);
+  await waitNextFrame(page);
+  await assertEdgelessSelectedRect(page, [130, 200, 111.7, 167.6]);
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -593,7 +593,8 @@ export async function zoomOutByKeyboard(page: Page) {
 
 export async function zoomResetByKeyboard(page: Page) {
   await page.keyboard.press(`${SHORT_KEY}+0`, { delay: 50 });
-  await waitNextFrame(page);
+  // Wait for animation
+  await waitNextFrame(page, 200);
 }
 
 export async function zoomInByKeyboard(page: Page) {

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -832,7 +832,7 @@ export async function assertEdgelessColorSameWithHexColor(
 
 export async function assertZoomLevel(page: Page, zoom: number) {
   const z = await getZoomLevel(page);
-  expect(z).toBe(zoom);
+  expect(z).toBe(Math.ceil(zoom));
 }
 
 export async function assertConnectorPath(


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/2945

- [x] Add toggle for list
- [x] Update editor layout
- [x] Update drag handle
- [x] Fix tests
- [x] Add new tests for toggle list
- [x] Update the `theme` package
  - See https://github.com/toeverything/design/pull/90
- [x] Update mobile padding
  - `@media screen and (max-width: 640px)`

Credits to https://github.com/toeverything/blocksuite/pull/1139

## Side effects

- Now a new class `with-drag-handle` will be added to block elements when the drag handle hovering
- Update `--affine-editor-width` from 800px to 944px
- Update `affine-doc-page-block-container` padding from 24px to 96px
- Update playwright viewport from 900px to 960px

---


https://github.com/toeverything/blocksuite/assets/18554747/868a95d6-5102-41ed-8618-bc8e2c5785fa

