### PR TITLE
fix: image flashing when resizing in edgeless

### DIFF
--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -6,6 +6,7 @@ import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import { css, html, type PropertyValues } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 import { stopPropagation } from '../__internal__/utils/event.js';
 import { DragHandleWidget } from '../widgets/drag-handle/index.js';
@@ -401,6 +402,16 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   }
 
   override render() {
+    const resizeImgStyle = {
+      width: 'unset',
+      height: 'unset',
+    };
+    const { width, height } = this.model;
+    if (width && height) {
+      resizeImgStyle.width = `${width}px`;
+      resizeImgStyle.height = `${height}px`;
+    }
+
     const img = {
       waitUploaded: html`<affine-image-block-loading-card
         content="Delivering content..."
@@ -415,7 +426,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     return html`
       <div style="position: relative;">
         <div class="affine-image-wrapper">
-          <div class="resizable-img">
+          <div class="resizable-img" style=${styleMap(resizeImgStyle)}>
             ${img} ${this._imageResizeBoardTemplate()}
           </div>
         </div>

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -389,16 +389,30 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     return ImageSelectedRectsContainer(readonly);
   }
 
-  override render() {
-    const resizeImgStyle = {
-      width: this.resizeImg?.style.width ?? 'unset',
-      height: this.resizeImg?.style.height ?? 'unset',
-    };
-    const { width, height } = this.model;
-    if (!this._isDragging && width && height) {
-      resizeImgStyle.width = `${width}px`;
-      resizeImgStyle.height = `${height}px`;
+  private _normalizeImageSize() {
+    // If is dragging, we should use the real size of the image
+    if (this._isDragging && this.resizeImg) {
+      return {
+        width: this.resizeImg.style.width,
+        height: this.resizeImg.style.height,
+      };
     }
+
+    const { width, height } = this.model;
+    if (!width || !height || width === 0 || height === 0) {
+      return {
+        width: 'unset',
+        height: 'unset',
+      };
+    }
+    return {
+      width: `${width}px`,
+      height: `${height}px`,
+    };
+  }
+
+  override render() {
+    const resizeImgStyle = this._normalizeImageSize();
 
     const img = {
       waitUploaded: html`<affine-image-block-loading-card

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -6,7 +6,6 @@ import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import { css, html, type PropertyValues } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { stopPropagation } from '../__internal__/utils/event.js';
 import { DragHandleWidget } from '../widgets/drag-handle/index.js';
@@ -402,16 +401,6 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   }
 
   override render() {
-    const resizeImgStyle = {
-      width: 'unset',
-      height: 'unset',
-    };
-    const { width, height } = this.model;
-    if (width && height) {
-      resizeImgStyle.width = `${width}px`;
-      resizeImgStyle.height = `${height}px`;
-    }
-
     const img = {
       waitUploaded: html`<affine-image-block-loading-card
         content="Delivering content..."
@@ -426,7 +415,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
     return html`
       <div style="position: relative;">
         <div class="affine-image-wrapper">
-          <div class="resizable-img" style=${styleMap(resizeImgStyle)}>
+          <div class="resizable-img">
             ${img} ${this._imageResizeBoardTemplate()}
           </div>
         </div>


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/4743

https://github.com/toeverything/blocksuite/assets/18554747/b86a45b9-dc73-42ac-97ed-3fced9fbcd6f

The new image toolbar widget broke the render diff

https://github.com/toeverything/blocksuite/blob/29c4afbe6309e3b32d9ca58cca34910f6941fe2c/packages/lit/src/element/lit-root.ts#L110-L121

See https://github.com/toeverything/blocksuite/pull/4187