### PR TITLE
fix(edgeless): typo in component naming

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -451,7 +451,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
 
       ${page.readonly
         ? nothing
-        : html` <edgeless-frame-tool-buttonz
+        : html`<edgeless-frame-tool-button
             .edgelessTool=${this.edgelessTool}
             .setEdgelessTool=${this.setEdgelessTool}
             .edgeless=${this.edgeless}


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/pull/4333