### PR TITLE
fix(page): viewport jilter when drag to left-bottom and cannot insert to page bottom from block-hub

### DIFF
--- a/packages/blocks/src/__internal__/utils/query.ts
+++ b/packages/blocks/src/__internal__/utils/query.ts
@@ -409,10 +409,10 @@ function hasBlockId(element: Element): element is BlockComponentElement {
 }
 
 /**
- * Returns `true` if element is default page.
+ * Returns `true` if element is doc page.
  */
-export function isDefaultPage({ tagName }: Element) {
-  return tagName === 'AFFINE-DEFAULT-PAGE';
+export function isDocPage({ tagName }: Element) {
+  return tagName === 'AFFINE-DOC-PAGE';
 }
 
 /**
@@ -431,7 +431,7 @@ export function isEdgelessPage(
  */
 function isPageOrNoteOrSurface(element: Element) {
   return (
-    isDefaultPage(element) ||
+    isDocPage(element) ||
     isEdgelessPage(element) ||
     isNote(element) ||
     isSurface(element)


### PR DESCRIPTION
To close #3684 #3924 

This issue caused by legacy doc page check api.
Now the page tagName change to 'AFFINE-DOC-PAGE', but the code still check 'AFFINE-DEFAULT-PAGE', this would let  function findBlockElement() return pageBlockElement too, and cause calculate drop target position out of page and jilter, this is incorrect, the findBlockElement() function should only return blockElement.

Now we can insert blank lines without jilter:

https://github.com/toeverything/blocksuite/assets/99816898/a0042a7c-87de-48f0-a8f6-f853d9d8e675


