### PR TITLE
fix(edgeless): remove shape overlay when element disconnect

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -147,6 +147,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
         this._autoCompleteOverlay.shapePoints = [];
       })
     );
+    this._disposables.add(() => this.removeOverlay());
   }
 
   private _createAutoCompletePanel(


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/5273