### PR TITLE
feat(database): optimize native selection

### DIFF
--- a/packages/blocks/src/database-block/table/clipboard.ts
+++ b/packages/blocks/src/database-block/table/clipboard.ts
@@ -25,6 +25,8 @@ type TableViewClipboardConfig = {
   data: DataViewManager;
 };
 
+const columnsContainInput = ['number', 'date', 'link', 'select'];
+
 export class TableViewClipboard implements BaseViewClipboard {
   private _disposables = new DisposableGroup();
   private _path: string[];
@@ -69,7 +71,7 @@ export class TableViewClipboard implements BaseViewClipboard {
         focus.columnIndex
       );
 
-      if (column.type !== 'number') {
+      if (!columnsContainInput.includes(column.type)) {
         const data = (cellToStringMap[column.type]?.(container) ??
           '') as string;
         const textClipboardItem = new ClipboardItem(

--- a/packages/blocks/src/database-block/table/clipboard.ts
+++ b/packages/blocks/src/database-block/table/clipboard.ts
@@ -25,8 +25,6 @@ type TableViewClipboardConfig = {
   data: DataViewManager;
 };
 
-const columnsContainInput = ['number', 'date', 'link', 'select'];
-
 export class TableViewClipboard implements BaseViewClipboard {
   private _disposables = new DisposableGroup();
   private _path: string[];
@@ -53,6 +51,7 @@ export class TableViewClipboard implements BaseViewClipboard {
   }
 
   private _onCopy = (context: UIEventStateContext) => {
+    const event = context.get('clipboardState').raw;
     const selection = getDatabaseSelection(this._root);
     const tableSelection = selection?.getSelection('table');
     if (!tableSelection) return;
@@ -71,7 +70,7 @@ export class TableViewClipboard implements BaseViewClipboard {
         focus.columnIndex
       );
 
-      if (!columnsContainInput.includes(column.type)) {
+      if (!(event.target instanceof HTMLInputElement)) {
         const data = (cellToStringMap[column.type]?.(container) ??
           '') as string;
         const textClipboardItem = new ClipboardItem(

--- a/packages/blocks/src/database-block/table/components/selection.ts
+++ b/packages/blocks/src/database-block/table/components/selection.ts
@@ -146,6 +146,14 @@ export class DatabaseSelectionView extends WithDisposable(ShadowlessElement) {
         return false;
       })
     );
+
+    this._disposables.add(
+      this.tableView.handleEvent('dragMove', context => {
+        const event = context.get('pointerState').raw;
+        event.preventDefault();
+        return true;
+      })
+    );
   }
 
   isValidSelection(selection?: TableViewSelection): boolean {


### PR DESCRIPTION
1. Prevent native selection from being selected while dragging.
2. Execute the default copy function of the browser when editing columns such as `number/date/link/select`.