### PR TITLE
fix(page): remove redundant entry in image popup

### DIFF
--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -66,7 +66,7 @@ export class IconButton extends LitElement {
     }
 
     /* not supported "until-found" yet */
-    :host[hidden] {
+    :host([hidden]) {
       display: none;
     }
 


### PR DESCRIPTION
Fix unexpected empty placeholder

<img width="325" alt="Screenshot 2023-09-15 at 22 50 39" src="https://github.com/toeverything/blocksuite/assets/18554747/3c14ee99-2184-4975-acf6-5019963926a0">
