### PR TITLE
fix(page): console error on deleting at the start of first paragraph

### DIFF
--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -120,7 +120,7 @@ export function getPreviousBlock(model: BaseBlockModel): BaseBlockModel | null {
 
     const prev = getPrev(model);
     if (prev) {
-      if (prev.role === 'content') {
+      if (prev.role === 'content' && !matchFlavours(prev, ['affine:frame'])) {
         return prev;
       } else {
         return iterate(prev);


### PR DESCRIPTION
closes #5386 

Changes:
- `affine-frame` should not be returned by getPreviousBlock. getPreviousBlock is used in text operations where `affine-frame` causes an exception.