### PR TITLE
refactor(page): switch to `affine-tooltip`

### DIFF
--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -62,15 +62,13 @@ export function AttachmentOptionsTemplate({
     >
       <icon-button size="24px" ?hidden=${true}>
         ${ViewIcon}
-        <tool-tip inert tip-position="top" role="tooltip">Preview</tool-tip>
+        <blocksuite-tooltip>Preview</blocksuite-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${true}></div>
 
       <icon-button size="24px" ?hidden=${true || readonly}>
         ${LinkIcon}
-        <tool-tip inert tip-position="top" role="tooltip"
-          >Turn into Link view</tool-tip
-        >
+        <blocksuite-tooltip>Turn into Link view</blocksuite-tooltip>
       </icon-button>
       <icon-button
         size="24px"
@@ -81,9 +79,7 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EmbedWebIcon}
-        <tool-tip inert tip-position="top" role="tooltip"
-          >Turn into Embed view</tool-tip
-        >
+        <blocksuite-tooltip>Turn into Embed view</blocksuite-tooltip>
       </icon-button>
       <div class="divider"></div>
 
@@ -110,7 +106,7 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EditIcon}
-        <tool-tip inert tip-position="top" role="tooltip">Rename</tool-tip>
+        <blocksuite-tooltip>Rename</blocksuite-tooltip>
       </icon-button>
       <icon-button
         size="24px"
@@ -120,7 +116,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${CaptionIcon}
-        <tool-tip inert tip-position="top" role="tooltip">Caption</tool-tip>
+        <blocksuite-tooltip>Caption</blocksuite-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${readonly}></div>
       <icon-button
