### PR TITLE
chore: hide unimplemented attachment options

### DIFF
--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -79,34 +79,28 @@ export function AttachmentOptionsTemplate({
       @mouseover=${onHover}
       @mouseleave=${onHoverLeave}
     >
-      <icon-button
-        class="has-tool-tip"
-        size="24px"
-        disabled
-        @click=${() => console.log('Coming soon...', model)}
-      >
+      <icon-button class="has-tool-tip" size="24px" disabled ?hidden=${true}>
         ${ViewIcon}
-        <tool-tip inert tip-position="top" role="tooltip"
-          >Preview(Coming soon)</tool-tip
-        >
+        <tool-tip inert tip-position="top" role="tooltip">Preview</tool-tip>
       </icon-button>
-      <div class="divider"></div>
+      <div class="divider" ?hidden=${true}></div>
 
       <icon-button
         class="has-tool-tip"
         size="24px"
-        ?disabled=${readonly || true}
-        @click=${() => console.log('Turn into Link view coming soon', model)}
+        ?disabled=${readonly}
+        ?hidden=${true}
       >
         ${LinkIcon}
         <tool-tip inert tip-position="top" role="tooltip"
-          >Turn into Link view(Coming soon)</tool-tip
+          >Turn into Link view</tool-tip
         >
       </icon-button>
       <icon-button
         class="has-tool-tip"
         size="24px"
-        ?disabled=${readonly || disableEmbed}
+        ?disabled=${readonly}
+        ?hidden=${disableEmbed}
         @click="${() => {
           turnIntoEmbedView(model);
           abortController.abort();
@@ -114,10 +108,10 @@ export function AttachmentOptionsTemplate({
       >
         ${EmbedWebIcon}
         <tool-tip inert tip-position="top" role="tooltip"
-          >Turn into Embed view${disableEmbed ? '(Images only)' : ''}</tool-tip
+          >Turn into Embed view</tool-tip
         >
       </icon-button>
-      <div class="divider"></div>
+      <div class="divider" ?hidden=${disableEmbed}></div>
 
       <icon-button
         class="has-tool-tip"

--- a/packages/blocks/src/attachment-block/components/styles.ts
+++ b/packages/blocks/src/attachment-block/components/styles.ts
@@ -109,7 +109,8 @@ export const styles = css`
     background-color: var(--affine-border-color);
   }
 
-  .affine-attachment-options > div[hidden] {
+  .affine-attachment-options > div[hidden],
+  icon-button[hidden] {
     display: none;
   }
 


### PR DESCRIPTION
<img width="824" alt="img_v2_b7ae26f8-697b-45d7-95cb-98d7b88cb8ag" src="https://github.com/toeverything/blocksuite/assets/18554747/ef0d27cf-38f4-42a0-a961-f567c94876c6">
