### PR TITLE
feat(edgeless): open secondary menu when evoke shape tool

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -130,6 +130,7 @@ export class EdgelessBrushToolButton extends WithDisposable(LitElement) {
 
     return html`
       <edgeless-toolbar-button
+        class="edgeless-brush-button"
         .tooltip=${this._brushMenu ? '' : getTooltipWithShortcut('Pen', 'P')}
         .tooltipOffset=${4}
         .active=${type === 'brush'}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -421,6 +421,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
           .setEdgelessTool=${this.setEdgelessTool}
         ></edgeless-brush-tool-button>
         <edgeless-toolbar-button
+          class="edgeless-eraser-button"
           .tooltip=${getTooltipWithShortcut('Eraser', 'E')}
           .tooltipOffset=${4}
           .active=${type === 'eraser'}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
@@ -101,6 +101,7 @@ export class EdgelessNoteToolButton extends WithDisposable(LitElement) {
     const arrowColor = type === 'note' ? 'currentColor' : '#77757D';
     return html`
       <edgeless-tool-icon-button
+        class="edgeless-note-button"
         .tooltip=${this._noteMenu ? '' : getTooltipWithShortcut('Note', 'N')}
         .tooltipOffset=${17}
         .active=${type === 'note'}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -229,8 +229,7 @@ export class EdgelessShapeToolButton extends WithDisposable(LitElement) {
           this._shapeToolLocalState?.strokeColor ?? DEFAULT_SHAPE_STROKE_COLOR,
         shapeStyle: this._shapeToolLocalState?.shapeStyle ?? ShapeStyle.General,
       });
-    }
-    if (this.edgelessTool.type === 'shape') {
+    } else {
       this._closeShapeMenu();
       this.setEdgelessTool({ type: 'default' });
     }

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -239,6 +239,7 @@ export class EdgelessShapeToolButton extends WithDisposable(LitElement) {
     const type = this.edgelessTool?.type;
     return html`
       <edgeless-toolbar-button
+        class="edgeless-shape-button"
         .tooltip=${this._shapeMenu ? '' : getTooltipWithShortcut('Shape', 'S')}
         .tooltipOffset=${5}
         .active=${type === 'shape'}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
@@ -108,6 +108,7 @@ export class EdgelessTextToolButton extends WithDisposable(LitElement) {
 
     return html`
       <edgeless-toolbar-button
+        class="edgeless-text-button"
         .tooltip=${this._textMenu ? '' : getTooltipWithShortcut('Text', 'T')}
         .tooltipOffset=${15}
         .active=${type === 'text'}

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -100,14 +100,14 @@ export function locatorEdgelessToolButton(
   innerContainer = true
 ) {
   const selector = {
-    default: '.edgeless-default-button.default',
-    pan: '.edgeless-default-button.pan',
+    default: '.edgeless-default-button',
+    pan: '.edgeless-default-button',
     shape: '.edgeless-shape-button',
     brush: '.edgeless-brush-button',
     eraser: '.edgeless-eraser-button',
     text: '.edgeless-text-button',
     connector: '.edgeless-connector-button',
-    note: '.edgeless-text-button',
+    note: '.edgeless-note-button',
   }[type];
 
   let buttonType;

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -92,26 +92,22 @@ type SpecialEdgelessTool = 'shape' | 'brush' | 'eraser' | 'text' | 'connector';
 
 type EdgelessTool = BasicEdgelessTool | SpecialEdgelessTool;
 type ZoomToolType = 'zoomIn' | 'zoomOut' | 'fitToScreen';
-type ToolType = EdgelessTool | ZoomToolType;
 type ComponentToolType = 'shape' | 'thin' | 'thick' | 'brush' | 'more';
 
 export function locatorEdgelessToolButton(
   page: Page,
-  type: ToolType,
+  type: EdgelessTool,
   innerContainer = true
 ) {
-  const text = {
-    default: /Select|Hand/,
-    pan: /Select|Hand/,
-    shape: 'Shape',
-    brush: 'Pen',
-    eraser: 'Eraser',
-    text: 'Text',
-    connector: 'Connector',
-    note: 'Note',
-    zoomIn: 'Zoom in',
-    zoomOut: 'Zoom out',
-    fitToScreen: 'Fit to screen',
+  const selector = {
+    default: '.edgeless-default-button.default',
+    pan: '.edgeless-default-button.pan',
+    shape: '.edgeless-shape-button',
+    brush: '.edgeless-brush-button',
+    eraser: '.edgeless-eraser-button',
+    text: '.edgeless-text-button',
+    connector: '.edgeless-connector-button',
+    note: '.edgeless-text-button',
   }[type];
 
   let buttonType;
@@ -125,9 +121,7 @@ export function locatorEdgelessToolButton(
     default:
       buttonType = 'edgeless-tool-icon-button';
   }
-  const button = page.locator(`edgeless-toolbar ${buttonType}`).filter({
-    hasText: text,
-  });
+  const button = page.locator(`edgeless-toolbar ${buttonType}${selector}`);
 
   return innerContainer ? button.locator('.icon-container') : button;
 }


### PR DESCRIPTION
Part of #4925 
When using the shortcut key S to evoke Shape, the secondary panel must also appear at the same time.