### PR TITLE
fix(page): delay when inserting attachments via dnd

### DIFF
--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import { type BaseBlockModel, type Page } from '@blocksuite/store';
+import type { BaseBlockModel, BlockProps, Page } from '@blocksuite/store';
 
 import type { AbstractEditor } from '../../_common/utils/index.js';
 import {
@@ -26,7 +26,7 @@ export type GetPageInfo = () => {
   pageBlock: DocPageBlockComponent | EdgelessPageBlockComponent | undefined;
 };
 
-type ImportHandler = (file: File) => Promise<Partial<BaseBlockModel> | void>;
+type ImportHandler = (file: File) => Promise<Partial<BlockProps> | void>;
 
 type FileDropRule = {
   name: string;

--- a/packages/blocks/src/_common/components/index.ts
+++ b/packages/blocks/src/_common/components/index.ts
@@ -4,5 +4,6 @@ export * from './drag-indicator.js';
 export * from './file-drop-manager.js';
 export * from './hover/index.js';
 export * from './menu-divider.js';
+export * from './toast.js';
 export * from './tooltip/index.js';
 import './portal.js';

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -115,12 +115,18 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
     );
   };
 
-  // Check if the blob is available
+  /**
+   * Check if the blob is available. It is necessary since the block may be copied from another workspace.
+   */
   private async _checkBlob() {
     const storage = this.page.blob;
     const sourceId = this.model.sourceId;
     if (!sourceId) return;
     if (!(await hasBlob(storage, sourceId))) {
+      console.warn(
+        'The attachment is unavailable since the blob is missing!',
+        this.model
+      );
       this._error = true;
     }
   }
