### PR TITLE
feat(edgeless): support updating dragging area when viewport updates

### DIFF
--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -315,7 +315,7 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   await page.waitForTimeout(300);
 });
 
-test.only('should also update dragging area when viewport changes', async ({
+test('should also update dragging area when viewport changes', async ({
   page,
 }) => {
   await enterPlaygroundRoom(page);

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -314,3 +314,50 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   expect(selectedRect).toBeVisible();
   await page.waitForTimeout(300);
 });
+
+test.only('should also update dragging area when viewport changes', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+  await actions.zoomResetByKeyboard(page);
+
+  // Panning to the top
+  await page.mouse.click(400, 600);
+  await setEdgelessTool(page, 'pan');
+  await dragBetweenCoords(
+    page,
+    {
+      x: 400,
+      y: 600,
+    },
+    {
+      x: 400,
+      y: 100,
+    }
+  );
+  await setEdgelessTool(page, 'default');
+  await page.mouse.click(200, 300);
+
+  const selectedRectClass = '.affine-edgeless-selected-rect';
+  let selectedRect = await page.locator(selectedRectClass);
+  expect(selectedRect).toBeHidden();
+  // set up initial dragging area
+  await page.mouse.move(200, 300);
+  await page.mouse.down();
+  await page.mouse.move(600, 200, { steps: 20 });
+  await page.waitForTimeout(300);
+
+  // wheel the viewport to the top
+  await page.mouse.wheel(0, -300);
+  await page.waitForTimeout(300);
+  await page.mouse.up();
+
+  // Expect to select the empty note
+  selectedRect = await page.locator(selectedRectClass);
+  await page.waitForTimeout(300);
+  expect(selectedRect).toBeVisible();
+  await page.waitForTimeout(300);
+});


### PR DESCRIPTION
Now we can simultaneously use the mouse scroll wheel or touchpad to update the dragging area when we drag with the mouse.

https://github.com/toeverything/blocksuite/assets/99816898/08d02fb4-2d21-4a0c-8b6a-3af53db2d7dc

