### PR TITLE
fix: improve embed related style

### DIFF
--- a/packages/blocks/src/components/rich-text/virgo/nodes/reference-node.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/reference-node.ts
@@ -37,8 +37,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
       text-decoration: none;
       cursor: pointer;
       user-select: none;
-      padding: 1px 4px 1px 2px;
-      margin: 0 2px;
+      padding: 1px 2px 1px 0;
     }
     .affine-reference:hover {
       background: var(--affine-hover-color);

--- a/packages/virgo/src/components/embed-gap.ts
+++ b/packages/virgo/src/components/embed-gap.ts
@@ -9,7 +9,7 @@ export const EmbedGap = html`<span
   data-virgo-text="true"
   style=${styleMap({
     userSelect: 'text',
-    padding: '0 1px',
+    padding: '0 0.5px',
     outline: 'none',
   })}
   >${ZERO_WIDTH_SPACE}</span

--- a/packages/virgo/src/components/virgo-line.ts
+++ b/packages/virgo/src/components/virgo-line.ts
@@ -88,7 +88,7 @@ export class VirgoLine extends LitElement {
     return html`<div style=${styleMap({
       // this padding is used to make cursor can be placed at the
       // start and end of the line when the first and last element is embed element
-      padding: '0 1px',
+      padding: '0 0.5px',
     })}>${renderElements}</div>`;
   }
 

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -161,7 +161,7 @@ test('normalize text element rect after change its font', async ({ page }) => {
 
   await page.mouse.click(140, 210);
   await waitNextFrame(page);
-  await assertEdgelessSelectedRect(page, [130, 200, 113.9, 167.6]);
+  await assertEdgelessSelectedRect(page, [130, 200, 112.875, 167.6]);
   const fontButton = page.locator('.text-font-family-button');
   await fontButton.click();
 

--- a/tests/selection/native.spec.ts
+++ b/tests/selection/native.spec.ts
@@ -1542,8 +1542,8 @@ test('press ArrowUp in the edge of two line', async ({ page }) => {
   await focusRichText(page, 0);
   await type(
     page,
-    // we need more four characters to get our expected result in local
-    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    // we need more three characters to get our expected result in local
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
   );
   await waitNextFrame(page);
   await pressArrowLeft(page);

--- a/tests/selection/native.spec.ts
+++ b/tests/selection/native.spec.ts
@@ -1548,7 +1548,7 @@ test('press ArrowUp in the edge of two line', async ({ page }) => {
   await waitNextFrame(page);
   await pressArrowLeft(page);
   await waitNextFrame(page);
-  await assertRichTextVRange(page, 0, 89);
+  await assertRichTextVRange(page, 0, 90);
 
   // aaa...
   // |a


### PR DESCRIPTION
Close #4249

before:
<img width="320" alt="image" src="https://github.com/toeverything/blocksuite/assets/50035259/9d772144-b4a1-467d-b8b1-96d44c5e07c9">

after:
<img width="281" alt="image" src="https://github.com/toeverything/blocksuite/assets/50035259/54fcc50f-c2e4-4794-8332-a9c241a96625">
