### PR TITLE
fix: paste should replace selected text

### DIFF
--- a/packages/blocks/src/page-block/clipboard/index.ts
+++ b/packages/blocks/src/page-block/clipboard/index.ts
@@ -119,6 +119,8 @@ export class ClipboardController implements ReactiveController {
 
     this._std.command
       .pipe()
+      .withRoot()
+      .try(cmd => [cmd.getTextSelection().deleteText()])
       .try(cmd => [
         cmd.getTextSelection().inline<'currentSelectionPath'>((ctx, next) => {
           const textSelection = ctx.currentTextSelection;


### PR DESCRIPTION
It seems like this minor change can fix #5592 . I'm not so sure.

![](https://github.com/toeverything/blocksuite/assets/8191686/72b6e899-eac5-4725-abae-8710cb00c03e)

And I don't quite understand how paste is working. The last function I saw related to paste is:
```ts
        this._std.clipboard.paste(
          e,
          this._std.page,
          ctx.parentBlock.model.id,
          ctx.blockIndex ? ctx.blockIndex + 1 : undefined
        );
```

And the implementation looks like following:
```ts
      const json = this.readFromClipboard(data);
      const slice = await this._getSnapshotByPriority(
        type => json[type],
        page,
        parent,
        index
      );
      assertExists(slice);
      return slice;
```

How return slice makes the paste done?  I didn't get it. It would be great if someone help to explain.


