### PR TITLE
fix(page): divider selection and deletion

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -509,10 +509,14 @@ function handleEmbedDividerCodeSibling(
   previousSibling: ExtendedModel,
   parent: ExtendedModel
 ) {
+  if (matchFlavours(previousSibling, ['affine:divider'])) {
+    page.deleteBlock(previousSibling);
+    return true;
+  }
+
   if (
     !matchFlavours(previousSibling, [
       'affine:image',
-      'affine:divider',
       'affine:code',
       'affine:bookmark',
       'affine:attachment',
@@ -739,13 +743,14 @@ function handleParagraphBlockForwardDelete(page: Page, model: ExtendedModel) {
       return true;
     }
     function handleEmbedDividerCodeSibling(nextSibling: ExtendedModel | null) {
+      if (matchFlavours(nextSibling, ['affine:divider'])) {
+        page.deleteBlock(nextSibling);
+        return true;
+      }
+
       if (
         !nextSibling ||
-        !matchFlavours(nextSibling, [
-          'affine:image',
-          'affine:divider',
-          'affine:code',
-        ])
+        !matchFlavours(nextSibling, ['affine:image', 'affine:code'])
       )
         return false;
       focusBlockByModel(nextSibling);

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -28,6 +28,14 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
 
   override connectedCallback() {
     super.connectedCallback();
+
+    this.handleEvent('click', () => {
+      this.root.selection.set([
+        this.root.selection.getInstance('block', {
+          path: this.path,
+        }),
+      ]);
+    });
   }
 
   override firstUpdated() {

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -8,6 +8,7 @@ import {
   focusTitle,
   initEmptyEdgelessState,
   initEmptyParagraphState,
+  initThreeDividers,
   initThreeParagraphs,
   pressArrowDown,
   pressArrowLeft,
@@ -17,6 +18,7 @@ import {
   pressBackspaceWithShortKey,
   pressEnter,
   pressEscape,
+  pressForwardDelete,
   pressShiftEnter,
   pressShiftTab,
   pressSpace,
@@ -1350,15 +1352,7 @@ test('delete empty text paragraph block should keep children blocks when followi
   await page.waitForTimeout(200);
 
   // Add to paragraph blocks
-  await focusRichText(page);
-  await type(page, '123');
-
-  await pressEnter(page);
-  await type(page, '456');
-
-  await pressEnter(page);
-  await type(page, '789');
-
+  await initThreeParagraphs(page);
   await assertRichTexts(page, ['123', '456', '789']);
 
   // Indent the second paragraph block
@@ -1668,4 +1662,31 @@ test('arrow up/down navigation within and across paragraphs containing different
   await assertRichTextVRange(page, 1, 90, 0);
   await pressArrowDown(page);
   await assertRichTextVRange(page, 1, 125, 0);
+});
+
+test('delete divider using keyboard from prev/next paragraph', async ({
+  page,
+}) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/4547',
+  });
+
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+
+  await initThreeDividers(page);
+  await assertDivider(page, 3);
+  await assertRichTexts(page, ['123', '123']);
+
+  await focusRichText(page, 0);
+  await pressForwardDelete(page);
+  await assertDivider(page, 2);
+
+  await focusRichText(page, 1);
+  await pressArrowLeft(page, 3);
+  await pressBackspace(page);
+  await assertDivider(page, 1);
+
+  await assertRichTexts(page, ['123', '123']);
 });

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -1355,10 +1355,14 @@ test('delete empty text paragraph block should keep children blocks when followi
 
   await pressEnter(page);
   await type(page, '456');
-  await assertRichTexts(page, ['123', '456']);
+
+  await pressEnter(page);
+  await type(page, '789');
+
+  await assertRichTexts(page, ['123', '456', '789']);
 
   // Indent the second paragraph block
-  await focusRichText(page, 1);
+  await focusRichText(page, 2);
   await pressTab(page);
 
   await assertStoreMatchJSX(
@@ -1373,9 +1377,13 @@ test('delete empty text paragraph block should keep children blocks when followi
   <affine:paragraph
     prop:text="123"
     prop:type="text"
+  />
+  <affine:paragraph
+    prop:text="456"
+    prop:type="text"
   >
     <affine:paragraph
-      prop:text="456"
+      prop:text="789"
       prop:type="text"
     />
   </affine:paragraph>
@@ -1384,10 +1392,10 @@ test('delete empty text paragraph block should keep children blocks when followi
   );
 
   // Delete the parent paragraph block
-  await focusRichText(page, 0);
+  await focusRichText(page, 1);
   await pressBackspace(page, 4);
 
-  await assertRichTexts(page, ['456']);
+  await assertRichTexts(page, ['123', '789']);
 
   await assertStoreMatchJSX(
     page,
@@ -1399,7 +1407,11 @@ test('delete empty text paragraph block should keep children blocks when followi
 >
   <affine:divider />
   <affine:paragraph
-    prop:text="456"
+    prop:text="123"
+    prop:type="text"
+  />
+  <affine:paragraph
+    prop:text="789"
     prop:type="text"
   />
 </affine:note>`,

--- a/tests/selection/native.spec.ts
+++ b/tests/selection/native.spec.ts
@@ -1921,3 +1921,24 @@ test('scroll vertically when adding multiple blocks', async ({ page }) => {
 
   expect(viewportScrollTop).toBeGreaterThan(400);
 });
+
+test('click to select divided', async ({ page }) => {
+  test.info().annotations.push({
+    type: 'issue',
+    description: 'https://github.com/toeverything/blocksuite/issues/4547',
+  });
+
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+
+  await focusRichText(page);
+  await type(page, '--- ');
+  await assertDivider(page, 1);
+
+  await page.click('affine-divider');
+  const selectedBlocks = page.locator('.selected,affine-block-selection');
+  await expect(selectedBlocks).toHaveCount(1);
+
+  await pressForwardDelete(page);
+  await assertDivider(page, 0);
+});


### PR DESCRIPTION
closes #4547

Changes:
- Clicking on the divider selects the divider block, which can then be deleted using backspace / delete
- Deleting divider using keyboard
   - Pressing backspace after a divider deletes the divider
   - Pressing delete before a divided deletes the divider
   

https://github.com/toeverything/blocksuite/assets/54364088/ce920eed-9eef-4345-95ac-49cd42e2389f
