### PR TITLE
feat(edgeless): support custom note background rgba color for adaptive theme

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -120,7 +120,7 @@ export class EdgelessBlockPortalNote extends WithDisposable(LitElement) {
       boxSizing: 'border-box',
       background: isHiddenNote
         ? 'transparent'
-        : `var(${background ?? DEFAULT_NOTE_COLOR})`,
+        : ( background.startsWith("rgba")  ? background : `var(${background ?? DEFAULT_NOTE_COLOR})`),
       boxShadow: isHiddenNote ? undefined : 'var(--affine-shadow-3)',
       pointerEvents: 'all',
       overflow: 'hidden',

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -120,7 +120,9 @@ export class EdgelessBlockPortalNote extends WithDisposable(LitElement) {
       boxSizing: 'border-box',
       background: isHiddenNote
         ? 'transparent'
-        : ( background.startsWith("rgba")  ? background : `var(${background ?? DEFAULT_NOTE_COLOR})`),
+        : background.startsWith('rgba')
+        ? background
+        : `var(${background ?? DEFAULT_NOTE_COLOR})`,
       boxShadow: isHiddenNote ? undefined : 'var(--affine-shadow-3)',
       pointerEvents: 'all',
       overflow: 'hidden',


### PR DESCRIPTION
Using this one liner we can use any color with `rgba(*,*,*,0.5)` where 0.5 is an example transparency, thus we can easily render custom colors outside the default palette that are enjoyable both on the dark theme and light theme