### PR TITLE
fix(page): sometimes page tags disappear

### DIFF
--- a/packages/store/src/workspace/meta.ts
+++ b/packages/store/src/workspace/meta.ts
@@ -311,9 +311,9 @@ export class WorkspaceMeta {
   };
 
   get properties(): PagesPropertiesMeta {
-    let meta = this._proxy.properties;
+    const meta = this._proxy.properties;
     if (!meta) {
-      this._proxy.properties = meta = {
+      return {
         tags: {
           options: [],
         },

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -65,11 +65,6 @@ export { assertExists };
 
 export const defaultStore: SerializedStore = {
   meta: {
-    properties: {
-      tags: {
-        options: [],
-      },
-    },
     pages: [
       {
         id: 'page:home',


### PR DESCRIPTION
should not init tags based on local state, because tags may exist on remote