### PR TITLE
feat(edgeless): use sans font family as default when adding canvas text

### DIFF
--- a/packages/blocks/src/page-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/text.ts
@@ -2,7 +2,7 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, assertInstanceOf } from '@blocksuite/global/utils';
 import { Workspace } from '@blocksuite/store';
 
-import { type FrameBlockModel, type GroupElement } from '../../../index.js';
+import type { FrameBlockModel, GroupElement } from '../../../index.js';
 import { ShapeElement } from '../../../surface-block/index.js';
 import {
   Bound,

--- a/packages/blocks/src/page-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/text.ts
@@ -2,7 +2,7 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, assertInstanceOf } from '@blocksuite/global/utils';
 import { Workspace } from '@blocksuite/store';
 
-import type { FrameBlockModel, GroupElement } from '../../../index.js';
+import { type FrameBlockModel, type GroupElement } from '../../../index.js';
 import { ShapeElement } from '../../../surface-block/index.js';
 import {
   Bound,
@@ -19,9 +19,9 @@ import { EdgelessGroupTitleEditor } from '../components/text/edgeless-group-titl
 import { EdgelessShapeTextEditor } from '../components/text/edgeless-shape-text-editor.js';
 import { EdgelessTextEditor } from '../components/text/edgeless-text-editor.js';
 import type { EdgelessPageBlockComponent } from '../edgeless-page-block.js';
-import type {
+import {
   GENERAL_CANVAS_FONT_FAMILY,
-  SCRIBBLED_CANVAS_FONT_FAMILY,
+  type SCRIBBLED_CANVAS_FONT_FAMILY,
 } from './consts.js';
 
 export type CANVAS_TEXT_FONT =
@@ -115,7 +115,8 @@ export function mountGroupTitleEditor(
 export function addText(
   edgeless: EdgelessPageBlockComponent,
   event: PointerEventState,
-  color: string = GET_DEFAULT_TEXT_COLOR()
+  color: string = GET_DEFAULT_TEXT_COLOR(),
+  fontFamily: CANVAS_TEXT_FONT = GENERAL_CANVAS_FONT_FAMILY
 ) {
   const [x, y] = edgeless.surface.viewport.toModelCoord(event.x, event.y);
   const selected = edgeless.surface.pickTop(x, y);
@@ -129,6 +130,7 @@ export function addText(
       xywh: new Bound(modelX, modelY, 32, 32).serialize(),
       text: new Workspace.Y.Text(),
       textAlign: 'left',
+      fontFamily,
       fontSize: 24,
       color: color,
       bold: false,

--- a/packages/blocks/src/surface-block/elements/text/consts.ts
+++ b/packages/blocks/src/surface-block/elements/text/consts.ts
@@ -14,7 +14,7 @@ export const TextElementDefaultProps: IElementDefaultProps<'text'> = {
   text: new Workspace.Y.Text(),
   color: '#000000',
   fontSize: 16,
-  fontFamily: "'Kalam', cursive",
+  fontFamily: 'sans-serif',
   textAlign: 'center',
   bold: false,
   italic: false,

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -165,24 +165,24 @@ test('normalize text element rect after change its font', async ({ page }) => {
   const fontButton = page.locator('.text-font-family-button');
   await fontButton.click();
 
-  // Default is Scribbled
-  await assertTextFont(page, 'Scribbled');
-  const generalTextFont = page.getByText('General');
-  await generalTextFont.click();
-  await waitNextFrame(page);
-  let selectedRect = await getEdgelessSelectedRect(page);
-  expect(selectedRect.width).toBeGreaterThan(lastWidth);
-  expect(selectedRect.height).toBeLessThan(lastHeight);
-  lastWidth = selectedRect.width;
-  lastHeight = selectedRect.height;
-  await fontButton.click();
+  // Default is General
   await assertTextFont(page, 'General');
   const scribbledTextFont = page.getByText('Scribbled');
   await scribbledTextFont.click();
   await waitNextFrame(page);
-  selectedRect = await getEdgelessSelectedRect(page);
+  let selectedRect = await getEdgelessSelectedRect(page);
   expect(selectedRect.width).toBeLessThan(lastWidth);
   expect(selectedRect.height).toBeGreaterThan(lastHeight);
+  lastWidth = selectedRect.width;
+  lastHeight = selectedRect.height;
+  await fontButton.click();
+  await assertTextFont(page, 'Scribbled');
+  const generalTextFont = page.getByText('General');
+  await generalTextFont.click();
+  await waitNextFrame(page);
+  selectedRect = await getEdgelessSelectedRect(page);
+  expect(selectedRect.width).toBeGreaterThan(lastWidth);
+  expect(selectedRect.height).toBeLessThan(lastHeight);
 });
 
 test('auto wrap text by dragging left and right edge', async ({ page }) => {
@@ -212,9 +212,9 @@ test('auto wrap text by dragging left and right edge', async ({ page }) => {
   let lastHeight = selectedRect.height;
 
   // move cursor to the right edge and drag it to resize the width of text element
-  await page.mouse.move(224, 160);
+  await page.mouse.move(130 + lastWidth, 160);
   await page.mouse.down();
-  await page.mouse.move(190, 160, {
+  await page.mouse.move(130 + lastWidth / 2, 160, {
     steps: 10,
   });
   await page.mouse.up();
@@ -241,7 +241,7 @@ test('auto wrap text by dragging left and right edge', async ({ page }) => {
   // move cursor to the left edge and drag it to resize the width of text element
   await page.mouse.move(130, 160);
   await page.mouse.down();
-  await page.mouse.move(96, 160, {
+  await page.mouse.move(79, 160, {
     steps: 10,
   });
   await page.mouse.up();
@@ -285,9 +285,9 @@ test('text element should have maxWidth after adjusting width by dragging left o
   let lastHeight = selectedRect.height;
 
   // move cursor to the right edge and drag it to resize the width of text element
-  await page.mouse.move(224, 160);
+  await page.mouse.move(130 + lastWidth, 160);
   await page.mouse.down();
-  await page.mouse.move(190, 160, {
+  await page.mouse.move(130 + lastWidth / 2, 160, {
     steps: 10,
   });
   await page.mouse.up();

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -300,7 +300,7 @@ test('text element should have maxWidth after adjusting width by dragging left o
   lastHeight = selectedRect.height;
 
   // enter edit mode
-  await page.mouse.dblclick(185, 200);
+  await page.mouse.dblclick(130 + lastWidth - 2, 200);
   await waitForVirgoStateUpdated(page);
   await waitNextFrame(page);
   await type(page, 'hello');

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -14,7 +14,10 @@ import {
   waitNextFrame,
   zoomResetByKeyboard,
 } from '../utils/actions/index.js';
-import { assertEdgelessCanvasText } from '../utils/asserts.js';
+import {
+  assertEdgelessCanvasText,
+  assertSelectedBound,
+} from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
 async function assertTextFont(page: Page, font: 'General' | 'Scribbled') {
@@ -300,7 +303,8 @@ test('text element should have maxWidth after adjusting width by dragging left o
   lastHeight = selectedRect.height;
 
   // enter edit mode
-  await page.mouse.dblclick(130 + lastWidth - 2, 200);
+  await waitNextFrame(page);
+  await page.mouse.dblclick(140, 180);
   await waitForVirgoStateUpdated(page);
   await waitNextFrame(page);
   await type(page, 'hello');


### PR DESCRIPTION
To close #5165 

https://github.com/toeverything/blocksuite/assets/99816898/98da7b2c-c432-41a3-8564-9af47c589647


