### PR TITLE
feat(page): support embed view for certain attachment types

### DIFF
--- a/packages/blocks/src/_legacy/content-parser/index.ts
+++ b/packages/blocks/src/_legacy/content-parser/index.ts
@@ -614,6 +614,7 @@ export class ContentParser {
         sourceId,
         size: file.size,
         type: file.type,
+        embed: false,
         children: [],
       };
       return [attachmentProps];

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -18,7 +18,7 @@ import {
   AttachmentBlockSchema,
 } from './attachment-model.js';
 import { AttachmentOptionsTemplate } from './components/options.js';
-import { renderEmbedView } from './embed.js';
+import { allowEmbed, renderEmbedView } from './embed.js';
 import {
   AttachmentBanner,
   ErrorBanner,
@@ -144,7 +144,9 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
       const blob = await getAttachmentBlob(this.model);
       if (!blob) throw new Error('Blob is missing!');
       // TODO we no need to create blob url when the attachment is not embedded
-      this._blobUrl = URL.createObjectURL(blob);
+      if (allowEmbed(this.model)) {
+        this._blobUrl = URL.createObjectURL(blob);
+      }
     } catch (error) {
       this._error = true;
       console.warn(

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -256,8 +256,14 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
     if (this.model.embed && this._blobUrl) {
       const embedView = renderEmbedView(this.model, this._blobUrl);
       if (embedView) {
-        return html`<div ${ref(this._hoverController.setReference)}>
+        return html`<div
+            ${ref(this._hoverController.setReference)}
+            class="affine-attachment-embed-container"
+          >
             ${embedView}
+            ${this.selected?.is('block')
+              ? html`<affine-block-selection></affine-block-selection>`
+              : null}
           </div>
           ${captionTemplate}`;
       }

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -26,8 +26,8 @@ import {
   styles,
 } from './styles.js';
 import {
-  downloadAttachment,
-  getAttachment,
+  downloadAttachmentBlob,
+  getAttachmentBlob,
   isAttachmentLoading,
 } from './utils.js';
 
@@ -141,7 +141,7 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
     const sourceId = this.model.sourceId;
     if (!sourceId) return;
     try {
-      const blob = await getAttachment(this.model);
+      const blob = await getAttachmentBlob(this.model);
       if (!blob) throw new Error('Blob is missing!');
       // TODO we no need to create blob url when the attachment is not embedded
       this._blobUrl = URL.createObjectURL(blob);
@@ -178,7 +178,7 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
     this._isDownloading = true;
     // TODO speed up download by using this._blobUrl
     try {
-      await downloadAttachment(this.model);
+      await downloadAttachmentBlob(this.model);
     } catch (error) {
       console.error(error);
       toast(`Failed to download ${shortName}!`);

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -13,6 +13,11 @@ import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
  * it means that the attachment is failed to upload.
  */
 
+/**
+ * @deprecated
+ */
+type BackwardCompatibleUndefined = undefined;
+
 export type AttachmentBlockProps = {
   name: string;
   size: number;
@@ -26,6 +31,10 @@ export type AttachmentBlockProps = {
   // The `loadingKey` and `sourceId` should not be existed at the same time.
   // loadingKey?: string | null;
   sourceId?: string;
+  /**
+   * Whether to show the attachment as an embed view.
+   */
+  embed: boolean | BackwardCompatibleUndefined;
 };
 
 export const defaultAttachmentProps: AttachmentBlockProps = {
@@ -34,6 +43,7 @@ export const defaultAttachmentProps: AttachmentBlockProps = {
   type: 'application/octet-stream',
   sourceId: undefined,
   caption: undefined,
+  embed: false,
 };
 
 export const AttachmentBlockSchema = defineBlockSchema({

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -5,6 +5,7 @@ import { createRef, ref, type RefOrCallback } from 'lit/directives/ref.js';
 
 import { createLitPortal } from '../../_common/components/portal.js';
 import {
+  BookmarkIcon,
   CaptionIcon,
   EditIcon,
   EmbedWebIcon,
@@ -14,7 +15,7 @@ import {
 } from '../../_common/icons/index.js';
 import { stopPropagation } from '../../_common/utils/event.js';
 import type { AttachmentBlockModel } from '../attachment-model.js';
-import { turnIntoEmbedView } from '../utils.js';
+import { allowEmbed, turnIntoEmbedAction } from '../embed.js';
 import { MoreMenu } from './more-menu.js';
 import { RenameModal } from './rename-model.js';
 import { styles } from './styles.js';
@@ -50,7 +51,7 @@ export function AttachmentOptionsTemplate({
         ).value = el);
   };
 
-  const disableEmbed = !model.type?.startsWith('image/');
+  const disableEmbed = !allowEmbed(model);
   const readonly = model.page.readonly;
   let moreMenuAbortController: AbortController | null = null;
   return html`<style>
@@ -72,11 +73,26 @@ export function AttachmentOptionsTemplate({
         ${LinkIcon}
         <affine-tooltip .offset=${12}>Turn into Link view</affine-tooltip>
       </icon-button>
+
       <icon-button
         size="32px"
+        ?hidden=${!model.embed}
+        ?disabled=${readonly}
+        @click="${() => {
+          model.page.updateBlock(model, { embed: false });
+          abortController.abort();
+        }}"
+      >
+        ${BookmarkIcon}
+        <affine-tooltip .offset=${12}>Turn into Card view</affine-tooltip>
+      </icon-button>
+
+      <icon-button
+        size="32px"
+        ?hidden=${model.embed}
         ?disabled=${readonly || disableEmbed}
         @click="${() => {
-          turnIntoEmbedView(model);
+          turnIntoEmbedAction(model);
           abortController.abort();
         }}"
       >

--- a/packages/blocks/src/attachment-block/embed.ts
+++ b/packages/blocks/src/attachment-block/embed.ts
@@ -34,21 +34,24 @@ const embedConfig: EmbedConfig[] = [
     action: model => turnIntoImage(model),
   },
   {
-    name: 'html/pdf/text',
+    name: 'pdf',
     check: model =>
-      // Temporarily only allows pdf
       model.type === 'application/pdf' && model.size <= MAX_EMBED_SIZE,
-    template: (_, blobUrl) =>
-      html`<iframe
+    template: (_, blobUrl) => {
+      // More options: https://tinytip.co/tips/html-pdf-params/
+      // https://chromium.googlesource.com/chromium/src/+/refs/tags/121.0.6153.1/chrome/browser/resources/pdf/open_pdf_params_parser.ts
+      const parameters = '#toolbar=0';
+      return html`<iframe
         style="width: 100%; color-scheme: auto;"
         height="480"
-        src=${blobUrl}
+        src=${blobUrl + parameters}
         loading="lazy"
         scrolling="no"
         frameborder="no"
         allowTransparency
         allowfullscreen
-      ></iframe>`,
+      ></iframe>`;
+    },
   },
   {
     name: 'video',

--- a/packages/blocks/src/attachment-block/embed.ts
+++ b/packages/blocks/src/attachment-block/embed.ts
@@ -1,0 +1,85 @@
+import { html, type TemplateResult } from 'lit';
+
+import type { AttachmentBlockModel } from './attachment-model.js';
+import { turnIntoImage } from './utils.js';
+
+type EmbedConfig = {
+  name: string;
+  /**
+   * Check if the attachment can be turned into embed view.
+   */
+  check: (model: AttachmentBlockModel) => boolean;
+  /**
+   * The action will be executed when the 「Turn into embed view」 button is clicked.
+   */
+  action?: (model: AttachmentBlockModel) => void;
+  /**
+   * The template will be used to render the embed view.
+   */
+  template?: (
+    model: AttachmentBlockModel,
+    blobUrl: string
+  ) => TemplateResult<1>;
+};
+
+// 10MB
+const MAX_EMBED_SIZE = 10 * 1024 * 1024;
+
+const embedConfig: EmbedConfig[] = [
+  {
+    name: 'image',
+    check: model =>
+      model.page.schema.flavourSchemaMap.has('affine:image') &&
+      model.type.startsWith('image/'),
+    action: model => turnIntoImage(model),
+  },
+  {
+    name: 'pdf',
+    check: model =>
+      model.type === 'application/pdf' && model.size <= MAX_EMBED_SIZE,
+    template: (_, blobUrl) =>
+      html`<iframe
+        style="width: 100%; color-scheme: auto;"
+        height="480"
+        scrolling="no"
+        src=${blobUrl}
+        frameborder="no"
+        loading="lazy"
+        allowTransparency
+        allowfullscreen
+      ></iframe>`,
+  },
+  {
+    name: 'video',
+    check: model =>
+      model.type.startsWith('video/') && model.size <= MAX_EMBED_SIZE,
+    template: (_, blobUrl) =>
+      html`<video
+        style="width: 100%;"
+        height="480"
+        controls
+        src=${blobUrl}
+      ></video>`,
+  },
+];
+
+export function allowEmbed(model: AttachmentBlockModel) {
+  return embedConfig.some(config => config.check(model));
+}
+
+export function turnIntoEmbedAction(model: AttachmentBlockModel) {
+  const config = embedConfig.find(config => config.check(model));
+  if (!config || !config.action) {
+    model.page.updateBlock<Partial<AttachmentBlockModel>>(model, {
+      embed: true,
+    });
+    return;
+  }
+  config.action(model);
+}
+
+export function renderEmbedView(model: AttachmentBlockModel, blobUrl: string) {
+  const config = embedConfig.find(config => config.check(model));
+  if (!config || !config.template) return null;
+  return config.template(model, blobUrl);
+}

--- a/packages/blocks/src/attachment-block/embed.ts
+++ b/packages/blocks/src/attachment-block/embed.ts
@@ -34,17 +34,18 @@ const embedConfig: EmbedConfig[] = [
     action: model => turnIntoImage(model),
   },
   {
-    name: 'pdf',
+    name: 'html/pdf/text',
     check: model =>
+      // Temporarily only allows pdf
       model.type === 'application/pdf' && model.size <= MAX_EMBED_SIZE,
     template: (_, blobUrl) =>
       html`<iframe
         style="width: 100%; color-scheme: auto;"
         height="480"
-        scrolling="no"
         src=${blobUrl}
-        frameborder="no"
         loading="lazy"
+        scrolling="no"
+        frameborder="no"
         allowTransparency
         allowfullscreen
       ></iframe>`,
@@ -54,12 +55,7 @@ const embedConfig: EmbedConfig[] = [
     check: model =>
       model.type.startsWith('video/') && model.size <= MAX_EMBED_SIZE,
     template: (_, blobUrl) =>
-      html`<video
-        style="width: 100%;"
-        height="480"
-        controls
-        src=${blobUrl}
-      ></video>`,
+      html`<video width="100%;" height="480" controls src=${blobUrl}></video>`,
   },
   {
     name: 'audio',

--- a/packages/blocks/src/attachment-block/embed.ts
+++ b/packages/blocks/src/attachment-block/embed.ts
@@ -61,6 +61,12 @@ const embedConfig: EmbedConfig[] = [
         src=${blobUrl}
       ></video>`,
   },
+  {
+    name: 'audio',
+    check: model =>
+      model.type.startsWith('audio/') && model.size <= MAX_EMBED_SIZE,
+    template: (_, blobUrl) => html`<audio controls src=${blobUrl}></audio>`,
+  },
 ];
 
 export function allowEmbed(model: AttachmentBlockModel) {

--- a/packages/blocks/src/attachment-block/embed.ts
+++ b/packages/blocks/src/attachment-block/embed.ts
@@ -65,7 +65,8 @@ const embedConfig: EmbedConfig[] = [
     name: 'audio',
     check: model =>
       model.type.startsWith('audio/') && model.size <= MAX_EMBED_SIZE,
-    template: (_, blobUrl) => html`<audio controls src=${blobUrl}></audio>`,
+    template: (_, blobUrl) =>
+      html`<audio controls src=${blobUrl} style="margin: 4px;"></audio>`,
   },
 ];
 
@@ -86,6 +87,9 @@ export function turnIntoEmbedAction(model: AttachmentBlockModel) {
 
 export function renderEmbedView(model: AttachmentBlockModel, blobUrl: string) {
   const config = embedConfig.find(config => config.check(model));
-  if (!config || !config.template) return null;
+  if (!config || !config.template) {
+    console.error('No embed view template found!', model, embedConfig);
+    return null;
+  }
   return config.template(model, blobUrl);
 }

--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -17,6 +17,13 @@ export const styles = css`
     cursor: pointer;
   }
 
+  .affine-attachment-embed-container {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    margin-top: calc(var(--affine-paragraph-space) + 8px);
+  }
+
   .affine-attachment-title {
     display: flex;
     gap: 8px;

--- a/packages/blocks/src/attachment-block/utils.ts
+++ b/packages/blocks/src/attachment-block/utils.ts
@@ -32,7 +32,7 @@ export function cloneAttachmentProperties(
   return clonedProps;
 }
 
-export async function getAttachment(model: AttachmentBlockModel) {
+export async function getAttachmentBlob(model: AttachmentBlockModel) {
   const blobManager = model.page.blob;
   const sourceId = model.sourceId;
   if (!sourceId) return null;
@@ -46,10 +46,10 @@ export async function getAttachment(model: AttachmentBlockModel) {
  * Since the size of the attachment may be very large,
  * the download process may take a long time!
  */
-export async function downloadAttachment(
+export async function downloadAttachmentBlob(
   attachmentModel: AttachmentBlockModel
 ) {
-  const attachment = await getAttachment(attachmentModel);
+  const attachment = await getAttachmentBlob(attachmentModel);
   if (!attachment) {
     toast('Failed to download attachment!');
     console.error(
@@ -215,7 +215,7 @@ export function isAttachmentLoading(modelId: string) {
 /**
  * Use it with caution! This function may take a long time!
  *
- * @deprecated
+ * @deprecated Use {@link getAttachmentBlob} instead.
  */
 export async function hasBlob(storage: BlobManager, sourceId: string) {
   return !!(await storage.get(sourceId));

--- a/packages/blocks/src/attachment-block/utils.ts
+++ b/packages/blocks/src/attachment-block/utils.ts
@@ -32,7 +32,7 @@ export function cloneAttachmentProperties(
   return clonedProps;
 }
 
-async function getAttachment(model: AttachmentBlockModel) {
+export async function getAttachment(model: AttachmentBlockModel) {
   const blobManager = model.page.blob;
   const sourceId = model.sourceId;
   if (!sourceId) return null;
@@ -66,7 +66,7 @@ export async function downloadAttachment(
 /**
  * Turn the attachment block into an image block.
  */
-export async function turnIntoEmbedView(model: AttachmentBlockModel) {
+export async function turnIntoImage(model: AttachmentBlockModel) {
   if (!model.page.schema.flavourSchemaMap.has('affine:image'))
     throw new Error('The image flavour is not supported!');
 
@@ -103,6 +103,7 @@ export function turnImageIntoCardView(model: ImageBlockModel, blob: Blob) {
     size: blob.size,
     type: blob.type,
     caption: model.caption,
+    embed: false,
     ...attachmentConvertData,
   };
   transformModel(model, 'affine:attachment', attachmentProp);
@@ -191,6 +192,7 @@ export async function appendAttachmentBlock(
     name: file.name,
     size: file.size,
     type: file.type,
+    embed: false,
   };
   const [newBlockId] = page.addSiblingBlocks(model, [props]);
   // Do not add await here, because upload may take a long time, we want to do it in the background.
@@ -212,6 +214,8 @@ export function isAttachmentLoading(modelId: string) {
 
 /**
  * Use it with caution! This function may take a long time!
+ *
+ * @deprecated
  */
 export async function hasBlob(storage: BlobManager, sourceId: string) {
   return !!(await storage.get(sourceId));

--- a/packages/docs/block-schema.md
+++ b/packages/docs/block-schema.md
@@ -6,7 +6,7 @@ This documentation is mostly written for BlockSuite maintainers. If you goal doe
 
 In BlockSuite, all blocks should have a schema. The schema of the block describes the data structure of the block.
 
-You can use the `defineSchema` function to define the schema of the block.
+You can use the `defineBlockSchema` function to define the schema of the block.
 
 ```ts
 import { defineBlockSchema } from '@blocksuite/store';

--- a/packages/editor/src/components/editor-container.ts
+++ b/packages/editor/src/components/editor-container.ts
@@ -256,6 +256,7 @@ export class EditorContainer
             name: file.name,
             size: file.size,
             type: file.type,
+            embed: false,
           };
         },
       });

--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -132,7 +132,8 @@ test('can insert attachment from slash menu', async ({ page }) => {
 
   await assertStoreMatchJSX(
     page,
-    `  <affine:note
+    `
+<affine:note
   prop:background="--affine-background-secondary-color"
   prop:edgeless={
     Object {
@@ -148,6 +149,7 @@ test('can insert attachment from slash menu', async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
+    prop:embed={false}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -188,6 +190,7 @@ test('should undo/redo works for attachment', async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
+    prop:embed={false}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -227,7 +230,8 @@ test('should undo/redo works for attachment', async ({ page }) => {
   await redoByKeyboard(page);
   await assertStoreMatchJSX(
     page,
-    `  <affine:note
+    `
+<affine:note
   prop:background="--affine-background-secondary-color"
   prop:edgeless={
     Object {
@@ -243,6 +247,7 @@ test('should undo/redo works for attachment', async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
+    prop:embed={false}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -308,7 +313,7 @@ test('should turn attachment to image works', async ({ page }) => {
   await assertStoreMatchJSX(
     page,
     `
-    <affine:note
+<affine:note
   prop:background="--affine-background-secondary-color"
   prop:edgeless={
     Object {
@@ -355,6 +360,7 @@ test('should turn attachment to image works', async ({ page }) => {
 >
   <affine:attachment
     prop:caption=""
+    prop:embed={false}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -437,6 +443,7 @@ test(`support dragging attachment block directly`, async ({ page }) => {
   prop:index="a0"
 >
   <affine:attachment
+    prop:embed={false}
     prop:name="${FILE_NAME}"
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -486,6 +493,7 @@ test(`support dragging attachment block directly`, async ({ page }) => {
     prop:index="a0"
   >
     <affine:attachment
+      prop:embed={false}
       prop:name="${FILE_NAME}"
       prop:size={${FILE_SIZE}}
       prop:sourceId="${FILE_ID}"
@@ -548,6 +556,7 @@ test(`support dragging attachment block directly`, async ({ page }) => {
       prop:type="text"
     />
     <affine:attachment
+      prop:embed={false}
       prop:name="${FILE_NAME}"
       prop:size={${FILE_SIZE}}
       prop:sourceId="${FILE_ID}"


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/3641 https://github.com/toeverything/blocksuite/issues/5033

This PR may need to undergo UI review.

There is a new property that has been added to the attachment model.

```ts
export type AttachmentBlockProps = {
  /**
   * Whether to show the attachment as an embed view.
   */
  embed: boolean | BackwardCompatibleUndefined;
}
```

https://github.com/toeverything/blocksuite/assets/18554747/2a9aaf43-85fa-417f-995d-73b0c89d338d

![Screenshot 2023-11-28 at 17 36 40](https://github.com/toeverything/blocksuite/assets/18554747/7b2abf5a-c229-4dac-85bc-a5fd48cd3593)


## Known issues

- The selection can not go through the iframe. The embed bookmark also has the same problem.

This issue can be resolved by applying a transparent layer over the iframe.

https://github.com/toeverything/blocksuite/assets/18554747/2b601be2-688d-4aef-a450-1e190d48d759

- The PDF will reset to page 0 when the page reloads. I think it's reasonable, as it is difficult to control the expected page number unless we add a new options button.
