### PR TITLE
Fix/edgeless copy frame and image

### DIFF
--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -4,12 +4,15 @@ import type {
   UIEventStateContext,
 } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
 import { type BlockSnapshot, fromJSON, Job } from '@blocksuite/store';
 import type { ReactiveController } from 'lit';
 
+import { matchFlavours } from '../../../_common/utils/index.js';
 import { groupBy } from '../../../_common/utils/iterable.js';
 import {
   getBlockElementByModel,
+  getBlockElementByPath,
   getEditorContainer,
   isPageMode,
 } from '../../../_common/utils/query.js';
@@ -30,7 +33,6 @@ import {
   type CanvasElement,
   GroupElement,
 } from '../../../surface-block/elements/index.js';
-import type { SurfaceElement } from '../../../surface-block/elements/surface-element.js';
 import { compare } from '../../../surface-block/managers/group-manager.js';
 import type { SurfaceBlockComponent } from '../../../surface-block/surface-block.js';
 import { Bound, getCommonBound } from '../../../surface-block/utils/bound.js';
@@ -40,7 +42,6 @@ import {
 } from '../../../surface-block/utils/xywh.js';
 import type { ClipboardController } from '../../clipboard/index.js';
 import type { EdgelessPageBlockComponent } from '../edgeless-page-block.js';
-import { xywhArrayToObject } from '../utils/convert.js';
 import { deleteElements } from '../utils/crud.js';
 import {
   isCanvasElementWithText,
@@ -117,6 +118,24 @@ export class EdgelessClipboardController implements ReactiveController {
       return true;
     });
   };
