### PR TITLE
fix: aligned arrow icon to the center of the font size container

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-text-menu.ts
@@ -85,9 +85,10 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
     .font-size-button-group {
       position: relative;
-      width: 76px;
+      width: 72px;
       height: 24px;
       line-height: 24px;
+      border-radius: 4px;
     }
 
     .font-size-button-group .selected-font-size-label {
@@ -97,6 +98,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
     .font-size-button-group .arrow-down-icon {
       position: absolute;
+      top: 2px;
       right: 4px;
     }
 


### PR DESCRIPTION
before:
![Firefox_Screenshot_2023-08-15T08-30-34 747Z](https://github.com/toeverything/blocksuite/assets/96860040/ba75160f-e440-479c-905f-130ea4cb17d2)

after:
![Firefox_Screenshot_2023-08-15T08-58-04 887Z](https://github.com/toeverything/blocksuite/assets/96860040/10508f09-f7ed-4079-af59-032475fa1e98)
