### PR TITLE
fix(page): arrow up/down navigation

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -9,7 +9,6 @@ import {
 } from '@blocksuite/virgo';
 
 import { matchFlavours } from '../../../../_common/utils/model.js';
-import { getNextBlock } from '../../../../note-block/utils.js';
 import type { PageBlockComponent } from '../../../../page-block/types.js';
 import { getSelectedContentModels } from '../../../../page-block/utils/selection.js';
 import { textFormatConfigs } from '../../../configs/text-format/config.js';
@@ -113,7 +112,10 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
 
   blockElement.bindHotKey({
     ArrowUp: ctx => {
-      if (!blockElement.selected?.is('text')) return;
+      if (!blockElement.selected?.is('text')) {
+        return;
+      }
+
       const vEditor = _getVirgo();
       const vRange = vEditor.getVRange();
       if (!vRange) {
@@ -127,19 +129,14 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         });
       }
 
-      const range = vEditor.toDomRange({
-        index: vRange.index,
-        length: 0,
-      });
-      assertExists(range);
-      if (vEditor.isFirstLine(vRange)) {
-        _preventDefault(ctx);
-        return;
-      }
-      return true;
+      _preventDefault(ctx);
+      return;
     },
     ArrowDown: ctx => {
-      if (!blockElement.selected?.is('text')) return;
+      if (!blockElement.selected?.is('text')) {
+        return;
+      }
+
       const vEditor = _getVirgo();
       const vRange = vEditor.getVRange();
       if (!vRange) {
@@ -153,17 +150,8 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         });
       }
 
