### PR TITLE
fix(edgeless): edgeless selection update error after undo

### DIFF
--- a/packages/blocks/src/page-block/edgeless/services/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/selection-manager.ts
@@ -57,7 +57,7 @@ export class EdgelessSelectionManager {
     return this.state.elements.reduce((pre, id) => {
       const element = this.container.getElementModel(id) as Selectable;
 
-      if (element) pre.push(element);
+      if (element && element.id) pre.push(element);
       return pre;
     }, [] as Selectable[]);
   }


### PR DESCRIPTION
Surface elements did not exist before the yEvent was triggered.

https://github.com/toeverything/blocksuite/assets/9301743/229a74cc-5a86-41bc-b3b4-dd8319e839a5

