### PR TITLE
fix(edgeless): group hotkey and show title at init

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
@@ -115,20 +115,22 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             this._setEdgelessTool(pageElement, { type: 'frame' });
           }
         },
-        'Mod-g': () => {
+        'Mod-g': ctx => {
           if (
             this.pageElement.selectionManager.elements.length > 1 &&
             !this.pageElement.selectionManager.editing
           ) {
+            ctx.get('keyboardState').event.preventDefault();
             pageElement.surface.group.createGroupOnSelected();
           }
         },
-        'Shift-Mod-g': () => {
+        'Shift-Mod-g': ctx => {
           const { selectionManager, surface } = this.pageElement;
           if (
             selectionManager.elements.length === 1 &&
             selectionManager.firstElement instanceof GroupElement
           ) {
+            ctx.get('keyboardState').event.preventDefault();
             surface.group.ungroup(selectionManager.firstElement);
           }
         },

--- a/packages/blocks/src/surface-block/elements/group/group-element.ts
+++ b/packages/blocks/src/surface-block/elements/group/group-element.ts
@@ -41,6 +41,7 @@ export class GroupElement extends SurfaceElement<IGroup, IGroupLocalRecord> {
     super.init();
 
     const { surface } = this;
+    surface.updateElementLocalRecord(this.id, { showTitle: true });
     this._cachedId = this.id;
     this.childElements.forEach(ele => {
       surface.setGroupParent(ele, this.id);


### PR DESCRIPTION
1. preventDefault for cmd+g and cmd+shift+g
2. showtitle at init
