### PR TITLE
fix: tsconfig 'module' must be set to 'NodeNext' when 'moduleResolution' is set to 'NodeNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "useDefineForClassFields": false,
     "experimentalDecorators": true,
-    "module": "ESNext",
+    "module": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "NodeNext",
     "strict": true,


### PR DESCRIPTION

See https://github.com/microsoft/TypeScript/pull/54567
https://github.com/toeverything/AFFiNE/commit/97de0ef5b498cf08e9b40e014a27e8839fdf53e1

Or set 'moduleResolution' to 'bundler' will be better?