### PR TITLE
fix(edgeless): shape text init font family should be consistent with shape style

### DIFF
--- a/packages/blocks/src/page-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/text.ts
@@ -3,7 +3,7 @@ import { assertExists, assertInstanceOf } from '@blocksuite/global/utils';
 import { Workspace } from '@blocksuite/store';
 
 import type { FrameBlockModel, GroupElement } from '../../../index.js';
-import { ShapeElement } from '../../../surface-block/index.js';
+import { ShapeElement, ShapeStyle } from '../../../surface-block/index.js';
 import {
   Bound,
   type IModelCoord,
@@ -21,7 +21,7 @@ import { EdgelessTextEditor } from '../components/text/edgeless-text-editor.js';
 import type { EdgelessPageBlockComponent } from '../edgeless-page-block.js';
 import {
   GENERAL_CANVAS_FONT_FAMILY,
-  type SCRIBBLED_CANVAS_FONT_FAMILY,
+  SCRIBBLED_CANVAS_FONT_FAMILY,
 } from './consts.js';
 
 export type CANVAS_TEXT_FONT =
@@ -65,6 +65,10 @@ export function mountShapeTextEditor(
     edgeless.surface.updateElement<PhasorElementType.SHAPE>(shapeElement.id, {
       text,
       color: GET_DEFAULT_LINE_COLOR(),
+      fontFamily:
+        shapeElement.shapeStyle === ShapeStyle.General
+          ? GENERAL_CANVAS_FONT_FAMILY
+          : SCRIBBLED_CANVAS_FONT_FAMILY,
     });
   }
   const updatedElement = edgeless.surface.pickById(shapeElement.id);

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -419,7 +419,7 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of \n
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 136]);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 109]);
 
   await page.mouse.dblclick(250, 200);
   await waitNextFrame(page);
@@ -432,23 +432,23 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of long text
-  // cccccccc -- wrap --> cccccc\ncc
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
+  // cccccccc -- wrap --> ccccc\nccc
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
 
   // try to decrease height
   await resizeElementByHandle(page, { x: 0, y: -50 }, 'bottom-right');
   // you can't decrease height because of min height to fit text
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
 
   // increase width to make text not wrap
   await resizeElementByHandle(page, { x: 50, y: 0 }, 'bottom-right');
   // the height of shape should be decreased because of long text not wrap
