### PR TITLE
fix(page): shift + arrow text selection

### DIFF
--- a/packages/block-std/src/selection/variants/text.ts
+++ b/packages/block-std/src/selection/variants/text.ts
@@ -12,6 +12,7 @@ export type TextRangePoint = {
 export type TextSelectionProps = {
   from: TextRangePoint;
   to: TextRangePoint | null;
+  isReverse?: boolean;
 };
 
 const TextSelectionSchema = z.object({
@@ -27,6 +28,7 @@ const TextSelectionSchema = z.object({
       length: z.number(),
     })
     .nullable(),
+  isReverse: z.boolean().nullable(),
 });
 
 export class TextSelection extends BaseSelection {
@@ -37,13 +39,25 @@ export class TextSelection extends BaseSelection {
 
   to: TextRangePoint | null;
 
-  constructor({ from, to }: TextSelectionProps) {
+  isReverse: boolean;
+
+  constructor({ from, to, isReverse }: TextSelectionProps) {
     super({
       path: from.path,
     });
     this.from = from;
 
     this.to = this._equalPoint(from, to) ? null : to;
+
+    this.isReverse = !!isReverse;
+  }
+
+  get start(): TextRangePoint {
+    return this.isReverse ? this.to ?? this.from : this.from;
+  }
+
+  get end(): TextRangePoint {
+    return this.isReverse ? this.from : this.to ?? this.from;
   }
 
   empty(): boolean {
@@ -80,6 +94,7 @@ export class TextSelection extends BaseSelection {
       type: 'text',
       from: this.from,
       to: this.to,
+      isReverse: this.isReverse,
     };
   }
 
@@ -88,6 +103,7 @@ export class TextSelection extends BaseSelection {
     return new TextSelection({
       from: json.from as TextRangePoint,
       to: json.to as TextRangePoint | null,
+      isReverse: !!json.isReverse,
     });
   }
 

--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -112,46 +112,10 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
 
   blockElement.bindHotKey({
     ArrowUp: ctx => {
-      if (!blockElement.selected?.is('text')) {
-        return;
-      }
-
-      const vEditor = _getVirgo();
-      const vRange = vEditor.getVRange();
-      if (!vRange) {
-        return;
-      }
-
-      if (vRange.length !== 0) {
-        vEditor.setVRange({
-          index: vRange.index,
-          length: 0,
-        });
-      }
-
       _preventDefault(ctx);
-      return;
     },
     ArrowDown: ctx => {
-      if (!blockElement.selected?.is('text')) {
-        return;
-      }
-
-      const vEditor = _getVirgo();
-      const vRange = vEditor.getVRange();
-      if (!vRange) {
-        return;
-      }
-
-      if (vRange.length !== 0) {
-        vEditor.setVRange({
-          index: vRange.index,
-          length: 0,
-        });
-      }
-
       _preventDefault(ctx);
-      return;
     },
     ArrowRight: ctx => {
       if (blockElement.selected?.is('block')) {

--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -190,6 +190,18 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
 
       return true;
     },
+    'Shift-ArrowUp': ctx => {
+      _preventDefault(ctx);
+    },
+    'Shift-ArrowDown': ctx => {
+      _preventDefault(ctx);
+    },
+    'Shift-ArrowRight': ctx => {
+      _preventDefault(ctx);
+    },
+    'Shift-ArrowLeft': ctx => {
+      _preventDefault(ctx);
+    },
     Escape: () => {
       if (blockElement.selected?.is('text')) {
         return _selectBlock();

--- a/packages/blocks/src/note-block/keymap.ts
+++ b/packages/blocks/src/note-block/keymap.ts
@@ -270,8 +270,7 @@ export function bindHotKey(blockElement: BlockElement) {
         })
         .run();
     },
-    'Shift-ArrowDown': ctx => {
-      ctx.get('defaultState').event.preventDefault();
+    'Shift-ArrowDown': () => {
       let anchorBlock: BlockElement | null = null;
       return root.std.command
         .pipe()
@@ -379,8 +378,7 @@ export function bindHotKey(blockElement: BlockElement) {
         ])
         .run();
     },
-    'Shift-ArrowUp': ctx => {
-      ctx.get('defaultState').event.preventDefault();
+    'Shift-ArrowUp': () => {
       let anchorBlock: BlockElement | null = null;
       return root.std.command
         .pipe()
@@ -485,8 +483,7 @@ export function bindHotKey(blockElement: BlockElement) {
         ])
         .run();
     },
-    'Shift-ArrowRight': ctx => {
-      ctx.get('defaultState').event.preventDefault();
+    'Shift-ArrowRight': () => {
       return root.std.command
         .pipe()
         .getTextSelection()
@@ -526,8 +523,7 @@ export function bindHotKey(blockElement: BlockElement) {
         ])
         .run();
     },
-    'Shift-ArrowLeft': ctx => {
-      ctx.get('defaultState').event.preventDefault();
+    'Shift-ArrowLeft': () => {
       return root.std.command
         .pipe()
         .getTextSelection()

--- a/packages/blocks/src/note-block/keymap.ts
+++ b/packages/blocks/src/note-block/keymap.ts
@@ -59,7 +59,7 @@ export function bindHotKey(blockElement: BlockElement) {
             .inline<'currentSelectionPath'>((ctx, next) => {
               const textSelection = ctx.currentTextSelection;
               assertExists(textSelection);
-              const end = textSelection.to ?? textSelection.from;
+              const end = textSelection.end;
               currentBlock = pathToBlock(blockElement, end.path);
               next({ currentSelectionPath: end.path });
             })
@@ -148,8 +148,9 @@ export function bindHotKey(blockElement: BlockElement) {
             .inline<'currentSelectionPath'>((ctx, next) => {
               const textSelection = ctx.currentTextSelection;
               assertExists(textSelection);
-              currentBlock = pathToBlock(blockElement, textSelection.from.path);
-              next({ currentSelectionPath: textSelection.from.path });
+              const end = textSelection.end;
+              currentBlock = pathToBlock(blockElement, end.path);
+              next({ currentSelectionPath: end.path });
             })
             .try(cmd => [
               // text selection - case 1: move cursor up within the same block

--- a/packages/blocks/src/note-block/utils.ts
+++ b/packages/blocks/src/note-block/utils.ts
@@ -239,6 +239,42 @@ export function selectBetween(
   });
 }
 
+export function collapseSelection() {
+  const selection = document.getSelection();
+  if (!selection) {
+    return;
+  }
+
+  if (selection.isCollapsed) {
+    return;
+  }
+
+  const isReverse = isRangeReverse();
+
+  if (isReverse) {
+    selection.collapseToStart();
+  } else {
+    selection.collapseToEnd();
+  }
+}
+
+export function isRangeReverse() {
+  const selection = document.getSelection();
+  if (!selection) {
+    return false;
+  }
+
+  const isReverse =
+    !!selection.anchorNode &&
+    !!selection.focusNode &&
+    (selection.anchorNode === selection.focusNode
+      ? selection.anchorOffset > selection.focusOffset
+      : selection.anchorNode.compareDocumentPosition(selection.focusNode) ===
+        Node.DOCUMENT_POSITION_PRECEDING);
+
+  return isReverse;
+}
+
 export function getCurrentCaretPos(tail: boolean) {
   const selection = document.getSelection();
   if (!selection || !selection.anchorNode) {
@@ -593,13 +629,7 @@ function getCurrentTextSelectionCarets():
 
   const range = selection.getRangeAt(0);
 
-  const isRangeReversed =
-    !!selection.anchorNode &&
-    !!selection.focusNode &&
-    (selection.anchorNode === selection.focusNode
-      ? selection.anchorOffset > selection.focusOffset
-      : selection.anchorNode.compareDocumentPosition(selection.focusNode) ===
-        Node.DOCUMENT_POSITION_PRECEDING);
+  const isRangeReversed = isRangeReverse();
 
   const startCaret: Caret = {
     node: isRangeReversed ? range.endContainer : range.startContainer,

--- a/packages/blocks/src/note-block/utils.ts
+++ b/packages/blocks/src/note-block/utils.ts
@@ -320,8 +320,6 @@ export function horizontalGetNextCaret(
         : point.y,
   };
 
-  // showPoint(_point, 'green');
-
   let move = caretFromPoint(_point.x, _point.y);
 
   const needContinue = () => {
@@ -398,7 +396,7 @@ export function moveCursorVertically(
 
   const nextCaret = horizontalGetNextCaret(
     {
-      x: cursorRect.x,
+      x: cursorRect.x + 1,
       y: forward
         ? cursorRect.top - cursorRect.height / 2
         : cursorRect.bottom + cursorRect.height / 2,
@@ -490,7 +488,7 @@ export function changeTextSelectionVertically(
 
   const nextEndCaret = horizontalGetNextCaret(
     {
-      x: cursorRect.x,
+      x: cursorRect.x + 1,
       y: upward
         ? cursorRect.top - cursorRect.height / 2
         : cursorRect.bottom + cursorRect.height / 2,

--- a/packages/blocks/src/note-block/utils.ts
+++ b/packages/blocks/src/note-block/utils.ts
@@ -396,7 +396,7 @@ export function moveCursorVertically(
 
   const nextCaret = horizontalGetNextCaret(
     {
-      x: cursorRect.x + 1,
+      x: cursorRect.x,
       y: forward
         ? cursorRect.top - cursorRect.height / 2
         : cursorRect.bottom + cursorRect.height / 2,
@@ -488,7 +488,7 @@ export function changeTextSelectionVertically(
 
   const nextEndCaret = horizontalGetNextCaret(
     {
-      x: cursorRect.x + 1,
+      x: cursorRect.x,
       y: upward
         ? cursorRect.top - cursorRect.height / 2
         : cursorRect.bottom + cursorRect.height / 2,

--- a/packages/lit/src/utils/range-synchronizer.ts
+++ b/packages/lit/src/utils/range-synchronizer.ts
@@ -65,6 +65,14 @@ export class RangeSynchronizer {
           return;
         }
         const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+        const isRangeReversed =
+          !!selection.anchorNode &&
+          !!selection.focusNode &&
+          (selection.anchorNode === selection.focusNode
+            ? selection.anchorOffset > selection.focusOffset
+            : selection.anchorNode.compareDocumentPosition(
+                selection.focusNode
+              ) === Node.DOCUMENT_POSITION_PRECEDING);
 
         if (
           this.filter.rangeToTextSelection &&
@@ -78,8 +86,10 @@ export class RangeSynchronizer {
         }
 
         if (range === null || range.intersectsNode(this.root)) {
-          this._prevSelection =
-            this._rangeManager.syncRangeToTextSelection(range);
+          this._prevSelection = this._rangeManager.syncRangeToTextSelection(
+            range,
+            isRangeReversed
+          );
         } else {
           this._prevSelection = null;
           this._selectionManager.clear(['text']);

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -1320,27 +1320,24 @@ test('should register custom elements in format quick bar', async ({
   await expect(page.getByTestId('custom-format-bar-element')).toBeVisible();
 });
 
-test.fixme(
-  'format quick bar should not break cursor jumping',
-  async ({ page }) => {
-    await enterPlaygroundRoom(page);
-    await initEmptyParagraphState(page);
-    await initThreeParagraphs(page);
-    await dragBetweenIndices(page, [1, 3], [1, 2]);
+test('format quick bar should not break cursor jumping', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await dragBetweenIndices(page, [1, 3], [1, 2]);
 
-    const { formatBar } = getFormatBar(page);
-    await expect(formatBar).toBeVisible();
+  const { formatBar } = getFormatBar(page);
+  await expect(formatBar).toBeVisible();
 
-    await pressArrowUp(page);
-    await type(page, '0');
-    await assertRichTexts(page, ['1203', '456', '789']);
+  await pressArrowUp(page);
+  await type(page, '0');
+  await assertRichTexts(page, ['1203', '456', '789']);
 
-    await dragBetweenIndices(page, [1, 3], [1, 2]);
-    await pressArrowDown(page);
-    await type(page, '0');
-    await assertRichTexts(page, ['1203', '456', '7809']);
-  }
-);
+  await dragBetweenIndices(page, [1, 3], [1, 2]);
+  await pressArrowDown(page);
+  await type(page, '0');
+  await assertRichTexts(page, ['1203', '456', '7809']);
+});
 
 test('selecting image should not show format bar', async ({ page }) => {
   test.info().annotations.push({


### PR DESCRIPTION
Closes: #2684 
Closes: #4435 
Closes: #1290

Changes:
- Text Selection: Implemented app logic for changing text selection using arrow keys inside the note block.
- Reverse Text Selection: If text selction has been made using mouse and user continues to modify the selection using keyboard, the selection should change from the last cursor position. For this to work for reverse text selection (right to left / bottom to top) I had to modify:
   - `_mergeRanges` to calculate if reverse selection is made.
   - `_renderRange` to render reverse selection correctly.
   - add `isReverse` property to `TextSelection` to store reverse selection state and calculate the start / end of selection.
- Format Bar: Format bar appears on text selection and hide the text, blocking it from caret position calculation. To prevent this I opted to hide all widgets before caret position calculation and then restore them to their original state.


https://github.com/toeverything/blocksuite/assets/54364088/ef57f25d-3f23-49cd-8f48-6d8bb9847584