### PR TITLE
feat(store): add `key` field for props updated slot

### DIFF
--- a/packages/blocks/src/_legacy/clipboard/page-clipboard.ts
+++ b/packages/blocks/src/_legacy/clipboard/page-clipboard.ts
@@ -89,8 +89,6 @@ export class PageClipboard implements Clipboard {
     await service.json2Block(focusedBlockModel, blocks, textSelection.from);
 
     this._page.captureSync();
-
-    this._page.slots.pasted.emit(blocks);
   };
 
   private _onCopy = async (ctx: UIEventStateContext) => {
@@ -101,8 +99,6 @@ export class PageClipboard implements Clipboard {
     await this._copyBlocksInPage();
 
     this._page.captureSync();
-
-    this._page.slots.copied.emit();
   };
 
   private async _copyBlocksInPage() {

--- a/packages/store/src/__tests__/block-tree.unit.spec.ts
+++ b/packages/store/src/__tests__/block-tree.unit.spec.ts
@@ -49,26 +49,26 @@ test('trigger props updated', async () => {
 
   root.count = 1;
   expect(onPropsUpdated).toBeCalledTimes(1);
-  expect(onPropsUpdated).toHaveBeenNthCalledWith(1, { name: 'count' });
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(1, { key: 'count' });
   expect(getCount()).toBe(1);
 
   root.count = 2;
   expect(onPropsUpdated).toBeCalledTimes(2);
-  expect(onPropsUpdated).toHaveBeenNthCalledWith(2, { name: 'count' });
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(2, { key: 'count' });
   expect(getCount()).toBe(2);
 
   root.style.color = 'blue';
   expect(onPropsUpdated).toBeCalledTimes(3);
-  expect(onPropsUpdated).toHaveBeenNthCalledWith(3, { name: 'style' });
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(3, { key: 'style' });
   expect(getColor()).toBe('blue');
 
   root.style = { color: 'red' };
   expect(onPropsUpdated).toBeCalledTimes(4);
-  expect(onPropsUpdated).toHaveBeenNthCalledWith(4, { name: 'style' });
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(4, { key: 'style' });
   expect(getColor()).toBe('red');
 
   root.style.color = 'green';
   expect(onPropsUpdated).toBeCalledTimes(5);
-  expect(onPropsUpdated).toHaveBeenNthCalledWith(5, { name: 'style' });
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(5, { key: 'style' });
   expect(getColor()).toBe('green');
 });

--- a/packages/store/src/__tests__/block-tree.unit.spec.ts
+++ b/packages/store/src/__tests__/block-tree.unit.spec.ts
@@ -49,23 +49,26 @@ test('trigger props updated', async () => {
 
   root.count = 1;
   expect(onPropsUpdated).toBeCalledTimes(1);
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(1, { name: 'count' });
   expect(getCount()).toBe(1);
 
   root.count = 2;
   expect(onPropsUpdated).toBeCalledTimes(2);
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(2, { name: 'count' });
   expect(getCount()).toBe(2);
 
   root.style.color = 'blue';
   expect(onPropsUpdated).toBeCalledTimes(3);
-
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(3, { name: 'style' });
   expect(getColor()).toBe('blue');
 
   root.style = { color: 'red' };
   expect(onPropsUpdated).toBeCalledTimes(4);
-
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(4, { name: 'style' });
   expect(getColor()).toBe('red');
 
   root.style.color = 'green';
   expect(onPropsUpdated).toBeCalledTimes(5);
+  expect(onPropsUpdated).toHaveBeenNthCalledWith(5, { name: 'style' });
   expect(getColor()).toBe('green');
 });

--- a/packages/store/src/schema/base.ts
+++ b/packages/store/src/schema/base.ts
@@ -187,7 +187,7 @@ export class BaseBlockModel<
 
   created = new Slot();
   deleted = new Slot();
-  propsUpdated = new Slot<{ name: string }>();
+  propsUpdated = new Slot<{ key: string }>();
   childrenUpdated = new Slot();
 
   get childMap() {

--- a/packages/store/src/schema/base.ts
+++ b/packages/store/src/schema/base.ts
@@ -187,7 +187,7 @@ export class BaseBlockModel<
 
   created = new Slot();
   deleted = new Slot();
-  propsUpdated = new Slot();
+  propsUpdated = new Slot<{ name: string }>();
   childrenUpdated = new Slot();
 
   get childMap() {
@@ -228,13 +228,6 @@ export class BaseBlockModel<
       return this;
     }
     return this.children[this.children.length - 1].lastChild();
-  }
-
-  firstItem(): BaseBlockModel | null {
-    if (!this.children.length) {
-      return this;
-    }
-    return this.children[0];
   }
 
   lastItem(): BaseBlockModel | null {

--- a/packages/store/src/workspace/block/block-tree.ts
+++ b/packages/store/src/workspace/block/block-tree.ts
@@ -5,7 +5,7 @@ import type { BaseBlockModel, Schema } from '../../schema/index.js';
 import { internalPrimitives } from '../../schema/index.js';
 import type { AwarenessStore, BlockSuiteDoc } from '../../yjs/index.js';
 import { Space } from '../space.js';
-import type { YBlock } from './block.js';
+import type { BlockOptions, YBlock } from './block.js';
 import { Block } from './block.js';
 import { propsToValue } from './utils.js';
 
@@ -30,7 +30,7 @@ export class BlockTree extends Space<FlatBlockMap> {
     this._schema = schema;
   }
 
-  protected _onBlockAdded(id: string) {
+  protected _onBlockAdded(id: string, options: BlockOptions = {}) {
     if (this._blocks.has(id)) {
       return;
     }
@@ -40,7 +40,7 @@ export class BlockTree extends Space<FlatBlockMap> {
       return;
     }
 
-    const block = new Block(this._schema, yBlock);
+    const block = new Block(this._schema, yBlock, options);
     this._blocks.set(id, block);
   }
 

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -45,7 +45,7 @@ export class Block {
             // @ts-ignore
             this.model[keyName] = proxy;
           });
-          this.model.propsUpdated.emit({ name: keyName });
+          this.model.propsUpdated.emit({ key: keyName });
           return;
         }
         if (type.action === 'delete') {
@@ -54,7 +54,7 @@ export class Block {
             // @ts-ignore
             delete this.model[keyName];
           });
-          this.model.propsUpdated.emit({ name: keyName });
+          this.model.propsUpdated.emit({ key: keyName });
           return;
         }
       });
