### PR TITLE
fix(edgeless): text editor should not have minWidth without adjusting width

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
@@ -421,7 +421,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       style=${styleMap({
         textAlign,
         fontFamily,
-        minWidth: `${rect.width}px`,
+        minWidth: hasMaxWidth ? `${rect.width}px` : 'none',
         maxWidth: hasMaxWidth ? `${w}px` : 'none',
         fontSize: `${fontSize}px`,
         fontWeight: bold ? 'bold' : 'normal',


### PR DESCRIPTION
before:

https://github.com/toeverything/blocksuite/assets/99816898/2005d4f4-0687-4ed3-97b3-ae8f860471fc

after:

https://github.com/toeverything/blocksuite/assets/99816898/de578e81-d7d5-4069-ab9d-581d338897e6

