### PR TITLE
chore: solve `delete CR`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -127,7 +127,12 @@ module.exports = {
         ],
       },
     ],
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'arrow-body-style': 'off',
     'prefer-arrow-callback': 'off',
   },


### PR DESCRIPTION
I opened the project on Windows,  After every line  I got:

```
[eslint] Delete `CR` [prettier/prettier]
```
![1700450488501](https://github.com/toeverything/blocksuite/assets/17617116/2b45cb76-8a1c-440e-a65a-ecf2ed3561cc)
So I added settings in `eslint.cjs`. It works fine
