### PR TITLE
fix: remove block by slash menu should not bring chilren to top

### DIFF
--- a/packages/blocks/src/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/widgets/slash-menu/config.ts
@@ -43,6 +43,7 @@ import { copyBlock } from '../../page-block/doc/utils.js';
 import {
   getSelectedContentBlockElements,
   onModelTextUpdated,
+  transformModel,
 } from '../../page-block/utils/index.js';
 import { updateBlockElementType } from '../../page-block/utils/operations/element/block-level.js';
 import type { ParagraphBlockModel } from '../../paragraph-block/index.js';
@@ -496,8 +497,8 @@ export const menuGroups: {
         name: 'Delete',
         alias: ['remove'],
         icon: DeleteIcon,
-        action: ({ pageElement, model }) => {
-          pageElement.page.deleteBlock(model, { bringChildrenTo: 'parent' });
+        action: ({ model }) => {
+          transformModel(model, 'affine:paragraph', { text: new Text('') });
         },
       },
     ],

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -614,12 +614,7 @@ export class Page extends Space<FlatBlockMap> {
     if (index > -1) {
       parent?.children.splice(parent.children.indexOf(model), 1);
     }
-    if (bringChildrenTo === 'parent' && parent) {
-      model.children.forEach(child => {
-        this.schema.validate(child.flavour, parent.flavour);
-      });
-      parent.children.unshift(...model.children);
-    } else if (bringChildrenTo instanceof BaseBlockModel) {
+    if (bringChildrenTo instanceof BaseBlockModel) {
       model.children.forEach(child => {
         this.schema.validate(child.flavour, bringChildrenTo.flavour);
       });
@@ -636,7 +631,6 @@ export class Page extends Space<FlatBlockMap> {
 
     this.transact(() => {
       this._yBlocks.delete(model.id);
-      const children = model.children.map(model => model.id);
       model.dispose();
 
       if (parent) {
@@ -646,11 +640,9 @@ export class Page extends Space<FlatBlockMap> {
         if (index > -1) {
           yChildren.delete(index, 1);
         }
-        if (options.bringChildrenTo === 'parent') {
-          yChildren.unshift(children);
-        } else if (options.bringChildrenTo instanceof BaseBlockModel) {
-          this.updateBlock(options.bringChildrenTo, {
-            children: options.bringChildrenTo.children,
+        if (bringChildrenTo instanceof BaseBlockModel) {
+          this.updateBlock(bringChildrenTo, {
+            children: bringChildrenTo.children,
           });
         }
 

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '@playwright/test';
-
 import * as actions from '../utils/actions/edgeless.js';
 import {
   createShapeElement,
@@ -16,8 +14,6 @@ import {
   enterPlaygroundRoom,
   getBoundingRect,
   initEmptyEdgelessState,
-  initThreeNotes,
-  initThreeOverlapFilledShapes,
   initThreeParagraphs,
   pasteByKeyboard,
   pressEnter,

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "composite": false
   },
-  "include": ["**.spec.ts", "**.test.ts"]
+  "include": ["**.spec.ts", "**.test.ts", "**/**.ts"]
 }


### PR DESCRIPTION
- Fix remove block by slash menu should not bring chilren to top
- The `bringChildrenTo: parent` will unshift all children to the parent which is confused
