### PR TITLE
fix: unexpected bridge display

### DIFF
--- a/packages/blocks/src/components/hover/middlewares/safe-area.ts
+++ b/packages/blocks/src/components/hover/middlewares/safe-area.ts
@@ -229,7 +229,7 @@ export type SafeBridgeOptions = { debug: boolean; idleTimeout: number };
  * Licensed under MIT.
  */
 export const safeBridge = ({
-  debug = true,
+  debug = false,
   idleTimeout = 500,
 }: Partial<SafeBridgeOptions> = {}): HoverMiddleware => {
   let abortController = new AbortController();


### PR DESCRIPTION
The debug option should be disabled by default

<img width="207" alt="Screenshot 2023-10-18 at 00 40 47" src="https://github.com/toeverything/blocksuite/assets/18554747/b751677f-fff1-4095-afd4-ff85584d248f">


Related to https://github.com/toeverything/blocksuite/pull/4965

