### PR TITLE
chore(page): tweak lang menu styles in code block

### DIFF
--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -551,6 +551,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
                   MAX_LANG_SELECT_HEIGHT,
                   availableHeight
                 )}px`,
+                pointerEvents: 'none',
                 ...(placement.startsWith('top')
                   ? {
                       display: 'flex',

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -59,13 +59,13 @@ export class LangList extends LitElement {
         justify-content: space-between;
         padding: 12px;
       }
+      .lang-item svg {
+        width: 20px;
+        height: 20px;
+      }
       .lang-item-active {
         color: var(--affine-blue-600);
         background: var(--affine-hover-color-filled);
-      }
-      .lang-item-active svg {
-        width: 20px;
-        height: 20px;
       }
 
       .divider {
@@ -237,7 +237,11 @@ export class LangList extends LitElement {
                 ].join(' ')}
               >
                 ${language.displayName ?? language.id}
-                <slot name="suffix">${isActive ? DoneIcon : nothing}</slot>
+                <slot name="suffix"
+                  >${this.currentLanguageId === language.id
+                    ? DoneIcon
+                    : nothing}</slot
+                >
               </icon-button>
             `;
           })}

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -20,6 +20,7 @@ export class LangList extends LitElement {
     return css`
       :host {
         max-height: 100%;
+        width: 230px;
         overflow: hidden;
         display: flex;
         flex-direction: column;
@@ -37,13 +38,12 @@ export class LangList extends LitElement {
         flex-direction: column;
         box-shadow: var(--affine-menu-shadow);
         border-radius: 8px;
-        padding: 12px 8px;
+        padding: 8px;
       }
 
       .lang-list-button-container {
         flex: 1;
-        overflow: scroll;
-        height: 424px;
+        overflow-y: scroll;
         padding-top: 5px;
         padding-left: 4px;
         padding-right: 4px;

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -28,6 +28,7 @@ export class LangList extends LitElement {
         color: var(--affine-text-primary-color);
         border-radius: 12px;
         z-index: var(--affine-z-index-popover);
+        pointer-events: auto;
       }
 
       .lang-list-container {


### PR DESCRIPTION
Supplement to https://github.com/toeverything/blocksuite/pull/4884

- Remove redundant `padding-bottom`
<img width="482" alt="Screenshot 2023-09-26 at 00 35 45" src="https://github.com/toeverything/blocksuite/assets/18554747/1ebaf53d-42e9-44d9-846a-f8686b3b2f08">

- The transparent background should not prevent the user from clicking
<img width="561" alt="Screenshot 2023-09-26 at 00 36 40" src="https://github.com/toeverything/blocksuite/assets/18554747/ee5469b1-e61b-4925-bf93-00e9c6ca663d">

- The active item should not follow when using the keyboard navigator

https://github.com/toeverything/blocksuite/assets/18554747/351574b6-14a7-4628-8cf2-7486a4fed0b6

