### PR TITLE
feat(store): support block level upgrade on schema

### DIFF
--- a/packages/blocks/src/database-block/database-model.ts
+++ b/packages/blocks/src/database-block/database-model.ts
@@ -1,5 +1,5 @@
 import type { Text } from '@blocksuite/store';
-import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
+import { BaseBlockModel, defineBlockSchema, nanoid } from '@blocksuite/store';
 
 import type {
   DatabaseViewData,
@@ -216,5 +216,30 @@ export const DatabaseBlockSchema = defineBlockSchema({
   },
   toModel: () => {
     return new DatabaseBlockModel();
+  },
+  onUpgrade: (data, previousVersion, latestVersion) => {
+    if (previousVersion >= 3 || latestVersion < 3) {
+      return;
+    }
+    const id = nanoid();
+    // @ts-expect-error
+    const title = data['titleColumnName'];
+    // @ts-expect-error
+    const width = data['titleColumnWidth'];
+    // @ts-expect-error
+    delete data['titleColumnName'];
+    // @ts-expect-error
+    delete data['titleColumnWidth'];
+    data.columns.unshift({
+      id,
+      type: 'title',
+      name: title,
+      data: {},
+    });
+    data.views.forEach(view => {
+      if (view.mode === 'table') {
+        view.columns.unshift({ id, width });
+      }
+    });
   },
 });

--- a/packages/blocks/src/surface-block/surface-model.ts
+++ b/packages/blocks/src/surface-block/surface-model.ts
@@ -4,21 +4,8 @@ type SurfaceBlockProps = {
   elements: Record<string, unknown>;
 };
 
