### PR TITLE
fix(database): kanban add button hover animation where :has is not supported

### DIFF
--- a/packages/blocks/src/database-block/kanban/group.ts
+++ b/packages/blocks/src/database-block/kanban/group.ts
@@ -72,6 +72,11 @@ const styles = css`
     opacity: 1;
   }
 
+  affine-data-view-kanban-group .add-card:hover {
+    background-color: var(--affine-hover-color);
+    color: var(--affine-text-primary-color);
+  }
+
   affine-data-view-kanban-group:has(.add-card:hover) .add-card {
     background-color: var(--affine-hover-color);
     color: var(--affine-text-primary-color);


### PR DESCRIPTION
to fix error I made in #5336 

In browsers where :has css pseudo-class is not supported, no hover animation will be shown on add button.

Changes:
- Keep both independent and linked css hover animation.