### PR TITLE
feat: edgeless toolbar update

### DIFF
--- a/packages/blocks/src/icons/edgeless.ts
+++ b/packages/blocks/src/icons/edgeless.ts
@@ -1706,149 +1706,6 @@ export const EdgelessImageIcon = html`<svg
   </defs>
 </svg> `;
 
-export const EdgelessConnectorIcon = html`<svg
-  width="48"
-  height="52"
-  viewBox="0 0 48 52"
-  fill="none"
-  xmlns="http://www.w3.org/2000/svg"
->
-  <rect
-    x="11"
-    y="35"
-    width="26"
-    height="10"
-    rx="4"
-    fill="url(#paint0_linear_4219_85601)"
-  />
-  <path
-    d="M43 15V38C43 39.1046 42.1046 40 41 40H37"
-    stroke="#B1A5FF"
-    stroke-width="1.5"
-  />
-  <g filter="url(#filter0_d_4219_85601)">
-    <rect x="41" y="24" width="4" height="10" rx="2" fill="#5438FF" />
-  </g>
-  <circle cx="43" cy="15" r="4" fill="url(#paint1_linear_4219_85601)" />
-  <path
-    d="M5 4V38C5 39.1045 5.89543 40 7 40H11"
-    stroke="#B1A5FF"
-    stroke-width="1.5"
-  />
-  <g filter="url(#filter1_d_4219_85601)">
-    <rect x="3" y="17" width="4" height="10" rx="2" fill="#5438FF" />
-  </g>
-  <path
-    d="M4.19187 0.462521C4.56513 -0.154174 5.43487 -0.154173 5.80813 0.462522L8.85362 5.49435C9.25033 6.1498 8.794 7 8.04549 7H1.95451C1.206 7 0.749671 6.1498 1.14638 5.49435L4.19187 0.462521Z"
-    fill="url(#paint2_linear_4219_85601)"
-  />
-  <defs>
-    <filter
-      id="filter0_d_4219_85601"
-      x="38"
-      y="21"
-      width="10"
-      height="16"
-      filterUnits="userSpaceOnUse"
-      color-interpolation-filters="sRGB"
-    >
-      <feFlood flood-opacity="0" result="BackgroundImageFix" />
-      <feColorMatrix
-        in="SourceAlpha"
-        type="matrix"
-        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-        result="hardAlpha"
-      />
-      <feOffset />
-      <feGaussianBlur stdDeviation="1.5" />
-      <feComposite in2="hardAlpha" operator="out" />
-      <feColorMatrix
-        type="matrix"
-        values="0 0 0 0 0.329412 0 0 0 0 0.219608 0 0 0 0 1 0 0 0 0.45 0"
-      />
-      <feBlend
-        mode="normal"
-        in2="BackgroundImageFix"
-        result="effect1_dropShadow_4219_85601"
-      />
-      <feBlend
-        mode="normal"
-        in="SourceGraphic"
-        in2="effect1_dropShadow_4219_85601"
-        result="shape"
-      />
-    </filter>
-    <filter
-      id="filter1_d_4219_85601"
-      x="0"
-      y="14"
-      width="10"
-      height="16"
-      filterUnits="userSpaceOnUse"
-      color-interpolation-filters="sRGB"
-    >
-      <feFlood flood-opacity="0" result="BackgroundImageFix" />
-      <feColorMatrix
-        in="SourceAlpha"
-        type="matrix"
-        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-        result="hardAlpha"
-      />
-      <feOffset />
-      <feGaussianBlur stdDeviation="1.5" />
-      <feComposite in2="hardAlpha" operator="out" />
-      <feColorMatrix
-        type="matrix"
-        values="0 0 0 0 0.329412 0 0 0 0 0.219608 0 0 0 0 1 0 0 0 0.45 0"
-      />
-      <feBlend
-        mode="normal"
-        in2="BackgroundImageFix"
-        result="effect1_dropShadow_4219_85601"
-      />
-      <feBlend
-        mode="normal"
-        in="SourceGraphic"
-        in2="effect1_dropShadow_4219_85601"
-        result="shape"
-      />
-    </filter>
-    <linearGradient
-      id="paint0_linear_4219_85601"
-      x1="24.5"
-      y1="45"
-      x2="24.5"
-      y2="35"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#5438FF" />
-      <stop offset="1" stop-color="#B1A5FF" />
-    </linearGradient>
-    <linearGradient
-      id="paint1_linear_4219_85601"
-      x1="42.9999"
-      y1="10.0026"
-      x2="42.9999"
-      y2="18.9999"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#5438FF" />
-      <stop offset="1" stop-color="#B1A5FF" />
-    </linearGradient>
-    <linearGradient
-      id="paint2_linear_4219_85601"
-      x1="4.99992"
-      y1="-0.872727"
-      x2="4.99992"
-      y2="6.99996"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#5438FF" />
-      <stop offset="1" stop-color="#B1A5FF" />
-    </linearGradient>
-  </defs>
-</svg> `;
-
 export const MoreIcon = html` <svg
   width="24"
   height="25"
@@ -2118,8 +1975,8 @@ export const ChangeShapeIcon = html`<svg
 
 export const ArrowRightSmallIcon = svg`<svg
   xmlns="http://www.w3.org/2000/svg"
-  width="16"
-  height="16"
+  width="32"
+  height="32"
   viewBox="0 0 24 24"
   fill="none"
 >
@@ -2316,5 +2173,21 @@ export const RemoteCursor = html`
         />
       </filter>
     </defs>
