### PR TITLE
fix(page): autoIdentityLink behavior

### DIFF
--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -504,7 +504,7 @@ test(scoped`automatic identify url text`, async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await focusRichText(page);
-  await type(page, 'abc https://google.com');
+  await type(page, 'abc https://google.com ');
 
   await assertStoreMatchJSX(
     page,
@@ -524,6 +524,9 @@ test(scoped`automatic identify url text`, async ({ page }) => {
           <text
             insert="https://google.com"
             link="https://google.com"
+          />
+          <text
+            insert=" "
           />
         </>
       }

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -143,7 +143,7 @@ test(scoped`copy url to create bookmark in page mode`, async ({ page }) => {
   await initEmptyParagraphState(page);
   await focusRichText(page);
 
-  await type(page, 'https://google.com');
+  await type(page, 'https://google.com ');
   await setVRangeInSelectedRichText(page, 0, 18);
   await copyByKeyboard(page);
   await focusRichText(page);
@@ -164,7 +164,10 @@ test(scoped`copy url to create bookmark in page mode`, async ({ page }) => {
         <>
           <text
             insert="https://google.com"
-            link="https://google.com/bookmark"
+            link="https://google.com"
+          />
+          <text
+            insert=" "
           />
         </>
       }
@@ -189,7 +192,7 @@ test(scoped`copy url to create bookmark in edgeless mode`, async ({ page }) => {
   await enterPlaygroundRoom(page);
   const ids = await initEmptyEdgelessState(page);
   await focusRichText(page);
-  await type(page, 'https://google.com');
+  await type(page, 'https://google.com ');
 
   await switchEditorMode(page);
 
@@ -217,7 +220,10 @@ test(scoped`copy url to create bookmark in edgeless mode`, async ({ page }) => {
         <>
           <text
             insert="https://google.com"
-            link="https://google.com/bookmark"
+            link="https://google.com"
+          />
+          <text
+            insert=" "
           />
         </>
       }
@@ -231,7 +237,7 @@ test(scoped`copy url to create bookmark in edgeless mode`, async ({ page }) => {
       prop:icon=""
       prop:image=""
       prop:type="card"
-      prop:url="https://google.com"
+      prop:url="https://google.com "
     />
   </affine:note>
 </affine:page>`

--- a/tests/link.spec.ts
+++ b/tests/link.spec.ts
@@ -131,39 +131,6 @@ async function createLinkBlock(page: Page, str: string, link: string) {
   return id;
 }
 
-test('text added after a link which has custom edited should not have link formatting', async ({
-  page,
-}) => {
-  await enterPlaygroundRoom(page);
-  const id = await createLinkBlock(page, 'link text', 'http://example.com');
-  await focusRichText(page, 0);
-  await type(page, 'after link');
-  await assertStoreMatchJSX(
-    page,
-    // XXX This snapshot is not exactly correct, but it's close enough for now.
-    // The first text after the link should not have the link formatting.
-    `
-<affine:paragraph
-  prop:text={
-    <>
-      <text
-        insert="Hello"
-      />
-      <text
-        insert="link text"
-        link="http://example.com"
-      />
-      <text
-        insert="after link"
-      />
-    </>
-  }
-  prop:type="text"
-/>`,
-    id
-  );
-});
-
 test('type character in link should not jump out link node', async ({
   page,
 }) => {


### PR DESCRIPTION
closes #4371 

Current Behavior: autoIdentifyLink executes on every key press. On typing inside the link triggers autoIdentifyLink, changing the link text and url

Changes:
- autoIdentifyLink executes only on pressing space after a non-link element.
- typing within the link element only changes the link text.

p.s.: popup on pasting a link is handled in affine, ref https://github.com/toeverything/blocksuite/issues/4371#issuecomment-1820821749