### PR TITLE
chore(store): expose the `linkIndexMap` in `BacklinkIndexer`

### DIFF
--- a/packages/store/src/indexer/backlink.ts
+++ b/packages/store/src/indexer/backlink.ts
@@ -65,8 +65,13 @@ function diffArray<T>(
 }
 
 export class BacklinkIndexer {
-  private _linkIndexMap: Record<PageId, Record<BlockId, LinkedNode[]>> = {};
   private _disposables = new DisposableGroup();
+
+  private _linkIndexMap: Record<PageId, Record<BlockId, LinkedNode[]>> = {};
+  get linkIndexMap() {
+    return this._linkIndexMap;
+  }
+
   public slots = {
     /**
      * Note: sys:children update will not trigger event


### PR DESCRIPTION
Used to remove `PageReferencesAtom` Atom in AFFiNE.
https://github.com/toeverything/AFFiNE/blob/canary/packages/frontend/hooks/src/use-block-suite-page-references.ts#L16-L40