-  await assertEdgelessSelectedRect(page, [200, 150, 150, 136]);
+  await assertEdgelessSelectedRect(page, [200, 150, 150, 109]);
 
   // try to decrease width
   await resizeElementByHandle(page, { x: -50, y: 0 }, 'bottom-right');
   // you can't decrease width after text can't wrap (each line just has 1 char)
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
 });
 
 test('change shape style', async ({ page }) => {

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -8,6 +8,7 @@ import {
   changeShapeStrokeWidth,
   changeShapeStyle,
   clickComponentToolbarMoreMenuButton,
+  getEdgelessSelectedRect,
   locatorEdgelessToolButton,
   locatorShapeStrokeStyleButton,
   openComponentToolbarMoreMenu,
@@ -419,7 +420,9 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of \n
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 109]);
+  let selectedRect = await getEdgelessSelectedRect(page);
+  let lastWidth = selectedRect.width;
+  let lastHeight = selectedRect.height;
 
   await page.mouse.dblclick(250, 200);
   await waitNextFrame(page);
@@ -433,22 +436,34 @@ test('auto wrap text in shape', async ({ page }) => {
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of long text
   // cccccccc -- wrap --> ccccc\nccc
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
+  selectedRect = await getEdgelessSelectedRect(page);
+  expect(selectedRect.width).toBe(lastWidth);
+  expect(selectedRect.height).toBeGreaterThan(lastHeight);
+  lastWidth = selectedRect.width;
+  lastHeight = selectedRect.height;
 
   // try to decrease height
   await resizeElementByHandle(page, { x: 0, y: -50 }, 'bottom-right');
   // you can't decrease height because of min height to fit text
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
+  selectedRect = await getEdgelessSelectedRect(page);
+  expect(selectedRect.width).toBe(lastWidth);
+  expect(selectedRect.height).toBe(lastHeight);
 
   // increase width to make text not wrap
   await resizeElementByHandle(page, { x: 50, y: 0 }, 'bottom-right');
   // the height of shape should be decreased because of long text not wrap
-  await assertEdgelessSelectedRect(page, [200, 150, 150, 109]);
+  selectedRect = await getEdgelessSelectedRect(page);
+  expect(selectedRect.width).toBeGreaterThan(lastWidth);
+  expect(selectedRect.height).toBeLessThan(lastHeight);
+  lastWidth = selectedRect.width;
+  lastHeight = selectedRect.height;
 
   // try to decrease width
   await resizeElementByHandle(page, { x: -50, y: 0 }, 'bottom-right');
   // you can't decrease width after text can't wrap (each line just has 1 char)
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
+  selectedRect = await getEdgelessSelectedRect(page);
+  expect(selectedRect.width).toBeLessThan(lastWidth);
+  expect(selectedRect.height).toBeGreaterThan(lastHeight);
 });
 
 test('change shape style', async ({ page }) => {

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -405,6 +405,11 @@ test('auto wrap text in shape', async ({ page }) => {
   await setEdgelessTool(page, 'shape');
   await waitNextFrame(page, 500);
 
+  const scribbledButton = page
+    .locator('edgeless-tool-icon-button')
+    .filter({ hasText: 'scribbled' });
+  await scribbledButton.click();
+
   await page.mouse.click(200, 150);
   await waitNextFrame(page);
   await page.mouse.dblclick(250, 200);
@@ -419,7 +424,7 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of \n
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 109]);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 136]);
 
   await page.mouse.dblclick(250, 200);
   await waitNextFrame(page);
@@ -432,20 +437,23 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of long text
-  // cccccccc -- wrap --> ccccc\nccc
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
+  // cccccccc -- wrap --> cccccc\ncc
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
 
   // try to decrease height
   await resizeElementByHandle(page, { x: 0, y: -50 }, 'bottom-right');
+  // you can't decrease height because of min height to fit text
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
+
   // increase width to make text not wrap
   await resizeElementByHandle(page, { x: 50, y: 0 }, 'bottom-right');
   // the height of shape should be decreased because of long text not wrap
-  await assertEdgelessSelectedRect(page, [200, 150, 150, 109]);
+  await assertEdgelessSelectedRect(page, [200, 150, 150, 136]);
 
   // try to decrease width
   await resizeElementByHandle(page, { x: -50, y: 0 }, 'bottom-right');
   // you can't decrease width after text can't wrap (each line just has 1 char)
-  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 168]);
 });
 
 test('change shape style', async ({ page }) => {

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -8,7 +8,6 @@ import {
   changeShapeStrokeWidth,
   changeShapeStyle,
   clickComponentToolbarMoreMenuButton,
-  getEdgelessSelectedRect,
   locatorEdgelessToolButton,
   locatorShapeStrokeStyleButton,
   openComponentToolbarMoreMenu,
@@ -420,9 +419,7 @@ test('auto wrap text in shape', async ({ page }) => {
   // select shape
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of \n
-  let selectedRect = await getEdgelessSelectedRect(page);
-  let lastWidth = selectedRect.width;
-  let lastHeight = selectedRect.height;
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 109]);
 
   await page.mouse.dblclick(250, 200);
   await waitNextFrame(page);
@@ -436,34 +433,19 @@ test('auto wrap text in shape', async ({ page }) => {
   await page.mouse.click(200, 150);
   // the height of shape should be increased because of long text
   // cccccccc -- wrap --> ccccc\nccc
-  selectedRect = await getEdgelessSelectedRect(page);
-  expect(selectedRect.width).toBe(lastWidth);
-  expect(selectedRect.height).toBeGreaterThan(lastHeight);
-  lastWidth = selectedRect.width;
-  lastHeight = selectedRect.height;
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
 
   // try to decrease height
   await resizeElementByHandle(page, { x: 0, y: -50 }, 'bottom-right');
-  // you can't decrease height because of min height to fit text
-  selectedRect = await getEdgelessSelectedRect(page);
-  expect(selectedRect.width).toBe(lastWidth);
-  expect(selectedRect.height).toBe(lastHeight);
-
   // increase width to make text not wrap
   await resizeElementByHandle(page, { x: 50, y: 0 }, 'bottom-right');
   // the height of shape should be decreased because of long text not wrap
-  selectedRect = await getEdgelessSelectedRect(page);
-  expect(selectedRect.width).toBeGreaterThan(lastWidth);
-  expect(selectedRect.height).toBeLessThan(lastHeight);
-  lastWidth = selectedRect.width;
-  lastHeight = selectedRect.height;
+  await assertEdgelessSelectedRect(page, [200, 150, 150, 109]);
 
   // try to decrease width
   await resizeElementByHandle(page, { x: -50, y: 0 }, 'bottom-right');
   // you can't decrease width after text can't wrap (each line just has 1 char)
-  selectedRect = await getEdgelessSelectedRect(page);
-  expect(selectedRect.width).toBeLessThan(lastWidth);
-  expect(selectedRect.height).toBeGreaterThan(lastHeight);
+  await assertEdgelessSelectedRect(page, [200, 150, 100, 132]);
 });
 
 test('change shape style', async ({ page }) => {


### PR DESCRIPTION
To close #5206 

https://github.com/toeverything/blocksuite/assets/99816898/8cca744e-7df2-4e49-a49b-d975d663ae6c

