### PR TITLE
fix(edgeless): hide overlay when pointer move on toolbar

### DIFF
--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -41,6 +41,7 @@ function shouldFilterMouseEvent(event: Event): boolean {
   if (!target || !(target instanceof HTMLElement)) {
     return false;
   }
+
   if (target.tagName === 'INPUT') {
     return true;
   }
@@ -50,6 +51,14 @@ function shouldFilterMouseEvent(event: Event): boolean {
   if (target.tagName === 'AFFINE-DRAG-HANDLE') {
     return true;
   }
+  if (
+    target.tagName === 'EDGELESS-TOOLBAR' ||
+    target.tagName === 'EDGELESS-ZOOM-TOOLBAR' ||
+    target.tagName === 'ZOOM-BAR-TOGGLE-BUTTON'
+  ) {
+    return true;
+  }
+
   return false;
 }
 

--- a/packages/blocks/src/widgets/drag-handle/index.ts
+++ b/packages/blocks/src/widgets/drag-handle/index.ts
@@ -851,8 +851,6 @@ export class DragHandleWidget extends WidgetElement {
     if (outOfPageViewPort && !inDragHandle && !inPage) {
       this._hide();
     }
-
-    return true;
   };
 
   override firstUpdated() {

--- a/packages/blocks/src/widgets/drag-handle/styles.ts
+++ b/packages/blocks/src/widgets/drag-handle/styles.ts
@@ -30,7 +30,7 @@ export const styles = css`
     cursor: grab;
   }
   @media print {
-    .affine-drag-handle {
+    .affine-drag-handle-widget {
       display: none;
     }
   }


### PR DESCRIPTION
Before:
When using shape or note tool in edgeless page, the overlay will follow pointer even the pointer move on toolbar, it is wired.

https://github.com/toeverything/blocksuite/assets/99816898/7a2e5c9a-4b0d-42f2-b9a0-0ebb07fd4b7a

After:
Hide overlay when pointer move on toolbar.

https://github.com/toeverything/blocksuite/assets/99816898/16e6736f-8fbe-44d5-a3b2-ebc5e8fa0581
