### PR TITLE
perf(page): increase code highlight cache size

### DIFF
--- a/packages/blocks/src/code-block/utils/highlight-cache.ts
+++ b/packages/blocks/src/code-block/utils/highlight-cache.ts
@@ -31,5 +31,5 @@ class LRUCache<K, V> {
 export type highlightCacheKey = `${string}-${string}-${string}`;
 
 export const highlightCache = new LRUCache<highlightCacheKey, IThemedToken[]>(
-  100
+  4000
 );


### PR DESCRIPTION
Improve the severe performance issues of the code-block in long texts.

before:
![image](https://github.com/toeverything/blocksuite/assets/50035259/fcbf5e89-44f3-4e18-8830-ecdd9a8bc8a4)

after:
![image](https://github.com/toeverything/blocksuite/assets/50035259/51989873-6f25-4d57-b947-12ddf05cfc36)
