### PR TITLE
feat(store): add `page.slots.ready`

### DIFF
--- a/packages/docs/event-api.md
+++ b/packages/docs/event-api.md
@@ -37,13 +37,12 @@ disposable.dispose();
 Under the `page` instance, you can subscribe to common events using `page.slots`:
 
 ```ts
-page.slots.rootAdded.on(() => {
-  // The `page.root` is not null at this point
-  // You can bind it to a component tree now
-  console.log('rootAdded!');
+page.slots.ready.on(() => {
+  // The `page.root` should be ready to use at this moment
+  console.log('page ready!');
 });
 
-page.addBlock('affine:page'); // rootAdded!
+page.addBlock('affine:page');
 ```
 
 Moreover, for any node in the block tree, events can be triggered when the node is updated:

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -55,11 +55,22 @@ export class Page extends Space<FlatBlockMap> {
   private _history!: Y.UndoManager;
   private _root: BaseBlockModel | null = null;
   private _blockMap = new Map<string, BaseBlockModel>();
-  private _synced = false;
+  private _initialized = false;
   private _shouldTransact = true;
 
   readonly slots = {
+    /**
+     * This fires when the block tree is initialized via API call or underlying existing ydoc binary.
+     * Note that this is different with the `doc.loaded` field,
+     * since `loaded` only indicates that the ydoc is loaded, not the block tree.
+     */
+    ready: new Slot(),
     historyUpdated: new Slot(),
+    /**
+     * This fires when the root block is added via API call or has just been initialized from existing ydoc.
+     * useful for internal block UI components to start subscribing following up events.
+     * Note that at this moment, the whole block tree may not be fully initialized yet.
+     */
     rootAdded: new Slot<BaseBlockModel>(),
     rootDeleted: new Slot<string | string[]>(),
     textUpdated: new Slot<Y.YTextEvent>(),
@@ -644,7 +655,7 @@ export class Page extends Space<FlatBlockMap> {
   }
 
   trySyncFromExistingDoc() {
-    if (this._synced) {
+    if (this._initialized) {
       throw new Error('Cannot sync from existing doc more than once');
     }
 
@@ -662,7 +673,8 @@ export class Page extends Space<FlatBlockMap> {
       this._handleYBlockAdd(visited, id);
     });
 
-    this._synced = true;
+    this._initialized = true;
+    this.slots.ready.emit();
   }
 
   dispose() {
@@ -674,7 +686,7 @@ export class Page extends Space<FlatBlockMap> {
     this.slots.blockUpdated.dispose();
     this.slots.onYEvent.dispose();
 
-    if (this._synced) {
+    if (this._initialized) {
       this._yBlocks.unobserveDeep(this._handleYEvents);
       this._yBlocks.clear();
     }
@@ -682,13 +694,6 @@ export class Page extends Space<FlatBlockMap> {
 
   private _initYBlocks() {
     const { _yBlocks } = this;
-    // Consider if we need to expose the ability to temporarily unobserve this._yBlocks.
-    // "unobserve" is potentially necessary to make sure we don't create
-    // an infinite loop when sync to remote then back to client.
-    // `action(a) -> YDoc' -> YEvents(a) -> YRemoteDoc' -> YEvents(a) -> YDoc'' -> ...`
-    // We could unobserve in order to short circuit by ignoring the sync of remote
-    // events we actually generated locally.
-    // _yBlocks.unobserveDeep(this._handleYEvents);
     _yBlocks.observeDeep(this._handleYEvents);
     this._history = new Y.UndoManager([_yBlocks], {
       trackedOrigins: new Set([this._ySpaceDoc.clientID]),
@@ -921,7 +926,7 @@ export class Page extends Space<FlatBlockMap> {
 
   override async waitForLoaded() {
     await super.waitForLoaded();
-    if (!this._synced) {
+    if (!this._initialized) {
       this.trySyncFromExistingDoc();
     }
 


### PR DESCRIPTION
close #5249

Not using `_synced` to avoid misunderstanding with the concept of "synced with server" during collaboration.
