### PR TITLE
fix(page): click at blank area should not change note sequence

### DIFF
--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -453,6 +453,7 @@ export class DocPageBlockComponent
       let paragraphId: string;
       let index = 0;
       const lastNote = this.model.children
+        .slice()
         .reverse()
         .find(
           child =>


### PR DESCRIPTION
Before: every time click blank area to add a tail paragraph will reverse the page model.children

https://github.com/toeverything/blocksuite/assets/99816898/8b5599dc-2386-463c-af2f-869ff3ce8a91

After:

https://github.com/toeverything/blocksuite/assets/99816898/5fc4413a-54e0-4a05-83e4-2eba6db86ff1


