### PR TITLE
fix(page): keeping list toggle state

### DIFF
--- a/packages/blocks/src/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/components/rich-text/rich-text-operations.ts
@@ -13,7 +13,6 @@ import {
   matchFlavours,
 } from '../../__internal__/utils/model.js';
 import {
-  getBlockElementByModel,
   getModelByElement,
   getNextBlock,
   getPreviousBlock,
@@ -24,8 +23,7 @@ import {
   focusTitle,
 } from '../../__internal__/utils/selection.js';
 import type { ExtendedModel } from '../../__internal__/utils/types.js';
-import type { ListBlockComponent } from '../../list-block/list-block.js';
-import type { PageBlockModel } from '../../models.js';
+import type { ListBlockModel, PageBlockModel } from '../../models.js';
 
 export function handleBlockEndEnter(page: Page, model: ExtendedModel) {
   const parent = page.getParent(model);
@@ -205,13 +203,10 @@ export function handleIndent(page: Page, model: ExtendedModel, offset = 0) {
 
   // 5. If parent is collapsed, expand it
   const newParent = previousSibling;
-  if (matchFlavours(newParent, ['affine:list'])) {
-    // page.updateBlock(parent, { showChildren: true });
-    const listEle = getBlockElementByModel(
-      newParent
-    ) as ListBlockComponent | null;
-    assertExists(listEle, 'parent element not found');
-    listEle.showChildren = true;
+  if (matchFlavours(newParent, ['affine:list']) && newParent.collapsed) {
+    page.updateBlock(newParent, {
+      collapsed: false,
+    } as Partial<ListBlockModel>);
   }
 
   asyncSetVRange(model, { index: offset, length: 0 });

--- a/packages/blocks/src/list-block/list-model.ts
+++ b/packages/blocks/src/list-block/list-model.ts
@@ -1,12 +1,21 @@
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 
 export type ListType = 'bulleted' | 'numbered' | 'todo' | 'toggle';
+
+declare const BackwardUndefined: unique symbol;
+/**
+ * The `collapsed` property may be `undefined` due to legacy data,
+ * but you should not manually set it to undefined.
+ */
+type ListCollapsed = boolean | typeof BackwardUndefined;
+
 export const ListBlockSchema = defineBlockSchema({
   flavour: 'affine:list',
   props: internal => ({
     type: 'bulleted' as ListType,
     text: internal.Text(),
     checked: false,
+    collapsed: false as ListCollapsed,
   }),
   metadata: {
     version: 1,

--- a/tests/block-hub.spec.ts
+++ b/tests/block-hub.spec.ts
@@ -4,15 +4,12 @@ import {
   dragBetweenCoords,
   enterPlaygroundRoom,
   focusRichText,
-  focusRichTextEnd,
   getBoundingClientRect,
   getCenterPosition,
   getCenterPositionByLocator,
   initEmptyParagraphState,
   initParagraphsByCount,
   initThreeParagraphs,
-  pressEnter,
-  type,
   waitNextFrame,
 } from './utils/actions/index.js';
 import { assertRichTexts, assertStoreMatchJSX } from './utils/asserts.js';
@@ -32,63 +29,63 @@ test('auto-scroll should be activate when adding blank lines or blocks', async (
   # Mozilla Public License Version 2.0
 
   Copyright (c) TOEVERYTHING PTE. LTD. and its affiliates.
-  
+
   1. Definitions
-  
+
   ---
-  
+
   1.1. Contributor
   means each individual or legal entity that creates, contributes to
   the creation of, or owns Covered Software.
-  
+
   1.2. Contributor Version
   means the combination of the Contributions of others (if any) used
   by a Contributor and that particular Contributor's Contribution.
-  
+
   1.3. Contribution
   means Covered Software of a particular Contributor.
-  
+
   1.4. Covered Software
   means Source Code Form to which the initial Contributor has attached
   the notice in Exhibit A, the Executable Form of such Source Code
   Form, and Modifications of such Source Code Form, in each case
   including portions thereof.
-  
+
   1.5. Incompatible With Secondary Licenses
   means
-  
+
       (a) that the initial Contributor has attached the notice described
           in Exhibit B to the Covered Software; or
-  
+
       (b) that the Covered Software was made available under the terms of
           version 1.1 or earlier of the License, but not also under the
           terms of a Secondary License.
-  
+
   1.6. Executable Form
   means any form of the work other than Source Code Form.
-  
+
   1.7. Larger Work
   means a work that combines Covered Software with other material, in
   a separate file or files, that is not Covered Software.
-  
+
   1.8. License
   means this document.
-  
+
   1.9. Licensable
   means having the right to grant, to the maximum extent possible,
   whether at the time of the initial grant or subsequently, any and
   all of the rights conveyed by this License.
-  
+
   1.10. Modifications
   means any of the following:
-  
+
       (a) any file in Source Code Form that results from an addition to,
           deletion from, or modification of the contents of Covered
           Software; or
-  
+
       (b) any new file in Source Code Form that contains any Covered
           Software.
-  
+
   1.11. Patent Claims of a Contributor
   means any patent claim(s), including without limitation, method,
   process, and apparatus claims, in any patent Licensable by such
@@ -393,6 +390,7 @@ test('drag numbered list block from list menu into text area and blockHub list c
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:type="numbered"
     />
     <affine:paragraph

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -848,6 +848,7 @@ test('cut will delete all content, and copy will reappear content', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:type="bulleted"
     />
   </affine:note>
@@ -897,22 +898,26 @@ test('cut will delete all content, and copy will reappear content', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="1"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="2"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="3"
         prop:type="bulleted"
       />
     </affine:list>
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="4"
       prop:type="bulleted"
     />

--- a/tests/drag.spec.ts
+++ b/tests/drag.spec.ts
@@ -146,36 +146,43 @@ test('move to the last block of each level in multi-level nesting', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="A"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="B"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />
@@ -199,36 +206,43 @@ test('move to the last block of each level in multi-level nesting', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="B"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="A"
           prop:type="bulleted"
         />
@@ -258,37 +272,44 @@ test('move to the last block of each level in multi-level nesting', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="A"
           prop:type="bulleted"
         />
       </affine:list>
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="B"
         prop:type="bulleted"
       />
@@ -318,38 +339,45 @@ test('move to the last block of each level in multi-level nesting', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />
       </affine:list>
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="B"
         prop:type="bulleted"
       />
     </affine:list>
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="A"
       prop:type="bulleted"
     />
@@ -447,36 +475,43 @@ test('should be able to drag & drop multiple blocks to nested block', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="A"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="B"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />
@@ -513,36 +548,43 @@ test('should be able to drag & drop multiple blocks to nested block', async ({
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="C"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="D"
         prop:type="bulleted"
       />
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="E"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="F"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="A"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="B"
           prop:type="bulleted"
         />
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="G"
           prop:type="bulleted"
         />

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -692,6 +692,7 @@ test('should format quick bar be able to change to heading paragraph type', asyn
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="123"
     prop:type="bulleted"
   />
@@ -1121,16 +1122,19 @@ test('should format quick bar with block selection works when update block type'
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="123"
     prop:type="bulleted"
   />
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="456"
     prop:type="bulleted"
   />
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="789"
     prop:type="bulleted"
   />

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -731,6 +731,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="hello"
     prop:type="bulleted"
   />
@@ -749,6 +750,7 @@ test('should hotkey work in paragraph', async ({ page }) => {
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="hello"
     prop:type="numbered"
   />

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -211,16 +211,19 @@ test('nested list blocks', async ({ page }) => {
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="123"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="456"
         prop:type="bulleted"
       >
         <affine:list
           prop:checked={false}
+          prop:collapsed={false}
           prop:text="789"
           prop:type="bulleted"
         />
@@ -244,16 +247,19 @@ test('nested list blocks', async ({ page }) => {
   >
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="123"
       prop:type="bulleted"
     />
     <affine:list
       prop:checked={false}
+      prop:collapsed={false}
       prop:text="456"
       prop:type="bulleted"
     >
       <affine:list
         prop:checked={false}
+        prop:collapsed={false}
         prop:text="789"
         prop:type="bulleted"
       />
@@ -390,6 +396,7 @@ test('should indent todo block preserve todo status', async ({ page }) => {
   >
     <affine:list
       prop:checked={true}
+      prop:collapsed={false}
       prop:text="todo item"
       prop:type="todo"
     />
@@ -412,6 +419,7 @@ test('should indent todo block preserve todo status', async ({ page }) => {
   />
   <affine:list
     prop:checked={true}
+    prop:collapsed={false}
     prop:text="todo item"
     prop:type="todo"
   />

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -608,7 +608,7 @@ test.describe('toggle list', () => {
 
   test('click toggle icon should collapsed list', async ({ page }) => {
     await enterPlaygroundRoom(page);
-    await initEmptyParagraphState(page);
+    const { noteId } = await initEmptyParagraphState(page);
     await initThreeLists(page);
     const toggleIcon = getToggleIcon(page);
     const prefixes = page.locator('.affine-list-block__prefix');
@@ -620,6 +620,36 @@ test.describe('toggle list', () => {
 
     await toggleIcon.click();
     await expect(prefixes).toHaveCount(2);
+    assertStoreMatchJSX(
+      page,
+      `
+<affine:note
+  prop:background="--affine-background-secondary-color"
+  prop:hidden={false}
+  prop:index="a0"
+>
+  <affine:list
+    prop:checked={false}
+    prop:collapsed={false}
+    prop:text="123"
+    prop:type="bulleted"
+  />
+  <affine:list
+    prop:checked={false}
+    prop:collapsed={true}
+    prop:text="456"
+    prop:type="bulleted"
+  >
+    <affine:list
+      prop:checked={false}
+      prop:collapsed={false}
+      prop:text="789"
+      prop:type="bulleted"
+    />
+  </affine:list>
+</affine:note>`,
+      noteId
+    );
 
     // Collapsed toggle icon should be show always
     await page.mouse.move(0, 0);
@@ -627,6 +657,36 @@ test.describe('toggle list', () => {
 
     await toggleIcon.click();
     await expect(prefixes).toHaveCount(3);
+    assertStoreMatchJSX(
+      page,
+      `
+<affine:note
+  prop:background="--affine-background-secondary-color"
+  prop:hidden={false}
+  prop:index="a0"
+>
+  <affine:list
+    prop:checked={false}
+    prop:collapsed={false}
+    prop:text="123"
+    prop:type="bulleted"
+  />
+  <affine:list
+    prop:checked={false}
+    prop:collapsed={false}
+    prop:text="456"
+    prop:type="bulleted"
+  >
+    <affine:list
+      prop:checked={false}
+      prop:collapsed={false}
+      prop:text="789"
+      prop:type="bulleted"
+    />
+  </affine:list>
+</affine:note>`,
+      noteId
+    );
 
     await page.mouse.move(0, 0);
     await waitNextFrame(page, 200);

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -361,6 +361,7 @@ test.describe('slash search', () => {
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:type="todo"
   />
 </affine:note>`,
@@ -800,6 +801,7 @@ test('delete block by slash menu should remove children', async ({ page }) => {
 >
   <affine:list
     prop:checked={false}
+    prop:collapsed={false}
     prop:text="123"
     prop:type="bulleted"
   />


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/4857

## Changes

- Add `collapsed` to the list model and default to `false`

---

- [x] Keeping list toggle state
- [x] Should expand list after indent collapsed block
- [x] Update snapshot