### PR TITLE
refactor(store): bring custom id generator back

### DIFF
--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -142,6 +142,25 @@ describe('basic', () => {
     });
   });
 
+  it('init workspace with custom id generator', async () => {
+    const options = createTestOptions();
+    let id = 100;
+    const workspace = new Workspace({
+      ...options,
+      idGenerator: () => {
+        return String(id++);
+      },
+    });
+    {
+      const page = workspace.createPage();
+      assert.equal(page.id, '100');
+    }
+    {
+      const page = workspace.createPage();
+      assert.equal(page.id, '101');
+    }
+  });
+
   it('workspace pages with yjs applyUpdate', async () => {
     const options = createTestOptions();
     const workspace = new Workspace(options);

--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -147,7 +147,8 @@ describe('basic', () => {
     let id = 100;
     const workspace = new Workspace({
       ...options,
-      idGenerator: () => {
+      idGenerator: type => {
+        assert.equal(type, 'page');
         return String(id++);
       },
     });

--- a/packages/store/src/workspace/store.ts
+++ b/packages/store/src/workspace/store.ts
@@ -57,7 +57,7 @@ export interface StoreOptions<
   id: string;
   providerCreators?: DocProviderCreator[];
   awareness?: Awareness<RawAwarenessState<Flags>>;
-  idGenerator?: Generator;
+  idGenerator?: Generator | IdGenerator;
   defaultFlags?: Partial<Flags>;
   blobStorages?: ((id: string) => BlobStorage)[];
 }
@@ -101,25 +101,29 @@ export class Store {
       merge(true, flagsPreset, defaultFlags)
     );
 
-    switch (idGenerator) {
-      case Generator.AutoIncrement: {
-        this.idGenerator = createAutoIncrementIdGenerator();
-        break;
-      }
-      case Generator.AutoIncrementByClientId: {
-        this.idGenerator = createAutoIncrementIdGeneratorByClientId(
-          this.doc.clientID
-        );
-        break;
-      }
-      case Generator.UUIDv4: {
-        this.idGenerator = uuidv4;
-        break;
-      }
-      case Generator.NanoID:
-      default: {
-        this.idGenerator = nanoid;
-        break;
+    if (typeof idGenerator === 'function') {
+      this.idGenerator = idGenerator;
+    } else {
+      switch (idGenerator) {
+        case Generator.AutoIncrement: {
+          this.idGenerator = createAutoIncrementIdGenerator();
+          break;
+        }
+        case Generator.AutoIncrementByClientId: {
+          this.idGenerator = createAutoIncrementIdGeneratorByClientId(
+            this.doc.clientID
+          );
+          break;
+        }
+        case Generator.UUIDv4: {
+          this.idGenerator = uuidv4;
+          break;
+        }
+        case Generator.NanoID:
+        default: {
+          this.idGenerator = nanoid;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
The reason is since https://github.com/toeverything/blocksuite/pull/4747, there is a breaking change from the id, we should bring a new id generator on the AFFiNE side so that we can distinguish the old and new page/workspace

Upstream: https://github.com/toeverything/blocksuite/pull/342, https://github.com/toeverything/blocksuite/issues/287