### PR TITLE
feat: override `getUpdateComplete` of `editor-container` and `lit-root`

### DIFF
--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -100,6 +100,15 @@ export class EditorContainer
     tagClicked: new Slot<{ tagId: string }>(),
   };
 
+  override async getUpdateComplete(): Promise<boolean> {
+    const result = await super.getUpdateComplete();
+    const root = this.root.value;
+    if (root) {
+      await root.updateComplete;
+    }
+    return result;
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 


### PR DESCRIPTION
In some scenarios, the outside needs to wait for the block element to finish rendering. This PR allows the outside to precisely know this moment through `editor.updateComplete` instead of using `setTimeout`.

related:
https://github.com/toeverything/AFFiNE/pull/4858/files#diff-3de211b8fe52fc353dfb51cc44c0f91272ffdeb8bc31481d69e1dfd8068c2da1R137-R142