### PR TITLE
fix: backwards compatible with remote selection

### DIFF
--- a/packages/block-std/src/selection/manager.ts
+++ b/packages/block-std/src/selection/manager.ts
@@ -128,10 +128,16 @@ export class SelectionManager {
     const map = new Map<number, BaseSelection[]>();
     this._store.getStates().forEach((state, id) => {
       if (id === this._store.awareness.clientID) return;
-
-      const selections = state.selection.map(json => {
-        return this._jsonToSelection(json);
-      });
+      const selections = state.selection
+        .map(json => {
+          try {
+            return this._jsonToSelection(json);
+          } catch (error) {
+            console.error('Parse remote selection failed:', id, json, error);
+            return null;
+          }
+        })
+        .filter((sel): sel is BaseSelection => !!sel);
       map.set(id, selections);
     });
     return map;

--- a/packages/block-std/src/selection/variants/text.ts
+++ b/packages/block-std/src/selection/variants/text.ts
@@ -28,7 +28,9 @@ const TextSelectionSchema = z.object({
       length: z.number(),
     })
     .nullable(),
-  isReverse: z.boolean().nullable(),
+  // The `optional()` is for backward compatibility,
+  // since `isReverse` may not exist in remote selection.
+  isReverse: z.boolean().optional(),
 });
 
 export class TextSelection extends BaseSelection {


### PR DESCRIPTION
Fix the error log in https://github.com/toeverything/AFFiNE/issues/4980

<img width="806" alt="Screenshot 2023-11-17 at 21 42 08" src="https://github.com/toeverything/blocksuite/assets/18554747/cb49fec7-eb48-4dec-96ed-ef4d9757be70">

```
slot.js:99 [
  {
    "code": "invalid_type",
    "expected": "boolean",
    "received": "undefined",
    "path": [
      "isReverse"
    ],
    "message": "Required"
  }
]
```

Since the remote data is unreliable, we should ignore the error when parsing failure.