### PR TITLE
perf(playground): lazy load style debug menu

### DIFF
--- a/packages/playground/apps/default/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/default/components/quick-edgeless-menu.ts
@@ -19,9 +19,6 @@ import '@shoelace-style/shoelace/dist/themes/dark.css';
 import {
   COLOR_VARIABLES,
   extractCssVariables,
-  FONT_FAMILY_VARIABLES,
-  SIZE_VARIABLES,
-  VARIABLES,
   ZipTransformer,
 } from '@blocksuite/blocks';
 import { NOTE_WIDTH } from '@blocksuite/blocks';
@@ -33,7 +30,6 @@ import type { SlTab, SlTabGroup } from '@shoelace-style/shoelace';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { Pane } from 'tweakpane';
 
 import {
   generateRoomId,
@@ -46,88 +42,11 @@ const plate: Record<string, string> = {};
 COLOR_VARIABLES.forEach((key: string) => {
   plate[key] = cssVariablesMap[key];
 });
-const OTHER_CSS_VARIABLES = VARIABLES.filter(
-  variable =>
-    !SIZE_VARIABLES.includes(variable) &&
-    !COLOR_VARIABLES.includes(variable) &&
-    !FONT_FAMILY_VARIABLES.includes(variable)
-);
 
 const basePath = import.meta.env.DEV
   ? 'node_modules/@shoelace-style/shoelace/dist'
   : 'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.87/dist';
 setBasePath(basePath);
-
-function init_css_debug_menu(styleMenu: Pane) {
-  if (styleMenu.title !== 'Waiting') {
-    return;
-  }
-  const style = document.documentElement.style;
-  styleMenu.title = 'CSS Debug Menu';
-  const sizeFolder = styleMenu.addFolder({ title: 'Size', expanded: false });
-  const fontFamilyFolder = styleMenu.addFolder({
-    title: 'Font Family',
-    expanded: false,
-  });
-  const colorFolder = styleMenu.addFolder({ title: 'Color', expanded: false });
-  const othersFolder = styleMenu.addFolder({
-    title: 'Others',
-    expanded: false,
-  });
-  SIZE_VARIABLES.forEach(name => {
-    sizeFolder
-      .addInput(
-        {
-          [name]: isNaN(parseFloat(cssVariablesMap[name]))
-            ? 0
-            : parseFloat(cssVariablesMap[name]),
-        },
-        name,
-        {
-          min: 0,
-          max: 100,
-        }
-      )
-      .on('change', e => {
-        style.setProperty(name, `${Math.round(e.value)}px`);
-      });
-  });
-  FONT_FAMILY_VARIABLES.forEach(name => {
-    fontFamilyFolder
-      .addInput(
-        {
-          [name]: cssVariablesMap[name],
-        },
-        name
-      )
-      .on('change', e => {
-        style.setProperty(name, e.value);
-      });
-  });
-  OTHER_CSS_VARIABLES.forEach(name => {
-    othersFolder
-      .addInput({ [name]: cssVariablesMap[name] }, name)
-      .on('change', e => {
-        style.setProperty(name, e.value);
-      });
-  });
-  fontFamilyFolder
-    .addInput(
-      {
-        '--affine-font-family':
-          'Roboto Mono, apple-system, BlinkMacSystemFont,Helvetica Neue, Tahoma, PingFang SC, Microsoft Yahei, Arial,Hiragino Sans GB, sans-serif, Apple Color Emoji, Segoe UI Emoji,Segoe UI Symbol, Noto Color Emoji',
-      },
-      '--affine-font-family'
-    )
-    .on('change', e => {
-      style.setProperty('--affine-font-family', e.value);
-    });
-  for (const plateKey in plate) {
-    colorFolder.addInput(plate, plateKey).on('change', e => {
-      style.setProperty(plateKey, e.value);
-    });
-  }
-}
 
 function getTabGroupTemplate({
   workspace,
@@ -230,9 +149,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
 
   @property({ attribute: false })
   readonly = false;
-
-  private _styleMenu!: Pane;
-  private _showStyleDebugMenu = false;
 
   @state()
   private _showTabMenu = false;
@@ -400,14 +316,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
     window.history.pushState({}, '', url);
   }
 
-  private _toggleStyleDebugMenu() {
-    init_css_debug_menu(this._styleMenu);
-    this._showStyleDebugMenu = !this._showStyleDebugMenu;
-    this._showStyleDebugMenu
-      ? (this._styleMenu.hidden = false)
-      : (this._styleMenu.hidden = true);
-  }
-
   private _setThemeMode(dark: boolean) {
     const html = document.querySelector('html');
 
@@ -481,7 +389,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
     return result;
   }
 
-  override firstUpdated() {
+  override async firstUpdated() {
     this._showTabMenu = this.workspace.meta.pageMetas.length > 1;
     this.workspace.slots.pageAdded.on(() => {
       this._showTabMenu = this.workspace.meta.pageMetas.length > 1;
@@ -493,9 +401,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
       this._canUndo = this.page.canUndo;
       this._canRedo = this.page.canRedo;
     });
-    this._styleMenu = new Pane({ title: 'Waiting' });
-    this._styleMenu.hidden = true;
-    this._styleMenu.element.style.width = '650';
   }
 
   override update(changedProperties: Map<string, unknown>) {
@@ -619,9 +524,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
                     <sl-menu-item @click=${this._shareUrl}>
                       Share URL</sl-menu-item
                     >
-                    <sl-menu-item @click=${this._toggleStyleDebugMenu}>
-                      Toggle CSS Debug Menu
-                    </sl-menu-item>
                   </sl-menu>
                 </sl-menu-item>
                 <sl-menu-item @click=${this._toggleDarkMode}>

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -34,7 +34,7 @@ import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.j
 import { css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import * as lz from 'lz-string';
-import { Pane } from 'tweakpane';
+import type { Pane } from 'tweakpane';
 
 import type { CustomCopilotPanel } from './copilot/custom-copilot-panel';
 // @ts-ignore
@@ -52,13 +52,14 @@ const OTHER_CSS_VARIABLES = VARIABLES.filter(
     !COLOR_VARIABLES.includes(variable) &&
     !FONT_FAMILY_VARIABLES.includes(variable)
 );
+let styleDebugMenuLoaded = false;
 
 const basePath = import.meta.env.DEV
   ? '/node_modules/@shoelace-style/shoelace/dist'
   : 'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.87/dist';
 setBasePath(basePath);
 
-function init_css_debug_menu(styleMenu: Pane, style: CSSStyleDeclaration) {
+function initStyleDebugMenu(styleMenu: Pane, style: CSSStyleDeclaration) {
   const sizeFolder = styleMenu.addFolder({ title: 'Size', expanded: false });
   const fontFamilyFolder = styleMenu.addFolder({
     title: 'Font Family',
@@ -338,7 +339,16 @@ export class DebugMenu extends ShadowlessElement {
     window.history.pushState({}, '', url);
   }
 
-  private _toggleStyleDebugMenu() {
+  private async _toggleStyleDebugMenu() {
+    if (!styleDebugMenuLoaded) {
+      styleDebugMenuLoaded = true;
+      const { Pane } = await import('tweakpane');
+      this._styleMenu = new Pane({ title: 'Waiting' });
+      this._styleMenu.hidden = true;
+      this._styleMenu.element.style.width = '650';
+      initStyleDebugMenu(this._styleMenu, document.documentElement.style);
+    }
+
     this._showStyleDebugMenu = !this._showStyleDebugMenu;
     this._showStyleDebugMenu
       ? (this._styleMenu.hidden = false)
@@ -422,11 +432,6 @@ export class DebugMenu extends ShadowlessElement {
       this._canUndo = this.page.canUndo;
       this._canRedo = this.page.canRedo;
     });
-    this._styleMenu = new Pane({ title: 'CSS Debug Menu' });
-    this._styleMenu.hidden = true;
-    this._styleMenu.element.style.width = '650';
-    const style = document.documentElement.style;
-    init_css_debug_menu(this._styleMenu, style);
   }
 
   override update(changedProperties: Map<string, unknown>) {


### PR DESCRIPTION
Close #4381 (not perfectly closed, but should be adequate FTM)

Before:

<img width="876" alt="image" src="https://github.com/toeverything/blocksuite/assets/7312949/f23f8bdc-8a4f-4334-a37a-3cd1b884d26e">

After:

<img width="876" alt="image" src="https://github.com/toeverything/blocksuite/assets/7312949/c991d715-1cc6-4c56-a8d4-6307bcbe3c10">
