### PR TITLE
fix: icon button active styles

### DIFF
--- a/packages/blocks/src/attachment-block/components/styles.ts
+++ b/packages/blocks/src/attachment-block/components/styles.ts
@@ -75,7 +75,6 @@ export const moreMenuStyles = css`
 
   .affine-attachment-options-more icon-button:hover.danger {
     background: var(--affine-background-error-color);
-    fill: var(--affine-error-color);
     color: var(--affine-error-color);
   }
 `;
@@ -114,6 +113,7 @@ export const styles = css`
 
   .affine-attachment-options .divider {
     width: 1px;
+    margin: 0 1.5px;
     height: 24px;
     background-color: var(--affine-border-color);
   }

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -48,7 +48,7 @@ export class IconButton extends LitElement {
     }
 
     ::slotted(svg) {
-      color: var(--affine-icon-color);
+      color: var(--svg-icon-color);
     }
 
     :host(:hover) {
@@ -63,7 +63,6 @@ export class IconButton extends LitElement {
     :host(:disabled) {
       background: transparent;
       color: var(--affine-text-disable-color);
-      fill: var(--affine-text-disable-color);
       cursor: not-allowed;
     }
 
@@ -72,15 +71,8 @@ export class IconButton extends LitElement {
       background: var(--affine-hover-color);
     }
 
-    /* You can add a 'active' attribute to the button to revert the active style */
-    :host([active]) {
-      fill: var(--affine-primary-color);
-      color: var(--affine-primary-color);
-    }
-
     :host(:active[active]) {
       background: transparent;
-      fill: var(--affine-icon-color);
     }
   `;
 
@@ -95,6 +87,9 @@ export class IconButton extends LitElement {
 
   @property()
   text: string | null = null;
+
+  @property({ attribute: true, type: Boolean })
+  active?: boolean = false;
 
   // Do not add `{ attribute: false }` option here, otherwise the `disabled` styles will not work
   @property({ attribute: true, type: Boolean })
@@ -153,6 +148,13 @@ export class IconButton extends LitElement {
   }
 
   override render() {
+    const iconColor = this.disabled
+      ? 'var(--affine-disabled-color)'
+      : this.active
+      ? 'var(--affine-primary-color)'
+      : 'var(--affine-icon-color)';
+    this.style.setProperty('--svg-icon-color', iconColor);
+
     return html`<slot></slot>${this.text
         ? // wrap a span around the text so we can ellipsis it automatically
           html`<span class="text">${this.text}</span>`

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -40,17 +40,6 @@ export class IconButton extends LitElement {
       pointer-events: auto;
     }
 
-    :host > .text {
-      flex: 1;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-    }
-
-    ::slotted(svg) {
-      color: var(--svg-icon-color);
-    }
-
     :host(:hover) {
       background: var(--affine-hover-color);
     }
@@ -73,6 +62,17 @@ export class IconButton extends LitElement {
 
     :host(:active[active]) {
       background: transparent;
+    }
+
+    :host > .text {
+      flex: 1;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    ::slotted(svg) {
+      color: var(--svg-icon-color);
     }
   `;
 
@@ -97,6 +97,7 @@ export class IconButton extends LitElement {
 
   constructor() {
     super();
+    // Allow activate button by pressing Enter key
     this.addEventListener('keypress', event => {
       if (this.disabled) {
         return;
@@ -148,12 +149,15 @@ export class IconButton extends LitElement {
   }
 
   override render() {
-    const iconColor = this.disabled
-      ? 'var(--affine-disabled-color)'
-      : this.active
-      ? 'var(--affine-primary-color)'
-      : 'var(--affine-icon-color)';
-    this.style.setProperty('--svg-icon-color', iconColor);
+    if (this.disabled) {
+      const disabledColor = 'var(--affine-disabled-color)';
+      this.style.setProperty('--svg-icon-color', disabledColor);
+    } else {
+      const iconColor = this.active
+        ? 'var(--affine-primary-color)'
+        : 'var(--affine-icon-color)';
+      this.style.setProperty('--svg-icon-color', iconColor);
+    }
 
     return html`<slot></slot>${this.text
         ? // wrap a span around the text so we can ellipsis it automatically


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/pull/4345

There are still some issues when hovering the danger button

<img width="877" alt="Screenshot 2023-08-31 at 15 12 22" src="https://github.com/toeverything/blocksuite/assets/18554747/40261517-40eb-49da-b575-095cb31a93f3">
