### PR TITLE
fix(page): tweak attachment styles

### DIFF
--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -210,8 +210,9 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
         class="affine-attachment-container"
         @click=${this._focusAttachment}
       >
-        <div class="affine-attachment-name">
-          ${AttachmentIcon16}${this.model.name}
+        <div class="affine-attachment-title">
+          ${AttachmentIcon16}
+          <span class="affine-attachment-name">${this.model.name}</span>
         </div>
         <div class="affine-attachment-desc">Unable to upload</div>
         ${this._attachmentTail(isError)}
@@ -224,9 +225,9 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
         @click=${this._focusAttachment}
         @dblclick=${this._downloadAttachment}
       >
-        <div class="affine-attachment-name">
-          ${this._isDownloading ? LoadingIcon : AttachmentIcon16}${this.model
-            .name}
+        <div class="affine-attachment-title">
+          ${this._isDownloading ? LoadingIcon : AttachmentIcon16}
+          <span class="affine-attachment-name">${this.model.name}</span>
         </div>
         <div class="affine-attachment-desc">
           ${humanFileSize(this.model.size)}

--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -17,9 +17,8 @@ export const styles = css`
     cursor: pointer;
   }
 
-  .affine-attachment-name {
+  .affine-attachment-title {
     display: flex;
-    align-items: center;
     gap: 8px;
 
     color: var(--affine-text-primary-color);
@@ -29,6 +28,16 @@ export const styles = css`
     text-overflow: ellipsis;
     fill: var(--affine-icon-color);
     user-select: none;
+  }
+
+  .affine-attachment-title > svg {
+    /* Align icon vertically to the center of the first line of text,  */
+    /* Assume the height of the icon is 16px */
+    margin-top: calc((var(--affine-line-height) - 16px) / 2);
+  }
+
+  .affine-attachment-name {
+    flex: 1;
   }
 
   .affine-attachment-desc {

--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -28,6 +28,7 @@ export const styles = css`
     text-overflow: ellipsis;
     fill: var(--affine-icon-color);
     user-select: none;
+    z-index: 1;
   }
 
   .affine-attachment-title > svg {

--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -39,6 +39,8 @@ export const styles = css`
 
   .affine-attachment-name {
     flex: 1;
+    word-wrap: break-word;
+    overflow: hidden;
   }
 
   .affine-attachment-desc {


### PR DESCRIPTION
- Fix icon styles when the name of the attachment exceeds one line

<img width="374" alt="Screenshot 2023-11-17 at 00 24 08" src="https://github.com/toeverything/blocksuite/assets/18554747/5e5f6220-7cda-42f1-83eb-a516834ccf45">

- Fix line break when the name of the attachment is lengthy
- Fix the height of the banner layer incorrectly

![Screenshot 2023-11-17 at 00 26 30](https://github.com/toeverything/blocksuite/assets/18554747/25b63cf3-f9fd-4aa4-b22b-663f40babe3b)
