### PR TITLE
feat(page): optimize large file download experience

### DIFF
--- a/packages/blocks/src/attachment-block/components/more-menu.ts
+++ b/packages/blocks/src/attachment-block/components/more-menu.ts
@@ -6,17 +6,22 @@ import {
   DownloadIcon,
   DuplicateIcon,
 } from '../../_common/icons/index.js';
-import type { AttachmentBlockModel } from '../attachment-model.js';
-import { cloneAttachmentProperties, downloadAttachment } from '../utils.js';
+import type {
+  AttachmentBlockModel,
+  AttachmentBlockProps,
+} from '../attachment-model.js';
+import { cloneAttachmentProperties } from '../utils.js';
 import { moreMenuStyles } from './styles.js';
 
 export const MoreMenu = ({
   ref: moreMenuRef,
   model,
+  downloadAttachment,
   abortController,
 }: {
   ref?: Ref<HTMLDivElement>;
   model: AttachmentBlockModel;
+  downloadAttachment: (model: AttachmentBlockModel) => void;
   abortController: AbortController;
 }) => {
   const readonly = model.page.readonly;
@@ -38,10 +43,11 @@ export const MoreMenu = ({
         text="Duplicate"
         ?hidden=${readonly}
         @click="${() => {
-          const prop = {
-            flavour: 'affine:attachment',
-            ...cloneAttachmentProperties(model),
-          };
+          const prop: { flavour: 'affine:attachment' } & AttachmentBlockProps =
+            {
+              flavour: 'affine:attachment',
+              ...cloneAttachmentProperties(model),
+            };
           model.page.addSiblingBlocks(model, [prop]);
         }}"
       >

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -23,11 +23,13 @@ export function AttachmentOptionsTemplate({
   anchor,
   model,
   showCaption,
+  downloadAttachment,
   abortController,
   ref: refOrCallback = createRef<HTMLDivElement>(),
 }: {
   anchor: HTMLElement;
   model: AttachmentBlockModel;
+  downloadAttachment: (model: AttachmentBlockModel) => void;
   showCaption: () => void;
   abortController: AbortController;
   ref?: RefOrCallback;
@@ -133,7 +135,7 @@ export function AttachmentOptionsTemplate({
           assertExists(containerEl);
           createLitPortal({
             container: containerEl,
-            template: MoreMenu({ model, abortController }),
+            template: MoreMenu({ model, abortController, downloadAttachment }),
             abortController: moreMenuAbortController,
             computePosition: {
               referenceElement: containerEl,

--- a/packages/blocks/src/attachment-block/utils.ts
+++ b/packages/blocks/src/attachment-block/utils.ts
@@ -41,6 +41,10 @@ async function getAttachment(model: AttachmentBlockModel) {
   return blob;
 }
 
+/**
+ * Since the size of the attachment may be very large,
+ * the download process may take a long time!
+ */
 export async function downloadAttachment(
   attachmentModel: AttachmentBlockModel
 ) {

--- a/packages/blocks/src/bookmark-block/embed.ts
+++ b/packages/blocks/src/bookmark-block/embed.ts
@@ -40,7 +40,7 @@ const embedConfig: EmbedConfig[] = [
   },
   {
     // See also https://publish.twitter.com/
-    name: 'X(Twitter) ',
+    name: 'X(Twitter)',
     format: url => {
       if (!['www.twitter.com', 'twitter.com', 'x.com'].includes(url.hostname))
         return null;


### PR DESCRIPTION
Since the attachment size becomes configurable in https://github.com/toeverything/blocksuite/pull/5158, the size of attachement may be very large.

This pr optimize large file download experience.  It includes the following improvements:

- Showing a toast when clicking download
- Showing a loading state when downloading
- Fixing the issue of multiple simultaneous downloads of attachments
