### PR TITLE
chore: move @toeverything/theme to peer dependency

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,11 +15,11 @@
   "peerDependencies": {
     "@blocksuite/blocks": "workspace:*",
     "@blocksuite/lit": "workspace:*",
-    "@blocksuite/store": "workspace:*"
+    "@blocksuite/store": "workspace:*",
+    "@toeverything/theme": "^0.7.9"
   },
   "dependencies": {
     "@blocksuite/global": "workspace:*",
-    "@toeverything/theme": "0.7.7",
     "lit": "^2.7.6",
     "marked": "^4.3.0",
     "turndown": "^7.1.2"
@@ -28,6 +28,7 @@
     "@blocksuite/blocks": "workspace:*",
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
+    "@toeverything/theme": "^0.7.9",
     "@types/marked": "^4.3.1",
     "@types/turndown": "^5.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       '@blocksuite/global':
         specifier: workspace:*
         version: link:../global
-      '@toeverything/theme':
-        specifier: 0.7.7
-        version: 0.7.7
       lit:
         specifier: ^2.7.6
         version: 2.7.6
@@ -263,6 +260,9 @@ importers:
       '@blocksuite/store':
         specifier: workspace:*
         version: link:../store
+      '@toeverything/theme':
+        specifier: ^0.7.9
+        version: 0.7.9
       '@types/marked':
         specifier: ^4.3.1
         version: 4.3.1
@@ -1602,9 +1602,9 @@ packages:
     resolution: {integrity: sha512-tvtmkI4ALjKThVVORh++sB9JnkFY7eGInKxNy+Df7WVQiF7T85tlvGADzlgX4Ic+CK5MIUzZ0jhOlQ/RRlgXpg==}
     dev: false
 
-  /@toeverything/theme@0.7.7:
-    resolution: {integrity: sha512-yGk1GiPnaDmm0uUqg/zzEVKahl1GusRZb+wy+wnVu+yjOmiD/3NlvdoSNdJC64iHYL1wH6dqxuw23oIGEmE6RQ==}
-    dev: false
+  /@toeverything/theme@0.7.9:
+    resolution: {integrity: sha512-CrgP/c2OrVIAWrAaASChUy8YBcr/u6fOt07sZUL72MsLGQ9IbfistfBZtcvPA2HyXUhAkktgM28WOx7Ga7ZHWA==}
+    dev: true
 
   /@toeverything/y-indexeddb@0.8.0-canary.4(yjs@13.6.7):
     resolution: {integrity: sha512-PQhuZhGYfydQy8+AZghdu/mtQ2vf1hQIZz4YW+7HE9X10RN0f4Sc3u2vlhvM3Y+exdK0E12iqhTvQ2kaskQ4hg==}


### PR DESCRIPTION
Fix the issue with possibly inconsistent theme versions of the blocksuite and affine.