### PR TITLE
feat(edgeless): toc ux optimization

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-card.ts
+++ b/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-card.ts
@@ -400,6 +400,7 @@ export class TOCNoteCard extends WithDisposable(LitElement) {
 
     return html`
       <div
+        @mousedown=${this._dispatchDragEvent}
         data-invisible="${this.invisible ? 'true' : 'false'}"
         class="card-container ${this.status ?? ''} ${mode}"
         style=${

--- a/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-panel.ts
@@ -398,7 +398,7 @@ export class TOCNotesPanel extends WithDisposable(LitElement) {
       undefined,
       this.offsetWidth,
       undefined,
-      287,
+      undefined,
     ]);
 
     this._oldViewport = {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -1195,9 +1195,7 @@ export class EdgelessPageBlockComponent
     return false;
   }
 
-  public getFitToScreenData(
-    viewportPadding: (number | undefined)[] = [0, 0, 0, 0]
-  ) {
+  public getFitToScreenData(padding: (number | undefined)[] = [0, 0, 0, 0]) {
     const bounds = [];
 
     this.notes.forEach(note => {
@@ -1209,7 +1207,7 @@ export class EdgelessPageBlockComponent
       bounds.push(surfaceElementsBound);
     }
 
-    const padding = viewportPadding.map(p => p ?? 0) as number[];
+    const [pt = 0, pr = 0, pb = 0, pl = 0] = padding;
     const { viewport } = this.surface;
     let { centerX, centerY, zoom } = viewport;
 
@@ -1219,14 +1217,12 @@ export class EdgelessPageBlockComponent
       assertExists(bound);
 
       zoom = Math.min(
-        (width - FIT_TO_SCREEN_PADDING - (padding[1] + padding[3])) / bound.w,
-        (height - FIT_TO_SCREEN_PADDING - (padding[0] + padding[2])) / bound.h
+        (width - FIT_TO_SCREEN_PADDING - (pr + pl)) / bound.w,
+        (height - FIT_TO_SCREEN_PADDING - (pt + pb)) / bound.h
       );
 
-      centerX =
-        bound.x + (bound.w + padding[1] / zoom) / 2 - padding[3] / zoom / 2;
-      centerY =
-        bound.y + (bound.h + padding[2] / zoom) / 2 - padding[0] / zoom / 2;
+      centerX = bound.x + (bound.w + pr / zoom) / 2 - pl / zoom / 2;
+      centerY = bound.y + (bound.h + pb / zoom) / 2 - pt / zoom / 2;
     } else {
       zoom = 1;
     }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -1195,7 +1195,9 @@ export class EdgelessPageBlockComponent
     return false;
   }
 
-  public getFitToScreenData() {
+  public getFitToScreenData(
+    viewportPadding: (number | undefined)[] = [0, 0, 0, 0]
+  ) {
     const bounds = [];
 
     this.notes.forEach(note => {
@@ -1207,6 +1209,7 @@ export class EdgelessPageBlockComponent
       bounds.push(surfaceElementsBound);
     }
 
+    const padding = viewportPadding.map(p => p ?? 0) as number[];
     const { viewport } = this.surface;
     let { centerX, centerY, zoom } = viewport;
 
@@ -1216,12 +1219,14 @@ export class EdgelessPageBlockComponent
       assertExists(bound);
 
       zoom = Math.min(
-        (width - FIT_TO_SCREEN_PADDING) / bound.w,
-        (height - FIT_TO_SCREEN_PADDING) / bound.h
+        (width - FIT_TO_SCREEN_PADDING - (padding[1] + padding[3])) / bound.w,
+        (height - FIT_TO_SCREEN_PADDING - (padding[0] + padding[2])) / bound.h
       );
 
-      centerX = bound.x + bound.w / 2;
-      centerY = bound.y + bound.h / 2;
+      centerX =
+        bound.x + (bound.w + padding[1] / zoom) / 2 - padding[3] / zoom / 2;
+      centerY =
+        bound.y + (bound.h + padding[2] / zoom) / 2 - padding[0] / zoom / 2;
     } else {
       zoom = 1;
     }


### PR DESCRIPTION
- synchronize toc card selection with edgeless selection state
- zoom out to fit all content when expand the toc panel and resume after collapsing
- card and be drag directly
- some naming convention