### PR TITLE
fix: optimize hasChanged for block element

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -200,7 +200,10 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
     this._updateLineNumbers();
   });
 
-  private _curLanguage: ILanguageRegistration = PLAIN_TEXT_REGISTRATION;
+  @state()
+  private get _curLanguage() {
+    return getStandardLanguage(this.model.language) ?? PLAIN_TEXT_REGISTRATION;
+  }
   private _highlighter: Highlighter | null = null;
   private async _startHighlight(lang: ILanguageRegistration) {
     const mode = queryCurrentMode();
@@ -299,7 +302,6 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
   override updated() {
     if (this.model.language !== this._curLanguage.id) {
       const lang = getStandardLanguage(this.model.language);
-      this._curLanguage = lang ?? PLAIN_TEXT_REGISTRATION;
       if (lang) {
         if (this._highlighter) {
           const currentLangs = this._highlighter.getLoadedLanguages();

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -200,12 +200,22 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
     this._updateLineNumbers();
   });
 
-  @state()
-  private get _curLanguage() {
-    return getStandardLanguage(this.model.language) ?? PLAIN_TEXT_REGISTRATION;
-  }
+  private _perviousLanguage: ILanguageRegistration = PLAIN_TEXT_REGISTRATION;
   private _highlighter: Highlighter | null = null;
   private async _startHighlight(lang: ILanguageRegistration) {
+    if (this._highlighter) {
+      const loadedLangs = this._highlighter.getLoadedLanguages();
+      if (!loadedLangs.includes(lang.id as Lang)) {
+        this._highlighter.loadLanguage(lang).then(() => {
+          const richText = this.querySelector('rich-text');
+          const vEditor = richText?.vEditor;
+          if (vEditor) {
+            vEditor.requestUpdate();
+          }
+        });
+      }
+      return;
+    }
     const mode = queryCurrentMode();
     this._highlighter = await getHighlighter({
       theme: mode === 'dark' ? DARK_THEME : LIGHT_THEME,
@@ -242,7 +252,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
     // set highlight options getter used by "exportToHtml"
     getService('affine:code').setHighlightOptionsGetter(() => {
       return {
-        lang: this._curLanguage.id as Lang,
+        lang: this._perviousLanguage.id as Lang,
         highlighter: this._highlighter,
       };
     });
@@ -300,23 +310,11 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
   }
 
   override updated() {
-    if (this.model.language !== this._curLanguage.id) {
+    if (this.model.language !== this._perviousLanguage.id) {
       const lang = getStandardLanguage(this.model.language);
+      this._perviousLanguage = lang ?? PLAIN_TEXT_REGISTRATION;
       if (lang) {
-        if (this._highlighter) {
-          const currentLangs = this._highlighter.getLoadedLanguages();
-          if (!currentLangs.includes(lang.id as Lang)) {
-            this._highlighter.loadLanguage(lang).then(() => {
-              const richText = this.querySelector('rich-text');
-              const vEditor = richText?.vEditor;
-              if (vEditor) {
-                vEditor.requestUpdate();
-              }
-            });
-          }
-        } else {
-          this._startHighlight(lang);
-        }
+        this._startHighlight(lang);
       } else {
         this._highlighter = null;
       }
@@ -399,8 +397,9 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
   }
 
   private _langListTemplate() {
-    const curLanguageDisplayName =
-      this._curLanguage.displayName ?? this._curLanguage.id;
+    const curLanguage =
+      getStandardLanguage(this.model.language) ?? PLAIN_TEXT_REGISTRATION;
+    const curLanguageDisplayName = curLanguage.displayName ?? curLanguage.id;
     return html`<div
       class="lang-list-wrapper"
       style="${this._showLangList ? 'visibility: visible;' : ''}"
@@ -418,7 +417,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
       </icon-button>
       ${this._showLangList
         ? html`<lang-list
-            .currentLanguageId=${this._curLanguage.id as Lang}
+            .currentLanguageId=${this._perviousLanguage.id as Lang}
             .slots=${this._langListSlots}
           ></lang-list>`
         : nothing}

--- a/packages/blocks/src/database-block/common/columns/title/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/title/cell-renderer.ts
@@ -173,9 +173,10 @@ export class TitleDetailCell extends BaseCellRenderer<string> {
 
   extra(): {
     model: BaseBlockModel;
-    result: TemplateResult;
+    result: TemplateResult | null;
   } {
-    return this.column.getExtra(this.rowId) as never;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this.column.getExtra(this.rowId) as any;
   }
 
   override render() {

--- a/packages/blocks/src/database-block/common/columns/title/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/title/cell-renderer.ts
@@ -173,7 +173,7 @@ export class TitleDetailCell extends BaseCellRenderer<string> {
 
   extra(): {
     model: BaseBlockModel;
-    result: TemplateResult | null;
+    result: TemplateResult;
   } {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return this.column.getExtra(this.rowId) as any;

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -516,7 +516,7 @@ export class DocPageBlockComponent
     `;
 
     const content = html`${repeat(
-      this.model?.children.filter(
+      this.model.children.filter(
         child => !(matchFlavours(child, ['affine:note']) && child.hidden)
       ),
       child => child.id,

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -40,7 +40,7 @@ export class BlockElement<
       return value !== oldValue;
     },
   })
-  widgets: Record<WidgetName, TemplateResult>;
+  widgets!: Record<WidgetName, TemplateResult>;
 
   @property({ attribute: false })
   page!: Page;

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -25,10 +25,22 @@ export class BlockElement<
   model!: Model;
 
   @property({ attribute: false })
-  content!: TemplateResult;
+  content: TemplateResult | null = null;
 
-  @property({ attribute: false })
-  widgets!: Record<WidgetName, TemplateResult>;
+  @property({
+    attribute: false,
+    hasChanged(value, oldValue) {
+      if (!value || !oldValue) {
+        return value !== oldValue;
+      }
+      // Is empty object
+      if (!Object.keys(value).length && !Object.keys(oldValue).length) {
+        return false;
+      }
+      return value !== oldValue;
+    },
+  })
+  widgets: Record<WidgetName, TemplateResult>;
 
   @property({ attribute: false })
   page!: Page;
@@ -119,7 +131,7 @@ export class BlockElement<
     );
   }
 
-  renderModel = (model: BaseBlockModel): TemplateResult => {
+  renderModel = (model: BaseBlockModel): TemplateResult | null => {
     return this.root.renderModel(model);
   };
 

--- a/packages/lit/src/element/lit-root.ts
+++ b/packages/lit/src/element/lit-root.ts
@@ -9,7 +9,7 @@ import type {
 import { BlockStore } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
-import type { PropertyValues, TemplateResult } from 'lit';
+import { nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import type { StaticValue } from 'lit/static-html.js';
@@ -102,22 +102,22 @@ export class BlockSuiteRoot extends WithDisposable(ShadowlessElement) {
     return this.renderModel(root);
   }
 
-  renderModel = (model: BaseBlockModel): TemplateResult | null => {
+  renderModel = (model: BaseBlockModel): TemplateResult => {
     const { flavour, children } = model;
     const schema = this.page.schema.flavourSchemaMap.get(flavour);
     if (!schema) {
       console.warn(`Cannot find schema for ${flavour}.`);
-      return null;
+      return html`${nothing}`;
     }
 
     const view = this.blockStore.specStore.getView(flavour);
     if (!view) {
       console.warn(`Cannot find view for ${flavour}.`);
-      return null;
+      return html`${nothing}`;
     }
 
     const tag = view.component;
-    const widgets: Record<string, TemplateResult> | null = view.widgets
+    const widgets: Record<string, TemplateResult> = view.widgets
       ? Object.entries(view.widgets).reduce((mapping, [key, tag]) => {
           const template = html`<${tag} ${unsafeStatic(
             this.widgetIdAttr


### PR DESCRIPTION
The `widgets` and `content` will cause a block re-render even if nothing has changed.

https://github.com/toeverything/blocksuite/blob/3bbe6d9ebd36e8e230ed72c47233cb4b72ffca8f/packages/lit/src/element/lit-root.ts#L143-L150

The pointless re-render is the root cause of the issue at https://github.com/toeverything/blocksuite/issues/4013

> In child expressions, `undefined`, `null`, `''`, and `nothing` all behave the same and render no nodes.

> hasChanged: A function that indicates if a property should be considered changed when it is set. The function should take the `newValue` and `oldValue` and return true if an update should be requested.