### PR TITLE
chore: use LitElement in WidgetElement

### DIFF
--- a/packages/blocks/src/widgets/drag-handle/index.ts
+++ b/packages/blocks/src/widgets/drag-handle/index.ts
@@ -438,7 +438,7 @@ export class DragHandleWidget extends WidgetElement {
     const event = state.raw;
     const { target, button } = event;
     const element = captureEventTarget(target);
-    const inside = !!element?.closest('.affine-drag-handle-container');
+    const inside = !!element?.closest('affine-drag-handle-widget');
     // Should only start dragging when pointer down on drag handle
     // And current mouse button is left button
     if (
@@ -450,7 +450,7 @@ export class DragHandleWidget extends WidgetElement {
       return;
     }
 
-    // Get current hover block eleemnt by path
+    // Get current hover block element by path
     const hoverBlockElement = this.root.viewStore.viewFromPath(
       'block',
       this._hoveredBlockPath

--- a/packages/blocks/src/widgets/drag-handle/index.ts
+++ b/packages/blocks/src/widgets/drag-handle/index.ts
@@ -38,6 +38,7 @@ import {
   getDragHandleContainerHeight,
   getNoteId,
   insideDatabaseTable,
+  renderStyles,
 } from './utils.js';
 
 @customElement('affine-drag-handle-widget')
@@ -211,6 +212,12 @@ export class DragHandleWidget extends WidgetElement {
     blockElements.forEach(element => {
       const container = document.createElement('div');
       container.classList.add('affine-block-element');
+
+      // XXX workaround for styles not applied to drag preview
+      // It will lost some inline styles such as <a> tag
+      const styles = (element.constructor as typeof BlockElement).styles ?? [];
+      renderStyles(styles, container);
+
       render(element.render(), container);
       container.querySelector('.selected')?.classList.remove('selected');
       fragment.appendChild(container);

--- a/packages/blocks/src/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/widgets/drag-handle/utils.ts
@@ -1,6 +1,7 @@
 import type { BaseSelection } from '@blocksuite/block-std';
 import type { BlockElement } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
+import type { CSSResultGroup } from 'lit';
 
 import { DEFAULT_DRAG_HANDLE_CONTAINER_HEIGHT } from './config.js';
 
@@ -70,3 +71,22 @@ export const getNoteId = (blockElement: BlockElement) => {
 
   return element.model.id;
 };
+
+export function renderStyles(styles: CSSResultGroup, container: HTMLElement) {
+  if (Array.isArray(styles)) {
+    styles.forEach(s => {
+      renderStyles(s, container);
+    });
+    return;
+  }
+  const styleEle = document.createElement('style');
+  if (styles instanceof CSSStyleSheet) {
+    const cssText = Array.from(styles.cssRules)
+      .map(rule => rule.cssText)
+      .join('\n');
+    styleEle.textContent = cssText;
+    return;
+  }
+  styleEle.textContent = styles.cssText;
+  container.appendChild(styleEle);
+}

--- a/packages/blocks/src/widgets/format-bar/component.ts/paragraph-button.ts
+++ b/packages/blocks/src/widgets/format-bar/component.ts/paragraph-button.ts
@@ -135,17 +135,17 @@ export const ParagraphButton = ({
   });
 
   const onHover = () => {
-    const button = formatBar.querySelector(
+    const button = formatBar.shadowRoot?.querySelector(
       '.paragraph-button'
     ) as HTMLElement | null;
-    const panel = formatBar.querySelector(
+    const panel = formatBar.shadowRoot?.querySelector(
       '.paragraph-panel'
     ) as HTMLElement | null;
     assertExists(button);
     assertExists(panel);
     panel.style.display = 'block';
     computePosition(button, panel, {
-      placement: 'top',
+      placement: 'top-start',
       middleware: [
         flip(),
         shift({
@@ -158,7 +158,7 @@ export const ParagraphButton = ({
     });
   };
   const onHoverEnd = () => {
-    const panel = formatBar.querySelector(
+    const panel = formatBar.shadowRoot?.querySelector(
       '.paragraph-panel'
     ) as HTMLElement | null;
     assertExists(panel);

--- a/packages/blocks/src/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/widgets/format-bar/format-bar.ts
@@ -48,7 +48,9 @@ export class AffineFormatBarWidget extends WidgetElement {
   }
 
   private get _formatBarElement() {
-    return this.querySelector(
+    const shadowRoot = this.shadowRoot;
+    assertExists(shadowRoot);
+    return shadowRoot.querySelector(
       `.${AFFINE_FORMAT_BAR_WIDGET_TAG}`
     ) as HTMLElement | null;
   }
@@ -285,7 +287,7 @@ export class AffineFormatBarWidget extends WidgetElement {
     //TODO: format bar in database
 
     const paragraphButton = ParagraphButton({
-      pageElement: pageElement,
+      pageElement,
       formatBar: this,
       selectedBlockElements,
       page,

--- a/packages/lit/src/element/widget-element.ts
+++ b/packages/lit/src/element/widget-element.ts
@@ -2,14 +2,14 @@ import type { EventName, UIEventHandler } from '@blocksuite/block-std';
 import type { BlockSuiteViewSpec } from '@blocksuite/block-std';
 import type { Page } from '@blocksuite/store';
 import { assertExists } from '@blocksuite/store';
+import { LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { WithDisposable } from '../with-disposable.js';
 import type { BlockElement } from './block-element.js';
 import type { BlockSuiteRoot } from './lit-root.js';
-import { ShadowlessElement } from './shadowless-element.js';
 
-export class WidgetElement extends WithDisposable(ShadowlessElement) {
+export class WidgetElement extends WithDisposable(LitElement) {
   @property({ attribute: false })
   root!: BlockSuiteRoot;
 


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/issues/3918

The `ShadowlessElement` will add the style to the global, causing unnoticed style leaks.