### PR TITLE
fix(page): error when quickly clicking actions in image block

### DIFF
--- a/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
@@ -29,7 +29,7 @@ export function ImageOptionsTemplate({
 }: {
   ref?: RefOrCallback;
   model: ImageBlockModel;
-  blob: Blob;
+  blob?: Blob;
   abortController: AbortController;
   /**
    * @deprecated
@@ -76,8 +76,9 @@ export function ImageOptionsTemplate({
         ${supportAttachment
           ? html`<icon-button
               size="32px"
-              ?hidden=${readonly}
+              ?hidden=${readonly || !blob}
               @click=${() => {
+                if (!blob) return;
                 abortController.abort();
                 turnImageIntoCardView(model, blob);
               }}
@@ -119,8 +120,10 @@ export function ImageOptionsTemplate({
         <icon-button
           size="32px"
           ?hidden=${readonly ||
+          !blob ||
           !model.page.awarenessStore.getFlag('enable_bultin_ledits')}
           @click="${() => {
+            if (!blob) return;
             abortController.abort();
             openLeditsEditor(model, blob, root);
           }}"

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -73,7 +73,7 @@ class ImageBlock extends BlockElement<ImageBlockModel> {
   @state()
   protected _source!: string;
 
-  blob!: Blob;
+  blob?: Blob;
 
   @state()
   protected _imageState: 'waitUploaded' | 'loading' | 'ready' | 'failed' =


### PR DESCRIPTION
The assignment of `blob` is done asynchronously, which means that the non-null assertion in this case is incorrect.

![Screenshot 2023-11-28 at 18 24 43](https://github.com/toeverything/blocksuite/assets/18554747/50e98d62-3a4c-40c9-a614-520ed98aa63b)

https://github.com/toeverything/blocksuite/blob/8ea9348556299c1e1247023515cfca5354713d2e/packages/blocks/src/image-block/image-block.ts#L113-L117