### PR TITLE
fix(page): mock selection of multiline text on create/edit link

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -165,8 +165,10 @@ export class LinkPopup extends WithDisposable(LitElement) {
     if (!this.vEditor.isVRangeValid(this.goalVRange)) return;
 
     assertExists(this.linkInput);
-    const link = normalizeUrl(this.linkInput.value);
-    if (!isValidUrl(link)) return;
+    const linkInputValue = this.linkInput.value;
+    if (!linkInputValue || !isValidUrl(linkInputValue)) return;
+
+    const link = normalizeUrl(linkInputValue);
 
     if (this.type === 'create') {
       this.vEditor.formatText(this.goalVRange, {
@@ -218,8 +220,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
     e.stopPropagation();
     if (e.key === 'Enter' && !e.isComposing) {
       e.preventDefault();
-      const link = this.linkInput?.value;
-      if (!link || !isValidUrl(link)) return;
       this._onConfirm();
     }
   }

--- a/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -43,8 +43,8 @@ export class LinkPopup extends WithDisposable(LitElement) {
   linkInput?: HTMLInputElement;
   @query('.popup-container')
   popupContainer?: HTMLDivElement;
-  @query('.mock-selection')
-  mockSelection?: HTMLDivElement;
+  @query('.mock-selection-container')
+  mockSelectionContainer?: HTMLDivElement;
   @query('.affine-confirm-button')
   confirmButton?: IconButton;
 
@@ -87,12 +87,19 @@ export class LinkPopup extends WithDisposable(LitElement) {
     assertExists(range);
 
     if (this.type !== 'view') {
-      assertExists(this.mockSelection);
-      const rangeRect = range.getBoundingClientRect();
-      this.mockSelection.style.left = `${rangeRect.left}px`;
-      this.mockSelection.style.top = `${rangeRect.top}px`;
-      this.mockSelection.style.width = `${rangeRect.width}px`;
-      this.mockSelection.style.height = `${rangeRect.height}px`;
+      const domRects = range.getClientRects();
+
+      Object.values(domRects).forEach(domRect => {
+        const mockSelection = document.createElement('div');
+        mockSelection.classList.add('mock-selection');
+        mockSelection.style.left = `${domRect.left}px`;
+        mockSelection.style.top = `${domRect.top}px`;
+        mockSelection.style.width = `${domRect.width}px`;
+        mockSelection.style.height = `${domRect.height}px`;
+
+        assertExists(this.mockSelectionContainer);
+        this.mockSelectionContainer.appendChild(mockSelection);
+      });
     }
 
     const visualElement = {
@@ -211,6 +218,8 @@ export class LinkPopup extends WithDisposable(LitElement) {
     e.stopPropagation();
     if (e.key === 'Enter' && !e.isComposing) {
       e.preventDefault();
+      const link = this.linkInput?.value;
+      if (!link || !isValidUrl(link)) return;
       this._onConfirm();
     }
   }
@@ -369,7 +378,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         <div class="popup-container" @keydown=${this._onKeydown}>
           ${popover}
         </div>
-        <div class="mock-selection"></div>
+        <div class="mock-selection-container"></div>
       </div>
     `;
   }


### PR DESCRIPTION
Closes: #5014 

Changes:
* Mulitple mock selection divs, derived using `getClientRects`, for representing text selection accurately.
* Check for `isValidUrl` in the `_onConfirm` method before `normalizeUrl`. Previously, an invalid URL was getting accepted on pressing the Enter key as this check was after normalizeUrl.


https://github.com/toeverything/blocksuite/assets/54364088/2a39ac1d-923e-4f7c-ba00-1b0fc3a49545


