### PR TITLE
refactor: move image toolbar widget to image block

### DIFF
--- a/packages/blocks/src/components/when-hover.ts
+++ b/packages/blocks/src/components/when-hover.ts
@@ -1,6 +1,5 @@
 import { DisposableGroup, whenHover } from '@blocksuite/global/utils';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
-import type { RefOrCallback } from 'lit/directives/ref.js';
 
 import type { AdvancedPortalOptions } from './portal.js';
 import { createLitPortal } from './portal.js';
@@ -15,11 +14,14 @@ export class WhenHoverController implements ReactiveController {
   host: ReactiveControllerHost;
 
   private _abortController?: AbortController;
-  private _setReference?: RefOrCallback;
+  private _setReference?: (element?: Element | undefined) => void;
   private _portal?: HTMLDivElement;
   private readonly _options: (options: OptionsParams) => WhenHoverOptions;
 
   get setReference() {
+    if (!this._setReference) {
+      throw new Error('setReference is not ready');
+    }
     return this._setReference;
   }
 
@@ -62,6 +64,7 @@ export class WhenHoverController implements ReactiveController {
     this._setReference = setReference;
     this._disposables.add(dispose);
   }
+
   hostDisconnected() {
     this._disposables.dispose();
   }

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -425,6 +425,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
           />
         </div>
       </div>
+      ${Object.values(this.widgets)}
     `;
   }
 }

--- a/packages/blocks/src/page-block/types.ts
+++ b/packages/blocks/src/page-block/types.ts
@@ -5,7 +5,6 @@ import type { EdgelessPageBlockComponent } from './edgeless/edgeless-page-block.
 
 export type DocPageBlockWidgetName =
   | 'modal'
-  | 'imageToolbar'
   | 'slashMenu'
   | 'linkedPage'
   | 'draggingArea'
@@ -14,7 +13,6 @@ export type DocPageBlockWidgetName =
   | typeof AFFINE_REMOTE_SELECTION_WIDGET_TAG;
 export type EdgelessPageBlockWidgetName =
   | 'modal'
-  | 'imageToolbar'
   | 'remoteSelection'
   | 'slashMenu'
   | 'linkedPage'

--- a/packages/blocks/src/preset/index.ts
+++ b/packages/blocks/src/preset/index.ts
@@ -31,7 +31,6 @@ const pageBlockSpec: LitBlockSpec<DocPageBlockWidgetName> = {
     component: literal`affine-doc-page`,
     widgets: {
       modal: literal`affine-modal-widget`,
-      imageToolbar: literal`affine-image-toolbar-widget`,
       slashMenu: literal`affine-slash-menu-widget`,
       linkedPage: literal`affine-linked-page-widget`,
       draggingArea: literal`affine-doc-dragging-area-widget`,
@@ -53,7 +52,6 @@ const edgelessBlockSpec: LitBlockSpec<EdgelessPageBlockWidgetName> = {
     component: literal`affine-edgeless-page`,
     widgets: {
       modal: literal`affine-modal-widget`,
-      imageToolbar: literal`affine-image-toolbar-widget`,
       slashMenu: literal`affine-slash-menu-widget`,
       linkedPage: literal`affine-linked-page-widget`,
       dragHandle: literal`affine-drag-handle-widget`,
@@ -118,6 +116,9 @@ export const pagePreset: LitBlockSpec[] = [
     service: ImageService,
     view: {
       component: literal`affine-image`,
+      widgets: {
+        imageToolbar: literal`affine-image-toolbar-widget`,
+      },
     },
   },
   {
@@ -190,6 +191,9 @@ export const edgelessPreset: LitBlockSpec[] = [
     service: ImageService,
     view: {
       component: literal`affine-image`,
+      widgets: {
+        imageToolbar: literal`affine-image-toolbar-widget`,
+      },
     },
   },
   {

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -64,6 +64,9 @@ export function ImageOptionsTemplate({
       .has-tool-tip.delete-image-button:hover > svg {
         color: var(--affine-error-color);
       }
+      icon-button[hidden] {
+        display: none;
+      }
 
       ${tooltipStyle}
     </style>
@@ -132,8 +135,8 @@ export function ImageOptionsTemplate({
         <icon-button
           class="has-tool-tip"
           size="32px"
-          ?hidden=${readonly ||
-          !model.page.awarenessStore.getFlag('enable_bultin_ledits')}
+          ?disabled=${readonly}
+          ?hidden=${!model.page.awarenessStore.getFlag('enable_bultin_ledits')}
           @click="${() => {
             abortController.abort();
             openLeditsEditor(model, blob, root);

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -1,0 +1,150 @@
+import type { BlockSuiteRoot } from '@blocksuite/lit';
+import { html, nothing } from 'lit';
+import { ref, type RefOrCallback } from 'lit/directives/ref.js';
+
+import { stopPropagation } from '../../__internal__/utils/event.js';
+import { turnImageIntoCardView } from '../../attachment-block/utils.js';
+import { tooltipStyle } from '../../components/tooltip/tooltip.js';
+import {
+  BookmarkIcon,
+  CaptionIcon,
+  CopyIcon,
+  DeleteIcon,
+  DownloadIcon,
+  HighLightDuotoneIcon,
+} from '../../icons/index.js';
+import {
+  copyImage,
+  downloadImage,
+  focusCaption,
+} from '../../image-block/image/utils.js';
+import { type ImageBlockModel } from '../../image-block/index.js';
+import { openLeditsEditor } from '../../image-block/ledits/main.js';
+
+export function ImageOptionsTemplate({
+  ref: containerRef,
+  model,
+  blob,
+  abortController,
+  root,
+}: {
+  ref: RefOrCallback;
+  model: ImageBlockModel;
+  blob: Blob;
+  abortController: AbortController;
+  /**
+   * @deprecated
+   */
+  root: BlockSuiteRoot;
+}) {
+  const supportAttachment =
+    model.page.schema.flavourSchemaMap.has('affine:attachment');
+  const readonly = model.page.readonly;
+
+  return html`
+    <style>
+      .affine-embed-editing-state-container > div {
+        display: block;
+        z-index: var(--affine-z-index-popover);
+      }
+
+      .embed-editing-state {
+        box-sizing: border-box;
+        box-shadow: var(--affine-shadow-2);
+        border-radius: 8px;
+        list-style: none;
+        padding: 4px;
+        background-color: var(--affine-background-overlay-panel-color);
+        margin: 0;
+      }
+      .has-tool-tip.delete-image-button:hover {
+        background: var(--affine-background-error-color);
+        color: var(--affine-error-color);
+      }
+      .has-tool-tip.delete-image-button:hover > svg {
+        color: var(--affine-error-color);
+      }
+
+      ${tooltipStyle}
+    </style>
+
+    <div
+      ${ref(containerRef)}
+      class="affine-embed-editing-state-container"
+      @pointerdown=${stopPropagation}
+    >
+      <div class="embed-editing-state">
+        ${supportAttachment
+          ? html`<icon-button
+              class="has-tool-tip"
+              size="32px"
+              ?disabled=${readonly}
+              @click=${() => {
+                abortController.abort();
+                turnImageIntoCardView(model, blob);
+              }}
+            >
+              ${BookmarkIcon}
+              <tool-tip inert role="tooltip">Turn into Card view</tool-tip>
+            </icon-button>`
+          : nothing}
+        <icon-button
+          class="has-tool-tip"
+          size="32px"
+          ?disabled=${readonly}
+          @click=${() => focusCaption(model)}
+        >
+          ${CaptionIcon}
+          <tool-tip inert tip-position="right" role="tooltip">Caption</tool-tip>
+        </icon-button>
+        <icon-button
+          class="has-tool-tip"
+          size="32px"
+          @click=${() => downloadImage(model)}
+        >
+          ${DownloadIcon}
+          <tool-tip inert tip-position="right" role="tooltip"
+            >Download</tool-tip
+          >
+        </icon-button>
+        <icon-button
+          class="has-tool-tip"
+          size="32px"
+          @click=${() => copyImage(model)}
+        >
+          ${CopyIcon}
+          <tool-tip inert tip-position="right" role="tooltip"
+            >Copy to clipboard</tool-tip
+          >
+        </icon-button>
+        <icon-button
+          class="has-tool-tip delete-image-button"
+          size="32px"
+          ?disabled=${readonly}
+          @click="${() => {
+            abortController.abort();
+            model.page.deleteBlock(model);
+          }}"
+        >
+          ${DeleteIcon}
+          <tool-tip inert tip-position="right" role="tooltip">Delete</tool-tip>
+        </icon-button>
+        <icon-button
+          class="has-tool-tip"
+          size="32px"
+          ?hidden=${readonly ||
+          !model.page.awarenessStore.getFlag('enable_bultin_ledits')}
+          @click="${() => {
+            abortController.abort();
+            openLeditsEditor(model, blob, root);
+          }}"
+        >
+          ${HighLightDuotoneIcon}
+          <tool-tip inert tip-position="right" role="tooltip"
+            >Edit with LEDITS</tool-tip
+          >
+        </icon-button>
+      </div>
+    </div>
+  `;
+}

--- a/packages/blocks/src/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/widgets/image-toolbar/index.ts
@@ -1,277 +1,53 @@
-import { assertExists } from '@blocksuite/global/utils';
 import { WidgetElement } from '@blocksuite/lit';
-import { autoUpdate, computePosition, offset, shift } from '@floating-ui/dom';
-import { css, html, nothing } from 'lit';
+import { offset, shift } from '@floating-ui/dom';
 import { customElement } from 'lit/decorators.js';
 
 import { PAGE_HEADER_HEIGHT } from '../../__internal__/consts.js';
-import { on } from '../../__internal__/utils/common.js';
-import { stopPropagation } from '../../__internal__/utils/event.js';
-import { turnImageIntoCardView } from '../../attachment-block/utils.js';
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
-import {
-  BookmarkIcon,
-  CaptionIcon,
-  CopyIcon,
-  DeleteIcon,
-  DownloadIcon,
-  HighLightDuotoneIcon,
-} from '../../icons/index.js';
-import {
-  copyImage,
-  downloadImage,
-  focusCaption,
-} from '../../image-block/image/utils.js';
-import type { ImageBlockComponent } from '../../image-block/index.js';
-import { type ImageBlockModel } from '../../image-block/index.js';
-import { openLeditsEditor } from '../../image-block/ledits/main.js';
+import { WhenHoverController } from '../../components/when-hover.js';
+import type { ImageBlockComponent } from '../../image-block/image-block.js';
+import { ImageOptionsTemplate } from './image-options.js';
 
 @customElement('affine-image-toolbar-widget')
 export class AffineImageToolbarWidget extends WidgetElement {
-  static override styles = [
-    css`
-      :host {
-        position: absolute;
-      }
-
-      .affine-embed-editing-state-container > div {
-        display: block;
-        z-index: var(--affine-z-index-popover);
-      }
-
-      .embed-editing-state {
-        box-sizing: border-box;
-        box-shadow: var(--affine-shadow-2);
-        border-radius: 8px;
-        list-style: none;
-        padding: 4px;
-        background-color: var(--affine-background-overlay-panel-color);
-        margin: 0;
-      }
-      .has-tool-tip.delete-image-button:hover {
-        background: var(--affine-background-error-color);
-        color: var(--affine-error-color);
-      }
-      .has-tool-tip.delete-image-button:hover > svg {
-        color: var(--affine-error-color);
-      }
-      .has-tool-tip[hidden] {
-        display: none;
-      }
-    `,
-    tooltipStyle,
-  ];
-
-  private _hovered = false;
-  private _hideTimer: ReturnType<typeof setTimeout> | null = null;
-  private _hiddenCleanup: (() => void)[] = [];
-  private imageModel: ImageBlockModel | null = null;
-  private blob: Blob | null = null;
-
-  get supportAttachment() {
-    return this.page.schema.flavourSchemaMap.has('affine:attachment');
-  }
-
-  private _onHover = () => {
-    this._hovered = true;
-  };
-
-  private _onHoverLeave = () => {
-    this._hovered = false;
-    this._hideAfterDelay();
-  };
-
-  private _hideAfterDelay = () => {
-    if (this._hideTimer) clearTimeout(this._hideTimer);
-
-    this._hideTimer = setTimeout(() => {
-      if (!this._hovered) {
-        this.hide();
-      }
-      this._hideTimer = null;
-    }, 150);
-  };
-
-  private async _updatePosition(anchor: HTMLElement) {
-    const pos = await computePosition(anchor, this, {
-      placement: 'right-start',
-      middleware: [
-        offset({
-          mainAxis: 12,
-          crossAxis: 10,
+  private _whenHover = new WhenHoverController(
+    this,
+    ({ setFloating, abortController }) => {
+      const imageBlock = this.pageElement as ImageBlockComponent;
+      return {
+        template: ImageOptionsTemplate({
+          ref: setFloating,
+          model: imageBlock.model,
+          blob: imageBlock.blob,
+          abortController,
+          root: this.pageElement.root,
         }),
-        shift({
-          crossAxis: true,
-          padding: {
-            top: PAGE_HEADER_HEIGHT + 12,
-            bottom: 12,
-            right: 12,
-          },
-        }),
-      ],
-    });
-
-    this.style.left = `${pos.x}px`;
-    this.style.top = `${pos.y}px`;
-  }
-
-  async show(options: {
-    anchor: HTMLElement;
-    model: ImageBlockModel;
-    blob: Blob;
-  }) {
-    if (this.imageModel && this.imageModel !== options.model) {
-      this.clear();
+        computePosition: {
+          referenceElement: imageBlock.resizeImg,
+          placement: 'right-start',
+          middleware: [
+            offset({
+              mainAxis: 12,
+              crossAxis: 10,
+            }),
+            shift({
+              crossAxis: true,
+              padding: {
+                top: PAGE_HEADER_HEIGHT + 12,
+                bottom: 12,
+                right: 12,
+              },
+            }),
+          ],
+          autoUpdate: true,
+        },
+      };
     }
-
-    this.imageModel = options.model;
-    this.blob = options.blob;
-    this.requestUpdate();
-
-    await this.updateComplete;
-    await this._updatePosition(options.anchor);
-
-    this._hiddenCleanup.push(
-      autoUpdate(options.anchor, this, () =>
-        this._updatePosition(options.anchor)
-      )
-    );
-    this._hiddenCleanup.push(
-      on(options.anchor, 'mouseover', () => {
-        this._onHover();
-      })
-    );
-    this._hiddenCleanup.push(
-      on(options.anchor, 'mouseleave', () => {
-        this._onHoverLeave();
-      })
-    );
-  }
-
-  clear() {
-    this._hiddenCleanup.forEach(cleanup => cleanup());
-    this._hiddenCleanup = [];
-    this.imageModel = null;
-    this.blob = null;
-  }
-
-  hide() {
-    this.clear();
-    this.requestUpdate();
-  }
+  );
 
   override connectedCallback() {
     super.connectedCallback();
-
-    this.pageElement.handleEvent('pointerMove', ctx => {
-      const e = ctx.get('pointerState');
-      const target = e.raw.target as HTMLElement;
-
-      if (target.tagName !== 'IMG') return;
-
-      const image = target.closest('affine-image') as ImageBlockComponent;
-
-      this.show({
-        anchor: image.resizeImg,
-        model: image.model,
-        blob: image.blob,
-      });
-    });
-  }
-
-  override render() {
-    const { imageModel: model, blob } = this;
-    const { readonly } = this.page;
-
-    if (!model) return nothing;
-
-    assertExists(blob);
-
-    return html`
-      <div
-        class="affine-embed-editing-state-container"
-        @pointerdown=${stopPropagation}
-        @mouseover=${this._onHover}
-        @mouseout=${this._onHoverLeave}
-      >
-        <div class="embed-editing-state">
-          ${this.supportAttachment
-            ? html`<icon-button
-                class="has-tool-tip"
-                size="32px"
-                ?hidden=${readonly}
-                @click=${() => {
-                  this.hide();
-                  turnImageIntoCardView(model, blob);
-                }}
-              >
-                ${BookmarkIcon}
-                <tool-tip inert role="tooltip">Turn into Card view</tool-tip>
-              </icon-button>`
-            : nothing}
-          <icon-button
-            class="has-tool-tip"
-            size="32px"
-            ?hidden=${readonly}
-            @click=${() => focusCaption(model)}
-          >
-            ${CaptionIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Caption</tool-tip
-            >
-          </icon-button>
-          <icon-button
-            class="has-tool-tip"
-            size="32px"
-            @click=${() => downloadImage(model)}
-          >
-            ${DownloadIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Download</tool-tip
-            >
-          </icon-button>
-          <icon-button
-            class="has-tool-tip"
-            size="32px"
-            @click=${() => copyImage(model)}
-          >
-            ${CopyIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Copy to clipboard</tool-tip
-            >
-          </icon-button>
-          <icon-button
-            class="has-tool-tip delete-image-button"
-            size="32px"
-            ?hidden=${readonly}
-            @click="${() => {
-              this.hide();
-              model.page.deleteBlock(model);
-            }}"
-          >
-            ${DeleteIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Delete</tool-tip
-            >
-          </icon-button>
-          <icon-button
-            class="has-tool-tip"
-            size="32px"
-            ?hidden=${readonly ||
-            !this.page.awarenessStore.getFlag('enable_bultin_ledits')}
-            @click="${() => {
-              this.hide();
-              openLeditsEditor(model, blob, this.root);
-            }}"
-          >
-            ${HighLightDuotoneIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Edit with LEDITS</tool-tip
-            >
-          </icon-button>
-        </div>
-      </div>
-    `;
+    const imageBlock = this.pageElement as ImageBlockComponent;
+    this._whenHover.setReference(imageBlock);
   }
 }
 

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -175,7 +175,7 @@ test('popup menu should follow position of image when scrolling', async ({
 
   await page.waitForTimeout(150);
 
-  const menu = page.locator('affine-image-toolbar-widget');
+  const menu = page.locator('.affine-embed-editing-state-container');
 
   expect(menu).toBeVisible();
 


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/pull/4589 https://github.com/toeverything/blocksuite/pull/4635

- Fix the issue where the image toolbar remains even after deleting the image block.
- Move image toolbar widget to the image block
- Using the new whenHoverController