### PR TITLE
fix(database): incorrect tag modal position

### DIFF
--- a/packages/blocks/src/_common/components/tags/multi-tag-select.ts
+++ b/packages/blocks/src/_common/components/tags/multi-tag-select.ts
@@ -510,6 +510,9 @@ const middleware: Middleware = {
     if (overflow.right > 0) {
       x = left - overflow.right;
     }
+    if (y < 0) {
+      y = 240;
+    }
     return {
       y,
       x,


### PR DESCRIPTION
With the screen enlarged, click the '+' plus button to cut the modal window at the top.

At that time, the value of the phase (==y) is negative.

So, when the y value is negative, I specified it as 240 to solve the truncation phenomenon.

Now, you can add tags without any inconvenience.

Thank you for giving me the opportunity to contribute.

<img width="714" alt="image" src="https://github.com/toeverything/blocksuite/assets/101880766/ae1fcd53-6d95-481a-b3b2-ec29835009a7">
