### PR TITLE
fix(edgeless): for group element, apply local record update recursively

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -41,6 +41,7 @@ import {
   Bound,
   clamp,
   getCommonBound,
+  GroupElement,
   type IBound,
   intersects,
   type IVec,
@@ -546,6 +547,12 @@ export class EdgelessPageBlockComponent extends BlockElement<
       if (!elementsSet.has(id) || !this.surface.pickById(id)) return;
 
       const element = this.surface.pickById(id) as EdgelessElement;
+
+      if (element instanceof GroupElement) {
+        this.applyLocalRecord(element.childElements.map(e => e.id));
+        return;
+      }
+
       const updateProps: Record<string, unknown> = {};
       let flag = false;
 


### PR DESCRIPTION
closes #5373 

before:

https://github.com/toeverything/blocksuite/assets/54364088/6cb2d47f-c9ae-45c0-be32-a195d0ee4208


after: 

https://github.com/toeverything/blocksuite/assets/54364088/0bc6efd6-4c92-4c4f-b91b-3130106a1f05

Changes:
- Group element update needs to be applied to all the child elements, recursively.