@@ -70,7 +70,7 @@ export class Block {
   private _getPropsProxy = (name: string, value: unknown) => {
     return valueToProps(value, {
       onChange: () => {
-        this.model.propsUpdated.emit({ name });
+        this.model.propsUpdated.emit({ key: name });
       },
     });
   };
@@ -152,7 +152,7 @@ export class Block {
           model.keys.includes(p)
         ) {
           this.yBlock.delete(`prop:${p}`);
-          this.model.propsUpdated.emit({ name: p });
+          this.model.propsUpdated.emit({ key: p });
         }
 
         return Reflect.deleteProperty(target, p);

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -9,6 +9,7 @@ import { propsToValue, valueToProps } from './utils.js';
 export type YBlock = Y.Map<unknown>;
 
 export type BlockOptions = Partial<{
+  onChange: (block: Block, key: string, value: unknown) => void;
   onYBlockUpdated: (block: Block) => void;
 }>;
 
@@ -79,7 +80,7 @@ export class Block {
   private _getPropsProxy = (name: string, value: unknown) => {
     return valueToProps(value, {
       onChange: () => {
-        this.model.propsUpdated.emit({ key: name });
+        this.options.onChange?.(this, name, value);
       },
     });
   };

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -40,29 +40,40 @@ export class Block {
         if (type.action === 'update' || type.action === 'add') {
           const value = this.yBlock.get(key);
           const keyName = key.replace('prop:', '');
-          const proxy = valueToProps(value, {
-            onChange: () => {
-              this.model.propsUpdated.emit();
-            },
+          const proxy = this._getPropsProxy(keyName, value);
+          this._byPassUpdate(() => {
+            // @ts-ignore
+            this.model[keyName] = proxy;
           });
-          this._byPassProxy = true;
-          // @ts-ignore
-          this.model[keyName] = proxy;
-          this._byPassProxy = false;
+          this.model.propsUpdated.emit({ name: keyName });
           return;
         }
         if (type.action === 'delete') {
           const keyName = key.replace('prop:', '');
-          this._byPassProxy = true;
-          // @ts-ignore
-          delete this.model[keyName];
-          this._byPassProxy = false;
+          this._byPassUpdate(() => {
+            // @ts-ignore
+            delete this.model[keyName];
+          });
+          this.model.propsUpdated.emit({ name: keyName });
           return;
         }
       });
-      this.model.propsUpdated.emit();
     });
   }
