### PR TITLE
fix(page): multiple link elements when part of selection has attributes

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -171,10 +171,14 @@ export class LinkPopup extends WithDisposable(LitElement) {
     const link = normalizeUrl(linkInputValue);
 
     if (this.type === 'create') {
-      this.vEditor.formatText(this.goalVRange, {
-        link: link,
-        reference: null,
-      });
+      this.vEditor.formatText(
+        this.goalVRange,
+        {
+          link: link,
+          reference: null,
+        },
+        { mode: 'replace' }
+      );
       this.vEditor.setVRange(this.goalVRange);
     } else if (this.type === 'edit') {
       const text = this.textInput?.value ?? link;


### PR DESCRIPTION
### Bug Description:
https://github.com/toeverything/blocksuite/pull/5241#issuecomment-1798213417

### Changes:
* Switched to `mode: 'replace'` in `formatText` method while creating new link, to clear all text attributes in selection.


https://github.com/toeverything/blocksuite/assets/54364088/aeb8e2fa-7a21-4959-bf49-e869cad05cd7

