### PR TITLE
fix(edgeless): content shifts when mounting shape text editor

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -158,6 +158,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       toRadian(rotate)
     );
     const [x, y] = this.edgeless.surface.toViewCoord(leftTopX, leftTopY);
+    console.log('x y width height', x, y, rect.width, rect.height);
 
     const virgoStyle = styleMap({
       position: 'absolute',
@@ -192,6 +193,8 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
     return html`<rich-text
       .yText=${this.element.text}
       .enableFormat=${false}
+      .enableAutoScrollHorizontally=${false}
+      .enableAutoScrollVertically=${false}
       style=${virgoStyle}
     ></rich-text>`;
   }

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -158,7 +158,6 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       toRadian(rotate)
     );
     const [x, y] = this.edgeless.surface.toViewCoord(leftTopX, leftTopY);
-    console.log('x y width height', x, y, rect.width, rect.height);
 
     const virgoStyle = styleMap({
       position: 'absolute',

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
@@ -436,6 +436,8 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       <rich-text
         .yText=${this.element.text}
         .enableFormat=${false}
+        .enableAutoScrollHorizontally=${false}
+        .enableAutoScrollVertically=${false}
         style=${hasPlaceholder
           ? styleMap({
               position: 'absolute',


### PR DESCRIPTION
To close #5017 

https://github.com/toeverything/blocksuite/assets/99816898/2c7e2e35-70f5-48a1-ad7b-034bbff91833

