### PR TITLE
feat(page): add overlay mask to attachment rename popover

### DIFF
--- a/packages/blocks/src/attachment-block/components/moreMenu.ts
+++ b/packages/blocks/src/attachment-block/components/moreMenu.ts
@@ -1,0 +1,57 @@
+import {
+  DeleteIcon,
+  DownloadIcon,
+  DuplicateIcon,
+} from '@blocksuite/global/config';
+import { html } from 'lit';
+import { type Ref, ref } from 'lit/directives/ref.js';
+
+import type { AttachmentBlockModel } from '../attachment-model.js';
+import { cloneAttachmentProperties, downloadAttachment } from '../utils.js';
+
+export const MoreMenu = ({
+  ref: moreMenuRef,
+  model,
+  abortController,
+}: {
+  ref: Ref<HTMLDivElement>;
+  model: AttachmentBlockModel;
+  abortController: AbortController;
+}) => {
+  return html`<div ${ref(moreMenuRef)} class="attachment-options-more" hidden>
+    <icon-button
+      width="120px"
+      height="32px"
+      text="Download"
+      @click="${() => downloadAttachment(model)}"
+    >
+      ${DownloadIcon}
+    </icon-button>
+    <icon-button
+      width="120px"
+      height="32px"
+      text="Duplicate"
+      @click="${() => {
+        const prop = {
+          flavour: 'affine:attachment',
+          ...cloneAttachmentProperties(model),
+        };
+        model.page.addSiblingBlocks(model, [prop]);
+      }}"
+    >
+      ${DuplicateIcon}
+    </icon-button>
+    <icon-button
+      width="120px"
+      height="32px"
+      text="Delete"
+      class="danger"
+      @click="${() => {
+        model.page.deleteBlock(model);
+        abortController.abort();
+      }}"
+    >
+      ${DeleteIcon}
+    </icon-button>
+  </div>`;
+};

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -1,25 +1,22 @@
 import {
   CaptionIcon,
-  ConfirmIcon,
-  DeleteIcon,
-  DownloadIcon,
-  DuplicateIcon,
   EditIcon,
   EmbedWebIcon,
   LinkIcon,
   MoreIcon,
   ViewIcon,
 } from '@blocksuite/global/config';
+import { createLitPortal } from '@blocksuite/lit';
 import { assertExists } from '@blocksuite/store';
 import { html } from 'lit';
-import { createRef, type Ref, ref } from 'lit/directives/ref.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 
 import { stopPropagation } from '../../__internal__/utils/event.js';
 import { getViewportElement } from '../../__internal__/utils/query.js';
-import { toast } from '../../components/toast.js';
 import type { ImageProps } from '../../image-block/image-model.js';
 import type { AttachmentBlockModel } from '../attachment-model.js';
