### PR TITLE
fix(edgeless): lost content with duplicate note action in edgeless #4521

### DIFF
--- a/packages/blocks/src/__internal__/service/legacy-services/note-service.ts
+++ b/packages/blocks/src/__internal__/service/legacy-services/note-service.ts
@@ -4,6 +4,7 @@ import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { SerializedBlock } from '../../utils/index.js';
 import { addSerializedBlocks } from '../json2block.js';
 import { BaseService } from '../service.js';
+import { getService } from '../singleton.js';
 
 export class NoteBlockService extends BaseService<NoteBlockModel> {
   override async json2Block(

--- a/packages/blocks/src/__internal__/service/service.ts
+++ b/packages/blocks/src/__internal__/service/service.ts
@@ -6,6 +6,7 @@ import type { TemplateResultType } from 'lit/directive-helpers.js';
 
 import type { BlockTransformContext, SerializedBlock } from '../utils/index.js';
 import { json2block } from './json2block.js';
+import { getService } from './singleton.js';
 
 // Breaking change introduced in lit@2.8.0
 // https://github.com/lit/lit/pull/3993

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -560,10 +560,9 @@ test('duplicate note should work correctly', async ({ page }) => {
 
   await selectNoteInEdgeless(page, ids.noteId);
 
-  const toolbar = locatorComponentToolbar(page);
-
   await triggerComponentToolbarAction(page, 'duplicate');
-  await expect(toolbar).toBeHidden();
+  const moreActionsContainer = await page.locator('.more-actions-container');
+  await expect(moreActionsContainer).toBeHidden();
 
   const noteLocator = await page.locator('edgeless-child-note');
   await expect(noteLocator).toHaveCount(2);
@@ -571,7 +570,7 @@ test('duplicate note should work correctly', async ({ page }) => {
 
   // content should be same
   await expect(
-    (await firstNote.allTextContents()) === (await secondNote.allTextContents())
+    (await firstNote.innerText()) === (await secondNote.innerText())
   ).toBeTruthy();
 
   // size should be same

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -264,7 +264,9 @@ test('drag handle should be shown when a note is actived in default mode or hidd
   await page.mouse.move(x, y);
   await expect(page.locator('.affine-drag-handle-container')).toBeHidden();
   await page.mouse.dblclick(x, y);
+  await waitNextFrame(page);
   await page.mouse.move(x, y);
+
   await expect(page.locator('.affine-drag-handle-container')).toBeVisible();
 
   await page.mouse.move(0, 0);

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -548,6 +548,37 @@ test('when editing text in edgeless, should hide component toolbar', async ({
   await expect(toolbar).toBeHidden();
 });
 
+test('duplicate note should work correctly', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  const ids = await initEmptyEdgelessState(page);
+  await initThreeParagraphs(page);
+  await assertRichTexts(page, ['123', '456', '789']);
+
+  await switchEditorMode(page);
+
+  await selectNoteInEdgeless(page, ids.noteId);
+
+  const toolbar = locatorComponentToolbar(page);
+
+  await triggerComponentToolbarAction(page, 'duplicate');
+  await expect(toolbar).toBeHidden();
+
+  const noteLocator = await page.locator('edgeless-child-note');
+  await expect(noteLocator).toHaveCount(2);
+  const [firstNote, secondNote] = await noteLocator.all();
+
+  // content should be same
+  await expect(
+    (await firstNote.allTextContents()) === (await secondNote.allTextContents())
+  ).toBeTruthy();
+
+  // size should be same
+  const firstNoteBox = await firstNote.boundingBox();
+  const secondNoteBox = await secondNote.boundingBox();
+  await expect(firstNoteBox?.width === secondNoteBox?.width).toBeTruthy();
+  await expect(firstNoteBox?.height === secondNoteBox?.height).toBeTruthy();
+});
+
 test('double click toolbar zoom button, should not add text', async ({
   page,
 }) => {

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -607,7 +607,8 @@ type Action =
   | 'changeConnectorStrokeColor'
   | 'changeConnectorStrokeStyles'
   | 'addFrame'
-  | 'createFrameOnMoreOption';
+  | 'createFrameOnMoreOption'
+  | 'duplicate';
 
 export async function triggerComponentToolbarAction(
   page: Page,
@@ -682,6 +683,18 @@ export async function triggerComponentToolbarAction(
         .locator('.more-actions-container .action-item')
         .filter({
           hasText: 'Frame Section',
+        });
+      await actionButton.click();
+      break;
+    }
+    case 'duplicate': {
+      const moreButton = locatorComponentToolbarMoreButton(page);
+      await moreButton.click();
+
+      const actionButton = moreButton
+        .locator('.more-actions-container .action-item')
+        .filter({
+          hasText: 'Duplicate',
         });
       await actionButton.click();
       break;

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -129,6 +129,7 @@ async function initEmptyEditor({
         const debugMenu: DebugMenu = document.createElement('debug-menu');
         debugMenu.workspace = workspace;
         debugMenu.editor = editor;
+        debugMenu.contentParser = editor.createContentParser();
         document.body.appendChild(debugMenu);
         window.debugMenu = debugMenu;
         window.editor = editor;


### PR DESCRIPTION
fix: #4521.

The `getService` import statement was deleted in [pr-4316 service.ts](https://github.com/toeverything/blocksuite/pull/4316/files#diff-ea130923a45d52986ac100629b83b0e49c6661ff6bf6e9718807b24655f08c3d) and [pr-4316 note-service.ts](https://github.com/toeverything/blocksuite/pull/4316/files#diff-4418768de534fcccdd14733aba3a21e49a6d879c8d0d9af87b45e0779211560c).

It was used but deleted. is this a mistake? And i add a unit test for this case.