### PR TITLE
fix: headings should not match the space hotkey

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
+++ b/packages/blocks/src/__internal__/rich-text/markdown-convert.ts
@@ -501,9 +501,11 @@ export function tryMatchSpaceHotkey(
   if (offset > prefix.length) {
     return ALLOW_DEFAULT;
   }
-  const isParagraphQuoteBlock = isEqual(model.type, 'quote');
+  const isParagraph = matchFlavours(model, ['affine:paragraph']);
+  const isHeading = isParagraph && model.type.startsWith('h');
+  const isParagraphQuoteBlock = isParagraph && isEqual(model.type, 'quote');
   const isCodeBlock = matchFlavours(model, ['affine:code']);
-  if (isParagraphQuoteBlock || isCodeBlock) {
+  if (isHeading || isParagraphQuoteBlock || isCodeBlock) {
     return ALLOW_DEFAULT;
   }
   let isConverted = false;


### PR DESCRIPTION
This closes #3876.