### PR TITLE
fix(edgeless): move grouped content together on dragging

### DIFF
--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -840,13 +840,13 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     }) as EdgelessElement[];
 
     let picked = last(results) ?? null;
+    const { activeGroup } = selectionManager;
     const first = picked;
-    if (selectionManager.activeGroup) {
+    if (activeGroup && picked && isDescendant(picked, activeGroup)) {
       let index = results.length - 1;
       while (
-        picked === selectionManager.activeGroup ||
-        (picked instanceof GroupElement &&
-          isDescendant(selectionManager.activeGroup, picked))
+        picked === activeGroup ||
+        (picked instanceof GroupElement && isDescendant(activeGroup, picked))
       ) {
         picked = results[--index];
       }


### PR DESCRIPTION
Before:

https://github.com/toeverything/blocksuite/assets/58546692/cacf9eb7-4528-4ef7-a337-714b3b3954ea



After: 

https://github.com/toeverything/blocksuite/assets/58546692/61f2d2ab-8476-4b70-9321-e05ebb2df317




