### PR TITLE
fix: error when drag image

### DIFF
--- a/packages/blocks/src/components/when-hover.ts
+++ b/packages/blocks/src/components/when-hover.ts
@@ -35,7 +35,9 @@ export class WhenHoverController implements ReactiveController {
   private _abortController?: AbortController;
   private _setReference?: (element?: Element | undefined) => void;
   private _portal?: HTMLDivElement;
-  private readonly _onHover: (options: OptionsParams) => HoverPortalOptions;
+  private readonly _onHover: (
+    options: OptionsParams
+  ) => HoverPortalOptions | null;
   private readonly _hoverOptions: HoverOptions;
 
   get setReference() {
@@ -51,7 +53,7 @@ export class WhenHoverController implements ReactiveController {
 
   constructor(
     host: ReactiveControllerHost,
-    onHover: (options: OptionsParams) => HoverPortalOptions,
+    onHover: (options: OptionsParams) => HoverPortalOptions | null,
     hoverOptions?: Partial<HoverOptions>
   ) {
     (this.host = host).addController(this);
@@ -78,6 +80,10 @@ export class WhenHoverController implements ReactiveController {
         setReference,
         abortController: this._abortController,
       });
+      if (!portalOptions) {
+        this._abortController.abort();
+        return;
+      }
       this._portal = createLitPortal({
         ...portalOptions,
         abortController: this._abortController,

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -2,6 +2,7 @@ import './image/placeholder/image-not-found.js';
 import './image/placeholder/loading-card.js';
 
 import { PathFinder } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import { css, html, type PropertyValues } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
@@ -90,7 +91,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   _input!: HTMLInputElement;
 
   @query('.resizable-img')
-  public readonly resizeImg!: HTMLElement;
+  public readonly resizeImg?: HTMLElement;
 
   @state()
   private _caption!: string;
@@ -131,13 +132,15 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
 
   override firstUpdated(changedProperties: PropertyValues) {
     super.firstUpdated(changedProperties);
+    const imageContainer = this.resizeImg;
+    assertExists(imageContainer);
 
     // exclude padding and border width
     const { width, height } = this.model;
 
     if (width && height) {
-      this.resizeImg.style.width = width + 'px';
-      this.resizeImg.style.height = height + 'px';
+      imageContainer.style.width = width + 'px';
+      imageContainer.style.height = height + 'px';
     }
 
     this.updateComplete.then(() => {

--- a/packages/blocks/src/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/widgets/image-toolbar/index.ts
@@ -11,6 +11,8 @@ import { ImageOptionsTemplate } from './image-options.js';
 export class AffineImageToolbarWidget extends WidgetElement {
   private _whenHover = new WhenHoverController(this, ({ abortController }) => {
     const imageBlock = this.pageElement as ImageBlockComponent;
+    const imageContainer = imageBlock.resizeImg;
+    if (!imageContainer) return null;
     return {
       template: ImageOptionsTemplate({
         model: imageBlock.model,
@@ -19,7 +21,7 @@ export class AffineImageToolbarWidget extends WidgetElement {
         root: this.pageElement.root,
       }),
       computePosition: {
-        referenceElement: imageBlock.resizeImg,
+        referenceElement: imageContainer,
         placement: 'right-start',
         middleware: [
           offset({


### PR DESCRIPTION
The `affine-drag-preview` will create a preview block when dragging, it is a little different from the actual image block


<img width="599" alt="Screenshot 2023-09-16 at 21 16 21" src="https://github.com/toeverything/blocksuite/assets/18554747/3c535069-e1ae-40e8-bd52-be0d921a82c9">


<img width="610" alt="Screenshot 2023-09-16 at 21 15 35" src="https://github.com/toeverything/blocksuite/assets/18554747/5c43ad6c-7183-4faf-802b-dc3236714b67">
