### PR TITLE
fix: add page bottom drop area for block hub

### DIFF
--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -22,6 +22,7 @@ import type {
 import {
   calcDropTarget,
   type DroppingType,
+  getBlockElementByModel,
   getClosestBlockElementByPoint,
   getDocPage,
   getEdgelessPage,
@@ -921,11 +922,19 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       this._resetDropState();
       return;
     }
-    const element = getClosestBlockElementByPoint(
+    let element: Element | null = null;
+    element = getClosestBlockElementByPoint(
       point,
       { container, rect: noteRect, snapToEdge: { x: false, y: true } },
       scale
     );
+    if (!element) {
+      const lastBlock = this._pageBlockElement.model.lastChild();
+      if (lastBlock) {
+        const lastElement = getBlockElementByModel(lastBlock);
+        element = lastElement;
+      }
+    }
     if (!element) {
       // if (this._mouseRoot.mode === 'page') {
       //   return;

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -929,10 +929,14 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       scale
     );
     if (!element) {
-      const lastBlock = this._pageBlockElement.model.lastChild();
-      if (lastBlock) {
-        const lastElement = getBlockElementByModel(lastBlock);
-        element = lastElement;
+      const { min, max } = noteRect;
+      // 24 refers to the padding of page.
+      if (point.x >= min.x + 24 && point.x <= max.x - 24) {
+        const lastBlock = this._pageBlockElement.model.lastChild();
+        if (lastBlock) {
+          const lastElement = getBlockElementByModel(lastBlock);
+          element = lastElement;
+        }
       }
     }
     if (!element) {


### PR DESCRIPTION
close: #4564

before:

https://github.com/toeverything/blocksuite/assets/15389209/f285b9bf-876e-4808-9fca-389889ecbc96



after:

https://github.com/toeverything/blocksuite/assets/15389209/c8e9ce07-99ec-48e8-9c66-4e3db3bb2c2d

