### PR TITLE
feat(page): supports the `enter` key for image caption

### DIFF
--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -414,6 +414,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   }
 
   private _onCaptionKeydown(e: KeyboardEvent) {
+    if (e.isComposing) return;
     if (e.key === 'Enter') {
       e.stopPropagation();
       const model = this.model;
@@ -437,10 +438,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
         parent,
         index + 1
       );
-      asyncFocusRichText(model.page, id, {
-        index: nextBlockText.length,
-        length: 0,
-      });
+      asyncFocusRichText(model.page, id);
     }
   }
 

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -17,6 +17,7 @@ import {
   insertThreeLevelLists,
   moveToImage,
   pasteByKeyboard,
+  pressArrowLeft,
   pressEnter,
   redoByKeyboard,
   type,
@@ -29,6 +30,7 @@ import {
   assertRichDragButton,
   assertRichImage,
   assertRichTexts,
+  assertRichTextVRange,
 } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
 
@@ -143,6 +145,25 @@ test('enter shortcut on focusing embed block and its caption', async ({
   await caption.click({ position: { x: 0, y: 0 } });
   await type(page, 'abc');
   await expect(caption).toHaveValue('abc123');
+});
+
+test('should support the enter key of image caption', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initImageState(page);
+  await assertRichImage(page, 1);
+
+  await moveToImage(page);
+  await assertImageOption(page);
+
+  const caption = page.locator('.affine-embed-wrapper-caption');
+  await focusCaption(page);
+  await type(page, 'abc123');
+  await pressArrowLeft(page, 3);
+  await pressEnter(page);
+  await expect(caption).toHaveValue('abc');
+
+  await assertRichTexts(page, ['123', '']);
+  await assertRichTextVRange(page, 0, 0, 0);
 });
 
 test('popup menu should follow position of image when scrolling', async ({


### PR DESCRIPTION
close: #4904


https://github.com/toeverything/blocksuite/assets/15389209/4cf6e1f5-eef2-4f42-aa0d-e93a1bc1a709