+  </svg>
+`;
+
+export const ConnectorIcon = html`
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M14.25 6.5C14.25 4.70507 15.7051 3.25 17.5 3.25C19.2949 3.25 20.75 4.70507 20.75 6.5C20.75 8.29493 19.2949 9.75 17.5 9.75C16.89 9.75 16.3193 9.58196 15.8316 9.28964L9.28964 15.8316C9.58196 16.3193 9.75 16.89 9.75 17.5C9.75 19.2949 8.29493 20.75 6.5 20.75C4.70507 20.75 3.25 19.2949 3.25 17.5C3.25 15.7051 4.70507 14.25 6.5 14.25C7.14146 14.25 7.73952 14.4358 8.24327 14.7566L14.7566 8.24327C14.4358 7.73952 14.25 7.14146 14.25 6.5ZM17.5 4.75C16.5335 4.75 15.75 5.5335 15.75 6.5C15.75 7.4665 16.5335 8.25 17.5 8.25C18.4665 8.25 19.25 7.4665 19.25 6.5C19.25 5.5335 18.4665 4.75 17.5 4.75ZM6.5 15.75C5.5335 15.75 4.75 16.5335 4.75 17.5C4.75 18.4665 5.5335 19.25 6.5 19.25C7.4665 19.25 8.25 18.4665 8.25 17.5C8.25 16.5335 7.4665 15.75 6.5 15.75Z"
+      fill="currentColor"
+    />
   </svg>
 `;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -47,20 +47,6 @@ export class EdgelessBrushToolButton extends WithDisposable(LitElement) {
     #edgeless-pen-icon:hover {
       top: 2px;
     }
-    .arrow-up-icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      position: absolute;
-      right: 2px;
-      top: 12px;
-      width: 14px;
-      height: 14px;
-      fill: var(--affine-icon-color);
-    }
-    .arrow-up-icon:hover {
-      background: var(--affine-hover-color);
-    }
   `;
 
   @property({ attribute: false })
