### PR TITLE
refactor(store): deprecate legacy validation

### DIFF
--- a/packages/global/index.d.ts
+++ b/packages/global/index.d.ts
@@ -1,4 +1,5 @@
 declare type BlockSuiteFlags = {
+  enable_legacy_validation: boolean;
   enable_transformer_clipboard: boolean;
   enable_expand_database_block: boolean;
   enable_bultin_ledits: boolean;

--- a/packages/store/src/workspace/meta.ts
+++ b/packages/store/src/workspace/meta.ts
@@ -203,7 +203,7 @@ export class WorkspaceMeta {
   }
 
   /**
-   * @internal Only for page initialization
+   * @deprecated Only used for legacy page version validation
    */
   validateVersion(workspace: Workspace) {
     const workspaceVersion = this._proxy.workspaceVersion;

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -776,17 +776,15 @@ export class Page extends Space<FlatBlockMap> {
     }
   };
 
-  validateVersion() {
-    this.workspace.meta.validateVersion(this.workspace);
-  }
-
   private _handleVersion() {
     // Initialization from empty yDoc, indicating that the document is new.
     if (!this.workspace.meta.hasVersion) {
       this.workspace.meta.writeVersion(this.workspace);
     } else {
       // Initialization from existing yDoc, indicating that the document is loaded from storage.
-      this.validateVersion();
+      if (this.awarenessStore.getFlag('enable_legacy_validation')) {
+        this.workspace.meta.validateVersion(this.workspace);
+      }
     }
   }
 

--- a/packages/store/src/workspace/store.ts
+++ b/packages/store/src/workspace/store.ts
@@ -52,7 +52,8 @@ export interface StoreOptions<
   blobStorages?: ((id: string) => BlobStorage)[];
 }
 
-const flagsPreset = {
+const FLAGS_PRESET = {
+  enable_legacy_validation: true,
   enable_transformer_clipboard: true,
   enable_expand_database_block: false,
   enable_bultin_ledits: false,
@@ -81,7 +82,7 @@ export class Store {
     this.awarenessStore = new AwarenessStore(
       this,
       awareness ?? new Awareness<RawAwarenessState>(this.doc),
-      merge(true, flagsPreset, defaultFlags)
+      merge(true, FLAGS_PRESET, defaultFlags)
     );
 
     if (typeof idGenerator === 'function') {


### PR DESCRIPTION
We are working towards a non-breaking block tree structure, so the validation process will be handled in application level (rather than on loading editor). This is made into an opt-in preset option for now. Please set the flag before `page.load`.

cc @joooye34 @Saul-Mirone 