### PR TITLE
fix(page): updated color of the "+ Add" 

### DIFF
--- a/packages/blocks/src/database-block/kanban/group.ts
+++ b/packages/blocks/src/database-block/kanban/group.ts
@@ -56,13 +56,13 @@ const styles = css`
     align-items: center;
     height: 28px;
     padding: 4px;
-    color: var(--affine-text-secondary-color);
     border-radius: 4px;
     cursor: pointer;
     font-size: var(--data-view-cell-text-size);
     line-height: var(--data-view-cell-text-line-height);
     visibility: hidden;
     transition: visibility 100ms ease-in-out;
+    color: var(--affine-text-secondary-color);
   }
 
   affine-data-view-kanban-group:hover .add-card {

--- a/packages/blocks/src/database-block/kanban/group.ts
+++ b/packages/blocks/src/database-block/kanban/group.ts
@@ -56,6 +56,7 @@ const styles = css`
     align-items: center;
     height: 28px;
     padding: 4px;
+    color: var(--affine-text-secondary-color);
     border-radius: 4px;
     cursor: pointer;
     font-size: var(--data-view-cell-text-size);
@@ -70,6 +71,7 @@ const styles = css`
 
   .add-card:hover {
     background-color: var(--affine-hover-color);
+    color: var(--affine-text-primary-color);
   }
 
   .sortable-ghost {


### PR DESCRIPTION
Fixed #4917
 
without hover:
![Screenshot (116)](https://github.com/toeverything/blocksuite/assets/96860040/f5faa1e3-8773-4e98-a6ce-093c37a84c6a)

with hover: 
![Screenshot (117)](https://github.com/toeverything/blocksuite/assets/96860040/c1ff6f7f-4235-4cda-91f8-6d0794adb29e)
