### PR TITLE
fix(edgeless): optimize shape text color when shape is transparent

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-shape-button.ts
@@ -39,7 +39,7 @@ import { lineSizeButtonStyles } from '../buttons/line-size-button.js';
 import type { LineStyleButtonProps } from '../buttons/line-style-button.js';
 import type { EdgelessToolIconButton } from '../buttons/tool-icon-button.js';
 import type { ColorEvent } from '../panel/color-panel.js';
-import { isTransparent } from '../panel/color-panel.js';
+import { GET_DEFAULT_LINE_COLOR, isTransparent } from '../panel/color-panel.js';
 import { ColorUnit } from '../panel/color-panel.js';
 import {
   LineStylesPanel,
@@ -313,11 +313,13 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
 
   private _getTextColor(fillColor: CssVariableName) {
     // When the shape is filled with black color, the text color should be white.
+    // When the shape is transparent, the text color should be set according to the theme.
     // Otherwise, the text color should be black.
-    const textColor =
-      fillColor === SHAPE_FILL_COLOR_BLACK
-        ? SHAPE_TEXT_COLOR_PURE_WHITE
-        : SHAPE_TEXT_COLOR_PURE_BLACK;
+    const textColor = isTransparent(fillColor)
+      ? GET_DEFAULT_LINE_COLOR()
+      : fillColor === SHAPE_FILL_COLOR_BLACK
+      ? SHAPE_TEXT_COLOR_PURE_WHITE
+      : SHAPE_TEXT_COLOR_PURE_BLACK;
 
     return textColor;
   }

--- a/packages/blocks/src/page-block/edgeless/utils/consts.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/consts.ts
@@ -51,6 +51,6 @@ export const SurfaceColor = '#6046FE';
 export const NoteColor = '#1E96EB';
 export const BlendColor = '#7D91FF';
 
-export const SHAPE_TEXT_COLOR_PURE_WHITE = 'white';
-export const SHAPE_TEXT_COLOR_PURE_BLACK = 'black';
+export const SHAPE_TEXT_COLOR_PURE_WHITE = '--affine-palette-line-white';
+export const SHAPE_TEXT_COLOR_PURE_BLACK = '--affine-palette-line-black';
 export const SHAPE_FILL_COLOR_BLACK = '--affine-palette-shape-black';

--- a/packages/blocks/src/page-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/text.ts
@@ -13,6 +13,7 @@ import {
 import {
   GET_DEFAULT_LINE_COLOR,
   GET_DEFAULT_TEXT_COLOR,
+  isTransparent,
 } from '../components/panel/color-panel.js';
 import { EdgelessFrameTitleEditor } from '../components/text/edgeless-frame-title-editor.js';
 import { EdgelessGroupTitleEditor } from '../components/text/edgeless-group-title-editor.js';
@@ -22,6 +23,9 @@ import type { EdgelessPageBlockComponent } from '../edgeless-page-block.js';
 import {
   GENERAL_CANVAS_FONT_FAMILY,
   SCRIBBLED_CANVAS_FONT_FAMILY,
+  SHAPE_FILL_COLOR_BLACK,
+  SHAPE_TEXT_COLOR_PURE_BLACK,
+  SHAPE_TEXT_COLOR_PURE_WHITE,
 } from './consts.js';
 
 export type CANVAS_TEXT_FONT =
@@ -62,9 +66,15 @@ export function mountShapeTextEditor(
 ) {
   if (!shapeElement.text) {
     const text = new Workspace.Y.Text();
+    const { fillColor } = shapeElement;
+    const color = isTransparent(fillColor)
+      ? GET_DEFAULT_LINE_COLOR()
+      : fillColor === SHAPE_FILL_COLOR_BLACK
+      ? SHAPE_TEXT_COLOR_PURE_WHITE
+      : SHAPE_TEXT_COLOR_PURE_BLACK;
     edgeless.surface.updateElement<PhasorElementType.SHAPE>(shapeElement.id, {
       text,
-      color: GET_DEFAULT_LINE_COLOR(),
+      color,
       fontFamily:
         shapeElement.shapeStyle === ShapeStyle.General
           ? GENERAL_CANVAS_FONT_FAMILY


### PR DESCRIPTION
By design:
[shape text](https://www.figma.com/file/hVxJQtEqyv5xw1AbCzc50M/%F0%9F%93%8C-AFFiNE-2023?type=design&node-id=12712-188780&mode=design&t=smZ2k380zorFPnx9-0)

When shape fillColor is black, the shape text color is white, otherwise the shape text color is black no matter what theme is.

<img width="1048" alt="Screenshot 2023-11-07 at 19 01 11" src="https://github.com/toeverything/blocksuite/assets/99816898/10783901-95ff-4e5b-ab75-2e7d06d130f5">

But I think maybe we should consider theme mode when shape is transparent to make it easy to read.