-export const SurfaceBlockSchema = defineBlockSchema({
-  flavour: 'affine:surface',
-  props: (): SurfaceBlockProps => ({
-    elements: {},
-  }),
-  metadata: {
-    version: 4,
-    role: 'hub',
-    parent: ['affine:page'],
-    children: [],
-  },
-  onUpgrade: (data, previousVersion, version) => {
-    if (previousVersion >= 4 || version !== 4) {
-      return;
-    }
+const migration = {
+  toV4: (data, previousVersion, latestVersion) => {
     const { elements } = data;
     Object.keys(elements).forEach(key => {
       const element = elements[key] as Record<string, unknown>;
@@ -36,6 +23,24 @@ export const SurfaceBlockSchema = defineBlockSchema({
         }
       }
     });
+  },
+} satisfies Record<string, (typeof SurfaceBlockSchema)['onUpgrade']>;
+
+export const SurfaceBlockSchema = defineBlockSchema({
+  flavour: 'affine:surface',
+  props: (): SurfaceBlockProps => ({
+    elements: {},
+  }),
+  metadata: {
+    version: 4,
+    role: 'hub',
+    parent: ['affine:page'],
+    children: [],
+  },
+  onUpgrade: (data, previousVersion, version) => {
+    if (previousVersion < 4 && version >= 4) {
+      migration.toV4(data, previousVersion, version);
+    }
   },
 });
 

--- a/packages/blocks/src/surface-block/surface-model.ts
+++ b/packages/blocks/src/surface-block/surface-model.ts
@@ -15,6 +15,28 @@ export const SurfaceBlockSchema = defineBlockSchema({
     parent: ['affine:page'],
     children: [],
   },
+  onUpgrade: (data, previousVersion, version) => {
+    if (previousVersion >= 4 || version !== 4) {
+      return;
+    }
+    const { elements } = data;
+    Object.keys(elements).forEach(key => {
+      const element = elements[key] as Record<string, unknown>;
+      const type = element.type;
+      if (type === 'shape' || type === 'text') {
+        const isBold = element.isBold;
+        const isItalic = element.isItalic;
+        delete element.isBold;
+        delete element.isItalic;
+        if (isBold) {
+          element.bold = true;
+        }
+        if (isItalic) {
+          element.italic = true;
+        }
+      }
+    });
+  },
 });
 
 export type SurfaceBlockModel = SchemaToModel<typeof SurfaceBlockSchema>;

--- a/packages/docs/attaching-editor.md
+++ b/packages/docs/attaching-editor.md
@@ -5,7 +5,7 @@ In the [Getting Started](./getting-started) section, we used a `SimpleAffineEdit
 ```ts
 import { AffineSchemas } from '@blocksuite/blocks/models';
 import type { Page } from '@blocksuite/store';
-import { Workspace } from '@blocksuite/store';
+import { Workspace, Schema } from '@blocksuite/store';
 import { LitElement } from 'lit';
 import { EditorContainer } from './editor-container.js';
 
@@ -16,7 +16,10 @@ export class SimpleAffineEditor extends LitElement {
   constructor() {
     super();
 
-    this.workspace = new Workspace({ id: 'foo' }).register(AffineSchemas);
+    const schema = new Schema();
+    schema.register(AffineSchemas);
+
+    this.workspace = new Workspace({ id: 'foo', schema });
     this.page = this.workspace.createPage({ init: true });
   }
 

--- a/packages/docs/data-persistence.md
+++ b/packages/docs/data-persistence.md
@@ -19,12 +19,14 @@ Different providers can handle the asynchronous IO over different network protoc
 Code example:
 
 ```ts
-import { Workspace } from '@blocksuite/store';
+import { Workspace, Schema } from '@blocksuite/store';
 import { AffineSchemas } from '@blocksuite/blocks/models';
 import { IndexeddbPersistence } from 'y-indexeddb';
 
-const workspace = new Workspace();
-workspace.register(AffineSchemas);
+const schema = new Schema();
+schema.register(AffineSchemas);
+
+const workspace = new Workspace({ schema });
 
 // `workspace.doc` is the underlying Yjs data structure
 const { doc } = workspace;

--- a/packages/docs/workspaces-and-pages.md
+++ b/packages/docs/workspaces-and-pages.md
@@ -9,12 +9,14 @@ BlockSuite is centered around the concept of blocks. However, to handle a large 
 A `Workspace` in BlockSuite acts as a top-level container for organizing pages. By creating workspaces, users can group and categorize different sets of pages, each representing a specific project or a collection of related content. Here is how we create a new workspace:
 
 ```ts
-import { Workspace } from '@blocksuite/store';
+import { Workspace, Schema } from '@blocksuite/store';
 
-const workspace = new Workspace({ id: 'foo' });
+const schema = new Schema();
 
 // We can register a batch of blocks to the workspace
-workspace.register(AffineSchemas);
+schema.register(AffineSchemas);
+
+const workspace = new Workspace({ id: 'foo', schema });
 ```
 
 ## Pages

--- a/packages/editor/src/components/simple-affine-editor.ts
+++ b/packages/editor/src/components/simple-affine-editor.ts
@@ -1,6 +1,6 @@
 import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
 import type { Page } from '@blocksuite/store';
-import { Workspace } from '@blocksuite/store';
+import { Schema, Workspace } from '@blocksuite/store';
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -20,9 +20,10 @@ export class SimpleAffineEditor extends LitElement {
 
   constructor() {
     super();
-    this.workspace = new Workspace({ id: 'test' })
-      .register(AffineSchemas)
-      .register(__unstableSchemas);
+    const schema = new Schema();
+
+    schema.register(AffineSchemas).register(__unstableSchemas);
+    this.workspace = new Workspace({ id: 'test', schema });
     this.page = this.workspace.createPage({ id: 'page0' });
     this.page.waitForLoaded().then(() => {
       const pageBlockId = this.page.addBlock('affine:page');

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -133,9 +133,7 @@ async function main() {
     return;
   }
 
-  const workspace = new Workspace(options)
-    .register(AffineSchemas)
-    .register(__unstableSchemas);
+  const workspace = new Workspace(options);
   window.workspace = workspace;
   window.blockSchemas = AffineSchemas;
   window.Y = Workspace.Y;

--- a/packages/playground/apps/default/utils.ts
+++ b/packages/playground/apps/default/utils.ts
@@ -11,6 +11,7 @@ import {
   assertExists,
   createIndexeddbStorage,
   Generator,
+  Schema,
   Utils,
   Workspace,
   type WorkspaceOptions,
@@ -78,11 +79,12 @@ Object.defineProperty(globalThis, 'debugFromFile', {
       extensions: ['.ydoc'],
     });
     const buffer = await file.arrayBuffer();
+    const schema = new Schema();
+    schema.register(AffineSchemas).register(__unstableSchemas);
     const workspace = new Workspace({
+      schema,
       id: 'temporary',
-    })
-      .register(AffineSchemas)
-      .register(__unstableSchemas);
+    });
     Workspace.Y.applyUpdate(workspace.doc, new Uint8Array(buffer));
     globalThis.debugWorkspace = workspace;
   },
@@ -141,9 +143,12 @@ export function createWorkspaceOptions(): WorkspaceOptions {
     createIndexeddbStorage,
   ];
   const idGenerator: Generator = Generator.NanoID;
+  const schema = new Schema();
+  schema.register(AffineSchemas).register(__unstableSchemas);
 
   return {
     id: 'quickEdgeless',
+    schema,
     providerCreators: [],
     idGenerator,
     blobStorages,

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -90,9 +90,7 @@ async function main() {
   if (window.workspace) {
     return;
   }
-  const workspace = new Workspace(options)
-    .register(AffineSchemas)
-    .register(__unstableSchemas);
+  const workspace = new Workspace(options);
   window.workspace = workspace;
   window.blockSchemas = AffineSchemas;
   window.Y = Workspace.Y;

--- a/packages/playground/apps/starter/utils.ts
+++ b/packages/playground/apps/starter/utils.ts
@@ -22,6 +22,7 @@ import {
   createMemoryStorage,
   createSimpleServerStorage,
   Generator,
+  Schema,
   Utils,
   Workspace,
   type WorkspaceOptions,
@@ -125,11 +126,13 @@ if (isE2E) {
         extensions: ['.ydoc'],
       });
       const buffer = await file.arrayBuffer();
+      const schema = new Schema();
+      schema.register(AffineSchemas).register(__unstableSchemas);
+
       const workspace = new Workspace({
+        schema,
         id: 'temporary',
-      })
-        .register(AffineSchemas)
-        .register(__unstableSchemas);
+      });
       Workspace.Y.applyUpdate(workspace.doc, new Uint8Array(buffer));
       globalThis.debugWorkspace = workspace;
     },
@@ -190,6 +193,9 @@ export async function tryInitExternalContent(
 export function createWorkspaceOptions(): WorkspaceOptions {
   const providerCreators: DocProviderCreator[] = [];
   const blobStorages: ((id: string) => BlobStorage)[] = [];
+  const schema = new Schema();
+  schema.register(AffineSchemas).register(__unstableSchemas);
+
   let idGenerator: Generator = Generator.AutoIncrement; // works only in single user mode
 
   if (providerArgs.includes('idb')) {
@@ -223,6 +229,7 @@ export function createWorkspaceOptions(): WorkspaceOptions {
 
   return {
     id: room,
+    schema,
     providerCreators,
     idGenerator,
     blobStorages,

--- a/packages/playground/examples/store/main.ts
+++ b/packages/playground/examples/store/main.ts
@@ -1,4 +1,4 @@
-import { type Page, Workspace } from '@blocksuite/store';
+import { type Page, Schema, Workspace } from '@blocksuite/store';
 
 import {
   type TodoContainerBlockModel,
@@ -7,8 +7,9 @@ import {
 } from './schema';
 
 function initPage() {
-  const workspace = new Workspace({ id: 'todo' });
-  workspace.register(TodoSchema);
+  const schema = new Schema();
+  schema.register(TodoSchema);
+  const workspace = new Workspace({ id: 'todo', schema });
   const page = workspace.createPage({ id: 'page0' });
   page.addBlock('todo:container');
   return page;

--- a/packages/store/src/__tests__/database.unit.spec.ts
+++ b/packages/store/src/__tests__/database.unit.spec.ts
@@ -11,12 +11,7 @@ import { NoteBlockSchema } from '../../../blocks/src/note-block/note-model.js';
 import { PageBlockSchema } from '../../../blocks/src/page-block/page-model.js';
 import { ParagraphBlockSchema } from '../../../blocks/src/paragraph-block/paragraph-model.js';
 import type { BaseBlockModel, Page } from '../index.js';
-import { Generator, Workspace } from '../index.js';
-
-function createTestOptions() {
-  const idGenerator = Generator.AutoIncrement;
-  return { id: 'test-workspace', idGenerator, isSSR: true };
-}
+import { Generator, Schema, Workspace } from '../index.js';
 
 const AffineSchemas = [
   ParagraphBlockSchema,
@@ -25,9 +20,16 @@ const AffineSchemas = [
   DatabaseBlockSchema,
 ];
 
+function createTestOptions() {
+  const idGenerator = Generator.AutoIncrement;
+  const schema = new Schema();
+  schema.register(AffineSchemas);
+  return { id: 'test-workspace', idGenerator, isSSR: true, schema };
+}
+
 async function createTestPage(pageId = 'page0') {
   const options = createTestOptions();
-  const workspace = new Workspace(options).register(AffineSchemas);
+  const workspace = new Workspace(options);
   const page = workspace.createPage({ id: pageId });
   await page.waitForLoaded();
   return page;

--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -7,12 +7,7 @@ import { NoteBlockSchema } from '../../../blocks/src/note-block/note-model.js';
 import { PageBlockSchema } from '../../../blocks/src/page-block/page-model.js';
 import { ParagraphBlockSchema } from '../../../blocks/src/paragraph-block/paragraph-model.js';
 import type { Page } from '../index.js';
-import { Generator, Workspace } from '../index.js';
-
-function createTestOptions() {
-  const idGenerator = Generator.AutoIncrement;
-  return { id: 'test-workspace', idGenerator, isSSR: true };
-}
+import { Generator, Schema, Workspace } from '../index.js';
 
 export const BlockSchemas = [
   ParagraphBlockSchema,
@@ -20,9 +15,16 @@ export const BlockSchemas = [
   NoteBlockSchema,
 ];
 
+function createTestOptions() {
+  const idGenerator = Generator.AutoIncrement;
+  const schema = new Schema();
+  schema.register(BlockSchemas);
+  return { id: 'test-workspace', idGenerator, isSSR: true, schema };
+}
+
 async function createTestPage(pageId = 'page0', workspace?: Workspace) {
   const options = createTestOptions();
-  const _workspace = workspace || new Workspace(options).register(BlockSchemas);
+  const _workspace = workspace || new Workspace(options);
   const page = _workspace.createPage({ id: pageId });
   await page.waitForLoaded();
   return page;

--- a/packages/store/src/__tests__/schema.unit.spec.ts
+++ b/packages/store/src/__tests__/schema.unit.spec.ts
@@ -12,11 +12,13 @@ import { ParagraphBlockSchema } from '../../../blocks/src/paragraph-block/paragr
 import { SchemaValidateError } from '../../../global/src/error/index.js';
 import { defineBlockSchema } from '../base';
 import { Generator } from '../store';
-import { Workspace } from '../workspace';
+import { Schema, Workspace } from '../workspace';
 
 function createTestOptions() {
   const idGenerator = Generator.AutoIncrement;
-  return { id: 'test-workspace', idGenerator, isSSR: true };
+  const schema = new Schema();
+  schema.register(BlockSchemas);
+  return { id: 'test-workspace', idGenerator, isSSR: true, schema };
 }
 
 const TestCustomNoteBlockSchema = defineBlockSchema({
@@ -58,7 +60,7 @@ const BlockSchemas = [
 const defaultPageId = 'page0';
 async function createTestPage(pageId = defaultPageId) {
   const options = createTestOptions();
-  const workspace = new Workspace(options).register(BlockSchemas);
+  const workspace = new Workspace(options);
   const page = workspace.createPage({ id: pageId });
   await page.waitForLoaded();
   return page;

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -94,6 +94,11 @@ export function defineBlockSchema<
     props: PropsGetter<Props>;
     flavour: Flavour;
   } & Metadata;
+  onUpgrade?: (
+    data: Props,
+    previousVersion: number,
+    latestVersion: number
+  ) => void;
 };
 
 export function defineBlockSchema({

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -38,7 +38,7 @@ export const BlockSchema = z.object({
   }),
   onUpgrade: z
     .function()
-    .args(z.record(z.any()), z.number(), z.number())
+    .args(z.any(), z.number(), z.number())
     .returns(z.void())
     .optional(),
 });

--- a/packages/store/src/base.ts
+++ b/packages/store/src/base.ts
@@ -36,6 +36,11 @@ export const BlockSchema = z.object({
       .optional(),
     toModel: z.function().args().returns(z.custom<BaseBlockModel>()).optional(),
   }),
+  onUpgrade: z
+    .function()
+    .args(z.record(z.any()), z.number(), z.number())
+    .returns(z.void())
+    .optional(),
 });
 
 export type BlockSchemaType = z.infer<typeof BlockSchema>;
@@ -76,6 +81,11 @@ export function defineBlockSchema<
   flavour: Flavour;
   metadata: Metadata;
   props?: (internalPrimitives: InternalPrimitives) => Props;
+  onUpgrade?: (
+    data: Props,
+    previousVersion: number,
+    latestVersion: number
+  ) => void;
   toModel?: () => Model;
 }): {
   version: number;
@@ -91,6 +101,7 @@ export function defineBlockSchema({
   props,
   metadata,
   toModel,
+  onUpgrade,
 }: {
   flavour: string;
   metadata: {
@@ -101,6 +112,11 @@ export function defineBlockSchema({
   };
   props?: (internalPrimitives: InternalPrimitives) => Record<string, unknown>;
   toModel?: () => BaseBlockModel;
+  onUpgrade?: (
+    data: Record<string, unknown>,
+    previousVersion: number,
+    latestVersion: number
+  ) => void;
 }): BlockSchemaType {
   const schema = {
     version: metadata.version,
@@ -112,6 +128,7 @@ export function defineBlockSchema({
       props,
       toModel,
     },
+    onUpgrade,
   } satisfies z.infer<typeof BlockSchema>;
   BlockSchema.parse(schema);
   return schema;

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -15,7 +15,8 @@ import type {
   YBlocks,
 } from '../workspace/page.js';
 import type { Page } from '../workspace/page.js';
-import type { BlockSuiteDoc } from '../yjs/index.js';
+import type { ProxyConfig } from '../yjs/config.js';
+import type { ProxyManager } from '../yjs/index.js';
 import { isPureObject } from '../yjs/index.js';
 import { native2Y } from '../yjs/utils.js';
 
@@ -112,12 +113,13 @@ export function syncBlockProps(
 
 export function toBlockProps(
   yBlock: YBlock,
-  doc: BlockSuiteDoc
+  proxy: ProxyManager
 ): Partial<BlockProps> {
+  const config: ProxyConfig = { deep: true };
   const prefixedProps = yBlock.toJSON() as PrefixedBlockProps;
   const props: Partial<BlockProps> = {};
   Object.keys(prefixedProps).forEach(key => {
-    if (prefixedProps[key]) {
+    if (prefixedProps[key] && key.startsWith('sys:')) {
       props[key.replace('sys:', '')] = prefixedProps[key];
     }
   });
@@ -128,14 +130,10 @@ export function toBlockProps(
     const key = prefixedKey.replace('prop:', '');
     const realValue = yBlock.get(prefixedKey);
     if (realValue instanceof Y.Map) {
-      const value = doc.proxy.createYProxy(realValue, {
-        deep: true,
-      });
+      const value = proxy.createYProxy(realValue, config);
       props[key] = value;
     } else if (realValue instanceof Y.Array) {
-      const value = doc.proxy.createYProxy(realValue, {
-        deep: true,
-      });
+      const value = proxy.createYProxy(realValue, config);
       props[key] = value;
     } else {
       props[key] = prefixedProps[prefixedKey];
@@ -143,6 +141,64 @@ export function toBlockProps(
   });
 
   return props;
+}
+
+export function toBlockMigrationData(
+  yBlock: YBlock,
+  proxy: ProxyManager
+): Partial<BlockProps> {
+  const config: ProxyConfig = { deep: true };
+  const prefixedProps = yBlock.toJSON() as PrefixedBlockProps;
+
+  const props: Partial<BlockProps> = {};
+  Object.keys(prefixedProps).forEach(prefixedKey => {
+    if (prefixedProps[prefixedKey] && prefixedKey.startsWith('prop:')) {
+      const realValue = yBlock.get(prefixedKey);
+      const key = prefixedKey.replace('prop:', '');
+      if (realValue instanceof Y.Map) {
+        const value = proxy.createYProxy(realValue, config);
+        props[key] = value;
+      } else if (realValue instanceof Y.Array) {
+        const value = proxy.createYProxy(realValue, config);
+        props[key] = value;
+      } else {
+        props[key] = prefixedProps[prefixedKey];
+      }
+    }
+  });
+
+  return new Proxy(props, {
+    has: (target, p) => {
+      return Reflect.has(target, p);
+    },
+    set: (target, p, value, receiver) => {
+      if (typeof p !== 'string') {
+        throw new Error('key cannot be a symbol');
+      }
+
+      if (isPureObject(value) || Array.isArray(value)) {
+        const _y = native2Y(value as Record<string, unknown> | unknown[], true);
+        yBlock.set(`prop:${p}`, _y);
+        const _value = proxy.createYProxy(_y, config);
+
+        return Reflect.set(target, p, _value, receiver);
+      }
+
+      yBlock.set(`prop:${p}`, value);
+      return Reflect.set(target, p, value, receiver);
+    },
+    get: (target, p, receiver) => {
+      return Reflect.get(target, p, receiver);
+    },
+    deleteProperty: (target, p): boolean => {
+      if (typeof p !== 'string') {
+        throw new Error('key cannot be a symbol');
+      }
+
+      yBlock.delete(`prop:${p}`);
+      return Reflect.deleteProperty(target, p);
+    },
+  });
 }
 
 export function encodeWorkspaceAsYjsUpdateV2(workspace: Workspace): string {

--- a/packages/store/src/workspace/index.ts
+++ b/packages/store/src/workspace/index.ts
@@ -1,4 +1,5 @@
 export type { PageMeta } from './meta.js';
 export { Page } from './page.js';
+export { Schema } from './schema.js';
 export type { WorkspaceOptions } from './workspace.js';
 export { Workspace } from './workspace.js';

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -765,7 +765,7 @@ export class Page extends Space<FlatBlockMap> {
   private _handleYBlockAdd(visited: Set<string>, id: string) {
     const yBlock = this._getYBlock(id);
 
-    const props = toBlockProps(yBlock, this.doc);
+    const props = toBlockProps(yBlock, this.doc.proxy);
     const model = this._createBlockModel({ ...props, id }, yBlock);
     this._blockMap.set(id, model);
 

--- a/packages/store/src/workspace/workspace.ts
+++ b/packages/store/src/workspace/workspace.ts
@@ -2,8 +2,6 @@ import { assertExists, Slot } from '@blocksuite/global/utils';
 import * as Y from 'yjs';
 
 import type { AwarenessStore } from '../awareness.js';
-import type { BlockSchemaType } from '../base.js';
-import { BlockSchema } from '../base.js';
 import { createMemoryStorage } from '../persistence/blob/memory-storage.js';
 import type { BlobManager, BlobStorage } from '../persistence/blob/types.js';
 import { sha } from '../persistence/blob/utils.js';
@@ -17,9 +15,11 @@ import type { QueryContent } from './indexer/search.js';
 import { SearchIndexer } from './indexer/search.js';
 import { type PageMeta, WorkspaceMeta } from './meta.js';
 import { Page } from './page.js';
-import { Schema } from './schema.js';
+import type { Schema } from './schema.js';
 
-export type WorkspaceOptions = StoreOptions;
+export type WorkspaceOptions = StoreOptions & {
+  schema: Schema;
+};
 
 export class Workspace {
   static Y = Y;
@@ -47,7 +47,7 @@ export class Workspace {
   };
 
   constructor(storeOptions: WorkspaceOptions) {
-    this._schema = new Schema(this);
+    this._schema = storeOptions.schema;
 
     this._store = new Store(storeOptions);
 
@@ -164,14 +164,6 @@ export class Workspace {
 
   registerProvider(providerCreator: DocProviderCreator, id?: string) {
     return this._store.registerProvider(providerCreator, id);
-  }
-
-  register(blockSchema: BlockSchemaType[]) {
-    blockSchema.forEach(schema => {
-      BlockSchema.parse(schema);
-      this.schema.flavourSchemaMap.set(schema.model.flavour, schema);
-    });
-    return this;
   }
 
   private _hasPage(pageId: string) {


### PR DESCRIPTION
# Run Migration

```ts
import { schema, workspace } from '@blocksuite/store';

const schema = new Schema();
schema.register(AffineBlocks);

// Migration can run without workspace
schema.upgradePage(oldBlockVersions, oldYDoc);

// create workspace with schema
const workspace = new Workspace({ schema });
```

---

# Write Migration

```ts
const migration = {
  toV4: (data, previousVersion, latestVersion) => {
    const { elements } = data;
    Object.keys(elements).forEach(key => {
      const element = elements[key] as Record<string, unknown>;
      const type = element.type;
      if (type === 'shape' || type === 'text') {
        const isBold = element.isBold;
        const isItalic = element.isItalic;
        delete element.isBold;
        delete element.isItalic;
        if (isBold) {
          element.bold = true;
        }
        if (isItalic) {
          element.italic = true;
        }
      }
    });
  },
} satisfies Record<string, (typeof SurfaceBlockSchema)['onUpgrade']>;

export const SurfaceBlockSchema = defineBlockSchema({
  flavour: 'affine:surface',
  props: (): SurfaceBlockProps => ({
    elements: {},
  }),
  metadata: {
    version: 4,
    role: 'hub',
    parent: ['affine:page'],
    children: [],
  },
  onUpgrade: (data, previousVersion, latestVersion) => {
    if (previousVersion < 4 && latestVersion >= 4) {
      migration.toV4(data, previousVersion, latestVersion);
    }
  },
});
```