@@ -184,9 +190,9 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
   }
 
   override render() {
-    const isLoading =
-      this.model.loadingKey && isAttachmentLoading(this.model.loadingKey);
-    const isError = !isLoading && (this._error || !this.model.sourceId);
+    const isLoading = isAttachmentLoading(this.model.id);
+    const isError = this._error || (!isLoading && !this.model.sourceId);
+
     if (isLoading) {
       return html`<div
         class="affine-attachment-container"

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -9,11 +9,15 @@ export type AttachmentBlockProps = {
   type: string;
   caption?: string;
 
-  // `loadingKey` is used to indicate whether the attachment is loading
-  // You can query the loading state by `isAttachmentLoading(loadingKey)`
-  // We can not use `loading: true` directly because the state will be stored in the model
-  //
-  // The `loadingKey` and `sourceId` should not be existed at the same time
+  /**
+   * `loadingKey` is used to indicate whether the attachment is uploading.
+   * You can query the loading state by calling `isAttachmentLoading(loadingKey)`
+   *
+   * We can not use `loading: true` directly because the state will be stored in the model,
+   * which will cause infinite loading of the block after reloading the page.
+   *
+   * NOTE: The `loadingKey` and `sourceId` should not be existed at the same time
+   */
   loadingKey?: string | null;
   sourceId?: string;
 };

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -1,5 +1,18 @@
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
+/**
+ * When the attachment is uploading, the `sourceId` is `undefined`.
+ * And we can query the upload status by the `isAttachmentLoading` function.
+ *
+ * Other collaborators will show a error attachment block when the blob is not uploaded.
+ * We can sync the upload status by the awareness system in the future.
+ *
+ * When the attachment is uploaded, the `sourceId` is the id of the blob.
+ *
+ * If there are no `sourceId` and the `isAttachmentLoading` function returns `false`,
+ * it means that the attachment is failed to upload.
+ */
+
 export type AttachmentBlockProps = {
   name: string;
   size: number;
@@ -8,17 +21,6 @@ export type AttachmentBlockProps = {
    */
   type: string;
   caption?: string;
-
-  /**
-   * `loadingKey` is used to indicate whether the attachment is uploading.
-   * You can query the loading state by calling `isAttachmentLoading(loadingKey)`
-   *
-   * We can not use `loading: true` directly because the state will be stored in the model,
-   * which will cause infinite loading of the block after reloading the page.
-   *
-   * NOTE: The `loadingKey` and `sourceId` should not be existed at the same time
-   */
-  loadingKey?: string | null;
   sourceId?: string;
 };
 
@@ -27,7 +29,6 @@ export const defaultAttachmentProps: AttachmentBlockProps = {
   size: 0,
   type: 'application/octet-stream',
   sourceId: undefined,
-  loadingKey: undefined,
   caption: undefined,
 };
 

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -4,8 +4,8 @@ import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
  * When the attachment is uploading, the `sourceId` is `undefined`.
  * And we can query the upload status by the `isAttachmentLoading` function.
  *
- * Other collaborators will show a error attachment block when the blob is not uploaded.
- * We can sync the upload status by the awareness system in the future.
+ * Other collaborators will see an error attachment block when the blob has not finished uploading.
+ * This issue can be resolve by sync the upload status through the awareness system in the future.
  *
  * When the attachment is uploaded, the `sourceId` is the id of the blob.
  *

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -21,6 +21,10 @@ export type AttachmentBlockProps = {
    */
   type: string;
   caption?: string;
+  // `loadingKey` was used to indicate whether the attachment is loading,
+  // which is currently unused but no breaking change is needed.
+  // The `loadingKey` and `sourceId` should not be existed at the same time.
+  // loadingKey?: string | null;
   sourceId?: string;
 };
 

--- a/packages/blocks/src/attachment-block/index.ts
+++ b/packages/blocks/src/attachment-block/index.ts
@@ -1,3 +1,4 @@
 export * from './attachment-block.js';
 export * from './attachment-model.js';
 export * from './attachment-service.js';
+export { uploadBlobForAttachment } from './utils.js';

--- a/packages/blocks/src/attachment-block/utils.ts
+++ b/packages/blocks/src/attachment-block/utils.ts
@@ -144,9 +144,11 @@ export async function uploadBlobForAttachment(
       console.error(attachmentModel);
       throw new Error('the model is not an attachment model!');
     }
-    page.updateBlock(attachmentModel, {
-      sourceId,
-    } satisfies Partial<AttachmentBlockProps>);
+    page.withoutTransact(() => {
+      page.updateBlock(attachmentModel, {
+        sourceId,
+      } satisfies Partial<AttachmentBlockProps>);
+    });
   } catch (error) {
     console.error(error);
     if (error instanceof Error) {

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -13,8 +13,10 @@ import {
   readImageSize,
   saveViewportToSession,
   ThemeObserver,
+  uploadBlobForAttachment,
 } from '@blocksuite/blocks';
 import { withTempBlobData } from '@blocksuite/blocks';
+import { toast } from '@blocksuite/blocks';
 import { ContentParser } from '@blocksuite/blocks/content-parser';
 import { IS_FIREFOX } from '@blocksuite/global/env';
 import {
@@ -232,7 +234,7 @@ export class EditorContainer
         name: 'Attachment',
         matcher: (file: File) => {
           if (file.size > maxFileSize) {
-            console.warn(
+            toast(
               `You can only upload files less than ${
                 maxFileSize / (1000 * 1000)
               }M.`
@@ -243,17 +245,17 @@ export class EditorContainer
         },
         handler: async (
           file: File
-        ): Promise<AttachmentBlockProps & { flavour: 'affine:attachment' }> => {
-          const storage = this.page.blob;
-          const sourceId = await storage.set(
-            new Blob([file], { type: file.type })
-          );
+        ): Promise<
+          AttachmentBlockProps & { id: string; flavour: 'affine:attachment' }
+        > => {
+          const blockId = this.page.generateBlockId();
+          uploadBlobForAttachment(this.page, blockId, file);
           return {
+            id: blockId,
             flavour: 'affine:attachment',
             name: file.name,
             size: file.size,
             type: file.type,
-            sourceId,
           };
         },
       });

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -543,7 +543,7 @@ export class Page extends Space<FlatBlockMap> {
 
   addSiblingBlocks(
     targetModel: BaseBlockModel,
-    props: Array<Partial<BaseBlockModel>>,
+    props: Array<Partial<BlockProps>>,
     place: 'after' | 'before' = 'after'
   ): string[] {
     if (!props.length) return [];

--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -133,7 +133,6 @@ test('can insert attachment from slash menu', async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
-    prop:loadingKey={null}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -236,7 +235,7 @@ test('should turn attachment to image works', async ({ page }) => {
   );
 });
 
-test('should attachment can be deleted works', async ({ page }) => {
+test('should attachment can be deleted', async ({ page }) => {
   await enterPlaygroundRoom(page);
   const { noteId } = await initEmptyParagraphState(page);
   const { attachment, insertAttachment, waitLoading } = getAttachment(page);
@@ -288,7 +287,6 @@ test(`support dragging attachment block directly`, async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
-    prop:loadingKey={null}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -328,7 +326,6 @@ test(`support dragging attachment block directly`, async ({ page }) => {
     prop:index="a0"
   >
     <affine:attachment
-      prop:loadingKey={null}
       prop:name="${FILE_NAME}"
       prop:size={${FILE_SIZE}}
       prop:sourceId="${FILE_ID}"
@@ -381,7 +378,6 @@ test(`support dragging attachment block directly`, async ({ page }) => {
       prop:type="text"
     />
     <affine:attachment
-      prop:loadingKey={null}
       prop:name="${FILE_NAME}"
       prop:size={${FILE_SIZE}}
       prop:sourceId="${FILE_ID}"


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/4622

Now the attachment can correctly show a loading state when inserted via drag and drop.

https://github.com/toeverything/blocksuite/assets/18554747/00c04e29-77b7-40cd-8ae9-1103eb159b78

This PR also sunsetting the `loadingKey` since I found the `page.addBlock` function supports the `id` parameter which is a better alternative to identify the block.

No need to perform the migration action because all legacy `loadingKey` will be ignored.

Note: other collaborators will see an error attachment block when the blob has not finished uploading. This issue can be resolve by sync the upload status through the awareness system in the future.