### PR TITLE
fix(edgeless): local record issue

### DIFF
--- a/packages/blocks/src/_common/utils/iterable.ts
+++ b/packages/blocks/src/_common/utils/iterable.ts
@@ -135,17 +135,20 @@ export function pickArray<T>(target: Array<T>, keys: number[]): Array<T> {
   }, [] as T[]);
 }
 
-export function pick<T, K extends Partial<keyof T>>(
+export function pick<T, K extends keyof T>(
   target: T,
   keys: K[]
-): Partial<T> {
-  return keys.reduce((pre, key) => {
-    pre[key] = target[key];
-    return pre;
-  }, {} as Partial<T>);
+): { [key in K]: T[K] } {
+  return keys.reduce(
+    (pre, key) => {
+      pre[key] = target[key];
+      return pre;
+    },
+    {} as { [key in K]: T[K] }
+  );
 }
 
-export function pickValues<T, K extends Partial<keyof T>>(
+export function pickValues<T, K extends keyof T>(
   target: T,
   keys: K[]
 ): Array<T[K]> {
@@ -172,4 +175,8 @@ export function isEmpty(obj: unknown) {
   }
 
   return false;
+}
+
+export function keys<T>(obj: T): (keyof T)[] {
+  return Object.keys(obj as object) as (keyof T)[];
 }

--- a/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
@@ -14,7 +14,7 @@ import {
 import { RemoteColorManager } from '../../../page-block/remote-color-manager/remote-color-manager.js';
 import { RemoteCursor } from '../../icons/index.js';
 import type { Selectable } from '../../utils/index.js';
-import { pick } from '../../utils/iterable.js';
+import { pickValues } from '../../utils/iterable.js';
 
 export const AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET =
   'affine-edgeless-remote-selection-widget';
@@ -189,15 +189,13 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlo
 
     const { _disposables, surface, page, edgeless } = this;
 
-    Object.values(
-      pick(surface.slots, ['elementAdded', 'elementRemoved', 'elementUpdated'])
-    ).forEach(slot => {
+    pickValues(edgeless.slots, [
+      'elementAdded',
+      'elementRemoved',
+      'elementUpdated',
+    ]).forEach(slot => {
       _disposables.add(slot.on(this._updateOnElementChange));
     });
-
-    _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(this._updateOnElementChange)
-    );
 
     _disposables.add(page.slots.blockUpdated.on(this._updateOnElementChange));
 

--- a/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
@@ -194,10 +194,12 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlo
     ).forEach(slot => {
       _disposables.add(slot.on(this._updateOnElementChange));
     });
+
     _disposables.add(
       edgeless.slots.elementSizeUpdated.on(this._updateOnElementChange)
     );
-    _disposables.add(page.slots.yBlockUpdated.on(this._updateOnElementChange));
+
+    _disposables.add(page.slots.blockUpdated.on(this._updateOnElementChange));
 
     _disposables.add(
       this.selection.slots.remoteUpdated.on(this._updateRemoteRects)

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -9,10 +9,12 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { stopPropagation } from '../_common/utils/event.js';
+import { buildPath } from '../_common/utils/query.js';
 import { asyncFocusRichText } from '../_common/utils/selection.js';
 import { AffineDragHandleWidget } from '../_common/widgets/drag-handle/index.js';
 import { captureEventTarget } from '../_common/widgets/drag-handle/utils.js';
 import { Bound } from '../surface-block/index.js';
+import type { SurfaceBlockComponent } from '../surface-block/surface-block.js';
 import { ImageResizeManager } from './image/image-resize-manager.js';
 import { ImageSelectedRectsContainer } from './image/image-selected-rects.js';
 import { shouldResizeImage } from './image/utils.js';
@@ -140,8 +142,20 @@ class ImageBlock extends BlockElement<ImageBlockModel> {
 
 @customElement('affine-edgeless-image')
 class ImageBlockEdgelessComponent extends ImageBlock {
+  get surface() {
+    const surface = this.model.page.getParent(this.model.id);
+
+    return this.root.view.viewFromPath(
+      'block',
+      buildPath(surface)
+    ) as SurfaceBlockComponent;
+  }
+
   override render() {
-    const bound = Bound.deserialize(this.model.xywh);
+    const bound = Bound.deserialize(
+      ((this.surface?.pickById(this.model.id) as ImageBlockModel) ?? this.model)
+        .xywh
+    );
     return html`<img
       style=${styleMap({
         transform: `rotate(${this.model.rotate}deg)`,

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
@@ -50,8 +50,11 @@ export class EdgelessAutoConnectLine extends WithDisposable(LitElement) {
     );
 
     _disposables.add(
-      surface.edgeless.slots.elementUpdated.on(event => {
-        if (isNoteBlock(surface.pickById(event.id)) && 'xywh' in event.props) {
+      surface.page.slots.blockUpdated.on(event => {
+        if (
+          isNoteBlock(surface.pickById(event.id)) &&
+          event.type === 'update'
+        ) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
@@ -50,10 +50,9 @@ export class EdgelessAutoConnectLine extends WithDisposable(LitElement) {
     );
 
     _disposables.add(
-      surface.page.slots.blockUpdated.on(event => {
+      surface.edgeless.slots.elementUpdated.on(event => {
         if (
-          isNoteBlock(surface.pickById(event.id)) &&
-          event.type === 'update'
+          this.elementsMap.has(surface.pickById(event.id) as AutoConnectElement)
         ) {
           this.requestUpdate();
         }

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
@@ -6,7 +6,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { Bound, type IVec, Vec } from '../../../../surface-block/index.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
-import { isNoteBlock } from '../../utils/query.js';
 import type { AutoConnectElement } from '../block-portal/edgeless-block-portal.js';
 
 const EXPAND_OFFSET = 40;

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
@@ -49,8 +49,8 @@ export class EdgelessAutoConnectLine extends WithDisposable(LitElement) {
     );
 
     _disposables.add(
-      surface.page.slots.yBlockUpdated.on(({ type, id }) => {
-        if (type === 'update' && isNoteBlock(surface.pickById(id))) {
+      surface.edgeless.slots.elementSizeUpdated.on(id => {
+        if (isNoteBlock(surface.pickById(id))) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-auto-connect-line.ts
@@ -42,6 +42,7 @@ export class EdgelessAutoConnectLine extends WithDisposable(LitElement) {
 
   protected override firstUpdated(): void {
     const { _disposables, surface } = this;
+
     _disposables.add(
       surface.viewport.slots.viewportUpdated.on(() => {
         this.requestUpdate();
@@ -49,8 +50,8 @@ export class EdgelessAutoConnectLine extends WithDisposable(LitElement) {
     );
 
     _disposables.add(
-      surface.edgeless.slots.elementSizeUpdated.on(id => {
-        if (isNoteBlock(surface.pickById(id))) {
+      surface.edgeless.slots.elementUpdated.on(event => {
+        if (isNoteBlock(surface.pickById(event.id)) && 'xywh' in event.props) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
@@ -11,7 +11,7 @@ import {
 import { Bound } from '../../../../surface-block/index.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
 import type { EdgelessPageBlockComponent } from '../../edgeless-page-block.js';
-import { isFrameBlock, isNoteBlock } from '../../utils/query.js';
+import { isNoteBlock } from '../../utils/query.js';
 import type { AutoConnectElement } from '../block-portal/edgeless-block-portal.js';
 
 function calculatePosition(gap: number, count: number, iconWidth: number) {

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
@@ -125,20 +125,6 @@ export class EdgelessIndexLabel extends WithDisposable(ShadowlessElement) {
     );
 
     _disposables.add(
-      edgeless.slots.elementUpdated.on(({ id, props }) => {
-        if (!('xywh' in props || 'rotate' in props)) return;
-
-        const block = surface.page.getBlockById(id);
-
-        if (isNoteBlock(block)) {
-          this.requestUpdate();
-        } else if (isFrameBlock(block) && this.elementsMap.has(block)) {
-          this.requestUpdate();
-        }
-      })
-    );
-
-    _disposables.add(
       edgeless.slots.elementUpdated.on(({ id }) => {
         const element = surface.pickById(id) as AutoConnectElement;
         if (element && this.elementsMap.has(element)) {

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
@@ -125,8 +125,11 @@ export class EdgelessIndexLabel extends WithDisposable(ShadowlessElement) {
     );
 
     _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(id => {
+      edgeless.slots.elementUpdated.on(({ id, props }) => {
+        if (!('xywh' in props || 'rotate' in props)) return;
+
         const block = surface.page.getBlockById(id);
+
         if (isNoteBlock(block)) {
           this.requestUpdate();
         } else if (isFrameBlock(block) && this.elementsMap.has(block)) {
@@ -136,17 +139,9 @@ export class EdgelessIndexLabel extends WithDisposable(ShadowlessElement) {
     );
 
     _disposables.add(
-      surface.slots.elementUpdated.on(({ id }) => {
+      edgeless.slots.elementUpdated.on(({ id }) => {
         const element = surface.pickById(id) as AutoConnectElement;
         if (element && this.elementsMap.has(element)) {
-          this.requestUpdate();
-        }
-      })
-    );
-
-    _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(id => {
-        if (isNoteBlock(surface.pickById(id))) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
+++ b/packages/blocks/src/page-block/edgeless/components/auto-connect/edgeless-index-label.ts
@@ -125,9 +125,9 @@ export class EdgelessIndexLabel extends WithDisposable(ShadowlessElement) {
     );
 
     _disposables.add(
-      surface.page.slots.yBlockUpdated.on(({ type, id }) => {
+      edgeless.slots.elementSizeUpdated.on(id => {
         const block = surface.page.getBlockById(id);
-        if (type === 'update' && isNoteBlock(block)) {
+        if (isNoteBlock(block)) {
           this.requestUpdate();
         } else if (isFrameBlock(block) && this.elementsMap.has(block)) {
           this.requestUpdate();

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -12,6 +12,7 @@ import '../component-toolbar/component-toolbar.js';
 
 import { assertExists, throttle } from '@blocksuite/global/utils';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
+import type { BaseBlockModel } from '@blocksuite/store';
 import { nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -234,6 +235,12 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
 
     _disposables.add(
       edgeless.surface.model.childrenUpdated.on(() => {
+        this.requestUpdate();
+      })
+    );
+
+    _disposables.add(
+      (page.root as BaseBlockModel).childrenUpdated.on(() => {
         this.requestUpdate();
       })
     );

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -30,16 +30,8 @@ export class EdgelessPortalBase<
     );
 
     this._disposables.add(
-      this.edgeless.slots.elementUpdated.on(() => {
-        this.requestUpdate();
-      })
-    );
-  }
-
-  override firstUpdated() {
-    this._disposables.add(
-      this.surface.page.slots.blockUpdated.on(e => {
-        if (e.id === this.model.id) {
+      this.edgeless.slots.elementUpdated.on(({ id }) => {
+        if (id === this.model.id) {
           this.requestUpdate();
         }
       })

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -24,11 +24,15 @@ export class EdgelessPortalBase<
     super.connectedCallback();
 
     this._disposables.add(
-      this.model.propsUpdated.on(() => this.requestUpdate())
+      this.model.childrenUpdated.on(() => {
+        this.requestUpdate();
+      })
     );
 
     this._disposables.add(
-      this.model.childrenUpdated.on(() => this.requestUpdate())
+      this.edgeless.slots.elementUpdated.on(() => {
+        this.requestUpdate();
+      })
     );
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -32,7 +32,7 @@ export class EdgelessPortalBase<
 
   override firstUpdated() {
     this._disposables.add(
-      this.surface.page.slots.yBlockUpdated.on(e => {
+      this.surface.page.slots.blockUpdated.on(e => {
         if (e.id === this.model.id) {
           this.requestUpdate();
         }

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -20,6 +20,10 @@ export class EdgelessPortalBase<
   @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
+  protected renderModel(model: T) {
+    return this.surface.root.renderModel(this.surface.unwrap(model));
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
 

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -23,11 +23,13 @@ export class EdgelessPortalBase<
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.edgeless.slots.elementSizeUpdated.on(id => {
-      if (this.model.id === id) {
-        this.requestUpdate();
-      }
-    });
+    this._disposables.add(
+      this.model.propsUpdated.on(() => this.requestUpdate())
+    );
+
+    this._disposables.add(
+      this.model.childrenUpdated.on(() => this.requestUpdate())
+    );
   }
 
   override firstUpdated() {

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/frame/edgeless-frame.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/frame/edgeless-frame.ts
@@ -25,9 +25,7 @@ class EdgelessBlockPortalFrame extends EdgelessPortalBase<FrameBlockModel> {
       transform: `translate(${bound.x}px, ${bound.y}px)`,
     });
 
-    return html`
-      <div style=${style}>${this.surface.root.renderModel(model)}</div>
-    `;
+    return html` <div style=${style}>${this.renderModel(model)}</div> `;
   }
 }
 

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/image/edgeless-image.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/image/edgeless-image.ts
@@ -9,7 +9,7 @@ import { EdgelessPortalBase } from '../edgeless-portal-base.js';
 @customElement('edgeless-block-portal-image')
 export class EdgelessBlockPortalImage extends EdgelessPortalBase<ImageBlockModel> {
   override render() {
-    const { model, surface, index } = this;
+    const { model, index } = this;
     const bound = Bound.deserialize(model.xywh);
     const style = {
       position: 'absolute',
@@ -20,7 +20,7 @@ export class EdgelessBlockPortalImage extends EdgelessPortalBase<ImageBlockModel
     };
 
     return html`
-      <div style=${styleMap(style)}>${surface.edgeless.renderModel(model)}</div>
+      <div style=${styleMap(style)}>${this.renderModel(model)}</div>
     `;
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -92,7 +92,6 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
   }
 
   override firstUpdated() {
-    super.firstUpdated();
     this._handleEditingTransition();
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -144,7 +144,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
         data-model-height="${modelH}"
       >
         <div class="note-background" style=${styleMap(backgroundStyle)}></div>
-        ${surface.edgeless.renderModel(model)}
+        ${this.renderModel(model)}
         <edgeless-note-mask
           .surface=${surface}
           .model=${this.model}

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -92,6 +92,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
   }
 
   override firstUpdated() {
+    super.firstUpdated();
     this._handleEditingTransition();
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
@@ -113,6 +113,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   }
 
   private _setNoteHidden(note: NoteBlockModel, hidden: boolean) {
+    note = this.surface.unwrap(note);
     this.surface.page.updateBlock(note, { hidden });
 
     const noteParent = this.surface.page.getParent(note);

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -228,7 +228,11 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
     ]).forEach(slot => _disposables.add(slot.on(this._updateOnSelectedChange)));
 
     _disposables.add(
-      edgeless.page.slots.yBlockUpdated.on(this._updateOnSelectedChange)
+      edgeless.slots.elementSizeUpdated.on(this._updateOnSelectedChange)
+    );
+
+    _disposables.add(
+      edgeless.page.slots.blockUpdated.on(this._updateOnSelectedChange)
     );
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -221,15 +221,11 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
       })
     );
 
-    pickValues(this.edgeless.surface.slots, [
+    pickValues(this.edgeless.slots, [
       'elementAdded',
       'elementRemoved',
       'elementUpdated',
     ]).forEach(slot => _disposables.add(slot.on(this._updateOnSelectedChange)));
-
-    _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(this._updateOnSelectedChange)
-    );
 
     _disposables.add(
       edgeless.page.slots.blockUpdated.on(this._updateOnSelectedChange)

--- a/packages/blocks/src/page-block/edgeless/components/note-status/index.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-status/index.ts
@@ -84,7 +84,7 @@ export class EdgelessNoteStatus extends WithDisposable(LitElement) {
     );
 
     this._disposables.add(
-      this.page.slots.yBlockUpdated.on(({ id }) => {
+      this.page.slots.blockUpdated.on(({ id }) => {
         const note = this.page.getBlockById(id) as NoteBlockModel;
 
         if (!note || matchFlavours(note, ['affine:note'])) {

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -401,7 +401,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     >,
     direction: HandleDirection
   ) => {
-    const { page, surface } = this;
+    const { surface, edgeless } = this;
 
     newBounds.forEach(({ bound }, id) => {
       const element = surface.pickById(id);
@@ -417,11 +417,11 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         if (height < NOTE_MIN_HEIGHT) {
           height = NOTE_MIN_HEIGHT;
         }
-        page.updateBlock(element, {
+        edgeless.updateElementInLocal(element.id, {
           xywh: serializeXYWH(bound.x, bound.y, bound.w, height),
         });
       } else if (isFrameBlock(element)) {
-        page.updateBlock(element, {
+        edgeless.updateElementInLocal(element.id, {
           xywh: bound.serialize(),
         });
       } else {
@@ -434,7 +434,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
             bound = normalizeTextBound(element, bound, true);
             // If the width of the text element has been changed by dragging,
             // We need to set hasMaxWidth to true for wrapping the text
-            surface.updateElement(id, {
+            edgeless.updateElementInLocal(id, {
               xywh: bound.serialize(),
               fontSize: element.fontSize * p,
               hasMaxWidth: true,
@@ -443,7 +443,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
             p = bound.h / element.h;
             // const newFontsize = element.fontSize * p;
             // bound = normalizeTextBound(element, bound, false, newFontsize);
-            surface.updateElement(id, {
+            edgeless.updateElementInLocal(id, {
               xywh: bound.serialize(),
               fontSize: element.fontSize * p,
             });
@@ -452,7 +452,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
           if (element instanceof ShapeElement) {
             bound = normalizeShapeBound(element, bound);
           }
-          surface.updateElement(id, {
+          edgeless.updateElementInLocal(id, {
             xywh: bound.serialize(),
           });
         }
@@ -489,6 +489,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   };
 
   private _onDragEnd = () => {
+    const selectedElements = this.edgeless.selectionManager.state.elements;
+    this.edgeless.applyLocalRecord(selectedElements);
+
     this._updateCursor(false);
     this.setToolbarVisible(true);
   };

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -324,6 +324,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     this.addEventListener('pointerdown', stopPropagation);
   }
 
+  get dragging() {
+    return this._resizeManager.dragging || this.edgeless.tools.dragging;
+  }
+
   get selection() {
     return this.edgeless.selectionManager;
   }

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -7,7 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { stopPropagation } from '../../../../_common/utils/event.js';
-import { pick } from '../../../../_common/utils/iterable.js';
+import { pickValues } from '../../../../_common/utils/iterable.js';
 import type {
   EdgelessElement,
   IPoint,
@@ -629,16 +629,18 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   };
 
   override firstUpdated() {
-    const { _disposables, page, slots, selection, surface, edgeless } = this;
+    const { _disposables, page, slots, selection, edgeless } = this;
 
     _disposables.add(
       // viewport zooming / scrolling
       slots.viewportUpdated.on(this._updateOnViewportChange)
     );
 
-    Object.values(
-      pick(surface.slots, ['elementAdded', 'elementRemoved', 'elementUpdated'])
-    ).forEach(slot => {
+    pickValues(edgeless.slots, [
+      'elementAdded',
+      'elementRemoved',
+      'elementUpdated',
+    ]).forEach(slot => {
       _disposables.add(slot.on(this._updateOnElementChange));
     });
 
@@ -648,9 +650,6 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       )
     );
 
-    _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(this._updateOnElementChange)
-    );
     _disposables.add(selection.slots.updated.on(this._updateOnSelectionChange));
     _disposables.add(page.slots.blockUpdated.on(this._updateOnElementChange));
     _disposables.add(

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -654,7 +654,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     _disposables.add(selection.slots.updated.on(this._updateOnSelectionChange));
     _disposables.add(page.slots.blockUpdated.on(this._updateOnElementChange));
     _disposables.add(
-      page.slots.yBlockUpdated.on(data => {
+      page.slots.blockUpdated.on(data => {
         this._updateOnElementChange(data, true);
       })
     );

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
@@ -330,7 +330,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       });
 
       this.disposables.add(
-        edgeless.surface.slots.elementUpdated.on(({ id }) => {
+        edgeless.slots.elementUpdated.on(({ id }) => {
           if (id === element.id) this.requestUpdate();
         })
       );

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -279,13 +279,13 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       })
     );
     _disposables.add(
-      page.slots.yBlockUpdated.on(e => {
+      page.slots.blockUpdated.on(e => {
         if (e.type === 'update' && 'index' in e.props) {
           this._updateFrames();
         }
       })
     );
-    _disposables.add(page.slots.yBlockUpdated);
+    _disposables.add(page.slots.blockUpdated);
     _disposables.add(slots.viewportUpdated.on(() => this.requestUpdate()));
     _disposables.add(
       edgeless.slots.readonlyUpdated.on(() => {

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/frame-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/frame-tool.ts
@@ -52,12 +52,13 @@ export class FrameToolController extends EdgelessToolController<FrameTool> {
     }
     assertExists(this._frame);
 
-    surface.updateElement(this._frame.id, {
+    this._edgeless.updateElementInLocal(this._frame.id, {
       xywh: Bound.fromPoints([this._startPoint, currentPoint]).serialize(),
     });
   }
   override onContainerDragEnd(): void {
     if (this._frame) {
+      this._edgeless.applyLocalRecord([this._frame.id]);
       this._edgeless.tools.setEdgelessTool({ type: 'default' });
       this._edgeless.selectionManager.setSelection({
         elements: [this._frame.id],

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -764,6 +764,8 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
       if (!element) return;
 
+      this.surface.refresh();
+
       const changedProps = pick(
         data.new,
         keys(data.new).filter(key => key in element)

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -27,10 +27,10 @@ import type {
 import {
   asyncFocusRichText,
   handleNativeRangeAtPoint,
-  matchFlavours,
   type ReorderingAction,
   type TopLevelBlockModel,
 } from '../../_common/utils/index.js';
+import { keys, pick } from '../../_common/utils/iterable.js';
 import { EdgelessClipboard } from '../../_legacy/clipboard/index.js';
 import { getService } from '../../_legacy/service/index.js';
 import type { ImageBlockModel } from '../../image-block/index.js';
@@ -199,7 +199,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
     zoomUpdated: new Slot<ZoomAction>(),
     pressShiftKeyUpdated: new Slot<boolean>(),
     cursorUpdated: new Slot<string>(),
-    elementSizeUpdated: new Slot<string>(),
     copyAsPng: new Slot<{
       blocks: TopLevelBlockModel[];
       shapes: PhasorElement[];
@@ -210,6 +209,13 @@ export class EdgelessPageBlockComponent extends BlockElement<
     tagClicked: new Slot<{ tagId: string }>(),
     readonlyUpdated: new Slot<boolean>(),
     draggingAreaUpdated: new Slot(),
+
+    elementUpdated: new Slot<{
+      id: string;
+      props: Record<string, unknown>;
+    }>(),
+    elementAdded: new Slot<string>(),
+    elementRemoved: new Slot<{ id: string; element: EdgelessElement }>(),
   };
 
   @query('affine-surface')
@@ -267,27 +273,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
   }
 
   private _initSlotEffects() {
-    const { _disposables, slots, page, surface } = this;
-    _disposables.add(
-      page.slots.blockUpdated.on(event => {
-        const block = page.getBlockById(event.id);
-
-        switch (event.type) {
-          case 'add':
-            if (matchFlavours(block, [NOTE, IMAGE, FRAME])) {
-              this.slots.elementSizeUpdated.emit(event.id);
-            }
-            break;
-          case 'update':
-            if (
-              matchFlavours(block, [NOTE, IMAGE, FRAME]) &&
-              ('prop:xywh' in event.props || 'prop:rotate' in event.props)
-            ) {
-              this.slots.elementSizeUpdated.emit(event.id);
-            }
-        }
-      })
-    );
+    const { _disposables, slots, surface } = this;
 
     _disposables.add(
       surface.viewport.slots.viewportUpdated.on(({ zoom, center }) => {
@@ -660,6 +646,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
   }
 
   override firstUpdated() {
+    this._initElementSlot();
     this._initSlotEffects();
     this._initResizeEffect();
     this._initPixelRatioChangeEffect();
@@ -773,14 +760,50 @@ export class EdgelessPageBlockComponent extends BlockElement<
   private _initLocalRecordManager() {
     this.localRecord = new LocalRecordManager<PhasorElementLocalRecordValues>();
     this.localRecord.slots.updated.on(({ id, data }) => {
-      if (this.page.getBlockById(id) && 'xywh' in data.new) {
-        if ('xywh' in data.new) this.slots.elementSizeUpdated.emit(id);
-      }
+      const element = this.surface.pickById(id);
+
+      if (!element) return;
+
+      const changedProps = pick(
+        data.new,
+        keys(data.new).filter(key => key in element)
+      );
+
+      this.slots.elementUpdated.emit({
+        id,
+        props: changedProps,
+      });
     });
 
     this.disposables.add(() => {
       this.localRecord.destroy();
     });
+  }
+
+  private _initElementSlot() {
+    this._disposables.add(
+      this.page.slots.blockUpdated.on(event => {
+        if (![IMAGE, NOTE, FRAME].includes(event.flavour as EdgelessBlockType))
+          return;
+
+        switch (event.type) {
+          case 'update':
+            this.slots.elementUpdated.emit({
+              id: event.id,
+              props: event.props,
+            });
+            break;
+          case 'add':
+            this.slots.elementAdded.emit(event.id);
+            break;
+          case 'delete':
+            this.slots.elementRemoved.emit({
+              id: event.id,
+              element: event.model as TopLevelBlockModel,
+            });
+        }
+      })
+    );
   }
 
   override connectedCallback() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -269,13 +269,22 @@ export class EdgelessPageBlockComponent extends BlockElement<
   private _initSlotEffects() {
     const { _disposables, slots, page, surface } = this;
     _disposables.add(
-      page.slots.yBlockUpdated.on(({ id, props }) => {
-        const block = page.getBlockById(id);
-        if (
-          matchFlavours(block, [NOTE, IMAGE, FRAME]) &&
-          ('prop:xywh' in props || 'prop:rotate' in props)
-        ) {
-          this.slots.elementSizeUpdated.emit(id);
+      page.slots.blockUpdated.on(event => {
+        const block = page.getBlockById(event.id);
+
+        switch (event.type) {
+          case 'add':
+            if (matchFlavours(block, [NOTE, IMAGE, FRAME])) {
+              this.slots.elementSizeUpdated.emit(event.id);
+            }
+            break;
+          case 'update':
+            if (
+              matchFlavours(block, [NOTE, IMAGE, FRAME]) &&
+              ('prop:xywh' in event.props || 'prop:rotate' in event.props)
+            ) {
+              this.slots.elementSizeUpdated.emit(event.id);
+            }
         }
       })
     );

--- a/packages/blocks/src/page-block/edgeless/services/local-record-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/local-record-manager.ts
@@ -11,7 +11,7 @@ export class LocalRecordManager<T> {
     updated: new Slot<{
       id: string;
       data: {
-        old: Partial<T> | undefined;
+        old: { [key in keyof Partial<T>]: Partial<T>[keyof T] } | undefined;
         new: Partial<T>;
       };
     }>(),

--- a/packages/blocks/src/page-block/edgeless/services/local-record-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/local-record-manager.ts
@@ -89,6 +89,13 @@ export function localRecordWrapper<T>(
   id: string
 ) {
   return new Proxy(model, {
+    has: (target, prop) => {
+      if (prop === rawSymbol) {
+        return true;
+      }
+
+      return Reflect.has(target, prop);
+    },
     get: (target, prop, receiver) => {
       if (prop === rawSymbol) {
         return model;

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -90,6 +90,12 @@ export class EdgelessToolsManager {
   // pressed shift key
   private _shiftKey = false;
 
+  private _dragging = false;
+
+  get dragging() {
+    return this._dragging;
+  }
+
   get selection() {
     return this.container.selectionManager;
   }
@@ -176,6 +182,7 @@ export class EdgelessToolsManager {
     }
 
     this._add('dragStart', ctx => {
+      this._dragging = true;
       const event = ctx.get('pointerState');
       if (shouldFilterMouseEvent(event.raw)) return;
       if (
@@ -200,6 +207,7 @@ export class EdgelessToolsManager {
       this._onContainerDragMove(event);
     });
     this._add('dragEnd', ctx => {
+      this._dragging = false;
       const event = ctx.get('pointerState');
       if (
         !isInsidePageTitle(event.raw.target) &&

--- a/packages/blocks/src/page-block/edgeless/utils/crud.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/crud.ts
@@ -32,7 +32,7 @@ export function deleteElements(
       const children = surface.page.root?.children ?? [];
       // FIXME: should always keep at least 1 note
       if (children.length > 1) {
-        surface.page.deleteBlock(element);
+        surface.page.deleteBlock(surface.unwrap(element));
       }
     } else {
       surface.removeElement(element.id);

--- a/packages/blocks/src/page-block/edgeless/utils/note.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/note.ts
@@ -73,7 +73,7 @@ export function addNote(
             const block = page.getBlockById(noteId);
             assertExists(block);
             if (!editing && isEmpty(block)) {
-              page.deleteBlock(element);
+              page.deleteBlock(edgeless.surface.unwrap(element));
             }
           });
         });

--- a/packages/blocks/src/surface-block/elements/index.ts
+++ b/packages/blocks/src/surface-block/elements/index.ts
@@ -20,7 +20,7 @@ import type {
 } from './surface-element.js';
 import { TextElementDefaultProps } from './text/consts.js';
 import { TextElement } from './text/text-element.js';
-import type { IText } from './text/types.js';
+import type { IText, ITextLocalRecord } from './text/types.js';
 
 // eslint-disable-next-line simple-import-sort/exports
 export { BrushElement } from './brush/brush-element.js';
@@ -59,7 +59,7 @@ export type IPhasorElementLocalRecord = {
   shape: IShapeLocalRecord;
   brush: IBrushLocalRecord;
   connector: ISurfaceElementLocalRecord;
-  text: ISurfaceElementLocalRecord;
+  text: ITextLocalRecord;
   group: IGroupLocalRecord;
 };
 

--- a/packages/blocks/src/surface-block/elements/surface-element.ts
+++ b/packages/blocks/src/surface-block/elements/surface-element.ts
@@ -75,7 +75,7 @@ export abstract class SurfaceElement<
     getLocalRecord: (id: string) => PhasorElementLocalRecordValues | undefined;
     onElementUpdated: (update: {
       id: string;
-      props: { [index: string]: { old: unknown; new: unknown } };
+      props: Record<string, unknown>;
     }) => void;
     updateElementLocalRecord: (
       id: string,
@@ -208,9 +208,9 @@ export abstract class SurfaceElement<
     this.renderer?.removeElement(this);
     this.renderer?.addElement(this);
     const e = events[0] as Y.YMapEvent<Y.Map<unknown>>;
-    const props: { [index: string]: { old: unknown; new: unknown } } = {};
-    e.changes.keys.forEach((change, key) => {
-      props[key] = { old: change.oldValue, new: this.yMap.get(key) };
+    const props: Record<string, unknown> = {};
+    e.changes.keys.forEach((_, key) => {
+      props[key] = this.yMap.get(key);
     });
     this.options.onElementUpdated({
       id: this.id,

--- a/packages/blocks/src/surface-block/elements/text/text-element.ts
+++ b/packages/blocks/src/surface-block/elements/text/text-element.ts
@@ -33,7 +33,7 @@ export class TextElement extends SurfaceElement<IText> {
 
   get fontSize() {
     return (
-      (this.localRecord as ITextLocalRecord).fontSize ??
+      (this.localRecord as ITextLocalRecord)?.fontSize ??
       (this.yMap.get('fontSize') as IText['fontSize'])
     );
   }
@@ -56,7 +56,7 @@ export class TextElement extends SurfaceElement<IText> {
 
   get hasMaxWidth() {
     return (
-      (this.localRecord as ITextLocalRecord).hasMaxWidth ??
+      (this.localRecord as ITextLocalRecord)?.hasMaxWidth ??
       (this.yMap.get('hasMaxWidth') as IText['hasMaxWidth'])
     );
   }

--- a/packages/blocks/src/surface-block/elements/text/text-element.ts
+++ b/packages/blocks/src/surface-block/elements/text/text-element.ts
@@ -10,7 +10,7 @@ import {
 import { type IVec } from '../../utils/vec.js';
 import { EdgelessSelectableMixin } from '../selectable.js';
 import { SurfaceElement } from '../surface-element.js';
-import type { IText, ITextDelta } from './types.js';
+import type { IText, ITextDelta, ITextLocalRecord } from './types.js';
 import {
   charWidth,
   deltaInsertsToChunks,
@@ -32,7 +32,10 @@ export class TextElement extends SurfaceElement<IText> {
   }
 
   get fontSize() {
-    return this.yMap.get('fontSize') as IText['fontSize'];
+    return (
+      (this.localRecord as ITextLocalRecord).fontSize ??
+      (this.yMap.get('fontSize') as IText['fontSize'])
+    );
   }
 
   get fontFamily() {
@@ -52,7 +55,10 @@ export class TextElement extends SurfaceElement<IText> {
   }
 
   get hasMaxWidth() {
-    return this.yMap.get('hasMaxWidth') as IText['hasMaxWidth'];
+    return (
+      (this.localRecord as ITextLocalRecord).hasMaxWidth ??
+      (this.yMap.get('hasMaxWidth') as IText['hasMaxWidth'])
+    );
   }
 
   get font() {

--- a/packages/blocks/src/surface-block/elements/text/types.ts
+++ b/packages/blocks/src/surface-block/elements/text/types.ts
@@ -1,7 +1,10 @@
 import type { Y } from '@blocksuite/store';
 
 import type { PhasorElementType } from '../edgeless-element.js';
-import { type ISurfaceElement } from '../surface-element.js';
+import {
+  type ISurfaceElement,
+  type ISurfaceElementLocalRecord,
+} from '../surface-element.js';
 
 export interface IText extends ISurfaceElement {
   type: PhasorElementType.TEXT;
@@ -21,4 +24,9 @@ export interface ITextDelta {
   attributes?: {
     [k: string]: unknown;
   };
+}
+
+export interface ITextLocalRecord extends ISurfaceElementLocalRecord {
+  fontSize: number;
+  hasMaxWidth: boolean;
 }

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -978,6 +978,12 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     return picked;
   }
 
+  /**
+   * Block model retrieved from the surface block will be wrapped with local record.
+   * You can use this function to unwrap them to get real model
+   * @param block
+   * @returns
+   */
   unwrap<T extends BaseBlockModel>(block: T) {
     return this.edgeless.localRecord.unwrap(block) as T;
   }

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -978,6 +978,10 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     return picked;
   }
 
+  unwrap<T extends BaseBlockModel>(block: T) {
+    return this.edgeless.localRecord.unwrap(block) as T;
+  }
+
   getSortedPhasorElementsWithViewportBounds() {
     return this.pickByBound(this.viewport.viewportBounds)
       .filter(e => !isTopLevelBlock(e))

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -550,7 +550,12 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     this._disposables.add(
       this.edgeless.localRecord.slots.updated.on(({ id, data }) => {
         this.refresh();
-        const element = this.pickById(id);
+
+        /**
+         *  should not use pickById here as this listener
+         *  is only applicable to surface element
+         */
+        const element = this._elements.get(id);
 
         if (!element) return;
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -831,7 +831,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     }
     const element = this.pickById(id);
     if (isTopLevelBlock(element)) {
-      this.page.updateBlock(element, properties);
+      this.page.updateBlock(this.unwrap(element), properties);
     } else {
       this.transact(() => {
         const element = this._elements.get(id);
@@ -857,7 +857,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     }
     const element = this.pickById(id);
     if (isTopLevelBlock(element)) {
-      this.page.deleteBlock(element);
+      this.page.deleteBlock(this.unwrap(element));
     } else {
       this.transact(() => {
         this._yContainer.delete(id);

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -23,7 +23,6 @@ import { isEmpty } from '../_common/utils/iterable.js';
 import { EdgelessConnectorManager } from '../page-block/edgeless/connector-manager.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import { EdgelessFrameManager } from '../page-block/edgeless/frame-manager.js';
-import { localRecordWrapper } from '../page-block/edgeless/services/local-record-manager.js';
 import { getGridBound } from '../page-block/edgeless/utils/bound-utils.js';
 import {
   isConnectable,
@@ -192,7 +191,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     return parent.children
       .filter(child => child.flavour === flavour)
       .map(child =>
-        localRecordWrapper(child, this.edgeless.localRecord)
+        this.edgeless.localRecord.wrap(child)
       ) as EdgelessBlockModelMap[T][];
   }
 
@@ -948,10 +947,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     const block = this.page.getBlockById(id);
 
     return block
-      ? (localRecordWrapper(
-          block,
-          this.edgeless.localRecord
-        ) as EdgelessElement)
+      ? (this.edgeless.localRecord.wrap(block) as EdgelessElement)
       : null;
   }
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -1,6 +1,6 @@
 import '../page-block/edgeless/components/block-portal/edgeless-block-portal.js';
 
-import { assertEquals, assertExists, Slot } from '@blocksuite/global/utils';
+import { assertEquals, assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import type { BlockProps } from '@blocksuite/store';
 import type { BaseBlockModel } from '@blocksuite/store';
@@ -19,7 +19,6 @@ import {
   type Selectable,
   type TopLevelBlockModel,
 } from '../_common/utils/index.js';
-import { isEmpty } from '../_common/utils/iterable.js';
 import { EdgelessConnectorManager } from '../page-block/edgeless/connector-manager.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import { EdgelessFrameManager } from '../page-block/edgeless/frame-manager.js';
@@ -166,15 +165,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
   private _lastTime = 0;
   private _cachedViewport = new Bound();
 
-  slots = {
-    elementUpdated: new Slot<{
-      id: id;
-      props: { [index: string]: { old: unknown; new: unknown } };
-    }>(),
-    elementAdded: new Slot<id>(),
-    elementRemoved: new Slot<{ id: id; element: SurfaceElement }>(),
-  };
-
   get edgeless() {
     return this.parentBlockElement as EdgelessPageBlockComponent;
   }
@@ -232,7 +222,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     this.group = new EdgelessGroupManager(this);
 
     this.init();
-    this._initRecordListener();
   }
 
   getCSSPropertyValue = (value: string) => {
@@ -259,7 +248,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     _disposables.add(edgeless.slots.reorderingShapesUpdated.on(this._reorder));
 
     _disposables.add(
-      this.slots.elementAdded.on(id => {
+      edgeless.slots.elementAdded.on(id => {
         const element = this.pickById(id);
         assertExists(element);
         if (element instanceof ConnectorElement) {
@@ -271,11 +260,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     );
 
     _disposables.add(
-      this.slots.elementUpdated.on(({ id, props }) => {
-        if ('xywh' in props || 'rotate' in props) {
-          this.edgeless.slots.elementSizeUpdated.emit(id);
-        }
-
+      edgeless.slots.elementUpdated.on(({ id, props }) => {
         const element = this.pickById(id);
         assertExists(element);
 
@@ -288,7 +273,9 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     );
 
     _disposables.add(
-      this.edgeless.slots.elementSizeUpdated.on(id => {
+      this.edgeless.slots.elementUpdated.on(({ id, props }) => {
+        if (!('xywh' in props || 'rotate' in props)) return;
+
         const element = this.pickById(id);
         if (isConnectable(element)) {
           this.connector.syncConnectorPos([element]);
@@ -504,10 +491,14 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
         }
       })
     );
+
     _disposables.add(
-      edgeless.slots.elementSizeUpdated.on(id => {
+      edgeless.slots.elementUpdated.on(({ id, props }) => {
+        if (!('rotate' in props || 'xywh' in props)) return;
+
         const element = this.pickById(id);
         assertExists(element);
+
         if (
           element instanceof BrushElement ||
           edgeless.selectionManager.editing
@@ -518,7 +509,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     );
 
     _disposables.add(
-      this.slots.elementAdded.on(id => {
+      edgeless.slots.elementAdded.on(id => {
         const element = this.pickById(id);
         assertExists(element);
         if (element instanceof BrushElement) return;
@@ -544,44 +535,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
   init() {
     this._syncFromExistingContainer();
     this._initEffects();
-  }
-
-  private _initRecordListener() {
-    this._disposables.add(
-      this.edgeless.localRecord.slots.updated.on(({ id, data }) => {
-        this.refresh();
-
-        /**
-         *  should not use pickById here as this listener
-         *  is only applicable to surface element
-         */
-        const element = this._elements.get(id);
-
-        if (!element) return;
-
-        const changedProps = Object.keys(data.new).reduce(
-          (pre, current) => {
-            if (current in element) {
-              pre[current] = {
-                old: data.old?.[current as keyof typeof data.old] ?? undefined,
-                new: data.new[current as keyof typeof data.new],
-              };
-            }
-            return pre;
-          },
-          {} as {
-            [index: string]: { old: unknown; new: unknown };
-          }
-        );
-
-        if (isEmpty(changedProps)) return;
-
-        this.slots.elementUpdated.emit({
-          id,
-          props: changedProps,
-        });
-      })
-    );
   }
 
   // query
@@ -643,16 +596,17 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     const type = yElement.get('type') as PhasorElementType;
     const id = yElement.get('id') as id;
     const ElementCtor = ElementCtors[type];
+    const { edgeless } = this;
     assertExists(ElementCtor);
     const element = new ElementCtor(yElement, {
       getLocalRecord: id => {
-        return this.edgeless.localRecord.get(id);
+        return edgeless.localRecord.get(id);
       },
       onElementUpdated: update => {
-        this.slots.elementUpdated.emit(update);
+        edgeless.slots.elementUpdated.emit(update);
       },
       updateElementLocalRecord: (id, record) => {
-        this.edgeless.localRecord.update(id, record);
+        edgeless.localRecord.update(id, record);
       },
       pickById: id => this.pickById(id),
       getGroupParent: (element: string | EdgelessElement) => {
@@ -668,7 +622,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     element.mount(this._renderer);
     this._elements.set(element.id, element);
     this._addToBatch(element);
-    this.slots.elementAdded.emit(id);
+    this.edgeless.slots.elementAdded.emit(id);
   }
 
   private _onYContainer = (event: Y.YMapEvent<Y.Map<unknown>>) => {
@@ -712,18 +666,19 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     if (type.action === 'add') {
       const yElement = this._yContainer.get(id) as Y.Map<unknown>;
       const type = yElement.get('type') as PhasorElementType;
+      const { edgeless } = this;
 
       const ElementCtor = ElementCtors[type];
       assertExists(ElementCtor);
       const element = new ElementCtor(yElement, {
         getLocalRecord: id => {
-          return this.edgeless.localRecord.get(id);
+          return edgeless.localRecord.get(id);
         },
         onElementUpdated: update => {
-          this.slots.elementUpdated.emit(update);
+          edgeless.slots.elementUpdated.emit(update);
         },
         updateElementLocalRecord: (id, record) => {
-          this.edgeless.localRecord.update(id, record);
+          edgeless.localRecord.update(id, record);
         },
         pickById: id => this.pickById(id),
         getGroupParent: (element: string | EdgelessElement) => {
@@ -740,7 +695,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
       this._elements.set(element.id, element);
 
       this._addToBatch(element);
-      this.slots.elementAdded.emit(id);
+      this.edgeless.slots.elementAdded.emit(id);
     } else if (type.action === 'update') {
       console.error('update event on yElements is not supported', event);
     } else if (type.action === 'delete') {
@@ -754,7 +709,7 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
       this._elements.delete(id);
       this.edgeless.localRecord.delete(id);
       this._removeFromBatch(element);
-      this.slots.elementRemoved.emit({ id, element });
+      this.edgeless.slots.elementRemoved.emit({ id, element });
     }
   };
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -569,21 +569,12 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
           }
         );
 
-        if (!isEmpty(changedProps)) {
-          // FIXME: for temporary solution
-          if (isTopLevelBlock(element)) {
-            this.page.slots.yBlockUpdated.emit({
-              id,
-              type: 'update',
-              props: changedProps,
-            });
-          } else {
-            this.slots.elementUpdated.emit({
-              id,
-              props: changedProps,
-            });
-          }
-        }
+        if (isEmpty(changedProps)) return;
+
+        this.slots.elementUpdated.emit({
+          id,
+          props: changedProps,
+        });
       })
     );
   }

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -90,6 +90,7 @@ export class Page extends Space<FlatBlockMap> {
           id: string;
           flavour: string;
           parent: string;
+          model: BaseBlockModel;
         }
       | {
           type: 'update';
@@ -771,6 +772,7 @@ export class Page extends Space<FlatBlockMap> {
       id,
       flavour: model.flavour,
       parent: this.getParent(model)?.id ?? '',
+      model,
     });
     model.deleted.emit();
     model.dispose();

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -98,12 +98,6 @@ export class Page extends Space<FlatBlockMap> {
           props: Partial<BlockProps>;
         }
     >(),
-    /** @deprecated should not depend on y-concepts directly */
-    yBlockUpdated: new Slot<{
-      id: string;
-      type: 'add' | 'update' | 'delete';
-      props: { [key: string]: { old: unknown; new: unknown } };
-    }>(),
     /** @deprecated */
     copied: new Slot(),
     /** @deprecated */
@@ -537,13 +531,6 @@ export class Page extends Space<FlatBlockMap> {
       oldProps,
       newProps,
     });
-
-    this.slots.blockUpdated.emit({
-      type: 'update',
-      flavour: model.flavour,
-      id: model.id,
-      props,
-    });
   }
 
   addSiblingBlocks(
@@ -837,10 +824,11 @@ export class Page extends Space<FlatBlockMap> {
         oldProps: oldProps,
         newProps: toBlockProps(yMap, this.doc.proxy),
       });
-      this.slots.yBlockUpdated.emit({
-        id: model.id,
-        props: yProps,
+      this.slots.blockUpdated.emit({
         type: 'update',
+        id: model.id,
+        flavour: model.flavour,
+        props: yProps,
       });
     }
     hasChildrenUpdate && model.childrenUpdated.emit();

--- a/tests/edgeless/element-toolbar.spec.ts
+++ b/tests/edgeless/element-toolbar.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from '@playwright/test';
+import {
+  getNoteProps,
+  locatorComponentToolbar,
+  selectNoteInEdgeless,
+  switchEditorMode,
+} from 'utils/actions/edgeless.js';
+import {
+  enterPlaygroundRoom,
+  initEmptyEdgelessState,
+  waitNextFrame,
+} from 'utils/actions/misc.js';
+
+import { test } from '../utils/playwright.js';
+
+test('toolbar should appear when select note', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  const { noteId } = await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  await selectNoteInEdgeless(page, noteId);
+
+  const toolbar = locatorComponentToolbar(page);
+  await expect(toolbar).toBeVisible();
+});
+
+test('toggle hidden/show button of note should work', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  const { noteId } = await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  await selectNoteInEdgeless(page, noteId);
+
+  const toolbar = locatorComponentToolbar(page);
+  const hideOnPageButton = toolbar.locator(
+    'edgeless-change-note-button > div:nth-child(1)'
+  );
+
+  await expect(hideOnPageButton).toBeVisible();
+  await hideOnPageButton.click();
+  expect((await getNoteProps(page, noteId))?.['hidden']).toBe(true);
+
+  const showOnPageButton = toolbar.locator(
+    'edgeless-change-note-button > div:nth-child(1)'
+  );
+  await expect(showOnPageButton).toBeVisible();
+  await showOnPageButton.click();
+
+  expect((await getNoteProps(page, noteId))?.['hidden']).toBe(false);
+});

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -529,16 +529,16 @@ test('undo/redo should work correctly after resizing', async ({ page }) => {
   await dragBetweenCoords(
     page,
     { x: box.x + 5, y: box.y + 5 },
-    { x: box.x + 105, y: box.y + 5 }
+    { x: box.x - 45, y: box.y + 5 }
   );
   const draggedRect = await getNoteRect(page, ids);
   assertRectEqual(draggedRect, {
     x: initRect.x,
     y: initRect.y,
-    w: initRect.w + 100,
+    w: initRect.w - 50,
     h: draggedRect.h, // not assert `h` here
   });
-  expect(draggedRect.h).toBeLessThan(initRect.h);
+  expect(draggedRect.h).toBeGreaterThan(initRect.h);
 
   await undoByKeyboard(page);
   await waitNextFrame(page);

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -75,6 +75,28 @@ export async function getNoteRect(
   return { x, y, w, h };
 }
 
+export async function getNoteProps(page: Page, noteId: string) {
+  const props = await page.evaluate(
+    ([id]) => {
+      const page = window.workspace.getPage('page:home');
+      const block = page?.getBlockById(id);
+      if (block?.flavour === 'affine:note') {
+        return (block as NoteBlockModel).keys.reduce(
+          (pre, key) => {
+            pre[key] = block[key as keyof typeof block] as string;
+            return pre;
+          },
+          {} as Record<string, string | number>
+        );
+      } else {
+        return null;
+      }
+    },
+    [noteId] as const
+  );
+  return props;
+}
+
 export async function registerFormatBarCustomElements(page: Page) {
   await page.click('sl-button[content="Register FormatBar Custom Elements"]');
 }


### PR DESCRIPTION
Close #5307 
Related #5305 

### Change
- remove redundant slots `elementSizeUpdated` and `yBlockUpdated`
- move `elementUpdated`, `elementAdded`, `elementDeleted` slots to edgeless component
- modifying properties in the local record will also trigger slots mentioned in the second item of the list
- add cache for the wrapped block model
- wrapped model may not be usable on the page API, add `unwrap` method to get the non-proxied model
- save data to local record during resize