+
+  private _byPassUpdate = (fn: () => void) => {
+    this._byPassProxy = true;
+    fn();
+    this._byPassProxy = false;
+  };
+
+  private _getPropsProxy = (name: string, value: unknown) => {
+    return valueToProps(value, {
+      onChange: () => {
+        this.model.propsUpdated.emit({ name });
+      },
+    });
+  };
 
   private _parseYBlock() {
     let id: string | undefined;
@@ -73,11 +84,7 @@ export class Block {
     this.yBlock.forEach((value, key) => {
       if (key.startsWith('prop:')) {
         const keyName = key.replace('prop:', '');
-        const proxy = valueToProps(value, {
-          onChange: () => {
-            this.model.propsUpdated.emit();
-          },
-        });
+        const proxy = this._getPropsProxy(keyName, value);
         props[keyName] = proxy;
       }
 
@@ -129,11 +136,7 @@ export class Block {
         ) {
           const yValue = propsToValue(value);
           this.yBlock.set(`prop:${p}`, yValue);
-          const proxy = valueToProps(yValue, {
-            onChange: () => {
-              this.model.propsUpdated.emit();
-            },
-          });
+          const proxy = this._getPropsProxy(p, yValue);
           return Reflect.set(target, p, proxy, receiver);
         }
 
@@ -149,7 +152,7 @@ export class Block {
           model.keys.includes(p)
         ) {
           this.yBlock.delete(`prop:${p}`);
-          this.model.propsUpdated.emit();
+          this.model.propsUpdated.emit({ name: p });
         }
 
         return Reflect.deleteProperty(target, p);

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -8,6 +8,10 @@ import { propsToValue, valueToProps } from './utils.js';
 
 export type YBlock = Y.Map<unknown>;
 
+export type BlockOptions = Partial<{
+  onYBlockUpdated: (block: Block) => void;
+}>;
+
 export class Block {
   readonly model: BaseBlockModel;
   readonly id: string;
@@ -17,7 +21,8 @@ export class Block {
 
   constructor(
     readonly schema: Schema,
-    readonly yBlock: YBlock
+    readonly yBlock: YBlock,
+    readonly options: BlockOptions = {}
   ) {
     const { id, flavour, yChildren, props } = this._parseYBlock();
 
@@ -58,6 +63,10 @@ export class Block {
           return;
         }
       });
+    });
+
+    this.yBlock.observeDeep(() => {
+      this.options.onYBlockUpdated?.(this);
     });
   }
 

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -515,12 +515,6 @@ export class Page extends BlockTree {
 
       callBackOrProps();
     });
-
-    this.slots.blockUpdated.emit({
-      type: 'update',
-      id: model.id,
-      flavour: model.flavour,
-    });
   }
 
   addSiblingBlocks(

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -78,10 +78,6 @@ export class Page extends BlockTree {
           flavour: string;
         }
     >(),
-    /** @deprecated */
-    copied: new Slot(),
-    /** @deprecated */
-    pasted: new Slot<Record<string, unknown>[]>(),
   };
 
   constructor({

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -696,6 +696,9 @@ export class Page extends BlockTree {
       return;
     }
     this._onBlockAdded(id, {
+      onChange: (block, key) => {
+        block.model.propsUpdated.emit({ key });
+      },
       onYBlockUpdated: block => {
         this.slots.blockUpdated.emit({
           type: 'update',

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -519,6 +519,12 @@ export class Page extends BlockTree {
 
       callBackOrProps();
     });
+
+    this.slots.blockUpdated.emit({
+      type: 'update',
+      id: model.id,
+      flavour: model.flavour,
+    });
   }
 
   addSiblingBlocks(

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -695,7 +695,15 @@ export class Page extends BlockTree {
       );
       return;
     }
-    this._onBlockAdded(id);
+    this._onBlockAdded(id, {
+      onYBlockUpdated: block => {
+        this.slots.blockUpdated.emit({
+          type: 'update',
+          id,
+          flavour: block.id,
+        });
+      },
+    });
     const block = this._blocks.get(id);
     assertExists(block);
     const model = block.model;


### PR DESCRIPTION
## 1. `block.propsUpdated` will be triggered with the changed `key`.

```ts
model.slots.propsUpdated.on(({ key }) => {
  if (key === 'someProp') {
    doSomething();
  }
})
```

## 2. `page.blockUpdated` will be triggered with `type: updated` when it's props changed.