@@ -159,7 +145,6 @@ export class EdgelessBrushToolButton extends WithDisposable(LitElement) {
           <div style=${styleMap({ color: `var(${this._color})` })}>
             ${EdgelessPenIcon}
           </div>
-          <div class="arrow-up-icon">${ArrowUpIcon}</div>
         </div>
       </edgeless-toolbar-button>
     `;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -10,7 +10,7 @@ import {
   type EdgelessTool,
   LineWidth,
 } from '../../../../../__internal__/index.js';
-import { ArrowUpIcon, EdgelessPenIcon } from '../../../../../icons/index.js';
+import { EdgelessPenIcon } from '../../../../../icons/index.js';
 import type { EdgelessPageBlockComponent } from '../../../edgeless-page-block.js';
 import { DEFAULT_BRUSH_COLOR } from '../../panel/color-panel.js';
 import { getTooltipWithShortcut } from '../../utils.js';

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/common/slide-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/common/slide-menu.ts
@@ -42,12 +42,13 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
       align-items: center;
       justify-content: center;
       position: absolute;
-      width: 18px;
-      height: 18px;
+      width: 32px;
+      height: 32px;
       border-radius: 50%;
       border: 1px solid var(--affine-border-color);
       background: var(--affine-background-overlay-panel-color);
       box-shadow: var(--affine-shadow-2);
+      color: var(--affine-icon-color);
       transition:
         transform 0.3s ease-in-out,
         opacity 0.5s ease-in-out;
@@ -58,7 +59,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
       opacity: 1;
       top: 50%;
       right: 0;
-      transform: translate(50%, -50%) scale(0.75);
+      transform: translate(50%, -50%) scale(0.5);
     }
     .next-slide-button:hover {
       cursor: pointer;
@@ -68,7 +69,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
       opacity: 0;
       top: 50%;
       left: 0;
-      transform: translate(-50%, -50%) scale(0.75);
+      transform: translate(-50%, -50%) scale(0.5);
     }
     .previous-slide-button:hover {
       cursor: pointer;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -9,7 +9,7 @@ import {
   type EdgelessTool,
   LineWidth,
 } from '../../../../../__internal__/index.js';
-import { EdgelessConnectorIcon } from '../../../../../icons/index.js';
+import { ArrowUpIcon, ConnectorIcon } from '../../../../../icons/index.js';
 import { ConnectorMode } from '../../../../../surface-block/index.js';
 import type { EdgelessPageBlockComponent } from '../../../edgeless-page-block.js';
 import { GET_DEFAULT_LINE_COLOR } from '../../panel/color-panel.js';
@@ -26,11 +26,10 @@ export class EdgelessConnectorToolButton extends WithDisposable(LitElement) {
       display: flex;
       position: relative;
     }
-    edgeless-toolbar-button svg {
-      transition: 0.3s ease-in-out;
-    }
-    edgeless-toolbar-button:hover svg {
-      transform: scale(1.15);
+    .edgeless-connector-button svg + svg {
+      position: absolute;
+      top: 4px;
+      right: 2px;
     }
   `;
 
@@ -51,7 +50,7 @@ export class EdgelessConnectorToolButton extends WithDisposable(LitElement) {
       this._connectorMenu = null;
     } else {
       this._connectorMenu = createPopper('edgeless-connector-menu', this, {
-        x: 110,
+        x: 50,
         y: -40,
       });
       this._connectorMenu.element.edgelessTool = this.edgelessTool;
@@ -94,10 +93,10 @@ export class EdgelessConnectorToolButton extends WithDisposable(LitElement) {
     const type = this.edgelessTool?.type;
 
     return html`
-      <edgeless-toolbar-button
+      <edgeless-tool-icon-button
         .tooltip=${this._connectorMenu ? '' : 'Connector'}
         .active=${type === 'connector'}
-        .activeMode=${'background'}
+        .iconContainerPadding=${8}
         class="edgeless-connector-button"
         @click=${() => {
           this.setEdgelessTool({
@@ -109,8 +108,8 @@ export class EdgelessConnectorToolButton extends WithDisposable(LitElement) {
           this._toggleMenu();
         }}
       >
-        ${EdgelessConnectorIcon}
-      </edgeless-toolbar-button>
+        ${ConnectorIcon} ${ArrowUpIcon}
+      </edgeless-tool-icon-button>
     `;
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -68,7 +68,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       box-shadow: var(--affine-shadow-2);
       border: 1px solid var(--affine-border-color);
       border-radius: 40px;
-      min-height: 52px;
+      height: 64px;
     }
     .edgeless-toolbar-container[level='second'] {
       position: absolute;
@@ -82,7 +82,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 10px;
+      gap: 8px;
     }
     .short-divider {
       width: 1px;
@@ -440,11 +440,6 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
           .edgeless=${this.edgeless}
           .setEdgelessTool=${this.setEdgelessTool}
         ></edgeless-shape-tool-button>
-        <edgeless-connector-tool-button
-          .edgelessTool=${this.edgelessTool}
-          .edgeless=${this.edgeless}
-          .setEdgelessTool=${this.setEdgelessTool}
-        ></edgeless-connector-tool-button>
       </div>
     `;
   }
@@ -457,19 +452,26 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
         <edgeless-tool-icon-button
           .tooltip=${getTooltipWithShortcut('Select', 'V')}
           .active=${type === 'default'}
-          .iconContainerPadding=${4}
+          .iconContainerPadding=${8}
           @click=${() => this.setEdgelessTool({ type: 'default' })}
         >
           ${SelectIcon}
         </edgeless-tool-icon-button>
+
         <edgeless-tool-icon-button
           .tooltip=${getTooltipWithShortcut('Hand', 'H')}
           .active=${type === 'pan'}
-          .iconContainerPadding=${4}
+          .iconContainerPadding=${8}
           @click=${() => this.setEdgelessTool({ type: 'pan', panning: false })}
         >
           ${HandIcon}
         </edgeless-tool-icon-button>
+
+        <edgeless-connector-tool-button
+          .edgelessTool=${this.edgelessTool}
+          .edgeless=${this.edgeless}
+          .setEdgelessTool=${this.setEdgelessTool}
+        ></edgeless-connector-tool-button>
 
         ${page.readonly
           ? nothing
@@ -481,7 +483,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           .tooltip=${'Presentation'}
-          .iconContainerPadding=${4}
+          .iconContainerPadding=${8}
           @click=${() => {
             this._index = this._currentFrameIndex;
             if (

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-tool-button.ts
@@ -19,19 +19,10 @@ export class EdgelessFrameToolButton extends WithDisposable(LitElement) {
       display: flex;
     }
 
-    .frame-button-group {
-      display: flex;
-      position: relative;
-      align-items: center;
-      justify-content: center;
-      width: 32px;
-      height: 32px;
-    }
-
     edgeless-tool-icon-button svg + svg {
       position: absolute;
-      top: 2px;
-      right: 0px;
+      top: 4px;
+      right: 2px;
     }
   `;
 
@@ -98,7 +89,7 @@ export class EdgelessFrameToolButton extends WithDisposable(LitElement) {
       <edgeless-tool-icon-button
         .tooltip=${this._frameMenu ? '' : getTooltipWithShortcut('Frame', 'F')}
         .active=${type === 'frame'}
-        .iconContainerPadding=${0}
+        .iconContainerPadding=${8}
         @click=${() => {
           this.setEdgelessTool({
             type: 'frame',
@@ -106,7 +97,7 @@ export class EdgelessFrameToolButton extends WithDisposable(LitElement) {
           this._toggleFrameMenu();
         }}
       >
-        <div class="frame-button-group">${LargeFrameIcon} ${ArrowUpIcon}</div>
+        ${LargeFrameIcon} ${ArrowUpIcon}
       </edgeless-tool-icon-button>
     `;
   }

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
@@ -32,7 +32,9 @@ export class EdgelessNoteToolButton extends WithDisposable(LitElement) {
     }
 
     edgeless-tool-icon-button svg + svg {
-      margin-left: 8px;
+      position: absolute;
+      top: 4px;
+      right: 2px;
     }
   `;
 
@@ -99,6 +101,7 @@ export class EdgelessNoteToolButton extends WithDisposable(LitElement) {
       <edgeless-tool-icon-button
         .tooltip=${this._noteMenu ? '' : getTooltipWithShortcut('Note', 'N')}
         .active=${type === 'note'}
+        .iconContainerPadding=${8}
         @click=${() => {
           this.setEdgelessTool({
             type: 'note',

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -124,7 +124,6 @@ export function locatorEdgelessToolButton(
     case 'brush':
     case 'text':
     case 'eraser':
-    case 'connector':
     case 'shape':
       buttonType = 'edgeless-toolbar-button';
       break;


### PR DESCRIPTION
Part of #4538 

- [x] Modify the style of the connector to be a separate icon.
- [x] Display icons and badges on the left side, but not on the right side.
- [x] Enlarge slide menu button
- [x] Enlarge icon container padding