### PR TITLE
fix: display of format bar while clicking the Bookmark Block

### DIFF
--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -254,13 +254,13 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
     }, 100);
   }
 
-  private _onCardClick() {
-    const selectionManager = this.root.selectionManager;
-    const blockSelection = selectionManager.getInstance('block', {
-      path: this.path,
-    });
-    selectionManager.setGroup('note', [blockSelection]);
-  }
+  // private _onCardClick() {
+  //   const selectionManager = this.root.selectionManager;
+  //   const blockSelection = selectionManager.getInstance('block', {
+  //     path: this.path,
+  //   });
+  //   selectionManager.setGroup('note', [blockSelection]);
+  // }
 
   private _onCardDbClick() {
     let link = this.model.url;

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -254,14 +254,6 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
     }, 100);
   }
 
-  // private _onCardClick() {
-  //   const selectionManager = this.root.selectionManager;
-  //   const blockSelection = selectionManager.getInstance('block', {
-  //     path: this.path,
-  //   });
-  //   selectionManager.setGroup('note', [blockSelection]);
-  // }
-
   private _onCardDbClick() {
     let link = this.model.url;
 


### PR DESCRIPTION
Fixed: #4047 

While clicking the bookmark block, the format bar does not display, but the format bar works fine with other elements such as paragraph etc
