### PR TITLE
feat(store): add content to search results

### DIFF
--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -39,12 +39,9 @@ describe('workspace.search works', () => {
       title: new page.Text(''),
     });
     const noteId = page.addBlock('affine:note', {}, pageId);
-    const text1 = new page.Text(
-      '英特尔第13代酷睿i7-1370P移动处理器现身Geekbench，14核心和5GHz'
-    );
-    const text2 = new page.Text(
-      '索尼考虑移植《GT赛车7》，又一PlayStation独占IP登陆PC平台'
-    );
+    const text1 =
+      '英特尔第13代酷睿i7-1370P移动处理器现身Geekbench，14核心和5GHz';
+    const text2 = '索尼考虑移植《GT赛车7》，又一PlayStation独占IP登陆PC平台';
     const expected1 = new Map([
       [
         '2',
@@ -66,7 +63,7 @@ describe('workspace.search works', () => {
     page.addBlock(
       'affine:paragraph',
       {
-        text: text1,
+        text: new page.Text(text1),
       },
       noteId
     );
@@ -74,7 +71,7 @@ describe('workspace.search works', () => {
     page.addBlock(
       'affine:paragraph',
       {
-        text: text2,
+        text: new page.Text(text2),
       },
       noteId
     );

--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -39,13 +39,34 @@ describe('workspace.search works', () => {
       title: new page.Text(''),
     });
     const noteId = page.addBlock('affine:note', {}, pageId);
-
+    const text1 = new page.Text(
+      '英特尔第13代酷睿i7-1370P移动处理器现身Geekbench，14核心和5GHz'
+    );
+    const text2 = new page.Text(
+      '索尼考虑移植《GT赛车7》，又一PlayStation独占IP登陆PC平台'
+    );
+    const expected1 = new Map([
+      [
+        '2',
+        {
+          content: text1,
+          space: page.id,
+        },
+      ],
+    ]);
+    const expected2 = new Map([
+      [
+        '3',
+        {
+          content: text2,
+          space: page.id,
+        },
+      ],
+    ]);
     page.addBlock(
       'affine:paragraph',
       {
-        text: new page.Text(
-          '英特尔第13代酷睿i7-1370P移动处理器现身Geekbench，14核心和5GHz'
-        ),
+        text: text1,
       },
       noteId
     );
@@ -53,9 +74,7 @@ describe('workspace.search works', () => {
     page.addBlock(
       'affine:paragraph',
       {
-        text: new page.Text(
-          '索尼考虑移植《GT赛车7》，又一PlayStation独占IP登陆PC平台'
-        ),
+        text: text2,
       },
       noteId
     );
@@ -63,10 +82,8 @@ describe('workspace.search works', () => {
     const id = page.id;
 
     queueMicrotask(() => {
-      expect(workspace.search('处理器')).toStrictEqual(
-        new Map([['2', `${id}`]])
-      );
-      expect(workspace.search('索尼')).toStrictEqual(new Map([['3', `${id}`]]));
+      expect(workspace.search('处理器')).toStrictEqual(expected1);
+      expect(workspace.search('索尼')).toStrictEqual(expected2);
     });
 
     const update = encodeStateAsUpdate(page.spaceDoc);
@@ -81,12 +98,8 @@ describe('workspace.search works', () => {
     applyUpdate(page2.spaceDoc, update);
     expect(page2.spaceDoc.toJSON()).toEqual(page.spaceDoc.toJSON());
     queueMicrotask(() => {
-      expect(workspace2.search('处理器')).toStrictEqual(
-        new Map([['2', `${id}`]])
-      );
-      expect(workspace2.search('索尼')).toStrictEqual(
-        new Map([['3', `${id}`]])
-      );
+      expect(workspace2.search('处理器')).toStrictEqual(expected1);
+      expect(workspace2.search('索尼')).toStrictEqual(expected2);
     });
   });
 });

--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -633,7 +633,10 @@ describe('workspace search', () => {
     const result = workspace.search('test');
     expect(result).toMatchInlineSnapshot(`
       Map {
-        "0" => "page:home",
+        "0" => {
+          "content": "test123",
+          "space": "page:home",
+        },
       }
     `);
   });

--- a/packages/store/src/indexer/search.ts
+++ b/packages/store/src/indexer/search.ts
@@ -11,7 +11,7 @@ const Index = FlexSearch.Index;
 
 export type QueryContent = string | Partial<DocumentSearchOptions<boolean>>;
 
-type SearchResult = { id: string; doc: { space: string } };
+type SearchResult = { id: string; doc: { space: string; content: string } };
 type SearchResults = { field: string; result: SearchResult[] };
 
 function tokenize(locale: string) {
@@ -70,7 +70,7 @@ export class SearchIndexer {
         id: 'id',
         index: ['content', 'reference', 'space'],
         tag: 'tags',
-        store: ['space'],
+        store: ['space', 'content'],
       },
       encode: tokenize(locale),
       tokenize: 'forward',
@@ -91,7 +91,7 @@ export class SearchIndexer {
   search(query: QueryContent) {
     return new Map(
       this._search(query).flatMap(({ result }) =>
-        result.map(r => [r.id, r.doc.space])
+        result.map(r => [r.id, { space: r.doc.space, content: r.doc.content }])
       )
     );
   }


### PR DESCRIPTION
The search results now include the content of the matched blocks.
![image](https://github.com/toeverything/blocksuite/assets/102217452/f6922d87-a6c9-44d4-82da-0c8c7c1aa29f)
