### PR TITLE
fix: added border radius to page tag selector

### DIFF
--- a/packages/blocks/src/components/tags/styles.ts
+++ b/packages/blocks/src/components/tags/styles.ts
@@ -29,6 +29,7 @@ export const styles = css`
     min-height: 44px;
     padding: 10px 8px;
     background: var(--affine-hover-color);
+    border-radius: 8px;
   }
 
   .select-input {


### PR DESCRIPTION
Fixed: #4108 

before:
![Firefox_Screenshot_2023-08-15T16-42-39 287Z](https://github.com/toeverything/blocksuite/assets/96860040/62bd0e78-50d8-4aa3-9336-0290def26924)

after:
![BlockSuite-Playground (2)](https://github.com/toeverything/blocksuite/assets/96860040/22cc2834-afdb-4b37-a24e-78289059001c)
