### PR TITLE
fix(edgeless): consider containerOffset when auto-panning

### DIFF
--- a/packages/blocks/src/page-block/edgeless/utils/panning-utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/panning-utils.ts
@@ -13,7 +13,10 @@ export function calPanDelta(
   // Get viewport edge
   const { left, top, width, height } = viewport;
   // Get pointer position
-  const { x, y } = e;
+  let { x, y } = e;
+  const { containerOffset } = e;
+  x += containerOffset.x;
+  y += containerOffset.y;
   // Check if pointer is near viewport edge
   const nearLeft = x < left + edgeDistance;
   const nearRight = x > left + width - edgeDistance;


### PR DESCRIPTION
To close #5486 

https://github.com/toeverything/blocksuite/assets/99816898/995450ca-d2cd-46df-a500-176b792388ce

