### PR TITLE
fix: added base UI font family to the Menu of edgeless

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -58,6 +58,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       display: block;
       color: var(--affine-text-primary-color);
       fill: currentColor;
+      font-family: var(--sl-font-sans);
     }
 
     .more-actions-container {

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -39,6 +39,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       justify-content: center;
       transform: translateX(-50%);
       user-select: none;
+      font-family: var(--sl-font-sans);
     }
     .edgeless-toolbar-container {
       display: flex;


### PR DESCRIPTION
fixed: #3781 
![Screenshot (10)](https://github.com/toeverything/blocksuite/assets/96860040/fbaad7be-77d0-4581-9f3f-e007208a3256)
@xell check this out