### PR TITLE
perf(store): support lazy reindex

### DIFF
--- a/packages/global/src/env/index.ts
+++ b/packages/global/src/env/index.ts
@@ -1,9 +1,12 @@
 const agent = globalThis.navigator?.userAgent ?? '';
 const platform = globalThis.navigator?.platform;
 
-export const IS_WEB = typeof window !== 'undefined';
+export const IS_WEB =
+  typeof window !== 'undefined' && typeof document !== 'undefined';
 
-const IS_SAFARI = /Apple Computer/.test(globalThis.navigator?.vendor);
+export const IS_NODE = typeof process !== 'undefined' && !IS_WEB;
+
+export const IS_SAFARI = /Apple Computer/.test(globalThis.navigator?.vendor);
 
 export const IS_FIREFOX =
   IS_WEB && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;

--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 // checkout https://vitest.dev/guide/debugging.html for debugging tests
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { applyUpdate, encodeStateAsUpdate } from 'yjs';
 
 // Use manual per-module import/export to support vitest environment on Node.js
@@ -29,6 +29,10 @@ async function createTestPage(pageId = 'page:home', workspace?: Workspace) {
   await page.waitForLoaded();
   return page;
 }
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['requestIdleCallback'] });
+});
 
 describe('workspace.search works', () => {
   it('workspace search matching', async () => {

--- a/packages/store/src/__tests__/indexer.unit.spec.ts
+++ b/packages/store/src/__tests__/indexer.unit.spec.ts
@@ -78,9 +78,11 @@ describe('workspace.search works', () => {
 
     const id = page.id;
 
-    queueMicrotask(() => {
-      expect(workspace.search('处理器')).toStrictEqual(expected1);
-      expect(workspace.search('索尼')).toStrictEqual(expected2);
+    requestIdleCallback(() => {
+      queueMicrotask(() => {
+        expect(workspace.search('处理器')).toStrictEqual(expected1);
+        expect(workspace.search('索尼')).toStrictEqual(expected2);
+      });
     });
 
     const update = encodeStateAsUpdate(page.spaceDoc);
@@ -94,9 +96,12 @@ describe('workspace.search works', () => {
     });
     applyUpdate(page2.spaceDoc, update);
     expect(page2.spaceDoc.toJSON()).toEqual(page.spaceDoc.toJSON());
-    queueMicrotask(() => {
-      expect(workspace2.search('处理器')).toStrictEqual(expected1);
-      expect(workspace2.search('索尼')).toStrictEqual(expected2);
+
+    requestIdleCallback(() => {
+      queueMicrotask(() => {
+        expect(workspace2.search('处理器')).toStrictEqual(expected1);
+        expect(workspace2.search('索尼')).toStrictEqual(expected2);
+      });
     });
   });
 });

--- a/packages/store/src/__tests__/workspace.unit.spec.ts
+++ b/packages/store/src/__tests__/workspace.unit.spec.ts
@@ -2,7 +2,7 @@
 // checkout https://vitest.dev/guide/debugging.html for debugging tests
 
 import type { Slot } from '@blocksuite/global/utils';
-import { assert, describe, expect, it, vi } from 'vitest';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Awareness } from 'y-protocols/awareness.js';
 import { applyUpdate, encodeStateAsUpdate } from 'yjs';
 
@@ -71,6 +71,10 @@ async function createTestPage(pageId = defaultPageId) {
   await page.waitForLoaded();
   return page;
 }
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['requestIdleCallback'] });
+});
 
 describe('basic', () => {
   it('can init workspace', async () => {
@@ -867,8 +871,10 @@ describe('workspace search', () => {
     });
     const noteId = page.addBlock('affine:note', {}, pageId);
     page.addBlock('affine:paragraph', {}, noteId);
-    const result = workspace.search('test');
-    expect(result).toMatchInlineSnapshot(`
+
+    requestIdleCallback(() => {
+      const result = workspace.search('test');
+      expect(result).toMatchInlineSnapshot(`
       Map {
         "0" => {
           "content": "test123",
@@ -876,5 +882,6 @@ describe('workspace search', () => {
         },
       }
     `);
+    });
   });
 });

--- a/packages/store/src/indexer/search.ts
+++ b/packages/store/src/indexer/search.ts
@@ -56,6 +56,8 @@ type IndexMeta = Readonly<{
   tags: string[];
 }>;
 
+const REINDEX_TIMEOUT = 200;
+
 export class SearchIndexer {
   private readonly _doc: BlockSuiteDoc;
   private readonly _indexer: FlexSearch.Document<IndexMeta, string[]>;
@@ -103,8 +105,9 @@ export class SearchIndexer {
     }
   }
 
-  private _reindex() {
+  private _reindex = () => {
     if (!this._reindexMap) return;
+
     for (const id of this._reindexMap.keys()) {
       const meta = this._reindexMap.get(id);
       if (meta) {
@@ -112,11 +115,12 @@ export class SearchIndexer {
         this._indexer.add(id, meta);
       }
     }
+
     setTimeout(() => {
       if (!this._reindexMap) return;
-      requestIdleCallback(this._reindex.bind(this), { timeout: 1000 });
-    }, 200);
-  }
+      requestIdleCallback(this._reindex, { timeout: 1000 });
+    }, REINDEX_TIMEOUT);
+  };
 
   search(query: QueryContent) {
     return new Map(


### PR DESCRIPTION
improve the performance for large content in single block:

before:
![image](https://github.com/toeverything/blocksuite/assets/25152247/e4d2868c-086d-4479-a1fa-787f202c4e39)

after:
<img width="888" alt="image" src="https://github.com/toeverything/blocksuite/assets/25152247/293d004a-5d24-4cef-813b-1e026de06b29">
