### PR TITLE
fix(page): selection should be able to go through iframe

### DIFF
--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -88,6 +88,14 @@ export const styles = css`
   .affine-attachment-caption::placeholder {
     color: var(--affine-placeholder-color);
   }
+
+  .overlay-mask {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 export const LoadingIcon = html`<svg


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/5579 by adding an overlay mask when the mouse is clicked down.