### PR TITLE
refactor: remove yjs as dependency in blocks package

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -4,15 +4,7 @@
     "scope-enum": [
       2,
       "always",
-      [
-        "page",
-        "edgeless",
-        "database",
-        "virgo",
-        "store",
-        "block-std",
-        "playground"
-      ]
+      ["page", "edgeless", "database", "virgo", "store", "std", "playground"]
     ]
   }
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -19,8 +19,7 @@
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@toeverything/theme": "^0.7.15",
-    "nanoid": "^4",
-    "yjs": "^13"
+    "nanoid": "^4"
   },
   "dependencies": {
     "@blocksuite/global": "workspace:*",
@@ -83,7 +82,6 @@
     "@types/autosize": "^4.0.1",
     "@types/marked": "^4.3.1",
     "@types/sortablejs": "^1.15.1",
-    "@types/turndown": "^5.0.1",
-    "yjs": "^13.6.7"
+    "@types/turndown": "^5.0.1"
   }
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -79,9 +79,7 @@
     "@blocksuite/lit": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@toeverything/theme": "^0.7.15",
-    "@types/autosize": "^4.0.1",
     "@types/marked": "^4.3.1",
-    "@types/sortablejs": "^1.15.1",
-    "@types/turndown": "^5.0.1"
+    "@types/sortablejs": "^1.15.1"
   }
 }

--- a/packages/blocks/src/bookmark-block/components/config.ts
+++ b/packages/blocks/src/bookmark-block/components/config.ts
@@ -1,6 +1,6 @@
 import type { BaseBlockModel } from '@blocksuite/store';
+import { Workspace } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
-import * as Y from 'yjs';
 
 import { toast } from '../..//components/toast.js';
 import { copyBlocks } from '../../__internal__/clipboard/utils/commons.js';
