### PR TITLE
fix(edgeless): reset cursor when the selection changes

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -623,6 +623,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   private _updateOnSelectionChange = () => {
     this._updateSelectedRect();
     this._updateResizeManagerState(true);
+    // Reset the cursor
+    this._updateCursor(false);
   };
 
   private _updateOnElementChange = (


### PR DESCRIPTION
Fixing the cursor style will not restore when the shape is deleted.

https://github.com/toeverything/blocksuite/assets/18554747/fb64bb06-3fb8-4f6c-9fa8-b6188b57d5a0

