### PR TITLE
fix(page): incorrect cursor position on pasting text

### DIFF
--- a/packages/blocks/src/_legacy/service/json2block.ts
+++ b/packages/blocks/src/_legacy/service/json2block.ts
@@ -7,6 +7,7 @@ import { handleBlockSplit } from '../../_common/components/rich-text/rich-text-o
 import {
   asyncGetBlockElementByModel,
   asyncSetVRange,
+  getVirgoByModel,
   type SerializedBlock,
 } from '../../_common/utils/index.js';
 import type { BlockModels } from '../../_common/utils/model.js';
@@ -161,7 +162,9 @@ export async function json2block(
     !shouldMergeFirstBlock &&
     (!isSinglePastedBlock || firstBlock.children.length > 0)
   ) {
-    asyncSetVRange(focusedBlockModel, {
+    const vEditor = getVirgoByModel(focusedBlockModel);
+    assertExists(vEditor);
+    vEditor.setVRange({
       index: textRangePoint.index,
       length: 0,
     });
@@ -176,7 +179,9 @@ export async function json2block(
       firstBlock?.text?.reduce((sum, data) => {
         return sum + (data.insert?.length || 0);
       }, 0) ?? 0;
-    asyncSetVRange(focusedBlockModel, {
+    const vEditor = getVirgoByModel(focusedBlockModel);
+    assertExists(vEditor);
+    vEditor.setVRange({
       index: (textRangePoint.index ?? 0) + textLength,
       length: 0,
     });

--- a/packages/blocks/src/_legacy/service/legacy-services/code-service.ts
+++ b/packages/blocks/src/_legacy/service/legacy-services/code-service.ts
@@ -107,7 +107,7 @@ export class CodeBlockService extends BaseService<CodeBlockModel> {
     const vEditor = getVirgoByModel(focusedBlockModel);
     assertExists(vEditor);
     vEditor.setVRange({
-      index: textRangePoint.index + textRangePoint.length,
+      index: textRangePoint.index + text.length,
       length: 0,
     });
   }

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -29,7 +29,11 @@ import {
   undoByKeyboard,
   updateBlockType,
 } from './utils/actions/index.js';
-import { assertRichTexts, assertStoreMatchJSX } from './utils/asserts.js';
+import {
+  assertRichTexts,
+  assertRichTextVRange,
+  assertStoreMatchJSX,
+} from './utils/asserts.js';
 import { test } from './utils/playwright.js';
 
 /**
@@ -326,6 +330,8 @@ test('drag copy paste', async ({ page }) => {
 
   const content = await getVirgoSelectionText(page);
   expect(content).toBe('useuse');
+
+  await assertRichTextVRange(page, 0, 6, 0);
 });
 
 test('keyboard selection and copy paste', async ({ page }) => {
@@ -343,6 +349,8 @@ test('keyboard selection and copy paste', async ({ page }) => {
 
   const content = await getVirgoSelectionText(page);
   expect(content).toBe('useuse');
+
+  await assertRichTextVRange(page, 0, 3, 0);
 });
 
 // FIXME: this test failed in headless mode but passed in non-headless mode


### PR DESCRIPTION
closes #5055 

before:

https://github.com/toeverything/blocksuite/assets/54364088/c0a845aa-704f-46d8-90ce-849fe66c628c

after:

https://github.com/toeverything/blocksuite/assets/54364088/b803e16b-e526-480a-b3b2-e75904624ef9


Changes:
- Text paste in code block: 
   1. corrected index calculation in overridden json2Block.
   2. modified existing copy/paste test to check for VRange after paste.
- Text paste in paragraph: `asyncSetVRange` is flaky and sets wrong cursor position at random. Switched to `getVirgoByModel` for focusedBlockModel.