### PR TITLE
feat(page): add spoiler prototype

### DIFF
--- a/packages/blocks/src/widgets/format-bar/components/background/const.ts
+++ b/packages/blocks/src/widgets/format-bar/components/background/const.ts
@@ -26,4 +26,9 @@ export const backgroundConfig: BackgroundConfig[] = [
     color: `var(--affine-text-highlight-${color})`,
     hotkey: null,
   })),
+  {
+    name: 'Spoiler',
+    color: 'var(--affine-text-primary-color)',
+    hotkey: null,
+  },
 ];


### PR DESCRIPTION
This is just a prototype, intended to demonstrate the potential of the blocksuite, and is not expected to be merged.

The spoiler feature is useful for preventing spoilers when sharing content, but it has no value in enterprise-level collaboration settings.

Before merging, careful evaluation is necessary.

https://github.com/toeverything/blocksuite/assets/18554747/43be5441-c20d-41b8-96bb-596d5d8c8144


