### PR TITLE
fix(page): autoscroll during native selection

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -136,8 +136,8 @@ export class RichText extends WithDisposable(ShadowlessElement) {
 
     // init auto scroll
     vEditor.disposables.add(
-      vEditor.slots.vRangeUpdated.on(([vRange]) => {
-        if (!vRange) return;
+      vEditor.slots.vRangeUpdated.on(([vRange, sync]) => {
+        if (!vRange || !sync) return;
 
         vEditor.waitForUpdate().then(() => {
           if (!vEditor.mounted) return;

--- a/packages/lit/src/utils/v-range-provider.ts
+++ b/packages/lit/src/utils/v-range-provider.ts
@@ -15,6 +15,7 @@ export const getVRangeProvider: (
   const root = element.root;
   const selectionManager = root.selection;
   const rangeManager = root.rangeManager;
+  const vRangeUpdatedSlot = new Slot<VRangeUpdatedProp>();
 
   assertExists(selectionManager);
   assertExists(rangeManager);
@@ -68,7 +69,8 @@ export const getVRangeProvider: (
       length: element.model.text.length,
     };
   };
-  const setVRange = (vRange: VRange | null) => {
+
+  const setVRange = (vRange: VRange | null, sync = true) => {
     if (!vRange) {
       selectionManager.clear(['text']);
     } else {
@@ -82,7 +84,9 @@ export const getVRangeProvider: (
       });
       selectionManager.setGroup('note', [textSelection]);
     }
+    vRangeUpdatedSlot.emit([vRange, sync]);
   };
+
   const getVRange = (): VRange | null => {
     const sl = document.getSelection();
     if (!sl || sl.rangeCount === 0) {
@@ -101,7 +105,6 @@ export const getVRangeProvider: (
     return calculateVRange(range, textSelection);
   };
 
-  const vRangeUpdatedSlot = new Slot<VRangeUpdatedProp>();
   selectionManager.slots.changed.on(() => {
     const textSelection = selectionManager.find('text');
     if (!textSelection) return;

--- a/packages/virgo/src/services/range.ts
+++ b/packages/virgo/src/services/range.ts
@@ -252,7 +252,7 @@ export class VirgoRangeService<TextAttributes extends BaseTextAttributes> {
     }
 
     if (this.vRangeProvider) {
-      this.vRangeProvider.setVRange(vRange);
+      this.vRangeProvider.setVRange(vRange, sync);
       return;
     }
 

--- a/packages/virgo/src/utils/transform-input.ts
+++ b/packages/virgo/src/utils/transform-input.ts
@@ -10,35 +10,26 @@ function handleInsertText<TextAttributes extends BaseTextAttributes>(
 ) {
   if (!data) return;
   editor.insertText(vRange, data, attributes);
-  editor.setVRange(
-    {
-      index: vRange.index + data.length,
-      length: 0,
-    },
-    false
-  );
+  editor.setVRange({
+    index: vRange.index + data.length,
+    length: 0,
+  });
 }
 
 function handleInsertParagraph(vRange: VRange, editor: VEditor) {
   editor.insertLineBreak(vRange);
-  editor.setVRange(
-    {
-      index: vRange.index + 1,
-      length: 0,
-    },
-    false
-  );
+  editor.setVRange({
+    index: vRange.index + 1,
+    length: 0,
+  });
 }
 
 function handleDelete(vRange: VRange, editor: VEditor) {
   editor.deleteText(vRange);
-  editor.setVRange(
-    {
-      index: vRange.index,
-      length: 0,
-    },
-    false
-  );
+  editor.setVRange({
+    index: vRange.index,
+    length: 0,
+  });
 }
 
 export function transformInput<TextAttributes extends BaseTextAttributes>(

--- a/packages/virgo/src/virgo.ts
+++ b/packages/virgo/src/virgo.ts
@@ -27,7 +27,7 @@ export type VirgoRootElement<
 
 export interface VRangeProvider {
   getVRange(): VRange | null;
-  setVRange(vRange: VRange | null): void;
+  setVRange(vRange: VRange | null, sync: boolean): void;
   vRangeUpdatedSlot: Slot<VRangeUpdatedProp>;
 }
 


### PR DESCRIPTION
closes #4988 

Bug happens only when selection and page scroll happens together.
`rich-text` has auto scrolling which tries to keep the entire selection in view, hence preventing selected text to scroll out of view.

Changes:
- autoscroll only when vrange is updated in `sync` mode.
- added slot event on v-range-provider for setVRange to trigger `sync`.
- native selection events will update vrange in `async` mode i.e. `sync = false`