### PR TITLE
refactor(edgeless): tear down edgeless element mixin

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
@@ -1,35 +1,12 @@
 import { BaseBlockModel } from '@blocksuite/store';
 
-import { BLOCK_BATCH } from '../../surface-block/batch.js';
-import type {
-  IEdgelessElement,
-  IVec,
-  PointLocation,
-  SerializedXYWH,
-} from '../../surface-block/index.js';
-import { Bound } from '../../surface-block/index.js';
+import { BlockEdgelessMixin } from '../../surface-block/elements/selectable.js';
 import type { EmbedProps } from './types.js';
 
-export class EmbedBlockModel<Props = object>
-  extends BaseBlockModel<EmbedProps<Props>>
-  implements IEdgelessElement
-{
-  elementBound!: Bound;
-  override xywh!: SerializedXYWH;
-  get batch() {
-    return BLOCK_BATCH;
-  }
+const EmbedBlockModelEdgeless = BlockEdgelessMixin(
+  class<Props = object> extends BaseBlockModel<EmbedProps<Props>> {}
+);
 
-  get connectable() {
-    return true;
-  }
-  containedByBounds!: (_: Bound) => boolean;
-  getNearestPoint!: (_: IVec) => IVec;
-  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  boxSelect!: (bound: Bound) => boolean;
-  hitTest(x: number, y: number): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    return bound.isPointInBound([x, y], 0);
-  }
-}
+export class EmbedBlockModel<
+  Props = object,
+> extends EmbedBlockModelEdgeless<Props> {}

--- a/packages/blocks/src/embed-github-block/embed-github-model.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-model.ts
@@ -1,6 +1,4 @@
 import { EmbedBlockModel } from '../_common/embed-block-helper/index.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
 import type { EmbedGithubBlockProps } from './types.js';
 
-@EdgelessSelectableMixin
 export class EmbedGithubBlockModel extends EmbedBlockModel<EmbedGithubBlockProps> {}

--- a/packages/blocks/src/embed-html-block/embed-html-model.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-model.ts
@@ -1,10 +1,8 @@
 import { EmbedBlockModel } from '../_common/embed-block-helper/index.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
 
 export type EmbedHtmlBlockProps = {
   html?: string;
   design?: string;
 };
 
-@EdgelessSelectableMixin
 export class EmbedHtmlBlockModel extends EmbedBlockModel<EmbedHtmlBlockProps> {}

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -5,20 +5,10 @@ import {
   DEFAULT_NOTE_COLOR,
   NOTE_SHADOWS,
 } from '../_common/edgeless/note/consts.js';
