### PR TITLE
fix(edgeless): edgeless toolbar submenu tooltip position

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-menu.ts
@@ -44,7 +44,6 @@ function ConnectorModeButtonGroup(
         .activeMode=${'background'}
         .iconContainerPadding=${2}
         .tooltip=${straightLineTooltip}
-        .tipPosition=${'top-end'}
         @click=${() => setConnectorMode(ConnectorMode.Straight)}
       >
         ${ConnectorLWithArrowIcon}

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu-config.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu-config.ts
@@ -31,6 +31,3 @@ export const NOTE_MENU_ITEMS = BLOCKHUB_TEXT_ITEMS.concat(BLOCKHUB_LIST_ITEMS)
   });
 
 export const NOTE_MENU_WIDTH = 442;
-
-export const TOP_END_TOOLTIP_TYPE = ['text', 'h1'];
-export const TOP_START_TOOLTIP_TYPE = ['bulleted', 'numbered', 'todo'];

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
@@ -7,12 +7,7 @@ import {
   type NoteChildrenFlavour,
 } from '../../../../../_common/utils/index.js';
 import type { EdgelessPageBlockComponent } from '../../../edgeless-page-block.js';
-import {
-  NOTE_MENU_ITEMS,
-  NOTE_MENU_WIDTH,
-  TOP_END_TOOLTIP_TYPE,
-  TOP_START_TOOLTIP_TYPE,
-} from './note-menu-config.js';
+import { NOTE_MENU_ITEMS, NOTE_MENU_WIDTH } from './note-menu-config.js';
 
 @customElement('edgeless-note-menu')
 export class EdgelessNoteMenu extends WithDisposable(LitElement) {
@@ -72,16 +67,6 @@ export class EdgelessNoteMenu extends WithDisposable(LitElement) {
     });
   }
 
-  private _getTooltipPosition(childType: string | null) {
-    if (!childType) return 'top';
-
-    return TOP_END_TOOLTIP_TYPE.includes(childType)
-      ? 'top-end'
-      : TOP_START_TOOLTIP_TYPE.includes(childType)
-      ? 'top-start'
-      : 'top';
-  }
-
   override render() {
     if (this.edgelessTool.type !== 'note') return nothing;
 
@@ -99,7 +84,6 @@ export class EdgelessNoteMenu extends WithDisposable(LitElement) {
                   .activeMode=${'background'}
                   .iconContainerPadding=${2}
                   .tooltip=${item.tooltip}
-                  .tipPosition=${this._getTooltipPosition(item.childType)}
                   @click=${() =>
                     this._updateNoteTool(
                       item.childFlavour,

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-menu.ts
@@ -124,7 +124,6 @@ export class EdgelessShapeMenu extends WithDisposable(LitElement) {
             <div class="shape-style-container">
               <edgeless-tool-icon-button
                 .tooltip=${'General'}
-                .tipPosition=${'top-end'}
                 .iconContainerPadding=${2}
                 .active=${shapeStyle === ShapeStyle.General}
                 .activeMode=${'background'}


### PR DESCRIPTION
Edgeless toolbar submenu tooltips are no longer affected by overflow since affine-tooltip is a portal currently with pr #4950.
So we can set all the submenu tooltip position as  default ('top'). 