@@ -55,7 +55,7 @@ export const config: ConfigItem[] = [
       const parent = page.getParent(model);
       const index = parent?.children.indexOf(model);
 
-      const yText = new Y.Text();
+      const yText = new Workspace.Y.Text();
       const insert = model.bookmarkTitle || model.caption || model.url;
       yText.insert(0, insert);
       yText.format(0, insert.length, { link: model.url });

--- a/packages/blocks/src/components/rich-text/markdown/inline.ts
+++ b/packages/blocks/src/components/rich-text/markdown/inline.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-useless-escape */
+import type { Y } from '@blocksuite/store';
 import {
   type VEditor,
   VKEYBOARD_ALLOW_DEFAULT,
@@ -7,7 +8,6 @@ import {
   type VKeyboardBindingHandler,
   type VRange,
 } from '@blocksuite/virgo';
-import type * as Y from 'yjs';
 
 interface InlineMarkdownMatch {
   name: string;

--- a/packages/blocks/src/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/components/rich-text/rich-text.ts
@@ -1,5 +1,7 @@
 import { assertExists } from '@blocksuite/global/utils';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
+import type { Y } from '@blocksuite/store';
+import { Workspace } from '@blocksuite/store';
 import {
   createVirgoKeyDownHandler,
   VEditor,
@@ -8,7 +10,6 @@ import {
 } from '@blocksuite/virgo';
 import { css, html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
-import * as Y from 'yjs';
 
 import { tryFormatInlineStyle } from './markdown/inline.js';
 import { onVBeforeinput, onVCompositionEnd } from './virgo/hooks.js';
@@ -173,7 +174,7 @@ export class RichText extends WithDisposable(ShadowlessElement) {
 
     // Rich-Text controls undo-redo itself if undoManager is not provided
     if (!this.undoManager) {
-      this.undoManager = new Y.UndoManager(this.yText, {
+      this.undoManager = new Workspace.Y.UndoManager(this.yText, {
         trackedOrigins: new Set([this.yText.doc.clientID]),
       });
 

--- a/packages/blocks/src/components/virgo-input/virgo-input.ts
+++ b/packages/blocks/src/components/virgo-input/virgo-input.ts
@@ -1,5 +1,5 @@
+import { Workspace, type Y } from '@blocksuite/store';
 import { VEditor, type VRange } from '@blocksuite/virgo';
-import * as Y from 'yjs';
 
 interface StackItem {
   meta: Map<'v-range', VRange | null>;
@@ -9,7 +9,7 @@ interface StackItem {
 export class VirgoInput {
   static Y_TEXT_NAME = 'Y_TEXT_NAME';
 
-  yDoc: Y.Doc = new Y.Doc();
+  yDoc: Y.Doc = new Workspace.Y.Doc();
   yText: Y.Text;
 
   vEditor: VEditor;
@@ -44,7 +44,7 @@ export class VirgoInput {
       this.type = type;
     }
 
-    if (yText instanceof Y.Text) {
+    if (yText instanceof Workspace.Y.Text) {
       if (yText.doc) {
         this.yText = yText;
         this.yDoc = yText.doc;
@@ -56,7 +56,7 @@ export class VirgoInput {
       this.yText.insert(0, text);
     }
 
-    this.undoManager = new Y.UndoManager(this.yText, {
+    this.undoManager = new Workspace.Y.UndoManager(this.yText, {
       trackedOrigins: new Set([this.yDoc.clientID]),
     });
     this.undoManager.on(

--- a/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
@@ -1,11 +1,10 @@
 import { assertExists } from '@blocksuite/global/utils';
 import type { Y } from '@blocksuite/store';
-import { Text } from '@blocksuite/store';
+import { Text, Workspace } from '@blocksuite/store';
 import { VEditor } from '@blocksuite/virgo';
 import { css } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
-import { Text as YText } from 'yjs';
 
 import { ClipboardItem } from '../../../../__internal__/clipboard/clipboard-item.js';
 import {
@@ -141,7 +140,7 @@ export class RichTextCell extends BaseCellRenderer<Y.Text> {
   }
 
   private _initYText = (text?: string) => {
-    const yText = new YText(text);
+    const yText = new Workspace.Y.Text(text);
     this.onChange(yText);
     return yText;
   };
@@ -231,7 +230,7 @@ export class RichTextCellEditing extends BaseCellRenderer<Y.Text> {
   }
 
   private _initYText = (text?: string) => {
-    const yText = new YText(text);
+    const yText = new Workspace.Y.Text(text);
 
     this.onChange(yText);
     return yText;

--- a/packages/blocks/src/database-block/common/header-area/text.ts
+++ b/packages/blocks/src/database-block/common/header-area/text.ts
@@ -1,12 +1,11 @@
 import { assertExists } from '@blocksuite/global/utils';
-import { Text } from '@blocksuite/store';
+import type { Y } from '@blocksuite/store';
+import { Text, Workspace } from '@blocksuite/store';
 import type { VRange } from '@blocksuite/virgo';
 import { VEditor } from '@blocksuite/virgo';
 import { css } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
-import * as Y from 'yjs';
-import { Doc, Text as YText } from 'yjs';
 
 import { ClipboardItem } from '../../../__internal__/clipboard/clipboard-item.js';
 import {
@@ -88,7 +87,7 @@ export const addHistoryToVEditor = (vEditor: VEditor) => {
   vEditor.slots.rangeUpdated.on(vRange => {
     range = vRange;
   });
-  const undoManager = new Y.UndoManager(vEditor.yText, {
+  const undoManager = new Workspace.Y.UndoManager(vEditor.yText, {
     trackedOrigins: new Set([vEditor.yText.doc?.clientID]),
   });
   undoManager.on('stack-item-added', (event: { stackItem: StackItem }) => {
@@ -148,7 +147,7 @@ class BaseTextCell extends BaseCellRenderer<unknown> {
 
   protected initVirgo(container: HTMLElement): VEditor {
     const yText = this.getYText(
-      this.titleColumn.getValue(this.rowId) as YText | string | undefined
+      this.titleColumn.getValue(this.rowId) as Y.Text | string | undefined
     );
     const vEditor = new VEditor(yText);
     this.vEditor = vEditor;
@@ -179,17 +178,17 @@ class BaseTextCell extends BaseCellRenderer<unknown> {
     );
   }
 
-  private getYText(text?: string | YText) {
-    if (this.isRichText && (text instanceof YText || text == null)) {
+  private getYText(text?: string | Y.Text) {
+    if (this.isRichText && (text instanceof Workspace.Y.Text || text == null)) {
       let yText = text;
       if (!yText) {
-        yText = new YText();
+        yText = new Workspace.Y.Text();
         this.titleColumn?.setValue(this.rowId, yText);
       }
       return yText;
     }
-    const yText = new Doc().getText('title');
-    if (text instanceof YText) {
+    const yText = new Workspace.Y.Doc().getText('title');
+    if (text instanceof Workspace.Y.Text) {
       return text;
     }
     yText.insert(0, text ?? '');

--- a/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -1,9 +1,9 @@
 import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 import { WithDisposable } from '@blocksuite/lit';
+import { Workspace } from '@blocksuite/store';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import * as Y from 'yjs';
 
 import { AutoCompleteArrowIcon } from '../../../../icons/index.js';
 import {
@@ -300,7 +300,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
   private _createShape() {
     return this.edgeless.surface.addElement(this._current.type, {
       ...this._current.serialize(),
-      text: new Y.Text(),
+      text: new Workspace.Y.Text(),
     });
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-preview.ts
+++ b/packages/blocks/src/page-block/edgeless/components/notes-toc-panel/toc-preview.ts
@@ -1,8 +1,8 @@
 import { noop } from '@blocksuite/global/utils';
 import { WithDisposable } from '@blocksuite/lit';
+import { Workspace } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
-import * as Y from 'yjs';
 
 import type { BlockModels } from '../../../../__internal__/utils/model.js';
 import {
@@ -99,7 +99,10 @@ export class TOCBlockPreview extends WithDisposable(LitElement) {
 
     this._disposables.add(
       this.block.page.slots.onYEvent.on(({ event }) => {
-        if (event instanceof Y.YTextEvent && event.path[0] === this.block.id) {
+        if (
+          event instanceof Workspace.Y.YTextEvent &&
+          event.path[0] === this.block.id
+        ) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -1,9 +1,9 @@
 import { assertExists } from '@blocksuite/global/utils';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
+import { Workspace } from '@blocksuite/store';
 import { html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import * as Y from 'yjs';
 
 import { isCssVariable } from '../../../../__internal__/theme/css-variables.js';
 import { VirgoInput } from '../../../../components/virgo-input/virgo-input.js';
@@ -77,7 +77,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
 
   mount(element: ShapeElement, edgeless: EdgelessPageBlockComponent) {
     if (!element.text) {
-      const text = new Y.Text();
+      const text = new Workspace.Y.Text();
       edgeless.surface.updateElement<'shape'>(element.id, {
         text,
         color: GET_DEFAULT_LINE_COLOR(),

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-menu.ts
@@ -1,9 +1,9 @@
 import { assertExists } from '@blocksuite/global/utils';
 import { WithDisposable } from '@blocksuite/lit';
+import { Workspace } from '@blocksuite/store';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import * as Y from 'yjs';
 
 import { type EdgelessTool } from '../../../../../__internal__/index.js';
 import { Bound } from '../../../../../surface-block/index.js';
@@ -113,7 +113,7 @@ export class EdgelessFrameMenu extends WithDisposable(LitElement) {
                       item.wh[1]
                     );
                     const id = edgeless.surface.addElement('frame', {
-                      title: new Y.Text(`Frame ${frames.length + 1}`),
+                      title: new Workspace.Y.Text(`Frame ${frames.length + 1}`),
                       batch: 'a0',
                       xywh: bound.serialize(),
                     });

--- a/packages/blocks/src/page-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/frame-manager.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import * as Y from 'yjs';
+import { Workspace } from '@blocksuite/store';
 
 import type { EdgelessElement } from '../../__internal__/utils/types.js';
 import type { NoteBlockModel } from '../../models.js';
@@ -110,7 +110,7 @@ export class EdgelessFrameManager {
       bound = bound.expand(0, offset);
     }
     const id = _edgeless.surface.addElement('frame', {
-      title: new Y.Text(`Frame ${frames.length + 1}`),
+      title: new Workspace.Y.Text(`Frame ${frames.length + 1}`),
       batch: 'a0',
       xywh: bound.serialize(),
     });

--- a/packages/blocks/src/page-block/edgeless/tool-controllers/frame-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/tool-controllers/frame-tool.ts
@@ -1,6 +1,6 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
-import * as Y from 'yjs';
+import { Workspace } from '@blocksuite/store';
 
 import { type FrameTool, type IPoint } from '../../../__internal__/index.js';
 import {
@@ -42,7 +42,7 @@ export class FrameToolController extends EdgelessToolController<FrameTool> {
       const frames = surface.frame.frames;
 
       const id = edgeless.surface.addElement('frame', {
-        title: new Y.Text(`Frame ${frames.length + 1}`),
+        title: new Workspace.Y.Text(`Frame ${frames.length + 1}`),
         batch: 'a0',
         xywh: Bound.fromPoints([this._startPoint, currentPoint]).serialize(),
       });

--- a/packages/blocks/src/page-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/text.ts
@@ -1,6 +1,6 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import * as Y from 'yjs';
+import { Workspace } from '@blocksuite/store';
 
 import type {
   FrameElement,
@@ -89,7 +89,7 @@ export function addText(
     );
     const id = edgeless.surface.addElement('text', {
       xywh: new Bound(modelX, modelY, 32, 32).serialize(),
-      text: new Y.Text(),
+      text: new Workspace.Y.Text(),
       textAlign: 'left',
       fontSize: 24,
       color: GET_DEFAULT_LINE_COLOR(),

--- a/packages/blocks/src/surface-block/elements/frame/constants.ts
+++ b/packages/blocks/src/surface-block/elements/frame/constants.ts
@@ -1,9 +1,9 @@
-import * as Y from 'yjs';
+import { Workspace } from '@blocksuite/store';
 
 import type { IElementDefaultProps } from '../index.js';
 
 export const FrameElementDefaultProps: IElementDefaultProps<'frame'> = {
   type: 'frame',
   xywh: '[0,0,0,0]',
-  title: new Y.Text('frame'),
+  title: new Workspace.Y.Text('frame'),
 };

--- a/packages/blocks/src/surface-block/elements/frame/types.ts
+++ b/packages/blocks/src/surface-block/elements/frame/types.ts
@@ -1,4 +1,4 @@
-import type * as Y from 'yjs';
+import type { Y } from '@blocksuite/store';
 
 import type {
   ISurfaceElement,

--- a/packages/blocks/src/surface-block/elements/shape/types.ts
+++ b/packages/blocks/src/surface-block/elements/shape/types.ts
@@ -1,4 +1,4 @@
-import type * as Y from 'yjs';
+import type { Y } from '@blocksuite/store';
 
 import type { IBound, ShapeStyle, StrokeStyle } from '../../consts.js';
 import type { RoughCanvas } from '../../rough/canvas.js';

--- a/packages/blocks/src/surface-block/elements/surface-element.ts
+++ b/packages/blocks/src/surface-block/elements/surface-element.ts
@@ -1,4 +1,4 @@
-import type * as Y from 'yjs';
+import type { Y } from '@blocksuite/store';
 
 import type { Renderer } from '../renderer.js';
 import type { RoughCanvas } from '../rough/canvas.js';

--- a/packages/blocks/src/surface-block/elements/text/constants.ts
+++ b/packages/blocks/src/surface-block/elements/text/constants.ts
@@ -1,4 +1,4 @@
-import * as Y from 'yjs';
+import { Workspace } from '@blocksuite/store';
 
 import type { IElementDefaultProps } from '../index.js';
 
@@ -8,7 +8,7 @@ export const TextElementDefaultProps: IElementDefaultProps<'text'> = {
 
   rotate: 0,
 
-  text: new Y.Text(),
+  text: new Workspace.Y.Text(),
   color: '#000000',
   fontSize: 16,
   fontFamily: "'Kalam', cursive",

--- a/packages/blocks/src/surface-block/elements/text/types.ts
+++ b/packages/blocks/src/surface-block/elements/text/types.ts
@@ -1,4 +1,4 @@
-import type * as Y from 'yjs';
+import type { Y } from '@blocksuite/store';
 
 import type { ISurfaceElement } from '../surface-element.js';
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -2,9 +2,9 @@ import '../page-block/edgeless/edgeless-blocks-container.js';
 
 import { assertExists, Slot } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
+import { Workspace, type Y } from '@blocksuite/store';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
-import * as Y from 'yjs';
 
 import { EdgelessConnectorManager } from '../page-block/edgeless/connector-manager.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
@@ -406,7 +406,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
 
     const id = generateElementId();
 
-    const yMap = new Y.Map();
+    const yMap = new Workspace.Y.Map();
 
     const defaultProps = ElementDefaultProps[type];
     const batch = this.getBatch(properties.batch ?? this._defaultBatch);
@@ -420,8 +420,11 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
 
     this._transact(() => {
       for (const [key, value] of Object.entries(props)) {
-        if ((key === 'text' || key === 'title') && !(value instanceof Y.Text)) {
-          yMap.set(key, new Y.Text(value));
+        if (
+          (key === 'text' || key === 'title') &&
+          !(value instanceof Workspace.Y.Text)
+        ) {
+          yMap.set(key, new Workspace.Y.Text(value));
         } else {
           yMap.set(key, value);
         }

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -53,16 +53,5 @@
   "dependencies": {
     "ansi-colors": "^4.1.3",
     "zod": "^3.22.2"
-  },
-  "devDependencies": {
-    "lit": "^2.8.0"
-  },
-  "peerDependencies": {
-    "lit": "^2.7"
-  },
-  "peerDependenciesMeta": {
-    "lit": {
-      "optional": true
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,9 +232,6 @@ importers:
       '@types/turndown':
         specifier: ^5.0.1
         version: 5.0.1
-      yjs:
-        specifier: ^13.6.7
-        version: 13.6.7
 
   packages/docs:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,10 +279,6 @@ importers:
       zod:
         specifier: ^3.22.2
         version: 3.22.2
-    devDependencies:
-      lit:
-        specifier: ^2.8.0
-        version: 2.8.0
 
   packages/lit:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,18 +220,12 @@ importers:
       '@toeverything/theme':
         specifier: ^0.7.15
         version: 0.7.15
-      '@types/autosize':
-        specifier: ^4.0.1
-        version: 4.0.1
       '@types/marked':
         specifier: ^4.3.1
         version: 4.3.1
       '@types/sortablejs':
         specifier: ^1.15.1
         version: 1.15.1
-      '@types/turndown':
-        specifier: ^5.0.1
-        version: 5.0.1
 
   packages/docs:
     dependencies:
@@ -1591,10 +1585,6 @@ packages:
       '@types/node': 18.17.14
     dev: true
 
-  /@types/autosize@4.0.1:
-    resolution: {integrity: sha512-iPJT/FCaSO79G6j+9n6gmFc5nhxZ1gDrA2UAvb5FslJ6FJQZnDfbBU0qp5vpp0Cbjj7+gOyjuWZ7RrXvRuETaA==}
-    dev: true
-
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
@@ -1788,10 +1778,6 @@ packages:
 
   /@types/trusted-types@2.0.3:
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
-
-  /@types/turndown@5.0.1:
-    resolution: {integrity: sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==}
-    dev: true
 
   /@types/web-bluetooth@0.0.17:
     resolution: {integrity: sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==}


### PR DESCRIPTION
We expose Yjs in `@blocksuite/store` so there's no need to install it dependently.