### PR TITLE
fix(page): incorrect cursor position when click slowly

### DIFF
--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -1,4 +1,3 @@
-import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 import {
@@ -19,6 +18,8 @@ import {
   pressArrowUp,
   pressEnter,
   registerFormatBarCustomElements,
+  scrollToBottom,
+  scrollToTop,
   selectAllByKeyboard,
   setSelection,
   switchReadonly,
@@ -726,46 +727,6 @@ test('should format quick bar not show at readonly mode', async ({ page }) => {
   await page.dblclick('.affine-rich-text', { position: { x: 10, y: 10 } });
   await expect(formatBar).not.toBeVisible();
 });
-
-async function scrollToTop(page: Page) {
-  await page.mouse.wheel(0, -1000);
-
-  await page.waitForFunction(() => {
-    const scrollContainer = document.querySelector('.affine-doc-viewport');
-    if (!scrollContainer) {
-      throw new Error("Can't find scroll container");
-    }
-    return scrollContainer.scrollTop < 10;
-  });
-}
-
-async function scrollToBottom(page: Page) {
-  // await page.mouse.wheel(0, 1000);
-
-  await page
-    .locator('.affine-doc-viewport')
-    .evaluate(node =>
-      node.scrollTo({ left: 0, top: 1000, behavior: 'smooth' })
-    );
-  // TODO switch to `scrollend`
-  // See https://developer.chrome.com/en/blog/scrollend-a-new-javascript-event/
-  await page.waitForFunction(() => {
-    const scrollContainer = document.querySelector('.affine-doc-viewport');
-    if (!scrollContainer) {
-      throw new Error("Can't find scroll container");
-    }
-
-    return (
-      // Wait for scrolled to the bottom
-      // Refer to https://stackoverflow.com/questions/3898130/check-if-a-user-has-scrolled-to-the-bottom-not-just-the-window-but-any-element
-      Math.abs(
-        scrollContainer.scrollHeight -
-          scrollContainer.scrollTop -
-          scrollContainer.clientHeight
-      ) < 10
-    );
-  });
-}
 
 test('should format bar follow scroll', async ({ page }) => {
   await enterPlaygroundRoom(page);

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -20,6 +20,7 @@ import {
   pressArrowLeft,
   pressEnter,
   redoByKeyboard,
+  scrollToTop,
   type,
   undoByKeyboard,
   waitNextFrame,
@@ -179,15 +180,7 @@ test('popup menu should follow position of image when scrolling', async ({
   await pressEnter(page);
   await insertThreeLevelLists(page, 6);
 
-  await page.evaluate(async () => {
-    const viewport = document.querySelector('.affine-doc-viewport');
-    if (!viewport) {
-      throw new Error();
-    }
-    viewport.scrollTo(0, 0);
-  });
-
-  await page.waitForTimeout(150);
+  await scrollToTop(page);
 
   const rect = await page.locator('.affine-image-wrapper img').boundingBox();
   if (!rect) throw new Error('image not found');

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -920,6 +920,9 @@ export const getCenterPositionByLocator: (
   };
 };
 
+/**
+ * @deprecated Use `page.locator(selector).boundingBox()` instead
+ */
 export const getBoundingClientRect: (
   page: Page,
   selector: string
@@ -1167,4 +1170,44 @@ export async function getCopyClipItemsInPage(page: Page) {
       .clipboard['_copyBlocksInPage']();
   });
   return clipItems;
+}
+
+export async function scrollToTop(page: Page) {
+  await page.mouse.wheel(0, -1000);
+
+  await page.waitForFunction(() => {
+    const scrollContainer = document.querySelector('.affine-doc-viewport');
+    if (!scrollContainer) {
+      throw new Error("Can't find scroll container");
+    }
+    return scrollContainer.scrollTop < 10;
+  });
+}
+
+export async function scrollToBottom(page: Page) {
+  // await page.mouse.wheel(0, 1000);
+
+  await page
+    .locator('.affine-doc-viewport')
+    .evaluate(node =>
+      node.scrollTo({ left: 0, top: 1000, behavior: 'smooth' })
+    );
+  // TODO switch to `scrollend`
+  // See https://developer.chrome.com/en/blog/scrollend-a-new-javascript-event/
+  await page.waitForFunction(() => {
+    const scrollContainer = document.querySelector('.affine-doc-viewport');
+    if (!scrollContainer) {
+      throw new Error("Can't find scroll container");
+    }
+
+    return (
+      // Wait for scrolled to the bottom
+      // Refer to https://stackoverflow.com/questions/3898130/check-if-a-user-has-scrolled-to-the-bottom-not-just-the-window-but-any-element
+      Math.abs(
+        scrollContainer.scrollHeight -
+          scrollContainer.scrollTop -
+          scrollContainer.clientHeight
+      ) < 10
+    );
+  });
 }


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/5034

When the block is long, the scrolling behavior using the native `scrollIntoView` API still appears unnatural.