+
+  private _blockQuery(model: BaseBlockModel) {
+    if (matchFlavours(model, ['affine:image', 'affine:frame'])) {
+      let current: BaseBlockModel | null = model;
+      const path: string[] = [];
+      while (current) {
+        // Top level image render under page block not surface block
+        if (!matchFlavours(current, ['affine:surface'])) {
+          path.unshift(current.id);
+        }
+        current = current.page.getParent(current);
+      }
+
+      return getBlockElementByPath(path);
+    } else {
+      return getBlockElementByModel(model);
+    }
+  }
 
   private _onCopy = async (
     _context: UIEventStateContext,
@@ -569,7 +588,7 @@ export class EdgelessClipboardController implements ReactiveController {
     edgeless: EdgelessPageBlockComponent,
     bound: IBound,
     nodes?: TopLevelBlockModel[],
-    surfaces?: SurfaceElement[]
+    canvasElements: CanvasElement[] = []
   ): Promise<HTMLCanvasElement | undefined> {
     const root = this.page.root;
     if (!root) return;
@@ -648,8 +667,8 @@ export class EdgelessClipboardController implements ReactiveController {
 
     const nodeElements = nodes ?? edgeless.getSortedElementsByBound(bound);
     for (const nodeElement of nodeElements) {
-      const blockElement = getBlockElementByModel(nodeElement)?.parentElement;
-      const blockBound = xywhArrayToObject(nodeElement);
+      const blockElement = this._blockQuery(nodeElement)?.parentElement;
+      const blockBound = Bound.deserialize(nodeElement.xywh);
       const canvasData = await html2canvas(
         blockElement as HTMLElement,
         html2canvasOption
@@ -661,12 +680,44 @@ export class EdgelessClipboardController implements ReactiveController {
         blockBound.w,
         blockBound.h
       );
+
+      if (nodeElement.flavour === EdgelessBlockType.FRAME) {
+        const blocksInsideFrame: TopLevelBlockModel[] = [];
+        this.surface.frame
+          .getElementsInFrame(nodeElement, false)
+          .forEach(ele => {
+            if (isTopLevelBlock(ele)) {
+              blocksInsideFrame.push(ele);
+            } else {
+              canvasElements.push(ele);
+            }
+          });
+
+        for (let i = 0; i < blocksInsideFrame.length; i++) {
+          const element = blocksInsideFrame[i];
+          const htmlElement = this._blockQuery(element)?.parentElement;
+          const blockBound = Bound.deserialize(element.xywh);
+          const canvasData = await html2canvas(
+            htmlElement as HTMLElement,
+            html2canvasOption
+          );
+
+          ctx.drawImage(
+            canvasData,
+            blockBound.x - bound.x + 50,
+            blockBound.y - bound.y + 50,
+            blockBound.w,
+            (blockBound.w / canvasData.width) * canvasData.height
+          );
+        }
+      }
+
       this._checkCanContinueToCanvas(pathname, pageMode);
     }
 
     const surfaceCanvas = edgeless.surface.viewport.getCanvasByBound(
       bound,
-      surfaces
+      canvasElements
     );
     ctx.drawImage(surfaceCanvas, 50, 50, bound.w, bound.h);
 

--- a/packages/blocks/src/page-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/frame-manager.ts
@@ -79,14 +79,16 @@ export class EdgelessFrameManager {
     this._frameOverlay.bound = null;
   }
 
-  getElementsInFrame(frame: FrameBlockModel) {
+  getElementsInFrame(frame: FrameBlockModel, fullyContained = true) {
     const bound = Bound.deserialize(frame.xywh);
     const elements: EdgelessElement[] =
       this._edgeless.surface.viewport.gridManager
         .search(bound, true)
         .filter(ele => !isFrameBlock(ele));
 
-    return elements.concat(getBlocksInFrame(this._edgeless.page, frame));
+    return elements.concat(
+      getBlocksInFrame(this._edgeless.page, frame, fullyContained)
+    );
   }
 
   createFrameOnSelected() {

--- a/tests/edgeless/copy-as-png.spec.ts
+++ b/tests/edgeless/copy-as-png.spec.ts
@@ -1,0 +1,67 @@
+import {
+  createShapeElement,
+  edgelessCommonSetup,
+  Shape,
+  triggerComponentToolbarAction,
+} from 'utils/actions/edgeless.js';
+import {
+  pasteByKeyboard,
+  selectAllByKeyboard,
+} from 'utils/actions/keyboard.js';
+import { waitNextFrame } from 'utils/actions/misc.js';
+import { assertBlockCount } from 'utils/asserts.js';
+
+import { test } from '../utils/playwright.js';
+
+test.describe.only('copy as png', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await edgelessCommonSetup(page);
+  });
+
+  test('copy to clipboard as PNG', async ({ page }) => {
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+
+    await selectAllByKeyboard(page);
+
+    await triggerComponentToolbarAction(page, 'copyAsPng');
+
+    await waitNextFrame(page);
+
+    await assertBlockCount(page, 'note', 0);
+    await assertBlockCount(page, 'image', 0);
+    await pasteByKeyboard(page);
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'note', 0);
+    await assertBlockCount(page, 'image', 1);
+  });
+
+  test('copy as png for frame', async ({ page }) => {
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createShapeElement(page, [100, 0], [200, 100], Shape.Square);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+    await triggerComponentToolbarAction(page, 'copyAsPng');
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 0);
+    await pasteByKeyboard(page);
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 1);
+  });
+
+  test('copy as png for image', async ({ page }) => {
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await triggerComponentToolbarAction(page, 'copyAsPng');
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 0);
+    await pasteByKeyboard(page);
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 1);
+    await triggerComponentToolbarAction(page, 'copyAsPng');
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 1);
+    await pasteByKeyboard(page);
+    await waitNextFrame(page);
+    await assertBlockCount(page, 'image', 2);
+  });
+});

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -2,11 +2,8 @@ import { expect } from '@playwright/test';
 
 import * as actions from '../utils/actions/edgeless.js';
 import {
-  createShapeElement,
-  edgelessCommonSetup,
   getNoteBoundBoxInEdgeless,
   setEdgelessTool,
-  Shape,
   switchEditorMode,
 } from '../utils/actions/edgeless.js';
 import {
@@ -18,10 +15,7 @@ import {
   getBoundingRect,
   initEmptyEdgelessState,
   initThreeParagraphs,
-  pasteByKeyboard,
   pressEnter,
-  selectAllByKeyboard,
-  triggerComponentToolbarAction,
   waitNextFrame,
 } from '../utils/actions/index.js';
 import {
@@ -156,26 +150,6 @@ test('when the selection is always a note, it should remain in an active state',
   await clickInCenter(page, bound);
   await waitNextFrame(page);
   await assertSelectionInNote(page, ids.noteId);
-});
-
-test('copy to clipboard as PNG', async ({ page, context }) => {
-  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-
-  await edgelessCommonSetup(page);
-  await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
-
-  await selectAllByKeyboard(page);
-
-  await triggerComponentToolbarAction(page, 'copyAsPng');
-
-  await waitNextFrame(page);
-
-  await assertBlockCount(page, 'note', 0);
-  await assertBlockCount(page, 'image', 0);
-  await pasteByKeyboard(page);
-  await waitNextFrame(page);
-  await assertBlockCount(page, 'note', 0);
-  await assertBlockCount(page, 'image', 1);
 });
 
 test('should auto panning when selection rectangle reaches viewport edges', async ({


### PR DESCRIPTION
This pr #5519 is implemented in `_legacy/edgeless-clipborad`. Now we're removing the _legacy code. So I moved the logic into the new clipboard. Meantime I completed the missing code for frame copy and add some tests.  \cc @donteatfriedrice 
