### PR TITLE
perf(edgeless): optimize viewport zooming and moving performance

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -200,7 +200,7 @@ export class EdgelessPageBlockComponent
       top: 0;
       left: 0;
       contain: layout style size;
-      visibility: auto;
+      content-visibility: auto;
       transform: translate(var(--affine-edgeless-x), var(--affine-edgeless-y))
         scale(var(--affine-zoom));
     }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -200,7 +200,7 @@ export class EdgelessPageBlockComponent
       top: 0;
       left: 0;
       contain: layout style size;
-      content-visibility: auto;
+      content-visibility: hidden;
       transform: translate(var(--affine-edgeless-x), var(--affine-edgeless-y))
         scale(var(--affine-zoom));
     }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -200,7 +200,6 @@ export class EdgelessPageBlockComponent
       top: 0;
       left: 0;
       contain: layout style size;
-      content-visibility: hidden;
       transform: translate(var(--affine-edgeless-x), var(--affine-edgeless-y))
         scale(var(--affine-zoom));
     }


### PR DESCRIPTION
Closes #3513

The edgeless mode are likely to experience lag on zooming and moving  when there's a massive amount of notes in the page. We could use css property `will-change` during the viewport's update and remove it after update has complete. This could bring us siginificant renering performance boost. See the comparison below:

Before use `will-change`:

https://github.com/toeverything/blocksuite/assets/9301743/52c186e4-2f7c-4059-9931-1fc30783f8fb

After use `will-change`:

https://github.com/toeverything/blocksuite/assets/9301743/910762e2-bab1-4cbf-a865-5dc5bdd2370c
