### PR TITLE
fix(edgeless): note does not update when other peers modified note

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -376,7 +376,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
     const bound = this._computeNextShape(type);
     const path = this._computeLine(type, this._current, bound);
 
-    autoCompleteOverlay.stroke = this.edgeless.computeValue(
+    autoCompleteOverlay.stroke = this._surface.getCSSPropertyValue(
       this._current.strokeColor
     );
     autoCompleteOverlay.linePoints = path;

--- a/packages/blocks/src/page-block/edgeless/components/edgeless-notes-container.ts
+++ b/packages/blocks/src/page-block/edgeless/components/edgeless-notes-container.ts
@@ -61,7 +61,7 @@ export class EdgelessNoteMask extends WithDisposable(LitElement) {
 }
 
 @customElement('edgeless-child-note')
-export class EdgelessChildNote extends LitElement {
+export class EdgelessChildNote extends WithDisposable(LitElement) {
   @property({ attribute: false })
   index!: number;
 
@@ -76,6 +76,22 @@ export class EdgelessChildNote extends LitElement {
 
   protected override createRenderRoot() {
     return this;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this._disposables.add(
+      this.model.propsUpdated.on(() => {
+        this.requestUpdate();
+      })
+    );
+
+    this._disposables.add(
+      this.model.childrenUpdated.on(() => {
+        this.requestUpdate();
+      })
+    );
   }
 
   override render() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-blocks-container.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-blocks-container.ts
@@ -164,6 +164,20 @@ export class EdgelessBlockContainer extends WithDisposable(LitElement) {
         this.requestUpdate();
       })
     );
+
+    _disposables.add(
+      edgeless.slots.readonlyUpdated.on(() => {
+        this.requestUpdate();
+      })
+    );
+
+    assertExists(page.root);
+
+    _disposables.add(
+      page.root.childrenUpdated.on(() => {
+        this.requestUpdate();
+      })
+    );
   }
 
   override render() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-blocks-container.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-blocks-container.ts
@@ -4,9 +4,8 @@ import './components/rects/edgeless-hover-rect.js';
 import './components/rects/edgeless-dragging-area-rect.js';
 import './components/note-slicer/index.js';
 
-import { noop, throttle } from '@blocksuite/global/utils';
+import { assertExists, noop, throttle } from '@blocksuite/global/utils';
 import { WithDisposable } from '@blocksuite/lit';
-import { type BaseBlockModel } from '@blocksuite/store';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -50,6 +49,8 @@ export class EdgelessBlockContainer extends WithDisposable(LitElement) {
 
   private _initNoteHeightUpdate() {
     const { page } = this.edgeless;
+    assertExists(page.root);
+
     const resetNoteResizeObserver = throttle(
       () => {
         requestAnimationFrame(() => {
@@ -59,15 +60,9 @@ export class EdgelessBlockContainer extends WithDisposable(LitElement) {
       16,
       { leading: true }
     );
-    const listenChildrenUpdate = (root: BaseBlockModel<object> | null) => {
-      if (!root) return;
 
-      this._disposables.add(root.childrenUpdated.on(resetNoteResizeObserver));
-    };
-
-    listenChildrenUpdate(page.root);
     this._disposables.add(
-      page.slots.rootAdded.on(root => listenChildrenUpdate(root))
+      page.root.childrenUpdated.on(resetNoteResizeObserver)
     );
   }
 

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -29,12 +29,7 @@ import {
   type TopLevelBlockModel,
 } from '../../__internal__/index.js';
 import { getService } from '../../__internal__/service/index.js';
-import type { CssVariableName } from '../../__internal__/theme/css-variables.js';
-import { isCssVariable } from '../../__internal__/theme/css-variables.js';
-import {
-  getThemePropertyValue,
-  listenToThemeChange,
-} from '../../__internal__/theme/utils.js';
+import { listenToThemeChange } from '../../__internal__/theme/utils.js';
 import { toast } from '../../components/toast.js';
 import type {
   EdgelessPageBlockWidgetName,
@@ -238,26 +233,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
     return this.model.children.find(
       child => child.flavour === 'affine:surface'
     ) as SurfaceBlockModel;
-  }
-
-  computeValue(value: string) {
-    const { parentElement } = this;
-    assertExists(parentElement);
-    if (isCssVariable(value)) {
-      const cssValue = getThemePropertyValue(
-        parentElement,
-        value as CssVariableName
-      );
-      if (cssValue === undefined) {
-        console.error(
-          new Error(
-            `All variables should have a value. Please check for any dirty data or variable renaming.Variable: ${value}`
-          )
-        );
-      }
-      return cssValue ?? value;
-    }
-    return value;
   }
 
   private _handleToolbarFlag() {
@@ -1023,7 +998,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
         .root=${this.root}
         .page=${this.page}
         .model=${this.surfaceBlockModel}
-        ._computedValue=${this.computeValue.bind(this)}
       >
       </affine-surface>
     `;

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -835,7 +835,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
         if (readonly !== page.readonly) {
           readonly = page.readonly;
           this.slots.readonlyUpdated.emit(readonly);
-          this.requestUpdate();
         }
       })
     );

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -6,8 +6,11 @@ import { Workspace, type Y } from '@blocksuite/store';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
+import {
+  type CssVariableName,
+  isCssVariable,
+} from '../__internal__/theme/css-variables.js';
 import { getThemePropertyValue } from '../__internal__/theme/utils.js';
-import { type CssVariableName, isCssVariable } from '../index.js';
 import { EdgelessConnectorManager } from '../page-block/edgeless/connector-manager.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import { EdgelessFrameManager } from '../page-block/edgeless/frame-manager.js';

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -6,6 +6,8 @@ import { Workspace, type Y } from '@blocksuite/store';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
+import { getThemePropertyValue } from '../__internal__/theme/utils.js';
+import { type CssVariableName, isCssVariable } from '../index.js';
 import { EdgelessConnectorManager } from '../page-block/edgeless/connector-manager.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import { EdgelessFrameManager } from '../page-block/edgeless/frame-manager.js';
@@ -26,7 +28,6 @@ import {
   type PhasorElementType,
 } from './elements/index.js';
 import type {
-  ComputedValue,
   HitTestOptions,
   SurfaceElement,
 } from './elements/surface-element.js';
@@ -125,9 +126,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
   @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
-  @property({ attribute: false })
-  private _computedValue!: ComputedValue;
-
   snap!: EdgelessSnapManager;
   connector!: EdgelessConnectorManager;
   frame!: EdgelessFrameManager;
@@ -169,6 +167,23 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
 
     this.init();
   }
+
+  private _getCSSPropertyValue = (value: string) => {
+    const root = this.root;
+    if (isCssVariable(value)) {
+      const cssValue = getThemePropertyValue(root, value as CssVariableName);
+      if (cssValue === undefined) {
+        console.error(
+          new Error(
+            `All variables should have a value. Please check for any dirty data or variable renaming.Variable: ${value}`
+          )
+        );
+      }
+      return cssValue ?? value;
+    }
+
+    return value;
+  };
 
   private _initEvents() {
     this._disposables.add(
@@ -282,7 +297,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     const ElementCtor = ElementCtors[type];
     assertExists(ElementCtor);
     const element = new ElementCtor(yElement, this);
-    element.computedValue = this._computedValue;
+    element.computedValue = this._getCSSPropertyValue;
     element.mount(this._renderer);
     this._elements.set(element.id, element);
     this._addToBatch(element);
@@ -334,7 +349,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
       const ElementCtor = ElementCtors[type];
       assertExists(ElementCtor);
       const element = new ElementCtor(yElement, this);
-      element.computedValue = this._computedValue;
+      element.computedValue = this._getCSSPropertyValue;
       element.mount(this._renderer);
       this._elements.set(element.id, element);
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -168,7 +168,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     this.init();
   }
 
-  private _getCSSPropertyValue = (value: string) => {
+  getCSSPropertyValue = (value: string) => {
     const root = this.root;
     if (isCssVariable(value)) {
       const cssValue = getThemePropertyValue(root, value as CssVariableName);
@@ -297,7 +297,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     const ElementCtor = ElementCtors[type];
     assertExists(ElementCtor);
     const element = new ElementCtor(yElement, this);
-    element.computedValue = this._getCSSPropertyValue;
+    element.computedValue = this.getCSSPropertyValue;
     element.mount(this._renderer);
     this._elements.set(element.id, element);
     this._addToBatch(element);
@@ -349,7 +349,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
       const ElementCtor = ElementCtors[type];
       assertExists(ElementCtor);
       const element = new ElementCtor(yElement, this);
-      element.computedValue = this._getCSSPropertyValue;
+      element.computedValue = this.getCSSPropertyValue;
       element.mount(this._renderer);
       this._elements.set(element.id, element);
 


### PR DESCRIPTION
close #4697

The `BlockSuiteRoot` component has built a rerender mechanism inside. But, it does not work for edgeless mode cause edgeless wraps everything inside `SurfaceBlock` which stops the notes that are deep inside the components tree from updating.

I added an extra slot listener to track notes' updates individually.