### PR TITLE
chore: update vscode settings

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -17,8 +17,5 @@
     "package.json": ".browserslist*, .circleci*, .codecov, .commitlint*, .cz-config.js, .czrc, .dlint.json, .dprint.json, .editorconfig, .eslint*, .firebase*, .flowconfig, .github*, .gitlab*, .gitpod*, .huskyrc*, .jslint*, .lighthouserc.*, .lintstagedrc*, .markdownlint*, .mocha*, .node-version, .nodemon*, .npm*, .nvmrc, .pm2*, .pnp.*, .pnpm*, .prettier*, .releaserc*, .sentry*, .stackblitz*, .styleci*, .stylelint*, .tazerc*, .textlint*, .tool-versions, .travis*, .versionrc*, .vscode*, .watchman*, .xo-config*, .yamllint*, .yarnrc*, Procfile, api-extractor.json, apollo.config.*, appveyor*, ava.config.*, azure-pipelines*, bower.json, build.config.*, commitlint*, crowdin*, cypress.*, dangerfile*, dlint.json, dprint.json, firebase.json, grunt*, gulp*, histoire.config.*, jasmine.*, jenkins*, jest.config.*, jsconfig.*, karma*, lerna*, lighthouserc.*, lint-staged*, nest-cli.*, netlify*, nodemon*, nx.*, package-lock.json, package.nls*.json, phpcs.xml, playwright.config.*, pm2.*, pnpm*, prettier*, pullapprove*, puppeteer.config.*, pyrightconfig.json, release-tasks.sh, renovate*, rollup.config.*, stylelint*, tsconfig.*, tsdoc.*, tslint*, tsup.config.*, turbo*, typedoc*, unlighthouse*, vercel*, vetur.config.*, vitest.config.*, webpack*, workspace.json, xo.config.*, yarn*"
   },
   "cSpell.words": ["backlink", "blocksuite"],
-  "vitest.include": [
-    // ignore playwrite tests
-    "**/packages/**/*.unit.spec.ts"
-  ]
+  "vitest.include": ["**/packages/**/*.unit.spec.ts"]
 }

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,9 +1,8 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
-  "editor.codeActionsOnSave": [
-    // "source.organizeImports",
-    "source.fixAll.eslint"
-  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
@@ -20,6 +19,6 @@
   "cSpell.words": ["backlink", "blocksuite"],
   "vitest.include": [
     // ignore playwrite tests
-    "**/packages/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"
+    "**/packages/**/*.unit.spec.ts"
   ]
 }


### PR DESCRIPTION
- After vscode 1.83.0, Code Actions' behavior on save in the editor has been modified from Booleans to an enum
  - See https://github.com/microsoft/vscode/pull/190516 https://github.com/microsoft/vscode/issues/163920#issuecomment-1721561959

> Code Actions' behavior on save in the editor has been modified from Booleans to an enum with the following options:
>
> `always`: Code Actions with always be run on any kind of save (autosave when exiting or changing focus, explicit save, etc).
> `explicit`: Code Actions will be run only when explicitly saving.
> `never`: Code Actions will never be run on save.