-import { cloneAttachmentProperties, downloadAttachment } from '../utils.js';
+import { MoreMenu } from './MoreMenu.js';
+import { RenameModal } from './renameModel.js';
 import { styles } from './styles.js';
 
 export function AttachmentOptionsTemplate({
@@ -68,8 +65,7 @@ export function AttachmentOptionsTemplate({
   });
 
   const moreMenuRef = createRef<HTMLDivElement>();
-  const renameRef = createRef<HTMLDivElement>();
-
+  const disableEmbed = !model.type?.startsWith('image/');
   return html`<style>
       ${styles}
     </style>
@@ -108,7 +104,7 @@ export function AttachmentOptionsTemplate({
       <icon-button
         class="has-tool-tip"
         size="24px"
-        ?disabled=${!model.type?.startsWith('image/')}
+        ?disabled=${disableEmbed}
         @click="${() => {
           const sourceId = model.sourceId;
           assertExists(sourceId);
@@ -123,7 +119,7 @@ export function AttachmentOptionsTemplate({
       >
         ${EmbedWebIcon}
         <tool-tip inert tip-position="top" role="tooltip"
-          >Turn into Embed view</tool-tip
+          >Turn into Embed view${disableEmbed ? '(Images only)' : ''}</tool-tip
         >
       </icon-button>
       <div class="divider"></div>
@@ -132,8 +128,16 @@ export function AttachmentOptionsTemplate({
         class="has-tool-tip"
         size="24px"
         @click="${() => {
-          containerRef.value?.toggleAttribute('hidden');
-          renameRef.value?.toggleAttribute('hidden');
+          abortController.abort();
+          const renameAbortController = new AbortController();
+          createLitPortal({
+            template: RenameModal({
+              model,
+              abortController: renameAbortController,
+              anchor,
+            }),
+            abortController: renameAbortController,
+          });
         }}"
       >
         ${EditIcon}
@@ -159,118 +163,5 @@ export function AttachmentOptionsTemplate({
         <tool-tip inert role="tooltip">More</tool-tip>
       </icon-button>
       ${MoreMenu({ model, abortController, ref: moreMenuRef })}
-      ${RenameModal({ model, abortController, ref: renameRef })}
     </div>`;
 }
-
-const RenameModal = ({
-  ref: renamePopoverRef,
-  model,
-  abortController,
-}: {
-  ref: Ref<HTMLDivElement>;
-  model: AttachmentBlockModel;
-  abortController: AbortController;
-}) => {
-  const originalName = model.name;
-  const nameWithoutExtension = originalName.slice(
-    0,
-    originalName.lastIndexOf('.')
-  );
-  const originalExtension = originalName.slice(originalName.lastIndexOf('.'));
-  const fixedExtension =
-    originalExtension.length <= 7 && // including the dot
-    originalName.length > originalExtension.length;
-
-  let fileName = fixedExtension ? nameWithoutExtension : originalName;
-  const extension = fixedExtension ? originalExtension : '';
-
-  const onConfirm = () => {
-    const newFileName = fileName + extension;
-    if (!newFileName) {
-      toast('File name cannot be empty');
-      return;
-    }
-    model.page.updateBlock(model, {
-      name: newFileName,
-    });
-    abortController.abort();
-  };
-  const onInput = (e: InputEvent) => {
-    fileName = (e.target as HTMLInputElement).value;
-  };
-  const onKeydown = (e: KeyboardEvent) => {
-    e.stopPropagation();
-    if (e.key === 'Enter' && !e.isComposing) {
-      e.preventDefault();
-      onConfirm();
-    }
-    return;
-  };
-
-  return html`<div
-    ${ref(renamePopoverRef)}
-    class="attachment-rename-container"
-    hidden
-  >
-    <div class="attachment-rename-input-wrapper">
-      <input
-        type="text"
-        .value=${fileName}
-        @input=${onInput}
-        @keydown=${onKeydown}
-      />
-      <span class="attachment-rename-extension">${extension}</span>
-    </div>
-    <icon-button class="affine-confirm-button" @click=${onConfirm}
-      >${ConfirmIcon}</icon-button
-    >
-  </div>`;
-};
-
-const MoreMenu = ({
-  ref: moreMenuRef,
-  model,
-  abortController,
-}: {
-  ref: Ref<HTMLDivElement>;
-  model: AttachmentBlockModel;
-  abortController: AbortController;
-}) => {
-  return html`<div ${ref(moreMenuRef)} class="attachment-options-more" hidden>
-    <icon-button
-      width="120px"
-      height="32px"
-      text="Download"
-      @click="${() => downloadAttachment(model)}"
-    >
-      ${DownloadIcon}
-    </icon-button>
-    <icon-button
-      width="120px"
-      height="32px"
-      text="Duplicate"
-      @click="${() => {
-        const prop = {
-          flavour: 'affine:attachment',
-          ...cloneAttachmentProperties(model),
-        };
-        model.page.addSiblingBlocks(model, [prop]);
-      }}"
-    >
-      ${DuplicateIcon}
-    </icon-button>
-    <icon-button
-      width="120px"
-      height="32px"
-      text="Delete"
-      class="danger"
-      @click="${() => {
-        model.page.deleteBlock(model);
-        abortController.abort();
-      }}"
-    >
-      ${DeleteIcon}
-    </icon-button>
-  </div>`;
-};

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -15,7 +15,7 @@ import { stopPropagation } from '../../__internal__/utils/event.js';
 import { getViewportElement } from '../../__internal__/utils/query.js';
 import type { ImageProps } from '../../image-block/image-model.js';
 import type { AttachmentBlockModel } from '../attachment-model.js';
-import { MoreMenu } from './MoreMenu.js';
+import { MoreMenu } from './moreMenu.js';
 import { RenameModal } from './renameModel.js';
 import { styles } from './styles.js';
 

--- a/packages/blocks/src/attachment-block/components/renameModel.ts
+++ b/packages/blocks/src/attachment-block/components/renameModel.ts
@@ -1,0 +1,87 @@
+import { ConfirmIcon } from '@blocksuite/global/config';
+import { html } from 'lit';
+import { createRef, ref } from 'lit/directives/ref.js';
+
+import { toast } from '../../components/toast.js';
+import type { AttachmentBlockModel } from '../attachment-model.js';
+import { renameStyles } from './styles.js';
+
+export const RenameModal = ({
+  anchor,
+  model,
+  abortController,
+}: {
+  anchor: HTMLElement;
+  model: AttachmentBlockModel;
+  abortController: AbortController;
+}) => {
+  const containerRef = createRef<HTMLDivElement>();
+  const updatePosition = () => {
+    const container = containerRef.value;
+    if (!container) return;
+    const { top, left, width } = anchor.getBoundingClientRect();
+    container.style.transform = `translate(calc(${
+      left + width
+    }px - 100%), calc(${top}px - 100% - 4px))`;
+  };
+  setTimeout(() => {
+    // Wait for the portal to be attached to the DOM
+    updatePosition();
+  });
+
+  const originalName = model.name;
+  const nameWithoutExtension = originalName.slice(
+    0,
+    originalName.lastIndexOf('.')
+  );
+  const originalExtension = originalName.slice(originalName.lastIndexOf('.'));
+  const fixedExtension =
+    originalExtension.length <= 7 && // including the dot
+    originalName.length > originalExtension.length;
+
+  let fileName = fixedExtension ? nameWithoutExtension : originalName;
+  const extension = fixedExtension ? originalExtension : '';
+
+  const onConfirm = () => {
+    const newFileName = fileName + extension;
+    if (!newFileName) {
+      toast('File name cannot be empty');
+      return;
+    }
+    model.page.updateBlock(model, {
+      name: newFileName,
+    });
+    abortController.abort();
+  };
+  const onInput = (e: InputEvent) => {
+    fileName = (e.target as HTMLInputElement).value;
+  };
+  const onKeydown = (e: KeyboardEvent) => {
+    e.stopPropagation();
+    if (e.key === 'Enter' && !e.isComposing) {
+      e.preventDefault();
+      onConfirm();
+    }
+    return;
+  };
+
+  return html`
+    <style>
+      ${renameStyles}
+    </style>
+    <div ${ref(containerRef)} class="attachment-rename-container">
+      <div class="attachment-rename-input-wrapper">
+        <input
+          type="text"
+          .value=${fileName}
+          @input=${onInput}
+          @keydown=${onKeydown}
+        />
+        <span class="attachment-rename-extension">${extension}</span>
+      </div>
+      <icon-button class="affine-confirm-button" @click=${onConfirm}
+        >${ConfirmIcon}</icon-button
+      >
+    </div>
+  `;
+};

--- a/packages/blocks/src/attachment-block/components/renameModel.ts
+++ b/packages/blocks/src/attachment-block/components/renameModel.ts
@@ -69,6 +69,10 @@ export const RenameModal = ({
     <style>
       ${renameStyles}
     </style>
+    <div
+      class="attachment-rename-overlay-mask"
+      @click="${() => abortController.abort()}"
+    ></div>
     <div ${ref(containerRef)} class="attachment-rename-container">
       <div class="attachment-rename-input-wrapper">
         <input

--- a/packages/blocks/src/attachment-block/components/styles.ts
+++ b/packages/blocks/src/attachment-block/components/styles.ts
@@ -2,10 +2,9 @@ import { css } from 'lit';
 
 import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 
-const renameStyles = css`
+export const renameStyles = css`
   .attachment-rename-container {
-    position: absolute;
-    right: 0;
+    position: fixed;
     top: 0;
 
     display: flex;
@@ -19,6 +18,7 @@ const renameStyles = css`
     padding: 12px;
     background: var(--affine-background-overlay-panel-color);
     box-shadow: var(--affine-shadow-2);
+    z-index: var(--affine-z-index-popover);
   }
 
   .attachment-rename-input-wrapper {
@@ -43,6 +43,15 @@ const renameStyles = css`
   .attachment-rename-extension {
     font-size: var(--affine-font-xs);
     color: var(--affine-text-secondary-color);
+  }
+
+  .attachment-rename-overlay-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: var(--affine-z-index-popover);
   }
 `;
 
@@ -104,6 +113,5 @@ export const styles = css`
   }
 
   ${tooltipStyle}
-  ${renameStyles}
   ${moreMenuStyles}
 `;


### PR DESCRIPTION
After hovering out, the rename popover should not hide.