-      const range = vEditor.toDomRange({
-        index: vRange.index,
-        length: 0,
-      });
-      assertExists(range);
-      if (vEditor.isLastLine(vRange) && getNextBlock(blockElement)) {
-        _preventDefault(ctx);
-        return;
-      }
-
-      return true;
+      _preventDefault(ctx);
+      return;
     },
     ArrowRight: ctx => {
       if (blockElement.selected?.is('block')) {

--- a/packages/blocks/src/note-block/keymap.ts
+++ b/packages/blocks/src/note-block/keymap.ts
@@ -49,84 +49,58 @@ export function bindHotKey(blockElement: BlockElement) {
           next();
         })
         .try(cmd => [
-          // text selection - case 1: move cursor down within the same block
+          // text selection
           cmd
             .getTextSelection()
             .inline<'currentSelectionPath'>((ctx, next) => {
               const textSelection = ctx.currentTextSelection;
               assertExists(textSelection);
               const end = textSelection.to ?? textSelection.from;
+              currentBlock = pathToBlock(blockElement, end.path);
               next({ currentSelectionPath: end.path });
             })
-            .inline((ctx, next) => {
-              assertExists(ctx.currentSelectionPath);
-              currentBlock = pathToBlock(
-                blockElement,
-                ctx.currentSelectionPath
-              );
-              assertExists(currentBlock);
-
-              const success = moveCursorVertically(currentBlock, false);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 2: move cursor down to the next block
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              const end = textSelection.to ?? textSelection.from;
-              next({ currentSelectionPath: end.path });
-            })
-            .getNextBlock({
-              filter: block => !!block.model.text,
-            })
-            .inline((ctx, next) => {
-              assertExists(ctx.nextBlock);
-
-              const success = moveCursorVertically(ctx.nextBlock, false);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 3: move cursor to the next block start
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              const end = textSelection.to ?? textSelection.from;
-              next({ currentSelectionPath: end.path });
-            })
-            .getNextBlock({
-              filter: block => !!block.model.text,
-            })
-            .inline((ctx, next) => {
-              assertExists(ctx.nextBlock);
-
-              const success = moveCursorToBlock(ctx.nextBlock, false);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 4: move cursor to the current block end
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              const end = textSelection.to ?? textSelection.from;
-              next({ currentSelectionPath: end.path });
-            })
-            .inline((_, next) => {
-              assertExists(currentBlock);
-              const success = moveCursorToBlock(currentBlock, true);
-              if (success) {
-                next();
-              }
-            }),
+            .try(cmd => [
+              // text selection - case 1: move cursor down within the same block
+              cmd.inline((_, next) => {
+                assertExists(currentBlock);
+                const success = moveCursorVertically(currentBlock, false);
+                if (success) {
+                  next();
+                }
+              }),
+              // text selection - case 2: move cursor down to the next block
+              cmd
+                .getNextBlock({
+                  filter: block => !!block.model.text,
+                })
+                .inline((ctx, next) => {
+                  assertExists(ctx.nextBlock);
+                  const success = moveCursorVertically(ctx.nextBlock, false);
+                  if (success) {
+                    next();
+                  }
+                }),
+              // text selection - case 3: move cursor to the next block start
+              cmd
+                .getNextBlock({
+                  filter: block => !!block.model.text,
+                })
+                .inline((ctx, next) => {
+                  assertExists(ctx.nextBlock);
+                  const success = moveCursorToBlock(ctx.nextBlock, false);
+                  if (success) {
+                    next();
+                  }
+                }),
+              // text selection - case 4: move cursor to the current block end
+              cmd.inline((_, next) => {
+                assertExists(currentBlock);
+                const success = moveCursorToBlock(currentBlock, true);
+                if (success) {
+                  next();
+                }
+              }),
+            ]),
 
           // block selection - select the next block
           cmd
@@ -164,77 +138,57 @@ export function bindHotKey(blockElement: BlockElement) {
           next();
         })
         .try(cmd => [
-          // text selection - case 1: move cursor up within the same block
+          // text selection
           cmd
             .getTextSelection()
             .inline<'currentSelectionPath'>((ctx, next) => {
               const textSelection = ctx.currentTextSelection;
               assertExists(textSelection);
+              currentBlock = pathToBlock(blockElement, textSelection.from.path);
               next({ currentSelectionPath: textSelection.from.path });
             })
-            .inline((ctx, next) => {
-              assertExists(ctx.currentSelectionPath);
-              currentBlock = pathToBlock(
-                blockElement,
-                ctx.currentSelectionPath
-              );
-              assertExists(currentBlock);
-              const success = moveCursorVertically(currentBlock, true);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 2: move cursor up to the previous block
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              next({ currentSelectionPath: textSelection.from.path });
-            })
-            .getPrevBlock({
-              filter: block => !!block.model.text,
-            })
-            .inline((ctx, next) => {
-              assertExists(ctx.prevBlock);
-              const success = moveCursorVertically(ctx.prevBlock, true);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 3: move cursor to the previous block end
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              next({ currentSelectionPath: textSelection.from.path });
-            })
-            .getPrevBlock({
-              filter: block => !!block.model.text,
-            })
-            .inline((ctx, next) => {
-              assertExists(ctx.prevBlock);
-              const success = moveCursorToBlock(ctx.prevBlock, true);
-              if (success) {
-                next();
-              }
-            }),
-          // text selection - case 4: move cursor to the current block start
-          cmd
-            .getTextSelection()
-            .inline<'currentSelectionPath'>((ctx, next) => {
-              const textSelection = ctx.currentTextSelection;
-              assertExists(textSelection);
-              next({ currentSelectionPath: textSelection.from.path });
-            })
-            .inline((_, next) => {
-              assertExists(currentBlock);
-              const success = moveCursorToBlock(currentBlock, false);
-              if (success) {
-                next();
-              }
-            }),
+            .try(cmd => [
+              // text selection - case 1: move cursor up within the same block
+              cmd.inline((_, next) => {
+                assertExists(currentBlock);
+                const success = moveCursorVertically(currentBlock, true);
+                if (success) {
+                  next();
+                }
+              }),
+              // text selection - case 2: move cursor up to the previous block
+              cmd
+                .getPrevBlock({
+                  filter: block => !!block.model.text,
+                })
+                .inline((ctx, next) => {
+                  assertExists(ctx.prevBlock);
+                  const success = moveCursorVertically(ctx.prevBlock, true);
+                  if (success) {
+                    next();
+                  }
+                }),
+              // text selection - case 3: move cursor to the previous block end
+              cmd
+                .getPrevBlock({
+                  filter: block => !!block.model.text,
+                })
+                .inline((ctx, next) => {
+                  assertExists(ctx.prevBlock);
+                  const success = moveCursorToBlock(ctx.prevBlock, true);
+                  if (success) {
+                    next();
+                  }
+                }),
+              // text selection - case 4: move cursor to the current block start
+              cmd.inline((_, next) => {
+                assertExists(currentBlock);
+                const success = moveCursorToBlock(currentBlock, false);
+                if (success) {
+                  next();
+                }
+              }),
+            ]),
 
           // block selection - select the previous block
           cmd

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -199,11 +199,11 @@ test('edgeless arrow up/down', async ({ page }) => {
 
   await pressArrowDown(page);
   await waitNextFrame(page);
-  await assertRichTextVRange(page, 1, 0, 0);
+  await assertRichTextVRange(page, 1, 4, 0);
 
   await pressArrowUp(page);
   await waitNextFrame(page);
-  await assertRichTextVRange(page, 0, 0, 0);
+  await assertRichTextVRange(page, 0, 4, 0);
 
   await pressArrowUp(page);
   await waitNextFrame(page);

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -19,6 +19,7 @@ import {
   pressEscape,
   pressShiftEnter,
   pressShiftTab,
+  pressSpace,
   pressTab,
   redoByClick,
   redoByKeyboard,
@@ -1605,4 +1606,54 @@ test('delete at the start of paragraph (multiple notes)', async ({ page }) => {
   await setSelection(page, 5, 0, 5, 0);
   await pressBackspace(page);
   await assertRichTexts(page, ['123456']);
+});
+
+test('arrow up/down navigation within and across paragraphs containing different types of text', async ({
+  page,
+}) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/5155',
+  });
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  await type(page, 'a'.repeat(20));
+  await assertRichTextVRange(page, 0, 20, 0);
+  await type(page, '*');
+  await type(page, 'i'.repeat(5));
+  await type(page, '*');
+  await pressSpace(page);
+  await assertRichTextVRange(page, 0, 25, 0);
+  await type(page, 'a'.repeat(100));
+  await assertRichTextVRange(page, 0, 125, 0);
+  await pressEnter(page);
+
+  await type(page, 'a'.repeat(100));
+  await assertRichTextVRange(page, 1, 100, 0);
+  await type(page, '*');
+  await type(page, 'i'.repeat(5));
+  await type(page, '*');
+  await pressSpace(page);
+  await assertRichTextVRange(page, 1, 105, 0);
+  await type(page, 'a'.repeat(20));
+  await assertRichTextVRange(page, 1, 125, 0);
+
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 1, 32, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 0, 125, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 0, 35, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 0, 0, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 0, 93, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 1, 0, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 1, 90, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 1, 125, 0);
 });

--- a/tests/quote.spec.ts
+++ b/tests/quote.spec.ts
@@ -2,10 +2,13 @@ import {
   enterPlaygroundRoom,
   focusRichText,
   initEmptyParagraphState,
+  pressArrowDown,
+  pressArrowRight,
+  pressArrowUp,
   pressEnter,
   type,
 } from './utils/actions/index.js';
-import { assertTextContain } from './utils/asserts.js';
+import { assertRichTextVRange, assertTextContain } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
 
 test('prohibit creating divider within quote', async ({ page }) => {
@@ -24,4 +27,75 @@ test('prohibit creating divider within quote', async ({ page }) => {
   await type(page, '---');
   await page.keyboard.press('Space', { delay: 50 });
   await assertTextContain(page, '---');
+});
+
+test('quote arrow up/down', async ({ page }) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/2834',
+  });
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  await type(page, 'hello');
+  await pressEnter(page);
+  await type(page, 'world');
+  await pressEnter(page);
+  await type(page, 'foo');
+  await pressEnter(page);
+  await type(page, '> 123123123');
+  await pressEnter(page);
+  await type(page, '123');
+  await pressEnter(page);
+  await type(page, '123123123');
+  await pressEnter(page);
+  await pressEnter(page);
+  await type(page, 'hello');
+  await pressEnter(page);
+  await type(page, 'world');
+  await pressEnter(page);
+  await type(page, 'foo');
+
+  await assertRichTextVRange(page, 6, 3, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 5, 2, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 4, 3, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 3, 14, 0);
+  await pressArrowRight(page, 9);
+  await assertRichTextVRange(page, 3, 23, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 3, 13, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 3, 3, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 2, 3, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 1, 2, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 0, 3, 0);
+  await pressArrowUp(page);
+  await assertRichTextVRange(page, 0, 0, 0);
+  await pressArrowRight(page, 4);
+  await assertRichTextVRange(page, 0, 4, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 1, 3, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 2, 3, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 3, 0, 0);
+  await pressArrowRight(page, 9);
+  await assertRichTextVRange(page, 3, 9, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 3, 13, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 3, 17, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 4, 5, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 5, 4, 0);
+  await pressArrowDown(page);
+  await assertRichTextVRange(page, 6, 3, 0);
 });


### PR DESCRIPTION
Closes: #5281 (duplicate of #5155)
Closes: #5155 
Closes: #2834 

Currently, the app only handles inter-block up/down navigation. Within the same block is handled by the browser. After many iterations, it felt to have consistent behavior and handle all edge cases either app or browser should completely handle the navigation.

This may be removed when migration to a single root content editable container is complete and the browser is able to handle navigation completely.