### PR TITLE
fix(edgeless): note duplicate issue & expose service api

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -60,6 +60,7 @@ import type {
   SurfaceBlockComponent,
 } from '../../surface-block/surface-block.js';
 import { type SurfaceBlockModel } from '../../surface-block/surface-model.js';
+import type { SurfaceService } from '../../surface-block/surface-service.js';
 import { ClipboardController as PageClipboardController } from '../clipboard/index.js';
 import type { FontLoader } from '../font-loader/font-loader.js';
 import type { PageBlockModel } from '../page-model.js';
@@ -304,9 +305,11 @@ export class EdgelessPageBlockComponent extends BlockElement<
       })
     );
 
+    const surfaceService = this.surface.service as SurfaceService;
     _disposables.add(
       slots.edgelessToolUpdated.on(edgelessTool => {
         this.edgelessTool = edgelessTool;
+        surfaceService.slots.edgelessToolUpdated.emit(edgelessTool);
         slots.cursorUpdated.emit(getCursorMode(edgelessTool));
       })
     );

--- a/packages/blocks/src/page-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/frame-manager.ts
@@ -119,6 +119,7 @@ export class EdgelessFrameManager {
     const frameModel = surface.pickById(id);
     _edgeless.page.captureSync();
     assertExists(frameModel);
+    surface.fitToViewport(bound);
     _edgeless.selectionManager.setSelection({
       elements: [frameModel.id],
       editing: false,

--- a/packages/blocks/src/page-block/edgeless/utils/clipboard-utils.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/clipboard-utils.ts
@@ -37,7 +37,12 @@ export async function duplicate(
       if (isNoteBlock(element)) {
         id = surface.addElement(
           element.flavour,
-          { xywh: bound.serialize() },
+          {
+            xywh: bound.serialize(),
+            hidden: element.hidden,
+            background: element.background,
+            edgeless: element.edgeless,
+          },
           page.root?.id
         );
         const block = page.getBlockById(id);
@@ -99,6 +104,12 @@ export async function duplicate(
       idMap.set(element.id, id);
       return id;
     })
+  );
+
+  edgeless.surface.fitToViewport(
+    edgelessElementsBound(
+      newElements.map(id => surface.pickById(id)) as EdgelessElement[]
+    )
   );
 
   if (select) {

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -16,7 +16,6 @@ import { getThemePropertyValue } from '../_common/theme/utils.js';
 import {
   type EdgelessElement,
   type ReorderingAction,
-  requestConnectedFrame,
   type Selectable,
   type TopLevelBlockModel,
 } from '../_common/utils/index.js';
@@ -27,9 +26,6 @@ import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless
 import { EdgelessFrameManager } from '../page-block/edgeless/frame-manager.js';
 import {
   isConnectable,
-  isFrameBlock,
-  isImageBlock,
-  isNoteBlock,
   isTopLevelBlock,
 } from '../page-block/edgeless/utils/query.js';
 import { EdgelessSnapManager } from '../page-block/edgeless/utils/snap-manager.js';

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -47,7 +47,6 @@ import {
 } from './elements/edgeless-element.js';
 import { GROUP_ROOT } from './elements/group/consts.js';
 import {
-  BrushElement,
   ConnectorElement,
   ElementCtors,
   ElementDefaultProps,

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -257,7 +257,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     this._initEvents();
     this.layer.init([...this._elements.values(), ...this.blocks]);
     this.init();
-    this._initEffects();
   }
 
   getCSSPropertyValue = (value: string) => {
@@ -382,51 +381,6 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
         });
     });
   };
-
-  private _initEffects() {
-    const { _disposables, page, edgeless } = this;
-    _disposables.add(
-      page.slots.blockUpdated.on(({ id, type }) => {
-        if (type === 'add') {
-          const model = page.getBlockById(id) as TopLevelBlockModel;
-          assertExists(model);
-          if (
-            isNoteBlock(model) ||
-            isFrameBlock(model) ||
-            isImageBlock(model)
-          ) {
-            requestConnectedFrame(() => {
-              this.fitElementToViewport(model);
-            }, this);
-          }
-        }
-      })
-    );
-
-    _disposables.add(
-      edgeless.slots.elementUpdated.on(({ id, props }) => {
-        const element = this.pickById(id);
-        assertExists(element);
-
-        if (
-          element instanceof BrushElement ||
-          edgeless.selectionManager.editing ||
-          (props && !('xywh' in props && 'rotate' in props))
-        )
-          return;
-        this.fitElementToViewport(element);
-      })
-    );
-
-    _disposables.add(
-      edgeless.slots.elementAdded.on(({ id }) => {
-        const element = this.pickById(id);
-        assertExists(element);
-        if (element instanceof BrushElement) return;
-        this.fitElementToViewport(element);
-      })
-    );
-  }
 
   private _updateIndexCanvases() {
     const evt = new CustomEvent('indexedcanvasupdate', {
@@ -789,9 +743,9 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     }
   }
 
-  fitElementToViewport(ele: EdgelessElement) {
+  fitToViewport(bound: Bound) {
     const { viewport } = this;
-    const bound = ele.elementBound.expand(30);
+    bound = bound.expand(30);
     if (Date.now() - this._lastTime > 200)
       this._cachedViewport = viewport.viewportBounds;
     this._lastTime = Date.now();

--- a/packages/blocks/src/surface-block/surface-service.ts
+++ b/packages/blocks/src/surface-block/surface-service.ts
@@ -1,11 +1,17 @@
 import { BlockService } from '@blocksuite/block-std';
+import { Slot } from '@blocksuite/global/utils';
 
 import type { NavigatorMode } from '../_common/edgeless/frame/consts.js';
 import { buildPath } from '../_common/utils/query.js';
+import type { EdgelessTool } from '../_common/utils/types.js';
 import type { SurfaceBlockComponent } from './surface-block.js';
 import type { SurfaceBlockModel } from './surface-model.js';
 
 export class SurfaceService extends BlockService<SurfaceBlockModel> {
+  slots = {
+    edgelessToolUpdated: new Slot<EdgelessTool>(),
+  };
+
   private _getSurfaceView() {
     const [surface] = this.page.getBlockByFlavour('affine:surface');
     const view = this.std.view.viewFromPath(


### PR DESCRIPTION
1. Fix note duplicate without edgeless props.
2. Add `edgelessToolUpdated ` slot to `SurfaceService`.
3. Place `fitToViewport` to seperate area instead of subscribing slot.