### PR TITLE
fix: editor doesn't use block presets from property

### DIFF
--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -268,7 +268,7 @@ export class EditorContainer
       this.model.id,
       html`<block-suite-root
         .page=${this.page}
-        .blocks=${this.mode === 'page' ? pagePreset : edgelessPreset}
+        .blocks=${this.mode === 'page' ? this.pagePreset : this.edgelessPreset}
       ></block-suite-root>`
     );
 


### PR DESCRIPTION
`editor-container` accepts the `pagePreset` and `edgelessPreset` property. However, they are not actually used. `block-suite-root` is instead given the default preset.

This is fixed by simply pointing to the correct reference. 