### PR TITLE
fix(page): update popover styles

### DIFF
--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -92,8 +92,8 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
       box-sizing: border-box;
       display: flex;
       align-items: center;
-      padding: 4px 8px;
-      gap: 4px;
+      padding: 8px;
+      gap: 8px;
       height: 40px;
 
       border-radius: 8px;
@@ -188,8 +188,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
 
         <div class="more-button-wrapper">
           <icon-button
-            width="32px"
-            height="32px"
+            size="24px"
             class="has-tool-tip more-button"
             @click=${() => {
               this._toggleMenu();

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -22,8 +22,8 @@ export class LangList extends LitElement {
         display: flex;
         flex-direction: column;
         background: var(--affine-background-overlay-panel-color);
+        color: var(--affine-text-primary-color);
         border-radius: 12px;
-        top: 24px;
         z-index: var(--affine-z-index-popover);
       }
 
@@ -62,6 +62,7 @@ export class LangList extends LitElement {
         border: 1px solid var(--affine-border-color);
         border-radius: 8px;
         padding: 4px 10px;
+        gap: 4px;
       }
 
       #filter-input {
@@ -89,11 +90,9 @@ export class LangList extends LitElement {
       }
 
       .search-icon {
-        height: 100%;
         display: flex;
-        padding-right: 4px;
         align-items: center;
-        fill: var(--affine-icon-color);
+        color: var(--affine-icon-color);
       }
     `;
   }

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -332,7 +332,7 @@ const styles = css`
     position: relative;
     border-radius: 4px;
     fill: var(--affine-icon-color);
-    color: var(--affine-popover-color);
+    color: var(--affine-text-primary-color);
     height: 36px;
   }
   .block-hub-icon-container svg {

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -97,8 +97,8 @@ export class IconButton extends LitElement {
   text: string | null = null;
 
   // Do not add `{ attribute: false }` option here, otherwise the `disabled` styles will not work
-  @property({ attribute: true })
-  disabled?: '' = undefined;
+  @property({ attribute: true, type: Boolean })
+  disabled?: boolean = undefined;
 
   constructor() {
     super();
@@ -115,8 +115,7 @@ export class IconButton extends LitElement {
     this.addEventListener(
       'click',
       event => {
-        // when disabled is '', it means the attribute is present
-        if (this.disabled === '') {
+        if (this.disabled === true) {
           event.preventDefault();
           event.stopPropagation();
         }

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -36,8 +36,7 @@ export class IconButton extends LitElement {
       cursor: pointer;
       user-select: none;
       font-family: var(--affine-font-family);
-      fill: var(--affine-icon-color);
-      color: var(--affine-popover-color);
+      color: var(--affine-text-primary-color);
       pointer-events: auto;
     }
 

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -40,11 +40,15 @@ export class IconButton extends LitElement {
       pointer-events: auto;
     }
 
-    :host > span {
+    :host > .text {
       flex: 1;
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
+    }
+
+    ::slotted(svg) {
+      color: var(--affine-icon-color);
     }
 
     :host(:hover) {
@@ -152,7 +156,7 @@ export class IconButton extends LitElement {
   override render() {
     return html`<slot></slot>${this.text
         ? // wrap a span around the text so we can ellipsis it automatically
-          html`<span>${this.text}</span>`
+          html`<span class="text">${this.text}</span>`
         : ''}<slot name="suffix"></slot>`;
   }
 }

--- a/packages/blocks/src/components/link-popover/styles.ts
+++ b/packages/blocks/src/components/link-popover/styles.ts
@@ -85,7 +85,7 @@ export const linkPopoverStyle = css`
     font-size: var(--affine-font-base);
     font-style: normal;
     line-height: 24px;
-    color: var(--affine-popover-color);
+    color: var(--affine-text-primary-color);
     z-index: var(--affine-z-index-popover);
     animation: affine-popover-fade-in 0.2s ease;
   }


### PR DESCRIPTION
- Remove deprecated `--affine-popover-color`
- Fix lit lint error for the disabled property in `icon-button`
- Update styles

<img width="953" alt="Screenshot 2023-08-25 at 20 24 31" src="https://github.com/toeverything/blocksuite/assets/18554747/e1ad47ec-64f5-42af-a1a0-7c6db5025474">