@@ -148,7 +144,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${MoreIcon}
-        <tool-tip inert role="tooltip">More</tool-tip>
+        <blocksuite-tooltip>More</blocksuite-tooltip>
       </icon-button>
     </div>`;
 }

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -62,15 +62,13 @@ export function AttachmentOptionsTemplate({
     >
       <icon-button size="24px" ?hidden=${true}>
         ${ViewIcon}
-        <blocksuite-tooltip .offset=${12}>Preview</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>Preview</affine-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${true}></div>
 
       <icon-button size="24px" ?hidden=${true || readonly}>
         ${LinkIcon}
-        <blocksuite-tooltip .offset=${12}
-          >Turn into Link view</blocksuite-tooltip
-        >
+        <affine-tooltip .offset=${12}>Turn into Link view</affine-tooltip>
       </icon-button>
       <icon-button
         size="24px"
@@ -81,9 +79,7 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EmbedWebIcon}
-        <blocksuite-tooltip .offset=${12}
-          >Turn into Embed view</blocksuite-tooltip
-        >
+        <affine-tooltip .offset=${12}>Turn into Embed view</affine-tooltip>
       </icon-button>
       <div class="divider"></div>
 
@@ -110,7 +106,7 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EditIcon}
-        <blocksuite-tooltip .offset=${12}>Rename</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>Rename</affine-tooltip>
       </icon-button>
       <icon-button
         size="24px"
@@ -120,7 +116,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${CaptionIcon}
-        <blocksuite-tooltip .offset=${12}>Caption</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>Caption</affine-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${readonly}></div>
       <icon-button
@@ -148,7 +144,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${MoreIcon}
-        <blocksuite-tooltip .offset=${12}>More</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>More</affine-tooltip>
       </icon-button>
     </div>`;
 }

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -60,20 +60,19 @@ export function AttachmentOptionsTemplate({
       class="affine-attachment-options"
       @pointerdown=${stopPropagation}
     >
-      <icon-button class="has-tool-tip" size="24px" ?hidden=${true}>
+      <icon-button size="24px" ?hidden=${true}>
         ${ViewIcon}
         <tool-tip inert tip-position="top" role="tooltip">Preview</tool-tip>
       </icon-button>
       <div class="divider" ?hidden=${true}></div>
 
-      <icon-button class="has-tool-tip" size="24px" ?hidden=${true || readonly}>
+      <icon-button size="24px" ?hidden=${true || readonly}>
         ${LinkIcon}
         <tool-tip inert tip-position="top" role="tooltip"
           >Turn into Link view</tool-tip
         >
       </icon-button>
       <icon-button
-        class="has-tool-tip"
         size="24px"
         ?disabled=${readonly || disableEmbed}
         @click="${() => {
@@ -89,7 +88,6 @@ export function AttachmentOptionsTemplate({
       <div class="divider"></div>
 
       <icon-button
-        class="has-tool-tip"
         size="24px"
         ?hidden=${readonly}
         @click="${() => {
@@ -115,7 +113,6 @@ export function AttachmentOptionsTemplate({
         <tool-tip inert tip-position="top" role="tooltip">Rename</tool-tip>
       </icon-button>
       <icon-button
-        class="has-tool-tip"
         size="24px"
         ?hidden=${readonly}
         @click=${() => {
@@ -128,7 +125,7 @@ export function AttachmentOptionsTemplate({
       <div class="divider" ?hidden=${readonly}></div>
       <icon-button
         size="24px"
-        class="has-tool-tip more-button"
+        class="more-button"
         @click=${() => {
           if (moreMenuAbortController) {
             moreMenuAbortController.abort();

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -62,13 +62,15 @@ export function AttachmentOptionsTemplate({
     >
       <icon-button size="24px" ?hidden=${true}>
         ${ViewIcon}
-        <blocksuite-tooltip>Preview</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>Preview</blocksuite-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${true}></div>
 
       <icon-button size="24px" ?hidden=${true || readonly}>
         ${LinkIcon}
-        <blocksuite-tooltip>Turn into Link view</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}
+          >Turn into Link view</blocksuite-tooltip
+        >
       </icon-button>
       <icon-button
         size="24px"
@@ -79,7 +81,9 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EmbedWebIcon}
-        <blocksuite-tooltip>Turn into Embed view</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}
+          >Turn into Embed view</blocksuite-tooltip
+        >
       </icon-button>
       <div class="divider"></div>
 
@@ -106,7 +110,7 @@ export function AttachmentOptionsTemplate({
         }}"
       >
         ${EditIcon}
-        <blocksuite-tooltip>Rename</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>Rename</blocksuite-tooltip>
       </icon-button>
       <icon-button
         size="24px"
@@ -116,7 +120,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${CaptionIcon}
-        <blocksuite-tooltip>Caption</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>Caption</blocksuite-tooltip>
       </icon-button>
       <div class="divider" ?hidden=${readonly}></div>
       <icon-button
@@ -144,7 +148,7 @@ export function AttachmentOptionsTemplate({
         }}
       >
         ${MoreIcon}
-        <blocksuite-tooltip>More</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>More</blocksuite-tooltip>
       </icon-button>
     </div>`;
 }

--- a/packages/blocks/src/attachment-block/components/styles.ts
+++ b/packages/blocks/src/attachment-block/components/styles.ts
@@ -1,8 +1,6 @@
 import { baseTheme } from '@toeverything/theme';
 import { css, unsafeCSS } from 'lit';
 
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
-
 export const renameStyles = css`
   .affine-attachment-rename-container {
     position: relative;
@@ -132,6 +130,4 @@ export const styles = css`
   icon-button[hidden] {
     display: none;
   }
-
-  ${tooltipStyle}
 `;

--- a/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-create-modal.ts
@@ -103,7 +103,10 @@ export class BookmarkCreateModal extends WithDisposable(LitElement) {
           </div>
         </div>
       </div>`;
-    return html`<blocksuite-portal .template=${modal}></blocksuite-portal>`;
+    return html`<blocksuite-portal
+      .template=${modal}
+      .shadowDom=${false}
+    ></blocksuite-portal>`;
   }
 }
 

--- a/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-edit-modal.ts
@@ -227,7 +227,10 @@ export class BookmarkEditModal extends WithDisposable(LitElement) {
           </div>
         </div>
       </div>`;
-    return html`<blocksuite-portal .template=${modal}></blocksuite-portal>`;
+    return html`<blocksuite-portal
+      .template=${modal}
+      .shadowDom=${false}
+    ></blocksuite-portal>`;
   }
 }
 

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -94,7 +94,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${icon}
-            <blocksuite-tooltip .offset=${12}>${tooltip}</blocksuite-tooltip>
+            <affine-tooltip .offset=${12}>${tooltip}</affine-tooltip>
           </icon-button>
           ${divider ? html`<div class="divider"></div>` : nothing} `;
       }
@@ -113,7 +113,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${MoreIcon}
-            <blocksuite-tooltip .offset=${12}>More</blocksuite-tooltip>
+            <affine-tooltip .offset=${12}>More</affine-tooltip>
           </icon-button>
         </div>
       </div>

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -94,7 +94,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${icon}
-            <tool-tip inert role="tooltip">${tooltip}</tool-tip>
+            <blocksuite-tooltip>${tooltip}</blocksuite-tooltip>
           </icon-button>
           ${divider ? html`<div class="divider"></div>` : nothing} `;
       }
@@ -113,7 +113,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${MoreIcon}
-            <tool-tip inert role="tooltip">More</tool-tip>
+            <blocksuite-tooltip>More</blocksuite-tooltip>
           </icon-button>
         </div>
       </div>

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -6,7 +6,6 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import { createLitPortal } from '../../components/portal.js';
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 import { MoreIcon } from '../../icons/index.js';
 import { BookmarkOperationMenu } from './bookmark-operation-popper.js';
 import {
@@ -18,7 +17,6 @@ import {
 @customElement('bookmark-toolbar')
 export class BookmarkToolbar extends WithDisposable(LitElement) {
   static override styles = css`
-    ${tooltipStyle}
     .bookmark-bar {
       box-sizing: border-box;
       display: flex;

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -87,7 +87,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
       ({ type, icon, tooltip, action, divider, disableWhen = () => false }) => {
         return html`<icon-button
             size="24px"
-            class="bookmark-toolbar-button has-tool-tip ${type}"
+            class="bookmark-toolbar-button ${type}"
             ?disabled=${disableWhen(this.model)}
             @click=${() => {
               action(this.model, this.onSelected, this);
@@ -107,7 +107,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
         <div class="more-button-wrapper">
           <icon-button
             size="24px"
-            class="has-tool-tip more-button"
+            class="more-button"
             @click=${() => {
               this._toggleMenu();
             }}

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -94,7 +94,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${icon}
-            <blocksuite-tooltip>${tooltip}</blocksuite-tooltip>
+            <blocksuite-tooltip .offset=${12}>${tooltip}</blocksuite-tooltip>
           </icon-button>
           ${divider ? html`<div class="divider"></div>` : nothing} `;
       }
@@ -113,7 +113,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
             }}
           >
             ${MoreIcon}
-            <blocksuite-tooltip>More</blocksuite-tooltip>
+            <blocksuite-tooltip .offset=${12}>More</blocksuite-tooltip>
           </icon-button>
         </div>
       </div>

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -31,7 +31,6 @@ import { HoverController } from '../components/index.js';
 import { createLitPortal } from '../components/portal.js';
 import { bindContainerHotkey } from '../components/rich-text/keymap/index.js';
 import type { RichText } from '../components/rich-text/rich-text.js';
-import { tooltipStyle } from '../components/tooltip/tooltip.js';
 import { ArrowDownIcon } from '../icons/index.js';
 import type { CodeBlockModel } from './code-model.js';
 import { CodeOptionTemplate } from './components/code-option.js';
@@ -174,8 +173,6 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
       background-color: var(--affine-background-overlay-panel-color);
       margin: 0;
     }
-
-    ${tooltipStyle}
   `;
 
   @state()

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -34,7 +34,7 @@ export function CodeOptionTemplate({
       }
       .affine-codeblock-option {
         box-shadow: var(--affine-shadow-2);
-        padding: 4px;
+        padding: 8px;
         border-radius: 8px;
         z-index: var(--affine-z-index-popover);
         background: var(--affine-background-overlay-panel-color);
@@ -55,7 +55,7 @@ export function CodeOptionTemplate({
         @click=${() => copyCode(model as CodeBlockModel)}
       >
         ${CopyIcon}
-        <blocksuite-tooltip tip-position="right"
+        <blocksuite-tooltip tip-position="right" .offset=${12}
           >Copy to Clipboard</blocksuite-tooltip
         >
       </icon-button>
@@ -66,7 +66,7 @@ export function CodeOptionTemplate({
         @click=${onClickWrap}
       >
         ${wrap ? CancelWrapIcon : WrapIcon}
-        <blocksuite-tooltip tip-position="right"
+        <blocksuite-tooltip tip-position="right" .offset=${12}
           >${wrap ? 'Cancel wrap' : 'Wrap code'}</blocksuite-tooltip
         >
       </icon-button>
@@ -82,7 +82,9 @@ export function CodeOptionTemplate({
             }}
           >
             ${DeleteIcon}
-            <blocksuite-tooltip tip-position="right">Delete</blocksuite-tooltip>
+            <blocksuite-tooltip tip-position="right" .offset=${12}
+              >Delete</blocksuite-tooltip
+            >
           </icon-button>`}
     </div>
   `;

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -55,8 +55,8 @@ export function CodeOptionTemplate({
         @click=${() => copyCode(model as CodeBlockModel)}
       >
         ${CopyIcon}
-        <blocksuite-tooltip tip-position="right" .offset=${12}
-          >Copy to Clipboard</blocksuite-tooltip
+        <affine-tooltip tip-position="right" .offset=${12}
+          >Copy to Clipboard</affine-tooltip
         >
       </icon-button>
       <icon-button
@@ -66,8 +66,8 @@ export function CodeOptionTemplate({
         @click=${onClickWrap}
       >
         ${wrap ? CancelWrapIcon : WrapIcon}
-        <blocksuite-tooltip tip-position="right" .offset=${12}
-          >${wrap ? 'Cancel wrap' : 'Wrap code'}</blocksuite-tooltip
+        <affine-tooltip tip-position="right" .offset=${12}
+          >${wrap ? 'Cancel wrap' : 'Wrap code'}</affine-tooltip
         >
       </icon-button>
       ${readonly
@@ -82,8 +82,8 @@ export function CodeOptionTemplate({
             }}
           >
             ${DeleteIcon}
-            <blocksuite-tooltip tip-position="right" .offset=${12}
-              >Delete</blocksuite-tooltip
+            <affine-tooltip tip-position="right" .offset=${12}
+              >Delete</affine-tooltip
             >
           </icon-button>`}
     </div>

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -2,7 +2,6 @@ import type { BaseBlockModel } from '@blocksuite/store';
 import { html, nothing } from 'lit';
 import { ref, type RefOrCallback } from 'lit/directives/ref.js';
 
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 import {
   CancelWrapIcon,
   CopyIcon,
@@ -47,8 +46,6 @@ export function CodeOptionTemplate({
       .delete-code-button:hover > svg {
         color: var(--affine-error-color);
       }
-
-      ${tooltipStyle}
     </style>
 
     <div ${ref(containerRef)} class="affine-codeblock-option">

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -55,8 +55,8 @@ export function CodeOptionTemplate({
         @click=${() => copyCode(model as CodeBlockModel)}
       >
         ${CopyIcon}
-        <tool-tip inert tip-position="right" role="tooltip"
-          >Copy to Clipboard</tool-tip
+        <blocksuite-tooltip tip-position="right"
+          >Copy to Clipboard</blocksuite-tooltip
         >
       </icon-button>
       <icon-button
@@ -66,8 +66,8 @@ export function CodeOptionTemplate({
         @click=${onClickWrap}
       >
         ${wrap ? CancelWrapIcon : WrapIcon}
-        <tool-tip inert tip-position="right" role="tooltip"
-          >${wrap ? 'Cancel wrap' : 'Wrap code'}</tool-tip
+        <blocksuite-tooltip tip-position="right"
+          >${wrap ? 'Cancel wrap' : 'Wrap code'}</blocksuite-tooltip
         >
       </icon-button>
       ${readonly
@@ -82,9 +82,7 @@ export function CodeOptionTemplate({
             }}
           >
             ${DeleteIcon}
-            <tool-tip inert tip-position="right" role="tooltip"
-              >Delete</tool-tip
-            >
+            <blocksuite-tooltip tip-position="right">Delete</blocksuite-tooltip>
           </icon-button>`}
     </div>
   `;

--- a/packages/blocks/src/code-block/components/code-option.ts
+++ b/packages/blocks/src/code-block/components/code-option.ts
@@ -51,7 +51,6 @@ export function CodeOptionTemplate({
     <div ${ref(containerRef)} class="affine-codeblock-option">
       <icon-button
         size="32px"
-        class="has-tool-tip"
         data-testid="copy-button"
         @click=${() => copyCode(model as CodeBlockModel)}
       >
@@ -62,7 +61,6 @@ export function CodeOptionTemplate({
       </icon-button>
       <icon-button
         size="32px"
-        class="has-tool-tip"
         data-testid="wrap-button"
         ?active=${wrap}
         @click=${onClickWrap}
@@ -77,7 +75,7 @@ export function CodeOptionTemplate({
         : html`<icon-button
             size="32px"
             data-testid="delete-button"
-            class="has-tool-tip delete-code-button"
+            class="delete-code-button"
             @click=${() => {
               if (readonly) return;
               model.page.deleteBlock(model);

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -465,12 +465,12 @@ function BlockHubCards(
                   </div>
                   <div class="card-icon-container">${icon}</div>
                   ${showTooltip
-                    ? html`<blocksuite-tooltip
+                    ? html`<affine-tooltip
                         tip-position=${shouldScroll &&
                         index === blockHubItems.length - 1
                           ? 'top'
                           : 'bottom'}
-                        >${tooltip}</blocksuite-tooltip
+                        >${tooltip}</affine-tooltip
                       >`
                     : null}
                 </div>
@@ -536,9 +536,9 @@ function BlockHubMenu(
       >
         ${BlockHubRoundedRectangleIcon}
         ${showTooltip
-          ? html`<blocksuite-tooltip tip-position="left" .offset=${8}
+          ? html`<affine-tooltip tip-position="left" .offset=${8}
               >Drag to insert blank line
-            </blocksuite-tooltip>`
+            </affine-tooltip>`
           : null}
       </div>
       <div
@@ -571,9 +571,9 @@ function BlockHubMenu(
       >
         ${DatabaseTableViewIcon}
         ${showTooltip
-          ? html`<blocksuite-tooltip tip-position="left" .offset=${8}>
+          ? html`<affine-tooltip tip-position="left" .offset=${8}>
               Drag to create a database
-            </blocksuite-tooltip>`
+            </affine-tooltip>`
           : null}
       </div>
       <div class="divider"></div>
@@ -1095,8 +1095,8 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
             ? CrossIcon
             : [
                 BlockHubIcon,
-                html`<blocksuite-tooltip tip-position="left"
-                  >Insert blocks</blocksuite-tooltip
+                html`<affine-tooltip tip-position="left"
+                  >Insert blocks</affine-tooltip
                 >`,
               ]}
         </div>

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -536,7 +536,7 @@ function BlockHubMenu(
       >
         ${BlockHubRoundedRectangleIcon}
         ${showTooltip
-          ? html`<blocksuite-tooltip tip-position="left"
+          ? html`<blocksuite-tooltip tip-position="left" .offset=${8}
               >Drag to insert blank line
             </blocksuite-tooltip>`
           : null}
@@ -571,7 +571,7 @@ function BlockHubMenu(
       >
         ${DatabaseTableViewIcon}
         ${showTooltip
-          ? html`<blocksuite-tooltip tip-position="left">
+          ? html`<blocksuite-tooltip tip-position="left" .offset=${8}>
               Drag to create a database
             </blocksuite-tooltip>`
           : null}

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -464,18 +464,15 @@ function BlockHubCards(
                     <div class="description">${description}</div>
                   </div>
                   <div class="card-icon-container">${icon}</div>
-                  <tool-tip
-                    tip-position=${shouldScroll &&
-                    index === blockHubItems.length - 1
-                      ? 'top'
-                      : 'bottom'}
-                    style="${showTooltip
-                      ? ''
-                      : 'display: none'}; z-index: ${blockHubItems.length -
-                    index}"
-                    arrow
-                    >${tooltip}</tool-tip
-                  >
+                  ${showTooltip
+                    ? html`<blocksuite-tooltip
+                        tip-position=${shouldScroll &&
+                        index === blockHubItems.length - 1
+                          ? 'top'
+                          : 'bottom'}
+                        >${tooltip}</blocksuite-tooltip
+                      >`
+                    : null}
                 </div>
               </div>
             </div>
@@ -538,14 +535,11 @@ function BlockHubMenu(
         affine-type="text"
       >
         ${BlockHubRoundedRectangleIcon}
-        <tool-tip
-          inert
-          role="tooltip"
-          tip-position="left"
-          arrow
-          ?hidden=${!showTooltip}
-          >Drag to insert blank line
-        </tool-tip>
+        ${showTooltip
+          ? html`<blocksuite-tooltip tip-position="left"
+              >Drag to insert blank line
+            </blocksuite-tooltip>`
+          : null}
       </div>
       <div
         class="block-hub-icon-container"
@@ -576,15 +570,11 @@ function BlockHubMenu(
         selected=${visibleCardType === 'database' ? 'true' : 'false'}
       >
         ${DatabaseTableViewIcon}
-        <tool-tip
-          inert
-          role="tooltip"
-          tip-position="left"
-          arrow
-          ?hidden=${!showTooltip}
-        >
-          Drag to create a database
-        </tool-tip>
+        ${showTooltip
+          ? html`<blocksuite-tooltip tip-position="left">
+              Drag to create a database
+            </blocksuite-tooltip>`
+          : null}
       </div>
       <div class="divider"></div>
     </div>
@@ -1105,8 +1095,8 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
             ? CrossIcon
             : [
                 BlockHubIcon,
-                html`<tool-tip tip-position="left" role="tooltip"
-                  >Insert blocks</tool-tip
+                html`<blocksuite-tooltip tip-position="left"
+                  >Insert blocks</blocksuite-tooltip
                 >`,
               ]}
         </div>

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -388,10 +388,6 @@ const styles = css`
     background: var(--affine-hover-color);
   }
 
-  [role='menuitem'] tool-tip {
-    font-size: var(--affine-font-sm);
-  }
-
   .block-hub-icons-container {
     width: 100%;
     overflow: hidden;

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -1113,15 +1113,14 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       >
         ${blockHubMenu}
         <div class=${classes} role="menuitem" style="cursor:pointer;">
-          ${this._expanded ? CrossIcon : BlockHubIcon}
-          <tool-tip
-            class=${this._expanded ? 'invisible' : ''}
-            inert
-            tip-position="left"
-            role="tooltip"
-            arrow
-            >Insert blocks
-          </tool-tip>
+          ${this._expanded
+            ? CrossIcon
+            : [
+                BlockHubIcon,
+                html`<tool-tip tip-position="left" role="tooltip"
+                  >Insert blocks</tool-tip
+                >`,
+              ]}
         </div>
         ${blockHubCards}
       </div>

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -454,9 +454,7 @@ function BlockHubCards(
             <div class="card-container-wrapper">
               <div class="card-container-inner">
                 <div
-                  class="card-container has-tool-tip ${isGrabbing
-                    ? 'grabbing'
-                    : ''}"
+                  class="card-container ${isGrabbing ? 'grabbing' : ''}"
                   draggable="true"
                   affine-flavour=${flavour}
                   affine-type=${type ?? ''}
@@ -532,9 +530,7 @@ function BlockHubMenu(
       style="height: ${expanded ? `${height}px` : '0'};"
     >
       <div
-        class="block-hub-icon-container has-tool-tip ${isGrabbing
-          ? 'grabbing'
-          : 'grab'}"
+        class="block-hub-icon-container ${isGrabbing ? 'grabbing' : 'grab'}"
         selected=${visibleCardType === 'blank' ? 'true' : 'false'}
         type="blank"
         draggable="true"
@@ -573,7 +569,7 @@ function BlockHubMenu(
         ${blockHubFileCards} ${EmbedWebIcon}
       </div>
       <div
-        class="block-hub-icon-container has-tool-tip"
+        class="block-hub-icon-container"
         type="database"
         draggable="true"
         affine-flavour="affine:database"
@@ -1095,7 +1091,6 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     const classes = classMap({
       'icon-expanded': this._expanded,
       'new-icon-in-edgeless': this._inEdgelessMode && !this._expanded,
-      'has-tool-tip': true,
       'new-icon': true,
     });
     return html`

--- a/packages/blocks/src/components/block-hub.ts
+++ b/packages/blocks/src/components/block-hub.ts
@@ -58,7 +58,6 @@ import { DocPageBlockComponent } from '../page-block/doc/doc-page-block.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import { autoScroll } from '../page-block/text-selection/utils.js';
 import { type DragIndicator } from './drag-indicator.js';
-import { tooltipStyle } from './tooltip/tooltip.js';
 
 export const BLOCKHUB_TEXT_ITEMS = [
   {
@@ -405,8 +404,6 @@ const styles = css`
     background: var(--affine-border-color);
     margin: 4px 0;
   }
-
-  ${tooltipStyle}
 `;
 
 type BlockHubItem = {

--- a/packages/blocks/src/components/button.ts
+++ b/packages/blocks/src/components/button.ts
@@ -12,7 +12,7 @@ import { customElement, property } from 'lit/decorators.js';
  *
  * @example
  * ```ts
- * html`<icon-button class="has-tool-tip" @click=${this.onUnlink}>
+ * html`<icon-button @click=${this.onUnlink}>
  *   ${UnlinkIcon}
  * </icon-button>`
  *

--- a/packages/blocks/src/components/portal.ts
+++ b/packages/blocks/src/components/portal.ts
@@ -40,6 +40,9 @@ export class Portal extends LitElement {
   @property({ attribute: false })
   public template = html``;
 
+  @property({ attribute: false })
+  public shadowDom: boolean | ShadowRootInit = true;
+
   private _portalRoot: HTMLElement | null = null;
 
   override disconnectedCallback(): void {
@@ -49,6 +52,12 @@ export class Portal extends LitElement {
 
   override createRenderRoot() {
     const portalRoot = document.createElement('div');
+    if (this.shadowDom) {
+      portalRoot.attachShadow({
+        mode: 'open',
+        ...(typeof this.shadowDom !== 'boolean' ? this.shadowDom : {}),
+      });
+    }
     portalRoot.classList.add('blocksuite-portal');
     this.container.append(portalRoot);
     this._portalRoot = portalRoot;
@@ -92,7 +101,7 @@ type PortalOptions = {
   /**
    * Defaults to `true`.
    */
-  shadowDom?: boolean;
+  shadowDom?: boolean | ShadowRootInit;
   renderOptions?: RenderOptions;
   /**
    * Defaults to `true`.
@@ -121,7 +130,10 @@ export function createSimplePortal({
     portalRoot.classList.add('blocksuite-portal');
   }
   if (shadowDom) {
-    portalRoot.attachShadow({ mode: 'open' });
+    portalRoot.attachShadow({
+      mode: 'open',
+      ...(typeof shadowDom !== 'boolean' ? shadowDom : {}),
+    });
   }
   signal.addEventListener('abort', () => {
     portalRoot.remove();

--- a/packages/blocks/src/components/portal.ts
+++ b/packages/blocks/src/components/portal.ts
@@ -52,16 +52,16 @@ export class Portal extends LitElement {
 
   override createRenderRoot() {
     const portalRoot = document.createElement('div');
-    if (this.shadowDom) {
-      portalRoot.attachShadow({
-        mode: 'open',
-        ...(typeof this.shadowDom !== 'boolean' ? this.shadowDom : {}),
-      });
-    }
+    const renderRoot = this.shadowDom
+      ? portalRoot.attachShadow({
+          mode: 'open',
+          ...(typeof this.shadowDom !== 'boolean' ? this.shadowDom : {}),
+        })
+      : portalRoot;
     portalRoot.classList.add('blocksuite-portal');
     this.container.append(portalRoot);
     this._portalRoot = portalRoot;
-    return portalRoot;
+    return renderRoot;
   }
 
   override render() {

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -254,7 +254,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
   private _viewTemplate() {
     return html`<div class="affine-link-popover">
       <div
-        class="affine-link-preview has-tool-tip"
+        class="affine-link-preview"
         @click=${() => {
           navigator.clipboard.writeText(this.currentLink);
           toast('Copied link to clipboard');
@@ -268,7 +268,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
       ${this._isBookmarkAllowed()
         ? html`<span class="affine-link-popover-dividing-line"></span
             ><icon-button
-              class="has-tool-tip"
               data-testid="link-to-card"
               @click=${() => this._linkToBookmark('card')}
             >
@@ -278,7 +277,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
         : nothing}
       ${this._isBookmarkAllowed() && allowEmbed(this.currentLink)
         ? html`<icon-button
-            class="has-tool-tip"
             data-testid="link-to-embed"
             @click=${() => this._linkToBookmark('embed')}
           >
@@ -288,7 +286,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
         : nothing}
       <span class="affine-link-popover-dividing-line"></span>
       <icon-button
-        class="has-tool-tip"
         data-testid="unlink"
         @click=${() => {
           if (this.vEditor.isVRangeValid(this.goalVRange)) {
@@ -302,7 +299,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
       </icon-button>
 
       <icon-button
-        class="has-tool-tip"
         data-testid="edit"
         @click=${() => {
           this.type = 'edit';

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -261,7 +261,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
           this.remove();
         }}
       >
-        <blocksuite-tooltip>Click to copy link</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}
+          >Click to copy link</blocksuite-tooltip
+        >
         <span style="overflow: hidden;">${this.currentLink}</span>
       </div>
 
@@ -272,7 +274,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
               @click=${() => this._linkToBookmark('card')}
             >
               ${BookmarkIcon}
-              <blocksuite-tooltip>Turn into Card view</blocksuite-tooltip>
+              <blocksuite-tooltip .offset=${12}
+                >Turn into Card view</blocksuite-tooltip
+              >
             </icon-button>`
         : nothing}
       ${this._isBookmarkAllowed() && allowEmbed(this.currentLink)
@@ -281,7 +285,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
             @click=${() => this._linkToBookmark('embed')}
           >
             ${EmbedWebIcon}
-            <blocksuite-tooltip>Turn into Embed view</blocksuite-tooltip>
+            <blocksuite-tooltip .offset=${12}
+              >Turn into Embed view</blocksuite-tooltip
+            >
           </icon-button>`
         : nothing}
       <span class="affine-link-popover-dividing-line"></span>
@@ -295,7 +301,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${UnlinkIcon}
-        <blocksuite-tooltip>Remove</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>Remove</blocksuite-tooltip>
       </icon-button>
 
       <icon-button
@@ -305,7 +311,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${EditIcon}
-        <blocksuite-tooltip>Edit</blocksuite-tooltip>
+        <blocksuite-tooltip .offset=${12}>Edit</blocksuite-tooltip>
       </icon-button>
     </div>`;
   }

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -261,7 +261,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
           this.remove();
         }}
       >
-        <tool-tip inert role="tooltip">Click to copy link</tool-tip>
+        <blocksuite-tooltip>Click to copy link</blocksuite-tooltip>
         <span style="overflow: hidden;">${this.currentLink}</span>
       </div>
 
@@ -272,7 +272,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
               @click=${() => this._linkToBookmark('card')}
             >
               ${BookmarkIcon}
-              <tool-tip inert role="tooltip">Turn into Card view</tool-tip>
+              <blocksuite-tooltip>Turn into Card view</blocksuite-tooltip>
             </icon-button>`
         : nothing}
       ${this._isBookmarkAllowed() && allowEmbed(this.currentLink)
@@ -281,7 +281,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
             @click=${() => this._linkToBookmark('embed')}
           >
             ${EmbedWebIcon}
-            <tool-tip inert role="tooltip">Turn into Embed view</tool-tip>
+            <blocksuite-tooltip>Turn into Embed view</blocksuite-tooltip>
           </icon-button>`
         : nothing}
       <span class="affine-link-popover-dividing-line"></span>
@@ -295,7 +295,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${UnlinkIcon}
-        <tool-tip inert role="tooltip">Remove</tool-tip>
+        <blocksuite-tooltip>Remove</blocksuite-tooltip>
       </icon-button>
 
       <icon-button
@@ -305,7 +305,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${EditIcon}
-        <tool-tip inert role="tooltip">Edit</tool-tip>
+        <blocksuite-tooltip>Edit</blocksuite-tooltip>
       </icon-button>
     </div>`;
   }

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -261,9 +261,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
           this.remove();
         }}
       >
-        <blocksuite-tooltip .offset=${12}
-          >Click to copy link</blocksuite-tooltip
-        >
+        <affine-tooltip .offset=${12}>Click to copy link</affine-tooltip>
         <span style="overflow: hidden;">${this.currentLink}</span>
       </div>
 
@@ -274,9 +272,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
               @click=${() => this._linkToBookmark('card')}
             >
               ${BookmarkIcon}
-              <blocksuite-tooltip .offset=${12}
-                >Turn into Card view</blocksuite-tooltip
-              >
+              <affine-tooltip .offset=${12}>Turn into Card view</affine-tooltip>
             </icon-button>`
         : nothing}
       ${this._isBookmarkAllowed() && allowEmbed(this.currentLink)
@@ -285,9 +281,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
             @click=${() => this._linkToBookmark('embed')}
           >
             ${EmbedWebIcon}
-            <blocksuite-tooltip .offset=${12}
-              >Turn into Embed view</blocksuite-tooltip
-            >
+            <affine-tooltip .offset=${12}>Turn into Embed view</affine-tooltip>
           </icon-button>`
         : nothing}
       <span class="affine-link-popover-dividing-line"></span>
@@ -301,7 +295,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${UnlinkIcon}
-        <blocksuite-tooltip .offset=${12}>Remove</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>Remove</affine-tooltip>
       </icon-button>
 
       <icon-button
@@ -311,7 +305,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         }}
       >
         ${EditIcon}
-        <blocksuite-tooltip .offset=${12}>Edit</blocksuite-tooltip>
+        <affine-tooltip .offset=${12}>Edit</affine-tooltip>
       </icon-button>
     </div>`;
   }

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/styles.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/styles.ts
@@ -165,8 +165,7 @@ export const linkPopupStyle = css`
   .affine-link-popover {
     display: flex;
     align-items: center;
-    height: 40px;
-    padding: 0 12px;
+    padding: 8px;
 
     background: var(--affine-background-overlay-panel-color);
     box-shadow: var(--affine-shadow-2);

--- a/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/styles.ts
+++ b/packages/blocks/src/components/rich-text/virgo/nodes/link-node/link-popup/styles.ts
@@ -1,8 +1,6 @@
 import { baseTheme } from '@toeverything/theme';
 import { css, unsafeCSS } from 'lit';
 
-import { tooltipStyle } from '../../../../../tooltip/tooltip.js';
-
 const editLinkStyle = css`
   .affine-link-edit-popover {
     box-sizing: border-box;
@@ -203,5 +201,4 @@ export const linkPopupStyle = css`
   }
 
   ${editLinkStyle}
-  ${tooltipStyle}
 `;

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -147,6 +147,8 @@ export class Tooltip extends LitElement {
   arrow = true;
 
   /**
+   * Default is `4px`
+   *
    * See https://floating-ui.com/docs/offset
    */
   @property({ attribute: false })
@@ -206,7 +208,7 @@ export class Tooltip extends LitElement {
           referenceElement: this.parentElement!,
           placement: this.placement,
           middleware: [
-            this.autoFlip && flip(),
+            this.autoFlip && flip({ padding: 12 }),
             offset((this.arrow ? TRIANGLE_HEIGHT : 0) + this.offset),
             arrow({
               element: portalRoot.shadowRoot!.querySelector('.arrow')!,

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -25,7 +25,7 @@ import { HoverController } from '../when-hover.js';
 export const tooltipStyle = css``;
 
 const styles = css`
-  .tooltip {
+  .blocksuite-tooltip {
     max-width: 280px;
     font-family: var(--affine-font-family);
     font-size: var(--affine-font-sm);
@@ -48,6 +48,7 @@ const styles = css`
 `;
 
 // See http://apps.eky.hk/css-triangle-generator/
+const TRIANGLE_HEIGHT = 6;
 const triangleMap = {
   top: {
     bottom: '-6px',
@@ -125,7 +126,7 @@ export class Tooltip extends LitElement {
    * See https://floating-ui.com/docs/offset
    */
   @property({ attribute: false })
-  offset = 10;
+  offset = 4;
 
   /**
    * Allow the tooltip to be interactive.
@@ -184,7 +185,7 @@ export class Tooltip extends LitElement {
                     }
                   `}
             </style>
-            <div class="tooltip">${slottedChildren}</div>
+            <div class="blocksuite-tooltip">${slottedChildren}</div>
             <div class="arrow" style=${styleMap(arrowStyles)}></div>
           `;
         },
@@ -193,7 +194,7 @@ export class Tooltip extends LitElement {
           placement: this.placement || 'top',
           middleware: [
             this.autoFlip && flip(),
-            offset(this.offset),
+            offset(TRIANGLE_HEIGHT + this.offset),
             arrow({
               element: portalRoot.shadowRoot!.querySelector('.arrow')!,
             }),

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -1,5 +1,17 @@
+import { assertExists } from '@blocksuite/global/utils';
+import {
+  arrow,
+  type ComputePositionReturn,
+  flip,
+  offset,
+  type Placement,
+} from '@floating-ui/dom';
 import { baseTheme } from '@toeverything/theme';
-import { css, unsafeCSS } from 'lit';
+import { css, html, LitElement, unsafeCSS } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
+
+import { HoverController } from '../when-hover.js';
 
 /**
  * @example
@@ -163,3 +175,171 @@ export const tooltipStyle = css`
     opacity: 0.2;
   }
 `;
+
+const styles = css`
+  :host {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    max-width: 280px;
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-sm);
+    border-radius: 4px;
+    padding: 6px 12px;
+    color: var(--affine-white);
+    background: var(--affine-tooltip);
+  }
+
+  .tooltip {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .arrow {
+    position: absolute;
+
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 5px 0 5px 6px;
+    border-color: transparent transparent transparent var(--affine-tooltip);
+  }
+`;
+
+@customElement('blocksuite-tooltip')
+export class Tooltip extends LitElement {
+  static override styles = css`
+    :host {
+      display: none;
+    }
+  `;
+
+  @property({ attribute: 'tip-position' })
+  placement?: Placement;
+
+  @property({ attribute: true, type: Boolean })
+  override hidden = false;
+
+  @property({ attribute: false })
+  allowInteractive = false;
+
+  private _hoverController = new HoverController(
+    this,
+    () => {
+      if (this.hidden) return null;
+
+      const slot = this.shadowRoot?.querySelector('slot');
+      if (!slot) throw new Error('slot not found in tooltip!');
+      const slottedChildren = slot
+        .assignedNodes()
+        .map(node => node.cloneNode(true));
+
+      // Ported from https://floating-ui.com/docs/tutorial#arrow-middleware
+      const updateArrowPosition = ({
+        placement,
+        middlewareData,
+      }: ComputePositionReturn): StyleInfo => {
+        // See http://apps.eky.hk/css-triangle-generator/
+        const triangleStyles = {
+          top: {
+            bottom: '-6px',
+            borderWidth: '6px 5px 0 5px',
+            borderColor:
+              'var(--affine-tooltip) transparent transparent transparent',
+          },
+          right: {
+            left: '-6px',
+            borderWidth: '5px 6px 5px 0',
+            borderColor:
+              'transparent var(--affine-tooltip) transparent transparent',
+          },
+          bottom: {
+            top: '-6px',
+            borderWidth: '0 5px 6px 5px',
+            borderColor:
+              'transparent transparent var(--affine-tooltip) transparent',
+          },
+          left: {
+            right: '-6px',
+            borderWidth: '5px 0 5px 6px',
+            borderColor:
+              'transparent transparent transparent var(--affine-tooltip)',
+          },
+        }[placement.split('-')[0]];
+
+        const arrowX = middlewareData.arrow?.x;
+        const arrowY = middlewareData.arrow?.y;
+
+        return {
+          left: arrowX != null ? `${arrowX}px` : '',
+          top: arrowY != null ? `${arrowY}px` : '',
+          right: '',
+          bottom: '',
+          ...triangleStyles,
+        };
+      };
+
+      let arrowStyles: StyleInfo = {};
+      return {
+        template: ({ positionSlot, updatePortal }) => {
+          positionSlot.on(data => {
+            arrowStyles = updateArrowPosition(data);
+            updatePortal();
+          });
+          return html`
+            <style>
+              ${styles}
+              ${this.allowInteractive
+                ? null
+                : css`
+                    :host {
+                      pointer-events: none;
+                    }
+                  `}
+            </style>
+            <div class="tooltip">${slottedChildren}</div>
+            <div class="arrow" style=${styleMap(arrowStyles)}></div>
+          `;
+        },
+        computePosition: portalRoot => ({
+          referenceElement: this.parentElement!,
+          placement: this.placement || 'top',
+          middleware: [
+            flip(),
+            offset(10),
+            arrow({
+              element: portalRoot.shadowRoot!.querySelector('.arrow')!,
+            }),
+          ],
+          autoUpdate: true,
+        }),
+      };
+    },
+    { leaveDelay: 0 }
+  );
+
+  override connectedCallback() {
+    super.connectedCallback();
+    const parent = this.parentElement;
+    assertExists(parent, 'Tooltip must have a parent element');
+    this._hoverController.setReference(parent);
+  }
+
+  private _handleSlotchange(e: Event) {
+    // console.warn('Dynamic tooltip is not supported yet!');
+    // TODO update tooltip
+  }
+
+  override render() {
+    // The actual tooltip render as a portal, so we only need to render the slot
+    return html`<slot @slotchange=${this._handleSlotchange}></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'blocksuite-tooltip': Tooltip;
+  }
+}

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -327,14 +327,14 @@ export class Tooltip extends LitElement {
     this._hoverController.setReference(parent);
   }
 
-  private _handleSlotchange(e: Event) {
-    // console.warn('Dynamic tooltip is not supported yet!');
-    // TODO update tooltip
-  }
+  // private _handleSlotchange(e: Event) {
+  // console.warn('Dynamic tooltip is not supported yet!');
+  // TODO update tooltip
+  // }
 
   override render() {
     // The actual tooltip render as a portal, so we only need to render the slot
-    return html`<slot @slotchange=${this._handleSlotchange}></slot>`;
+    return html`<slot></slot>`;
   }
 }
 

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -12,18 +12,6 @@ import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
 import { HoverController } from '../when-hover.js';
 
-/**
- * @example
- * ```html
- * <icon-button class="has-tool-tip" style="${tooltipStyle}">
- *    Button
- *    <tool-tip inert role="tooltip">Tooltip</tool-tip>
- * </icon-button>
- * ```
- * Reference to https://web.dev/building-a-tooltip-component/
- */
-export const tooltipStyle = css``;
-
 const styles = css`
   .blocksuite-tooltip {
     box-sizing: border-box;
@@ -187,7 +175,9 @@ export class Tooltip extends LitElement {
                     }
                   `}
             </style>
-            <div class="blocksuite-tooltip">${slottedChildren}</div>
+            <div class="blocksuite-tooltip" role="tooltip">
+              ${slottedChildren}
+            </div>
             <div class="arrow" style=${styleMap(arrowStyles)}></div>
           `;
         },

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -14,7 +14,7 @@ import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 import { HoverController } from '../when-hover.js';
 
 const styles = css`
-  .blocksuite-tooltip {
+  .affine-tooltip {
     box-sizing: border-box;
     max-width: 280px;
     min-height: 32px;
@@ -90,18 +90,18 @@ const updateArrowStyles = ({
  * ```ts
  * // Simple usage
  * html`
- * <blocksuite-tooltip>Content</blocksuite-tooltip>
+ * <affine-tooltip>Content</affine-tooltip>
  * `
  * // With placement
  * html`
- * <blocksuite-tooltip tip-position="top">
+ * <affine-tooltip tip-position="top">
  *   Content
- * </blocksuite-tooltip>
+ * </affine-tooltip>
  * `
  *
  * // With custom properties
  * html`
- * <blocksuite-tooltip
+ * <affine-tooltip
  *   .zIndex=${0}
  *   .offset=${4}
  *   .autoFlip=${true}
@@ -110,11 +110,11 @@ const updateArrowStyles = ({
  *   .allowInteractive=${false}
  * >
  *   Content
- * </blocksuite-tooltip>
+ * </affine-tooltip>
  * `
  * ```
  */
-@customElement('blocksuite-tooltip')
+@customElement('affine-tooltip')
 export class Tooltip extends LitElement {
   static override styles = css`
     :host {
@@ -198,9 +198,7 @@ export class Tooltip extends LitElement {
             <style>
               ${this._getStyles()}
             </style>
-            <div class="blocksuite-tooltip" role="tooltip">
-              ${slottedChildren}
-            </div>
+            <div class="affine-tooltip" role="tooltip">${slottedChildren}</div>
             <div class="arrow" style=${styleMap(arrowStyles)}></div>
           `;
         },
@@ -268,6 +266,6 @@ export class Tooltip extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'blocksuite-tooltip': Tooltip;
+    'affine-tooltip': Tooltip;
   }
 }

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -6,8 +6,7 @@ import {
   offset,
   type Placement,
 } from '@floating-ui/dom';
-import { baseTheme } from '@toeverything/theme';
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
@@ -23,158 +22,7 @@ import { HoverController } from '../when-hover.js';
  * ```
  * Reference to https://web.dev/building-a-tooltip-component/
  */
-export const tooltipStyle = css`
-  tool-tip {
-    --affine-tooltip-offset: 8px;
-    --affine-tooltip-round: 4px;
-    font-family: ${unsafeCSS(baseTheme.fontSansFamily)};
-    position: absolute;
-    inline-size: max-content;
-    text-align: center;
-    font-size: var(--affine-font-sm);
-    padding: 5px 12px;
-    color: var(--affine-white);
-    background: var(--affine-tooltip);
-    opacity: 0;
-    transition:
-      opacity 0.2s ease,
-      transform 0.2s ease;
-    pointer-events: none;
-    user-select: none;
-
-    /* Default is top-start */
-    left: 0;
-    top: 0;
-    border-radius: var(--affine-tooltip-round);
-    transform: translate(0, calc(-100% - var(--affine-tooltip-offset)));
-  }
-  tool-tip:is([tip-position='top']) {
-    left: 50%;
-    border-radius: var(--affine-tooltip-round);
-    transform: translate(-50%, calc(-100% - var(--affine-tooltip-offset)));
-  }
-  tool-tip:is([tip-position='right']) {
-    left: unset;
-    right: 0;
-    transform: translateX(calc(100% + var(--affine-tooltip-offset)));
-  }
-  tool-tip:is([tip-position='right']):not(:is([arrow])) {
-    border-top-left-radius: 0;
-  }
-  tool-tip:is([tip-position='left']) {
-    left: 0;
-    top: 50%;
-    transform: translate(calc(-100% - var(--affine-tooltip-offset)), -50%);
-  }
-  tool-tip:is([tip-position='bottom']) {
-    top: unset;
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, calc(100% + var(--affine-tooltip-offset)));
-  }
-
-  /** basic triangle style */
-  tool-tip:is([arrow])::before {
-    position: absolute;
-    content: '';
-    background: var(--affine-tooltip);
-    width: 10px;
-    height: 10px;
-    border-radius: 2px;
-    clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
-  }
-
-  /* work for tip-position='top' */
-  tool-tip:is([arrow]):is([tip-position='top']) {
-    transform: translate(-50%, calc(-100% - var(--affine-tooltip-offset) * 2));
-  }
-  tool-tip:is([arrow]):is([tip-position='top'])::before {
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, 40%) scaleX(0.8) rotate(135deg);
-  }
-
-  /* work for tip-position='right' */
-  tool-tip:is([arrow]):is([tip-position='right']) {
-    transform: translateX(calc(100% + var(--affine-tooltip-offset) * 2));
-  }
-  tool-tip:is([arrow]):is([tip-position='right'])::before {
-    left: 0;
-    bottom: 50%;
-    transform: translate(-40%, 50%) scaleY(0.8) rotate(-135deg);
-  }
-
-  /* work for tip-position='left' */
-  tool-tip:is([arrow]):is([tip-position='left']) {
-    transform: translate(calc(-100% - var(--affine-tooltip-offset) * 2), -50%);
-  }
-  tool-tip:is([arrow]):is([tip-position='left'])::before {
-    right: 0;
-    bottom: 50%;
-    transform: translate(40%, 50%) scaleY(0.8) rotate(45deg);
-  }
-
-  /* work for tip-position='bottom' */
-  tool-tip:is([arrow]):is([tip-position='bottom']) {
-    transform: translate(-50%, calc(100% + var(--affine-tooltip-offset) * 2));
-  }
-  tool-tip:is([arrow]):is([tip-position='bottom'])::before {
-    left: 50%;
-    bottom: 100%;
-    transform: translate(-50%, 60%) scaleX(0.8) rotate(-45deg);
-  }
-
-  /* work for tip-position='top-end' */
-  tool-tip:is([arrow]):is([tip-position='top-end']) {
-    transform: translate(-15%, calc(-100% - var(--affine-tooltip-offset) * 2));
-  }
-  tool-tip:is([arrow]):is([tip-position='top-end'])::before {
-    left: 30%;
-    bottom: 0;
-    transform: translate(-50%, 40%) scaleX(0.8) rotate(135deg);
-  }
-  /* work for tip-position='top-start' */
-  tool-tip:is([arrow]):is([tip-position='top-start']) {
-    transform: translate(-75%, calc(-100% - var(--affine-tooltip-offset) * 2));
-  }
-  tool-tip:is([arrow]):is([tip-position='top-start'])::before {
-    right: 5%;
-    bottom: 0;
-    transform: translate(-50%, 40%) scaleX(0.8) rotate(135deg);
-  }
-  .has-tool-tip {
-    position: relative;
-  }
-  .has-tool-tip:is(:hover, :focus-visible, :active) > tool-tip {
-    opacity: 1;
-    transition-delay: 200ms;
-  }
-  /** style for shortcut tooltip */
-  .tooltip-with-shortcut {
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: center;
-    gap: 10px;
-  }
-  .tooltip__shortcut {
-    font-size: 12px;
-    position: relative;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 16px;
-    min-width: 16px;
-  }
-  .tooltip__shortcut::before {
-    content: '';
-    border-radius: 4px;
-    position: absolute;
-    inset: 0;
-    background: currentColor;
-    opacity: 0.2;
-  }
-`;
+export const tooltipStyle = css``;
 
 const styles = css`
   :host {
@@ -221,6 +69,10 @@ export class Tooltip extends LitElement {
 
   @property({ attribute: true, type: Boolean })
   override hidden = false;
+
+  // TODO
+  @property({ attribute: false })
+  noArrow = false;
 
   @property({ attribute: false })
   allowInteractive = false;

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -56,7 +56,9 @@ const styles = css`
   }
 `;
 
-@customElement('blocksuite-tooltip')
+// TODO migrate to `blocksuite-tooltip`
+// @customElement('blocksuite-tooltip')
+@customElement('tool-tip')
 export class Tooltip extends LitElement {
   static override styles = css`
     :host {
@@ -192,6 +194,6 @@ export class Tooltip extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'blocksuite-tooltip': Tooltip;
+    'tool-tip': Tooltip;
   }
 }

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -26,7 +26,9 @@ export const tooltipStyle = css``;
 
 const styles = css`
   .blocksuite-tooltip {
+    box-sizing: border-box;
     max-width: 280px;
+    min-height: 32px;
     font-family: var(--affine-font-family);
     font-size: var(--affine-font-sm);
     border-radius: 4px;
@@ -194,7 +196,7 @@ export class Tooltip extends LitElement {
           placement: this.placement || 'top',
           middleware: [
             this.autoFlip && flip(),
-            offset(TRIANGLE_HEIGHT + this.offset),
+            offset((this.arrow ? TRIANGLE_HEIGHT : 0) + this.offset),
             arrow({
               element: portalRoot.shadowRoot!.querySelector('.arrow')!,
             }),
@@ -222,7 +224,8 @@ export class Tooltip extends LitElement {
   }
 
   override render() {
-    // The actual tooltip render as a portal, so we only need to render the slot
+    // The actual tooltip will render as a portal, and all content inside the slot will be treated as a template.
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots
     return html`<slot></slot>`;
   }
 }

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -209,7 +209,11 @@ export class Tooltip extends LitElement {
     super.connectedCallback();
     const parent = this.parentElement;
     assertExists(parent, 'Tooltip must have a parent element');
-    this._hoverController.setReference(parent);
+
+    // Wait for render
+    setTimeout(() => {
+      this._hoverController.setReference(parent);
+    }, 0);
   }
 
   getPortal() {

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -161,7 +161,8 @@ export class Tooltip extends LitElement {
           return html`
             <style>
               ${styles}
-              .tooltip {
+              :host {
+                z-index: var(--affine-z-index-popover);
                 ${
                 // All the styles are applied to the tooltip element
                 this.style.cssText

--- a/packages/blocks/src/components/tooltip/tooltip.ts
+++ b/packages/blocks/src/components/tooltip/tooltip.ts
@@ -84,9 +84,7 @@ const updateArrowStyles = ({
   };
 };
 
-// TODO migrate to `blocksuite-tooltip`
-// @customElement('blocksuite-tooltip')
-@customElement('tool-tip')
+@customElement('blocksuite-tooltip')
 export class Tooltip extends LitElement {
   static override styles = css`
     :host {
@@ -223,6 +221,6 @@ export class Tooltip extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'tool-tip': Tooltip;
+    'blocksuite-tooltip': Tooltip;
   }
 }

--- a/packages/blocks/src/components/when-hover.ts
+++ b/packages/blocks/src/components/when-hover.ts
@@ -98,6 +98,7 @@ export class HoverController implements ReactiveController {
   }
 
   hostDisconnected() {
+    this._abortController?.abort();
     this._disposables.dispose();
   }
 }

--- a/packages/blocks/src/database-block/common/header/tools/add-row/add-row.ts
+++ b/packages/blocks/src/database-block/common/header/tools/add-row/add-row.ts
@@ -23,18 +23,10 @@ const styles = css`
     cursor: grab;
   }
 
-  .new-record > tool-tip {
-    max-width: 280px;
-  }
-
   .new-record svg {
     width: 16px;
     height: 16px;
     fill: var(--affine-icon-color);
-  }
-
-  .edgeless .new-record > tool-tip {
-    display: none;
   }
 `;
 
@@ -164,7 +156,7 @@ export class DataViewHeaderToolsAddRow extends BaseTool {
       return;
     }
     return html` <div
-      class="has-tool-tip affine-database-toolbar-item new-record"
+      class="affine-database-toolbar-item new-record"
       draggable="true"
       @click="${this._onAddNewRecord}"
     >

--- a/packages/blocks/src/database-block/common/header/tools/search.ts
+++ b/packages/blocks/src/database-block/common/header/tools/search.ts
@@ -4,6 +4,7 @@ import { baseTheme } from '@toeverything/theme';
 import { css, html, unsafeCSS } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 import { stopPropagation } from '../../../../__internal__/utils/event.js';
 import {
@@ -49,14 +50,6 @@ const styles = css`
     padding-right: 8px;
     height: 100%;
     cursor: pointer;
-  }
-
-  .close-icon .code {
-    width: 31px;
-    height: 18px;
-    padding: 2px 6px;
-    border-radius: 4px;
-    background: var(--affine-white-10);
   }
 
   .affine-database-search-input-icon {
@@ -184,7 +177,18 @@ export class DataViewHeaderToolsSearch extends BaseTool<
         <div class="close-icon" @mousedown="${this._clearSearch}">
           ${DatabaseSearchClose}
           <blocksuite-tooltip>
-            <span class="code">Esc</span> to clear all
+            <span
+              style=${styleMap({
+                display: 'flex',
+                alignItems: 'center',
+                boxSizing: 'border-box',
+                padding: '2px 6px',
+                borderRadius: '4px',
+                background: 'var(--affine-white-10)',
+              })}
+              >Esc</span
+            >
+            to clear all
           </blocksuite-tooltip>
         </div>
       </label>

--- a/packages/blocks/src/database-block/common/header/tools/search.ts
+++ b/packages/blocks/src/database-block/common/header/tools/search.ts
@@ -183,9 +183,9 @@ export class DataViewHeaderToolsSearch extends BaseTool<
         />
         <div class="close-icon" @mousedown="${this._clearSearch}">
           ${DatabaseSearchClose}
-          <tool-tip inert arrow tip-position="top" role="tooltip">
+          <blocksuite-tooltip>
             <span class="code">Esc</span> to clear all
-          </tool-tip>
+          </blocksuite-tooltip>
         </div>
       </label>
     `;

--- a/packages/blocks/src/database-block/common/header/tools/search.ts
+++ b/packages/blocks/src/database-block/common/header/tools/search.ts
@@ -181,7 +181,7 @@ export class DataViewHeaderToolsSearch extends BaseTool<
           @pointerdown="${stopPropagation}"
           @blur="${this._onSearchBlur}"
         />
-        <div class="has-tool-tip close-icon" @mousedown="${this._clearSearch}">
+        <div class="close-icon" @mousedown="${this._clearSearch}">
           ${DatabaseSearchClose}
           <tool-tip inert arrow tip-position="top" role="tooltip">
             <span class="code">Esc</span> to clear all

--- a/packages/blocks/src/database-block/common/header/tools/search.ts
+++ b/packages/blocks/src/database-block/common/header/tools/search.ts
@@ -176,7 +176,7 @@ export class DataViewHeaderToolsSearch extends BaseTool<
         />
         <div class="close-icon" @mousedown="${this._clearSearch}">
           ${DatabaseSearchClose}
-          <blocksuite-tooltip>
+          <affine-tooltip>
             <span
               style=${styleMap({
                 display: 'flex',
@@ -189,7 +189,7 @@ export class DataViewHeaderToolsSearch extends BaseTool<
               >Esc</span
             >
             to clear all
-          </blocksuite-tooltip>
+          </affine-tooltip>
         </div>
       </label>
     `;

--- a/packages/blocks/src/database-block/table/table-view.ts
+++ b/packages/blocks/src/database-block/table/table-view.ts
@@ -10,7 +10,6 @@ import { html } from 'lit/static-html.js';
 
 import type { TableViewSelection } from '../../__internal__/index.js';
 import { popMenu } from '../../components/menu/index.js';
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 import { renderUniLit } from '../../components/uni-component/uni-component.js';
 import { AddCursorIcon } from '../../icons/index.js';
 import { BaseDataView } from '../common/base-data-view.js';
@@ -126,7 +125,6 @@ const styles = css`
     justify-content: center;
     align-items: flex-start;
   }
-  ${tooltipStyle}
 `;
 
 @customElement('affine-database-table')

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -99,11 +99,11 @@ export class EdgelessToolIconButton extends LitElement {
       >
         <slot></slot>
         ${tooltip
-          ? html`<blocksuite-tooltip
+          ? html`<affine-tooltip
               tip-position=${this.tipPosition}
               .arrow=${this.arrow}
               .offset=${this.tooltipOffset}
-              >${tooltip}</blocksuite-tooltip
+              >${tooltip}</affine-tooltip
             >`
           : nothing}
       </div>

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -56,6 +56,9 @@ export class EdgelessToolIconButton extends LitElement {
   arrow = true;
 
   @property({ attribute: false })
+  tooltipOffset = 8;
+
+  @property({ attribute: false })
   active = false;
 
   @property({ attribute: false })
@@ -99,6 +102,7 @@ export class EdgelessToolIconButton extends LitElement {
           ? html`<blocksuite-tooltip
               tip-position=${this.tipPosition}
               .arrow=${this.arrow}
+              .offset=${this.tooltipOffset}
               >${tooltip}</blocksuite-tooltip
             >`
           : nothing}

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -37,14 +37,6 @@ export class EdgelessToolIconButton extends LitElement {
       cursor: not-allowed;
       color: var(--affine-text-disable-color);
     }
-
-    tool-tip {
-      z-index: 12;
-    }
-
-    tool-tip:is([arrow]):is([tip-position='top'])::before {
-      margin-top: -4px;
-    }
   `;
 
   @property({ attribute: false })

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -3,8 +3,6 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { tooltipStyle } from '../../../../components/tooltip/tooltip.js';
-
 @customElement('edgeless-tool-icon-button')
 export class EdgelessToolIconButton extends LitElement {
   static override styles = css`
@@ -39,8 +37,6 @@ export class EdgelessToolIconButton extends LitElement {
       cursor: not-allowed;
       color: var(--affine-text-disable-color);
     }
-
-    ${tooltipStyle}
 
     tool-tip {
       z-index: 12;

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -1,3 +1,4 @@
+import type { Placement } from '@floating-ui/dom';
 import type { TemplateResult } from 'lit';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -49,8 +50,7 @@ export class EdgelessToolIconButton extends LitElement {
   tooltip!: string | TemplateResult<1>;
 
   @property({ attribute: false })
-  tipPosition: 'top' | 'bottom' | 'left' | 'right' | 'top-end' | 'top-start' =
-    'top';
+  tipPosition: Placement = 'top';
 
   @property({ attribute: false })
   arrow = true;
@@ -96,12 +96,10 @@ export class EdgelessToolIconButton extends LitElement {
       >
         <slot></slot>
         ${tooltip
-          ? html`<tool-tip
-              inert
-              role="tooltip"
+          ? html`<blocksuite-tooltip
               tip-position=${this.tipPosition}
-              ?arrow=${this.arrow}
-              >${tooltip}</tool-tip
+              .arrow=${this.arrow}
+              >${tooltip}</blocksuite-tooltip
             >`
           : nothing}
       </div>

--- a/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/tool-icon-button.ts
@@ -81,7 +81,7 @@ export class EdgelessToolIconButton extends LitElement {
 
   override render() {
     const tooltip = this.coming ? '(Coming soon)' : this.tooltip;
-    const classnames = `icon-container has-tool-tip active-mode-${this.activeMode}`;
+    const classnames = `icon-container active-mode-${this.activeMode}`;
     const iconContainerStyles = styleMap({
       '--icon-container-padding': `${this.iconContainerPadding}px`,
     });

--- a/packages/blocks/src/page-block/edgeless/components/buttons/toolbar-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/toolbar-button.ts
@@ -1,7 +1,6 @@
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { tooltipStyle } from '../../../../components/tooltip/tooltip.js';
 import { EdgelessToolIconButton } from './tool-icon-button.js';
 
 @customElement('edgeless-toolbar-button')
@@ -35,8 +34,6 @@ export class EdgelessToolbarButton extends EdgelessToolIconButton {
       cursor: not-allowed;
       color: var(--affine-text-disable-color);
     }
-
-    ${tooltipStyle}
 
     tool-tip {
       z-index: 12;

--- a/packages/blocks/src/page-block/edgeless/components/buttons/toolbar-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/buttons/toolbar-button.ts
@@ -34,10 +34,6 @@ export class EdgelessToolbarButton extends EdgelessToolIconButton {
       cursor: not-allowed;
       color: var(--affine-text-disable-color);
     }
-
-    tool-tip {
-      z-index: 12;
-    }
   `;
 
   override render() {

--- a/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
@@ -111,7 +111,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
   @property({ attribute: false })
   hasTooltip = true;
 
-  @query('.line-width-panel.has-tool-tip')
+  @query('.line-width-panel')
   private _lineWidthPanel!: HTMLElement;
 
   @query('.line-width-overlay')
@@ -314,7 +314,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
 
   override render() {
     return html`<div
-      class="line-width-panel has-tool-tip"
+      class="line-width-panel"
       @mousedown="${(e: Event) => e.preventDefault()}"
     >
       <div class="line-width-button">

--- a/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
@@ -339,7 +339,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
       <div class="bottom-line"></div>
       <div class="line-width-overlay"></div>
       ${this.hasTooltip
-        ? html`<blocksuite-tooltip>Thickness</blocksuite-tooltip>`
+        ? html`<affine-tooltip>Thickness</affine-tooltip>`
         : nothing}
     </div>`;
   }

--- a/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
@@ -339,9 +339,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
       <div class="bottom-line"></div>
       <div class="line-width-overlay"></div>
       ${this.hasTooltip
-        ? html`<tool-tip inert role="tooltip" tip-position="top" arrow>
-            Thickness
-          </tool-tip>`
+        ? html`<blocksuite-tooltip>Thickness</blocksuite-tooltip>`
         : nothing}
     </div>`;
   }

--- a/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
@@ -103,11 +103,6 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
       background-color: var(--affine-icon-color);
       z-index: 1;
     }
-
-    tool-tip {
-      z-index: 12;
-      top: -8px;
-    }
   `;
 
   @property({ attribute: false })

--- a/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/page-block/edgeless/components/panel/line-width-panel.ts
@@ -3,7 +3,6 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query, queryAll } from 'lit/decorators.js';
 
 import { LineWidth } from '../../../../__internal__/utils/types.js';
-import { tooltipStyle } from '../../../../components/tooltip/tooltip.js';
 
 type DragConfig = {
   stepWidth: number;
@@ -104,8 +103,6 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
       background-color: var(--affine-icon-color);
       z-index: 1;
     }
-
-    ${tooltipStyle}
 
     tool-tip {
       z-index: 12;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -131,6 +131,7 @@ export class EdgelessBrushToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-toolbar-button
         .tooltip=${this._brushMenu ? '' : getTooltipWithShortcut('Pen', 'P')}
+        .tooltipOffset=${4}
         .active=${type === 'brush'}
         @click=${() => {
           this.setEdgelessTool({

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-menu.ts
@@ -9,7 +9,6 @@ import {
   type LineWidth,
 } from '../../../../../__internal__/index.js';
 import type { CssVariableName } from '../../../../../__internal__/theme/css-variables.js';
-import { tooltipStyle } from '../../../../../components/tooltip/tooltip.js';
 import {
   ConnectorCWithArrowIcon,
   ConnectorLWithArrowIcon,
@@ -105,12 +104,6 @@ export class EdgelessConnectorMenu extends LitElement {
       margin: 0 16px;
       background-color: var(--affine-border-color);
       display: inline-block;
-    }
-
-    ${tooltipStyle}
-
-    tool-tip {
-      z-index: 12;
     }
   `;
 

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -97,6 +97,7 @@ export class EdgelessConnectorToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-tool-icon-button
         .tooltip=${this._connectorMenu ? '' : 'Connector'}
+        .tooltipOffset=${17}
         .active=${type === 'connector'}
         .iconContainerPadding=${8}
         class="edgeless-connector-button"

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/default/default-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/default/default-tool-button.ts
@@ -93,6 +93,7 @@ export class EdgelessDefaultToolButton extends WithDisposable(LitElement) {
         .tooltip=${type === 'pan'
           ? getTooltipWithShortcut('Hand', 'H')
           : getTooltipWithShortcut('Select', 'V')}
+        .tooltipOffset=${17}
         .active=${type === 'default' || type === 'pan'}
         .iconContainerPadding=${8}
         @click=${this._changeTool}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -422,6 +422,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
         ></edgeless-brush-tool-button>
         <edgeless-toolbar-button
           .tooltip=${getTooltipWithShortcut('Eraser', 'E')}
+          .tooltipOffset=${4}
           .active=${type === 'eraser'}
           @click=${() => this.setEdgelessTool({ type: 'eraser' })}
         >
@@ -449,6 +450,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
           .disabled=${this._imageLoading}
           .activeMode=${'background'}
           .tooltip=${'Image'}
+          .tooltipOffset=${12}
           @click=${() => this._addImages()}
         >
           ${EdgelessImageIcon}
@@ -483,6 +485,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           .tooltip=${'Presentation'}
+          .tooltipOffset=${17}
           .iconContainerPadding=${8}
           @click=${() => {
             this._index = this._currentFrameIndex;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-tool-button.ts
@@ -90,6 +90,7 @@ export class EdgelessFrameToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-tool-icon-button
         .tooltip=${this._frameMenu ? '' : getTooltipWithShortcut('Frame', 'F')}
+        .tooltipOffset=${17}
         .active=${type === 'frame'}
         .iconContainerPadding=${8}
         @click=${() => {

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
@@ -102,6 +102,7 @@ export class EdgelessNoteToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-tool-icon-button
         .tooltip=${this._noteMenu ? '' : getTooltipWithShortcut('Note', 'N')}
+        .tooltipOffset=${17}
         .active=${type === 'note'}
         .iconContainerPadding=${8}
         @click=${() => {

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -233,6 +233,7 @@ export class EdgelessShapeToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-toolbar-button
         .tooltip=${this._shapeMenu ? '' : getTooltipWithShortcut('Shape', 'S')}
+        .tooltipOffset=${5}
         .active=${type === 'shape'}
       >
         <div class="container-clip">

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
@@ -109,6 +109,7 @@ export class EdgelessTextToolButton extends WithDisposable(LitElement) {
     return html`
       <edgeless-toolbar-button
         .tooltip=${this._textMenu ? '' : getTooltipWithShortcut('Text', 'T')}
+        .tooltipOffset=${15}
         .active=${type === 'text'}
         .activeMode=${'background'}
         @click=${() => {

--- a/packages/blocks/src/page-block/edgeless/components/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/components/utils.ts
@@ -123,10 +123,40 @@ export function createButtonPopper(
 }
 
 export function getTooltipWithShortcut(tip: string, shortcut: string) {
-  return html`<div class="tooltip-with-shortcut">
-    <span class="tooltip__label">${tip}</span>
-    <span class="tooltip__shortcut">${shortcut}</span>
-  </div>`;
+  // style for shortcut tooltip
+  const styles = css`
+    .tooltip-with-shortcut {
+      display: flex;
+      flex-wrap: nowrap;
+      align-items: center;
+      gap: 10px;
+    }
+    .tooltip__shortcut {
+      font-size: 12px;
+      position: relative;
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 16px;
+      min-width: 16px;
+    }
+    .tooltip__shortcut::before {
+      content: '';
+      border-radius: 4px;
+      position: absolute;
+      inset: 0;
+      background: currentColor;
+      opacity: 0.2;
+    }
+  `;
+  return html`<style>
+      ${styles}
+    </style>
+    <div class="tooltip-with-shortcut">
+      <span class="tooltip__label">${tip}</span>
+      <span class="tooltip__shortcut">${shortcut}</span>
+    </div>`;
 }
 
 export function readImageSize(file: File) {

--- a/packages/blocks/src/widgets/format-bar/components/action-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/action-items.ts
@@ -15,7 +15,6 @@ export const ActionItems = (root: BlockSuiteRoot) =>
           >`;
       return html`<icon-button
         size="32px"
-        class="has-tool-tip"
         data-testid=${id}
         ?disabled=${!enabled}
         @click=${() => enabled && action(root)}

--- a/packages/blocks/src/widgets/format-bar/components/action-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/action-items.ts
@@ -9,10 +9,8 @@ export const ActionItems = (root: BlockSuiteRoot) =>
     .map(({ id, name, icon, action, enabledWhen, disabledToolTip }) => {
       const enabled = enabledWhen(root);
       const toolTip = enabled
-        ? html`<tool-tip inert role="tooltip">${name}</tool-tip>`
-        : html`<tool-tip tip-position="top" inert role="tooltip"
-            >${disabledToolTip}</tool-tip
-          >`;
+        ? html`<blocksuite-tooltip>${name}</blocksuite-tooltip>`
+        : html`<blocksuite-tooltip>${disabledToolTip}</blocksuite-tooltip>`;
       return html`<icon-button
         size="32px"
         data-testid=${id}

--- a/packages/blocks/src/widgets/format-bar/components/action-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/action-items.ts
@@ -9,8 +9,8 @@ export const ActionItems = (root: BlockSuiteRoot) =>
     .map(({ id, name, icon, action, enabledWhen, disabledToolTip }) => {
       const enabled = enabledWhen(root);
       const toolTip = enabled
-        ? html`<blocksuite-tooltip>${name}</blocksuite-tooltip>`
-        : html`<blocksuite-tooltip>${disabledToolTip}</blocksuite-tooltip>`;
+        ? html`<affine-tooltip>${name}</affine-tooltip>`
+        : html`<affine-tooltip>${disabledToolTip}</affine-tooltip>`;
       return html`<icon-button
         size="32px"
         data-testid=${id}

--- a/packages/blocks/src/widgets/format-bar/components/inline-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/inline-items.ts
@@ -18,7 +18,6 @@ export const InlineItems = (formatBar: AffineFormatBarWidget) => {
       ({ id, name, icon, action, activeWhen }) =>
         html`<icon-button
           size="32px"
-          class="has-tool-tip"
           data-testid=${id}
           ?active=${activeWhen(root)}
           @click=${() => {

--- a/packages/blocks/src/widgets/format-bar/components/inline-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/inline-items.ts
@@ -26,7 +26,7 @@ export const InlineItems = (formatBar: AffineFormatBarWidget) => {
           }}
         >
           ${icon}
-          <tool-tip inert role="tooltip">${name}</tool-tip>
+          <blocksuite-tooltip>${name}</blocksuite-tooltip>
         </icon-button>`
     )}
     <div class="divider"></div>

--- a/packages/blocks/src/widgets/format-bar/components/inline-items.ts
+++ b/packages/blocks/src/widgets/format-bar/components/inline-items.ts
@@ -26,7 +26,7 @@ export const InlineItems = (formatBar: AffineFormatBarWidget) => {
           }}
         >
           ${icon}
-          <blocksuite-tooltip>${name}</blocksuite-tooltip>
+          <affine-tooltip>${name}</affine-tooltip>
         </icon-button>`
     )}
     <div class="divider"></div>

--- a/packages/blocks/src/widgets/format-bar/styles.ts
+++ b/packages/blocks/src/widgets/format-bar/styles.ts
@@ -1,7 +1,5 @@
 import { css } from 'lit';
 
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
-
 const paragraphButtonStyle = css`
   .paragraph-button-icon > svg:nth-child(2) {
     transition-duration: 0.3s;
@@ -77,5 +75,4 @@ export const formatBarStyle = css`
   }
 
   ${paragraphButtonStyle}
-  ${tooltipStyle}
 `;

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -58,11 +58,11 @@ export function ImageOptionsTemplate({
         background-color: var(--affine-background-overlay-panel-color);
         margin: 0;
       }
-      .has-tool-tip.delete-image-button:hover {
+      .delete-image-button:hover {
         background: var(--affine-background-error-color);
         color: var(--affine-error-color);
       }
-      .has-tool-tip.delete-image-button:hover > svg {
+      .delete-image-button:hover > svg {
         color: var(--affine-error-color);
       }
     </style>
@@ -75,7 +75,6 @@ export function ImageOptionsTemplate({
       <div class="embed-editing-state">
         ${supportAttachment
           ? html`<icon-button
-              class="has-tool-tip"
               size="32px"
               ?hidden=${readonly}
               @click=${() => {
@@ -88,7 +87,6 @@ export function ImageOptionsTemplate({
             </icon-button>`
           : nothing}
         <icon-button
-          class="has-tool-tip"
           size="32px"
           ?hidden=${readonly}
           @click=${() => focusCaption(model)}
@@ -96,28 +94,20 @@ export function ImageOptionsTemplate({
           ${CaptionIcon}
           <tool-tip inert tip-position="right" role="tooltip">Caption</tool-tip>
         </icon-button>
-        <icon-button
-          class="has-tool-tip"
-          size="32px"
-          @click=${() => downloadImage(model)}
-        >
+        <icon-button size="32px" @click=${() => downloadImage(model)}>
           ${DownloadIcon}
           <tool-tip inert tip-position="right" role="tooltip"
             >Download</tool-tip
           >
         </icon-button>
-        <icon-button
-          class="has-tool-tip"
-          size="32px"
-          @click=${() => copyImage(model)}
-        >
+        <icon-button size="32px" @click=${() => copyImage(model)}>
           ${CopyIcon}
           <tool-tip inert tip-position="right" role="tooltip"
             >Copy to clipboard</tool-tip
           >
         </icon-button>
         <icon-button
-          class="has-tool-tip delete-image-button"
+          class="delete-image-button"
           size="32px"
           ?hidden=${readonly}
           @click="${() => {
@@ -129,7 +119,6 @@ export function ImageOptionsTemplate({
           <tool-tip inert tip-position="right" role="tooltip">Delete</tool-tip>
         </icon-button>
         <icon-button
-          class="has-tool-tip"
           size="32px"
           ?hidden=${readonly ||
           !model.page.awarenessStore.getFlag('enable_bultin_ledits')}

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -83,7 +83,7 @@ export function ImageOptionsTemplate({
               }}
             >
               ${BookmarkIcon}
-              <tool-tip inert role="tooltip">Turn into Card view</tool-tip>
+              <blocksuite-tooltip>Turn into Card view</blocksuite-tooltip>
             </icon-button>`
           : nothing}
         <icon-button
@@ -92,18 +92,16 @@ export function ImageOptionsTemplate({
           @click=${() => focusCaption(model)}
         >
           ${CaptionIcon}
-          <tool-tip inert tip-position="right" role="tooltip">Caption</tool-tip>
+          <blocksuite-tooltip tip-position="right">Caption</blocksuite-tooltip>
         </icon-button>
         <icon-button size="32px" @click=${() => downloadImage(model)}>
           ${DownloadIcon}
-          <tool-tip inert tip-position="right" role="tooltip"
-            >Download</tool-tip
-          >
+          <blocksuite-tooltip tip-position="right">Download</blocksuite-tooltip>
         </icon-button>
         <icon-button size="32px" @click=${() => copyImage(model)}>
           ${CopyIcon}
-          <tool-tip inert tip-position="right" role="tooltip"
-            >Copy to clipboard</tool-tip
+          <blocksuite-tooltip tip-position="right"
+            >Copy to clipboard</blocksuite-tooltip
           >
         </icon-button>
         <icon-button
@@ -116,7 +114,7 @@ export function ImageOptionsTemplate({
           }}"
         >
           ${DeleteIcon}
-          <tool-tip inert tip-position="right" role="tooltip">Delete</tool-tip>
+          <blocksuite-tooltip tip-position="right">Delete</blocksuite-tooltip>
         </icon-button>
         <icon-button
           size="32px"
@@ -128,8 +126,8 @@ export function ImageOptionsTemplate({
           }}"
         >
           ${HighLightDuotoneIcon}
-          <tool-tip inert tip-position="right" role="tooltip"
-            >Edit with LEDITS</tool-tip
+          <blocksuite-tooltip tip-position="right"
+            >Edit with LEDITS</blocksuite-tooltip
           >
         </icon-button>
       </div>

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -4,7 +4,6 @@ import { ref, type RefOrCallback } from 'lit/directives/ref.js';
 
 import { stopPropagation } from '../../__internal__/utils/event.js';
 import { turnImageIntoCardView } from '../../attachment-block/utils.js';
-import { tooltipStyle } from '../../components/tooltip/tooltip.js';
 import {
   BookmarkIcon,
   CaptionIcon,
@@ -66,8 +65,6 @@ export function ImageOptionsTemplate({
       .has-tool-tip.delete-image-button:hover > svg {
         color: var(--affine-error-color);
       }
-
-      ${tooltipStyle}
     </style>
 
     <div

--- a/packages/blocks/src/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/widgets/image-toolbar/image-options.ts
@@ -83,7 +83,7 @@ export function ImageOptionsTemplate({
               }}
             >
               ${BookmarkIcon}
-              <blocksuite-tooltip>Turn into Card view</blocksuite-tooltip>
+              <affine-tooltip>Turn into Card view</affine-tooltip>
             </icon-button>`
           : nothing}
         <icon-button
@@ -92,16 +92,16 @@ export function ImageOptionsTemplate({
           @click=${() => focusCaption(model)}
         >
           ${CaptionIcon}
-          <blocksuite-tooltip tip-position="right">Caption</blocksuite-tooltip>
+          <affine-tooltip tip-position="right">Caption</affine-tooltip>
         </icon-button>
         <icon-button size="32px" @click=${() => downloadImage(model)}>
           ${DownloadIcon}
-          <blocksuite-tooltip tip-position="right">Download</blocksuite-tooltip>
+          <affine-tooltip tip-position="right">Download</affine-tooltip>
         </icon-button>
         <icon-button size="32px" @click=${() => copyImage(model)}>
           ${CopyIcon}
-          <blocksuite-tooltip tip-position="right"
-            >Copy to clipboard</blocksuite-tooltip
+          <affine-tooltip tip-position="right"
+            >Copy to clipboard</affine-tooltip
           >
         </icon-button>
         <icon-button
@@ -114,7 +114,7 @@ export function ImageOptionsTemplate({
           }}"
         >
           ${DeleteIcon}
-          <blocksuite-tooltip tip-position="right">Delete</blocksuite-tooltip>
+          <affine-tooltip tip-position="right">Delete</affine-tooltip>
         </icon-button>
         <icon-button
           size="32px"
@@ -126,9 +126,7 @@ export function ImageOptionsTemplate({
           }}"
         >
           ${HighLightDuotoneIcon}
-          <blocksuite-tooltip tip-position="right"
-            >Edit with LEDITS</blocksuite-tooltip
-          >
+          <affine-tooltip tip-position="right">Edit with LEDITS</affine-tooltip>
         </icon-button>
       </div>
     </div>

--- a/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
@@ -711,9 +711,9 @@ export class ImportPage extends WithDisposable(LitElement) {
               @click="${this._openLearnImportLink}"
             >
               ${HelpIcon}
-              <blocksuite-tooltip>
+              <affine-tooltip>
                 Learn how to Import your Notion pages into AFFiNE.
-              </blocksuite-tooltip>
+              </affine-tooltip>
             </div>
           </icon-button>
           <icon-button class="button-item" text="Coming soon..." disabled>

--- a/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
@@ -707,7 +707,7 @@ export class ImportPage extends WithDisposable(LitElement) {
             ${NotionIcon}
             <div
               slot="suffix"
-              class="button-suffix has-tool-tip"
+              class="button-suffix"
               @click="${this._openLearnImportLink}"
             >
               ${HelpIcon}

--- a/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
@@ -711,9 +711,9 @@ export class ImportPage extends WithDisposable(LitElement) {
               @click="${this._openLearnImportLink}"
             >
               ${HelpIcon}
-              <tool-tip inert arrow tip-position="top" role="tooltip">
+              <blocksuite-tooltip>
                 Learn how to Import your Notion pages into AFFiNE.
-              </tool-tip>
+              </blocksuite-tooltip>
             </div>
           </icon-button>
           <icon-button class="button-item" text="Coming soon..." disabled>

--- a/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/import-page.ts
@@ -707,7 +707,7 @@ export class ImportPage extends WithDisposable(LitElement) {
             ${NotionIcon}
             <div
               slot="suffix"
-              class="has-tool-tip"
+              class="button-suffix has-tool-tip"
               @click="${this._openLearnImportLink}"
             >
               ${HelpIcon}

--- a/packages/blocks/src/widgets/linked-page/import-page/styles.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/styles.ts
@@ -72,7 +72,7 @@ export const styles = css`
     align-items: center;
   }
 
-  .has-tool-tip {
+  .button-suffix {
     display: flex;
     margin-left: auto;
   }

--- a/packages/blocks/src/widgets/linked-page/import-page/styles.ts
+++ b/packages/blocks/src/widgets/linked-page/import-page/styles.ts
@@ -1,8 +1,6 @@
 import { baseTheme } from '@toeverything/theme';
 import { css, unsafeCSS } from 'lit';
 
-import { tooltipStyle } from '../../../components/tooltip/tooltip.js';
-
 export const styles = css`
   .container {
     position: absolute;
@@ -87,6 +85,4 @@ export const styles = css`
     height: 100vh;
     z-index: var(--affine-z-index-popover);
   }
-
-  ${tooltipStyle}
 `;

--- a/packages/global/src/utils/misc.ts
+++ b/packages/global/src/utils/misc.ts
@@ -109,6 +109,12 @@ export const whenHover = (
 
   const addHoverListener = (element?: Element) => {
     if (!element) return;
+    // see https://stackoverflow.com/questions/14795099/pure-javascript-to-check-if-something-has-hover-without-setting-on-mouseover-ou
+    const alreadyHover = element.matches(':hover');
+    if (alreadyHover && !abortController.signal.aborted) {
+      // When the element is already hovered, we need to trigger the callback manually
+      onHover(new MouseEvent('mouseover'));
+    }
     element.addEventListener('mouseover', onHover, {
       signal: abortController.signal,
     });

--- a/tests/block-hub.spec.ts
+++ b/tests/block-hub.spec.ts
@@ -305,7 +305,7 @@ test('drag Heading1 block from text menu into text area and blockHub text cards 
 
   const headingPos = await getCenterPosition(
     page,
-    '.has-tool-tip[affine-flavour="affine:paragraph"][affine-type="h1"]'
+    '.card-container[affine-flavour="affine:paragraph"][affine-type="h1"]'
   );
   const targetPos = await getCenterPosition(page, '[data-block-id="2"]');
   await dragBetweenCoords(
@@ -365,7 +365,7 @@ test('drag numbered list block from list menu into text area and blockHub list c
 
   const numberedListPos = await getCenterPosition(
     page,
-    '.has-tool-tip[affine-flavour="affine:list"][affine-type="numbered"]'
+    '.card-container[affine-flavour="affine:list"][affine-type="numbered"]'
   );
   const targetPos = await getCenterPosition(page, '[data-block-id="2"]');
   await dragBetweenCoords(
@@ -425,7 +425,7 @@ test('should auto hide card list when dragging a card', async ({ page }) => {
 
   const numberedListPos = await getCenterPosition(
     page,
-    '.has-tool-tip[affine-flavour="affine:list"][affine-type="numbered"]'
+    '.card-container[affine-flavour="affine:list"][affine-type="numbered"]'
   );
   const targetPos = await getCenterPosition(page, '[data-block-id="2"]');
   await dragBetweenCoords(

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -78,7 +78,7 @@ test(scoped`create bookmark by blockhub`, async ({ page }) => {
   );
   await expect(blockHubListContainer).toBeVisible();
   await page.click(
-    '.has-tool-tip[affine-flavour="affine:bookmark"][affine-type="bookmark"]'
+    '.card-container[affine-flavour="affine:bookmark"][affine-type="bookmark"]'
   );
   await page.waitForTimeout(200);
   await type(page, inputUrl);

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -215,7 +215,7 @@ test('the tooltip of more button should be hidden when the action menu is shown'
   await expect(moreButton).toBeVisible();
 
   const moreButtonBox = await moreButton.boundingBox();
-  const tooltip = page.locator('.blocksuite-tooltip');
+  const tooltip = page.locator('.affine-tooltip');
 
   assertExists(moreButtonBox);
 

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -215,7 +215,7 @@ test('the tooltip of more button should be hidden when the action menu is shown'
   await expect(moreButton).toBeVisible();
 
   const moreButtonBox = await moreButton.boundingBox();
-  const tooltip = moreButton.locator('tool-tip');
+  const tooltip = page.locator('.blocksuite-tooltip');
 
   assertExists(moreButtonBox);
 

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -164,7 +164,7 @@ test('the tooltip of shape tool button should be hidden when the shape menu is s
 
   const shapeTool = locatorEdgelessToolButton(page, 'shape');
   const shapeToolBox = await shapeTool.boundingBox();
-  const tooltip = page.locator('.blocksuite-tooltip');
+  const tooltip = page.locator('.affine-tooltip');
 
   assertExists(shapeToolBox);
 

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -164,7 +164,7 @@ test('the tooltip of shape tool button should be hidden when the shape menu is s
 
   const shapeTool = locatorEdgelessToolButton(page, 'shape');
   const shapeToolBox = await shapeTool.boundingBox();
-  const tooltip = shapeTool.locator('tool-tip');
+  const tooltip = page.locator('.blocksuite-tooltip');
 
   assertExists(shapeToolBox);
 


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/3744

Sunsetting `tool-tip`. The new `affine-tooltip` is a portal, so it will not be affected by overflow, and it uses the floating API, ensuring that it won't exceed the window.

https://github.com/toeverything/blocksuite/assets/18554747/b928943a-94ee-403e-b688-8b0ce51e7df3

## Motivation

The legacy `tool-tip` was introduced at https://github.com/toeverything/blocksuite/pull/178 last year. The `tool-tip` is so simple, it only has a few styles. It works well but can be blocked or extend beyond the window.

## Migrate guide

```diff
- <icon-button class="has-tool-tip" style="${tooltipStyle}">
-   <tool-tip inert tip-position="top" role="tooltip">Preview</tool-tip>
+ <icon-button>
+   <affine-tooltip tip-position="top">Preview</affine-tooltip>
</icon-button>
```

## API

```ts
 // Simple usage
 html`
 <blocksuite-tooltip>Content</blocksuite-tooltip>
 `
 // With placement
 html`
 <affine-tooltip tip-position="top">
   Content
 </affine-tooltip>
 `

 // With custom properties
 html`
 <affine-tooltip
   .zIndex=${0}
   .offset=${4}
   .autoFlip=${true}
   .arrow=${true}
   .tooltipStyle=${css`:host { z-index: 0; --affine-tooltip: #fff; }`}
   .allowInteractive=${false}
 >
   Content
 </affine-tooltip>
 `
```

## Drawbacks

In order to make the tooltip usage simpler, the content in the `slot` will be **cloned** to the portal. This causes the tooltip to be unable to show dynamic content and cannot add event listeners.

```html
// Need to clone the static slot content
<affine-tooltip>slot content</affine-tooltip>

// No above-mentioned drawbacks, but it decreases developer-friendliness.
<affine-tooltip .template=${html`content`}></affine-tooltip>
```


