### PR TITLE
test: cleanup invalid test cases

### DIFF
--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -14,7 +14,7 @@ import {
   dragBetweenCoords,
   enterPlaygroundRoom,
   focusRichText,
-  getAllNotes,
+  getAllNoteIds,
   getEditorLocator,
   getRichTextBoundingBox,
   importMarkdown,
@@ -801,10 +801,10 @@ test(scoped`paste note block with background`, async ({ page }) => {
 
   await page.mouse.move(0, 0);
   await pasteByKeyboard(page, false);
-  const notes = await getAllNotes(page);
-  await Array.from(notes).map(async note => {
-    await assertEdgelessNoteBackground(page, note.id, color);
-  });
+  const noteIds = await getAllNoteIds(page);
+  for (const noteId of noteIds) {
+    await assertEdgelessNoteBackground(page, noteId, color);
+  }
 });
 
 test(scoped`copy and paste to selection block selection`, async ({ page }) => {

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -433,9 +433,11 @@ export async function getNoteBoundBoxInEdgeless(page: Page, noteId: string) {
   return bound;
 }
 
-export async function getAllNotes(page: Page) {
+export async function getAllNoteIds(page: Page) {
   return await page.evaluate(() => {
-    return document.querySelectorAll('affine-note');
+    return Array.from(document.querySelectorAll('affine-note')).map(
+      note => note.model.id
+    );
   });
 }
 


### PR DESCRIPTION
- `page.evaluate()` returns a serializable value or undefined, in this case, `Array.from(notes)` will be `[]`
- loop promises mistakenly