### PR TITLE
test: fix flaky situation for addNote

### DIFF
--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -22,6 +22,7 @@ import {
   enterPlaygroundRoom,
   getEditorLocator,
   initEmptyEdgelessState,
+  waitForRange,
   waitForVirgoStateUpdated,
   waitNextFrame,
 } from './misc.js';
@@ -316,6 +317,11 @@ export async function addBasicConnectorElement(
 export async function addNote(page: Page, text: string, x: number, y: number) {
   await setEdgelessTool(page, 'note');
   await page.mouse.click(x, y);
+  const newNoteId = await page.evaluate(() => {
+    const allNotes = document.querySelectorAll('affine-note');
+    return allNotes[allNotes.length - 1].model.id;
+  });
+  await waitForRange(page, `affine-note[data-block-id="${newNoteId}"]`);
   await waitForVirgoStateUpdated(page);
   await type(page, text);
 }


### PR DESCRIPTION
I noticed the test, 'add Note', is quite flaky.

![image](https://github.com/toeverything/blocksuite/assets/17249775/57d862f8-b454-4f78-93b3-89a6c688fa95)


Analyse it against code:
https://github.com/toeverything/blocksuite/blob/d2d415496842176f67b398f90c64825f63bfe214/tests/edgeless/note.spec.ts#L120-L131

https://github.com/toeverything/blocksuite/blob/d2d415496842176f67b398f90c64825f63bfe214/tests/utils/actions/edgeless.ts#L316-L321

placed the new note block, then type some characters, but maybe the note is not focused at the moment, so that type action will trigger changing tool to 'pan', and then only input the part of characters to note (often 'ello'). 
> There is a delay between mounting note block and adding range to it.

In my understanding, it must wait for range so that be able to type in the note. I look through other places where call `addNote`, work similarly.