-import { BLOCK_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import type {
-  HitTestOptions,
-  IEdgelessElement,
-} from '../surface-block/elements/edgeless-element.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
+import { BlockEdgelessMixin } from '../surface-block/elements/selectable.js';
 import type { StrokeStyle } from '../surface-block/index.js';
-import {
-  Bound,
-  type IVec,
-  type PointLocation,
-  type SerializedXYWH,
-} from '../surface-block/index.js';
+import { type SerializedXYWH } from '../surface-block/index.js';
 
 export const NoteBlockSchema = defineBlockSchema({
   flavour: 'affine:note',
@@ -66,6 +56,7 @@ type NoteProps = {
   index: string;
   hidden: boolean;
   edgeless: NoteEdgelessProps;
+  rotate: number;
 };
 
 type NoteEdgelessProps = {
@@ -79,34 +70,12 @@ type NoteEdgelessProps = {
   collapsedHeight: number;
 };
 
-@EdgelessSelectableMixin
-export class NoteBlockModel
-  extends BaseBlockModel<NoteProps>
-  implements IEdgelessElement
-{
-  override flavour!: EdgelessBlockType.NOTE;
-  elementBound!: Bound;
-
-  get connectable() {
-    return true;
+const NoteBlockModelEdgeless = BlockEdgelessMixin(
+  class extends BaseBlockModel<NoteProps> {
+    override flavour!: EdgelessBlockType.NOTE;
   }
+);
 
-  get batch() {
-    return BLOCK_BATCH;
-  }
-
-  get rotate() {
-    return 0;
-  }
-
-  containedByBounds!: (_: Bound) => boolean;
-  getNearestPoint!: (_: IVec) => IVec;
-  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  boxSelect!: (bound: Bound) => boolean;
-
-  hitTest(x: number, y: number, _: HitTestOptions): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    return bound.isPointInBound([x, y], 0);
-  }
+export class NoteBlockModel extends NoteBlockModelEdgeless {
+  override rotate = 0;
 }

--- a/packages/blocks/src/surface-block/elements/edgeless-element.ts
+++ b/packages/blocks/src/surface-block/elements/edgeless-element.ts
@@ -28,11 +28,11 @@ export interface HitTestOptions {
 }
 export interface IEdgelessElement {
   xywh: SerializedXYWH;
-  rotate: number;
-  connectable: boolean;
   index: string;
-  batch: string | null;
-  elementBound: Bound;
+  readonly rotate: number;
+  readonly connectable: boolean;
+  readonly batch: string | null;
+  readonly elementBound: Bound;
   containedByBounds(bounds: Bound): boolean;
   getNearestPoint(point: IVec): IVec;
   intersectWithLine(start: IVec, end: IVec): PointLocation[] | null;

--- a/packages/blocks/src/surface-block/elements/text/text-element.ts
+++ b/packages/blocks/src/surface-block/elements/text/text-element.ts
@@ -8,11 +8,12 @@ import {
   getPointsFromBoundsWithRotation,
   linePolygonIntersects,
   pointInPolygon,
+  polygonGetPointTangent,
   polygonNearestPoint,
   rotatePoints,
 } from '../../utils/math-utils.js';
+import { PointLocation } from '../../utils/point-location.js';
 import { type IVec } from '../../utils/vec.js';
-import { EdgelessSelectableMixin } from '../selectable.js';
 import { SurfaceElement } from '../surface-element.js';
 import type { IText, ITextDelta, ITextLocalRecord } from './types.js';
 import {
@@ -25,7 +26,6 @@ import {
   wrapText,
 } from './utils.js';
 
-@EdgelessSelectableMixin
 export class TextElement extends SurfaceElement<IText> {
   get text() {
     return this.yMap.get('text') as IText['text'];
@@ -213,5 +213,19 @@ export class TextElement extends SurfaceElement<IText> {
         ctx.restore();
       }
     }
+  }
+
+  override getRelativePointLocation(relativePoint: IVec): PointLocation {
+    const bound = Bound.deserialize(this.xywh);
+    const point = bound.getRelativePoint(relativePoint);
+    const rotatePoint = rotatePoints(
+      [point],
+      bound.center,
+      this.rotate ?? 0
+    )[0];
+    const points = rotatePoints(bound.points, bound.center, this.rotate ?? 0);
+    const tangent = polygonGetPointTangent(points, rotatePoint);
+
+    return new PointLocation(rotatePoint, tangent);
   }
 }

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -827,14 +827,12 @@ export class SurfaceBlockComponent extends BlockElement<SurfaceBlockModel> {
     };
     const pickBlock = () => {
       const candidates = this.layer.blocksGrid.search(hitTestBound);
-      const picked = candidates.filter(element =>
-        element.hitTest(x, y, options)
-      );
+      const picked = candidates.filter(element => element.hitTest(x, y));
       return picked as EdgelessElement[];
     };
     const pickFrames = () => {
       return this.layer.frames.filter(frame =>
-        frame.hitTest(x, y, options)
+        frame.hitTest(x, y)
       ) as EdgelessElement[];
     };
 


### PR DESCRIPTION
Our current project involves rendering blocks onto a canvas, with an emphasis on scalability. These blocks must integrate specific methods and properties, especially required for seamless interaction with existing canvas elements. To address these requirements, we have formulated the following design strategy.

So if blocks need to be rendered on canvas, it must support three fields which are `xywh`, `index`, `rotate`.

The design ensures 
1. methods and properties such as `elementBound`, `hitTest` etc, have default implementations, yet allowing individual models the flexibility to easily override them as needed. 
2. acilitate easy expansion or addition of new models within the edgeless.


Usage:
```ts
const blockModelEdgeless = BlockEdgelessMixin(
  class extends BaseBlockModel<Props> {
     // model definitions here
  }
);
export blockModel extends blockModelEdgeless {
  // overrides here
}
```
cc\ @doodlewind @Saul-Mirone @doouding 
