### PR TITLE
fix: try add new block first when transform block

### DIFF
--- a/packages/blocks/src/page-block/utils/operations/model.ts
+++ b/packages/blocks/src/page-block/utils/operations/model.ts
@@ -57,6 +57,10 @@ export function transformModel(
     ...props,
   };
   const index = parent.children.indexOf(model);
+
+  // Sometimes the new block can not be added due to some reason, e.g. invalid schema check.
+  // So we need to try to add the new block first, and if it fails, we will not delete the old block.
+  const id = page.addBlock(flavour, blockProps, parent, index);
   page.deleteBlock(model);
-  return page.addBlock(flavour, blockProps, parent, index);
+  return id;
 }


### PR DESCRIPTION
Sometimes the new block can not be added due to some reason, e.g. invalid schema check.

So we need to try to add the new block first, and if it fails, we will not delete the old block.