### PR TITLE
test: switch to `expectConsoleMessage`

### DIFF
--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -269,8 +269,8 @@ test('image loading but failed', async ({ page }) => {
   );
   expectConsoleMessage(page, 'Cannot find blob, retrying', 'warning');
   expectConsoleMessage(page, 'Error: Cannot find blob');
-  const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
 
+  const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
   const timeout = 2000;
 
   // block image data request, force wait 100ms for loading test,
@@ -313,6 +313,7 @@ test('image loading but success', async ({ page }) => {
     'Failed to load resource: the server responded with a status of 404 (Not Found)'
   );
   expectConsoleMessage(page, 'Cannot find blob, retrying', 'warning');
+
   const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
   const imageBuffer = await readFile(
     fileURLToPath(new URL('./fixtures/smile.png', import.meta.url))

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -13,6 +13,7 @@ import {
   dragEmbedResizeByTopLeft,
   dragEmbedResizeByTopRight,
   enterPlaygroundRoom,
+  expectConsoleStartsWith,
   initImageState,
   insertThreeLevelLists,
   moveToImage,
@@ -261,6 +262,16 @@ async function initMockImage(page: Page) {
 }
 
 test('image loading but failed', async ({ page }) => {
+  expectConsoleStartsWith(
+    page,
+    'Error: Failed to fetch blob _e2e_test_image_id_'
+  );
+  expectConsoleStartsWith(
+    page,
+    'Failed to load resource: the server responded with a status of 404 (Not Found)'
+  );
+  expectConsoleStartsWith(page, 'Cannot find blob, retrying', 'warning');
+  expectConsoleStartsWith(page, 'Error: Cannot find blob');
   const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
 
   const timeout = 2000;
@@ -299,6 +310,15 @@ test('image loading but failed', async ({ page }) => {
 });
 
 test('image loading but success', async ({ page }) => {
+  expectConsoleStartsWith(
+    page,
+    'Error: Failed to fetch blob _e2e_test_image_id_'
+  );
+  expectConsoleStartsWith(
+    page,
+    'Failed to load resource: the server responded with a status of 404 (Not Found)'
+  );
+  expectConsoleStartsWith(page, 'Cannot find blob, retrying', 'warning');
   const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
   const imageBuffer = await readFile(
     fileURLToPath(new URL('./fixtures/smile.png', import.meta.url))

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -13,7 +13,7 @@ import {
   dragEmbedResizeByTopLeft,
   dragEmbedResizeByTopRight,
   enterPlaygroundRoom,
-  expectConsoleStartsWith,
+  expectConsoleMessage,
   initImageState,
   insertThreeLevelLists,
   moveToImage,
@@ -262,16 +262,13 @@ async function initMockImage(page: Page) {
 }
 
 test('image loading but failed', async ({ page }) => {
-  expectConsoleStartsWith(
-    page,
-    'Error: Failed to fetch blob _e2e_test_image_id_'
-  );
-  expectConsoleStartsWith(
+  expectConsoleMessage(page, 'Error: Failed to fetch blob _e2e_test_image_id_');
+  expectConsoleMessage(
     page,
     'Failed to load resource: the server responded with a status of 404 (Not Found)'
   );
-  expectConsoleStartsWith(page, 'Cannot find blob, retrying', 'warning');
-  expectConsoleStartsWith(page, 'Error: Cannot find blob');
+  expectConsoleMessage(page, 'Cannot find blob, retrying', 'warning');
+  expectConsoleMessage(page, 'Error: Cannot find blob');
   const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
 
   const timeout = 2000;
@@ -310,15 +307,12 @@ test('image loading but failed', async ({ page }) => {
 });
 
 test('image loading but success', async ({ page }) => {
-  expectConsoleStartsWith(
-    page,
-    'Error: Failed to fetch blob _e2e_test_image_id_'
-  );
-  expectConsoleStartsWith(
+  expectConsoleMessage(page, 'Error: Failed to fetch blob _e2e_test_image_id_');
+  expectConsoleMessage(
     page,
     'Failed to load resource: the server responded with a status of 404 (Not Found)'
   );
-  expectConsoleStartsWith(page, 'Cannot find blob, retrying', 'warning');
+  expectConsoleMessage(page, 'Cannot find blob, retrying', 'warning');
   const room = await enterPlaygroundRoom(page, { blobStorage: ['mock'] });
   const imageBuffer = await readFile(
     fileURLToPath(new URL('./fixtures/smile.png', import.meta.url))

--- a/tests/import.spec.ts
+++ b/tests/import.spec.ts
@@ -4,6 +4,7 @@ import { expect } from '@playwright/test';
 
 import {
   enterPlaygroundRoom,
+  expectConsoleMessage,
   transformHtml,
   transformMarkdown,
 } from './utils/actions/index.js';
@@ -746,6 +747,10 @@ test(scoped`import notion html-format table`, async ({ page }) => {
 
 // todo this is temporary solution
 test(scoped`import notion markdown-format image`, async ({ page }) => {
+  expectConsoleMessage(
+    page,
+    'Failed to load resource: the server responded with a status of 404 (Not Found)'
+  );
   await enterPlaygroundRoom(page);
 
   const tempText = `

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -45,26 +45,7 @@ function shamefullyIgnoreConsoleMessage(message: ConsoleMessage): boolean {
   if (!process.env.CI) {
     return true;
   }
-  const ignoredMessages = [
-    // basic.spec.ts
-    "Caught error while handling a Yjs update TypeError: Cannot read properties of undefined (reading 'toJSON')",
-    // clipboard.spec.ts
-    "TypeError: Cannot read properties of null (reading 'model')",
-    // basic.spec.ts › should readonly mode not be able to modify text
-    'cannot modify data in readonly mode',
-    // Firefox warn on quill
-    // See https://github.com/quilljs/quill/issues/2030
-    '[JavaScript Warning: "Use of Mutation Events is deprecated. Use MutationObserver instead."',
-    "addRange(): The given range isn't in document.",
-    //#region embed.spec.ts
-    'Failed to load resource: the server responded with a status of 404 (Not Found)',
-    'Failed to load resource: the server responded with a status of 403 ()',
-    'Error while getting blob HTTPError: Request failed with status code 404 Not Found',
-    'Error: Failed to fetch blob',
-    'Error: Cannot find blob',
-    'Cannot find blob',
-    //#endregion
-  ];
+  const ignoredMessages: string[] = [];
   return ignoredMessages.some(msg => message.text().startsWith(msg));
 }
 

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -161,9 +161,19 @@ function isIgnoredLog(
   return '__ignore' in message && !!message.__ignore;
 }
 
-export function expectConsoleStartsWith(
+/**
+ * Expect console message to be called in the test.
+ *
+ * This function **should** be called before the `enterPlaygroundRoom` function!
+ *
+ * ```ts
+ * expectConsoleMessage(page, 'Failed to load resource'); // Default type is 'error'
+ * expectConsoleMessage(page, '[vite] connected.', 'warning'); // Specify type
+ * ```
+ */
+export function expectConsoleMessage(
   page: Page,
-  log: string,
+  logPrefixOrRegex: string | RegExp,
   type:
     | 'log'
     | 'debug'
@@ -196,7 +206,12 @@ export function expectConsoleStartsWith(
       ignoredLog(message);
       return;
     }
-    if (message.type() === type && message.text().startsWith(log)) {
+    const sameType = message.type() === type;
+    const textMatch =
+      logPrefixOrRegex instanceof RegExp
+        ? logPrefixOrRegex.test(message.text())
+        : message.text().startsWith(logPrefixOrRegex);
+    if (sameType && textMatch) {
       ignoredLog(message);
     }
   });
@@ -230,7 +245,7 @@ export async function enterPlaygroundRoom(
       expect
         .soft('Unexpected console message: ' + message.text())
         .toBe(
-          'Please remove the "console.log" statements from the code. It is advised not to output logs in a production environment.'
+          'Please remove the "console.log" or declare `expectConsoleMessage` before `enterPlaygroundRoom`. It is advised not to output logs in a production environment.'
         );
     }
     console.log(`Console ${message.type()}: ${message.text()}`);


### PR DESCRIPTION
Sunsetting the `shamefullyIgnoreConsoleMessage`.

Now, all console messages need to be explicitly declared by the new test API `expectConsoleMessage`.

NOTE: `expectConsoleMessage` **should** be called before the `enterPlaygroundRoom` function!

## Some references

> ## Soft Assertions
> By default, failed assertion will terminate test execution. Playwright also supports soft assertions: failed soft assertions do not terminate test execution, but mark the test as failed.
>
> https://playwright.dev/docs/test-assertions#soft-assertions