### PR TITLE
fix: align arrow icon in page info

### DIFF
--- a/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
+++ b/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
@@ -140,7 +140,7 @@ export class PageMetaData extends WithDisposable(LitElement) {
 
     .meta-data-expanded-item .arrow-icon svg {
       fill: var(--affine-icon-color);
-       height: 25px;
+      height: 25px;
     }
 
     .meta-data-expanded-item .value {

--- a/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
+++ b/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
@@ -138,6 +138,11 @@ export class PageMetaData extends WithDisposable(LitElement) {
       fill: var(--affine-icon-color);
     }
 
+    .meta-data-expanded-item .type-1 svg {
+      fill: var(--affine-icon-color);
+      padding-top:5px;
+    }
+
     .meta-data-expanded-item .value {
       flex: 1;
     }
@@ -335,7 +340,7 @@ export class PageMetaData extends WithDisposable(LitElement) {
       </div>`;
     };
     return html` <div class="meta-data-expanded-item">
-      <div class="type">${DualLinkIcon16}</div>
+      <div class="type-1">${DualLinkIcon16}</div>
       <div class="value">
         <div class="backlinks">
           <div class="title">Linked to this page</div>

--- a/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
+++ b/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
@@ -138,9 +138,9 @@ export class PageMetaData extends WithDisposable(LitElement) {
       fill: var(--affine-icon-color);
     }
 
-    .meta-data-expanded-item .type-1 svg {
+    .meta-data-expanded-item .arrow-icon svg {
       fill: var(--affine-icon-color);
-      padding-top:5px;
+       height: 25px;
     }
 
     .meta-data-expanded-item .value {
@@ -340,7 +340,7 @@ export class PageMetaData extends WithDisposable(LitElement) {
       </div>`;
     };
     return html` <div class="meta-data-expanded-item">
-      <div class="type-1">${DualLinkIcon16}</div>
+      <div class="arrow-icon">${DualLinkIcon16}</div>
       <div class="value">
         <div class="backlinks">
           <div class="title">Linked to this page</div>

--- a/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
+++ b/packages/blocks/src/page-block/doc/meta-data/meta-data.ts
@@ -138,7 +138,7 @@ export class PageMetaData extends WithDisposable(LitElement) {
       fill: var(--affine-icon-color);
     }
 
-    .meta-data-expanded-item .arrow-icon svg {
+    .meta-data-expanded-item .link-icon svg {
       fill: var(--affine-icon-color);
       height: 25px;
     }
@@ -340,7 +340,7 @@ export class PageMetaData extends WithDisposable(LitElement) {
       </div>`;
     };
     return html` <div class="meta-data-expanded-item">
-      <div class="arrow-icon">${DualLinkIcon16}</div>
+      <div class="link-icon">${DualLinkIcon16}</div>
       <div class="value">
         <div class="backlinks">
           <div class="title">Linked to this page</div>


### PR DESCRIPTION
fixed: #3883 
![BlockSuite-Playground](https://github.com/toeverything/blocksuite/assets/96860040/aa993294-049e-4918-826c-de1887d23cba)

If you need any changes then let me know.
Thank you so much for your assistance.