### PR TITLE
refactor: remove extra props for edgeless selectable mixin

### DIFF
--- a/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
@@ -1,31 +1,53 @@
-import { Bound } from '../utils/bound.js';
+import type { Constructor } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
+
+import { BLOCK_BATCH } from '../../../surface-block/batch.js';
 import {
+  Bound,
   getBoundsWithRotation,
   getPointsFromBoundsWithRotation,
+  type IEdgelessElement,
+  type IVec,
   linePolygonIntersects,
+  PointLocation,
   polygonGetPointTangent,
   polygonNearestPoint,
   rotatePoints,
-} from '../utils/math-utils.js';
-import { PointLocation } from '../utils/point-location.js';
-import type { IVec } from '../utils/vec.js';
-import type { IEdgelessElement } from './edgeless-element.js';
+  type SerializedXYWH,
+} from '../../../surface-block/index.js';
 
-export const EdgelessSelectableMixin = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends new (...args: any[]) => IEdgelessElement,
->(
-  originalClass: T
-) =>
-  class extends originalClass {
-    override get elementBound() {
+export type EdgelessSelectableProps = {
+  xywh: SerializedXYWH;
+  index: string;
+  rotate: number;
+};
+
+export function makeSelectableInEdgeless<
+  Props extends EdgelessSelectableProps,
+  T extends Constructor<BaseBlockModel<Props>> = Constructor<
+    BaseBlockModel<Props>
+  >,
+>(SuperClass: T) {
+  class DerivedSelectableInEdgelessClass
+    extends SuperClass
+    implements IEdgelessElement
+  {
+    connectable = true;
+    batch = BLOCK_BATCH;
+
+    get elementBound() {
       const bound = Bound.deserialize(this.xywh);
       return Bound.from(
         getBoundsWithRotation({ ...bound, rotate: this.rotate })
       );
     }
 
-    override containedByBounds(bounds: Bound): boolean {
+    hitTest(x: number, y: number): boolean {
+      const bound = Bound.deserialize(this.xywh);
+      return bound.isPointInBound([x, y], 0);
+    }
+
+    containedByBounds(bounds: Bound): boolean {
       const bound = Bound.deserialize(this.xywh);
       const points = getPointsFromBoundsWithRotation({
         x: bound.x,
@@ -37,7 +59,7 @@ export const EdgelessSelectableMixin = <
       return points.some(point => bounds.containsPoint(point));
     }
 
-    override getNearestPoint(point: IVec): IVec {
+    getNearestPoint(point: IVec): IVec {
       const bound = Bound.deserialize(this.xywh);
       return polygonNearestPoint(
         rotatePoints(bound.points, bound.center, this.rotate ?? 0),
@@ -45,7 +67,7 @@ export const EdgelessSelectableMixin = <
       );
     }
 
-    override intersectWithLine(start: IVec, end: IVec): PointLocation[] | null {
+    intersectWithLine(start: IVec, end: IVec): PointLocation[] | null {
       const bound = Bound.deserialize(this.xywh);
       return linePolygonIntersects(
         start,
@@ -54,7 +76,7 @@ export const EdgelessSelectableMixin = <
       );
     }
 
-    override getRelativePointLocation(relativePoint: IVec): PointLocation {
+    getRelativePointLocation(relativePoint: IVec): PointLocation {
       const bound = Bound.deserialize(this.xywh);
       const point = bound.getRelativePoint(relativePoint);
       const rotatePoint = rotatePoints(
@@ -68,7 +90,7 @@ export const EdgelessSelectableMixin = <
       return new PointLocation(rotatePoint, tangent);
     }
 
-    override boxSelect(bound: Bound): boolean {
+    boxSelect(bound: Bound): boolean {
       return (
         this.containedByBounds(bound) ||
         bound.points.some((point, i, points) =>
@@ -76,4 +98,9 @@ export const EdgelessSelectableMixin = <
         )
       );
     }
-  };
+  }
+
+  return DerivedSelectableInEdgelessClass as Constructor<
+    BaseBlockModel<Props> & IEdgelessElement
+  >;
+}

--- a/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
@@ -19,7 +19,7 @@ import {
 export type EdgelessSelectableProps = {
   xywh: SerializedXYWH;
   index: string;
-  rotate: number;
+  rotate?: number;
 };
 
 export function selectable<
@@ -34,6 +34,7 @@ export function selectable<
   {
     connectable = true;
     batch = BLOCK_BATCH;
+    override rotate = 0;
 
     get elementBound() {
       const bound = Bound.deserialize(this.xywh);

--- a/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/edgeless-selectable.ts
@@ -22,7 +22,7 @@ export type EdgelessSelectableProps = {
   rotate: number;
 };
 
-export function makeSelectableInEdgeless<
+export function selectable<
   Props extends EdgelessSelectableProps,
   T extends Constructor<BaseBlockModel<Props>> = Constructor<
     BaseBlockModel<Props>

--- a/packages/blocks/src/_common/edgeless/mixin/index.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/index.ts
@@ -1,0 +1,1 @@
+export * from './edgeless-selectable.js';

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -6,10 +6,11 @@ import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { Bound } from '../../surface-block/index.js';
-import type { EmbedProps } from './types.js';
+import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
 
 export class EmbedBlockElement<
-  Model extends BaseBlockModel<EmbedProps> = BaseBlockModel<EmbedProps>,
+  Model extends
+    BaseBlockModel<EdgelessSelectableProps> = BaseBlockModel<EdgelessSelectableProps>,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
 > extends BlockElement<Model, Service, WidgetName> {

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
@@ -3,7 +3,7 @@ import type { BaseBlockModel } from '@blocksuite/store';
 
 import {
   type EdgelessSelectableProps,
-  makeSelectableInEdgeless,
+  selectable,
 } from '../edgeless/mixin/index.js';
 import type { EmbedProps } from './types.js';
 
@@ -13,7 +13,7 @@ export function makeEmbedModel<
     BaseBlockModel<Props>
   >,
 >(SuperClass: T) {
-  return makeSelectableInEdgeless<Props & EdgelessSelectableProps>(
+  return selectable<Props & EdgelessSelectableProps>(
     SuperClass as Constructor<BaseBlockModel<Props & EdgelessSelectableProps>>
   );
 }

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
@@ -1,35 +1,21 @@
-import { BaseBlockModel } from '@blocksuite/store';
+import type { Constructor } from '@blocksuite/global/utils';
+import type { BaseBlockModel } from '@blocksuite/store';
 
-import { BLOCK_BATCH } from '../../surface-block/batch.js';
-import type {
-  IEdgelessElement,
-  IVec,
-  PointLocation,
-  SerializedXYWH,
-} from '../../surface-block/index.js';
-import { Bound } from '../../surface-block/index.js';
+import {
+  type EdgelessSelectableProps,
+  makeSelectableInEdgeless,
+} from '../edgeless/mixin/index.js';
 import type { EmbedProps } from './types.js';
 
-export class EmbedBlockModel<Props = object>
-  extends BaseBlockModel<EmbedProps<Props>>
-  implements IEdgelessElement
-{
-  elementBound!: Bound;
-  override xywh!: SerializedXYWH;
-  get batch() {
-    return BLOCK_BATCH;
-  }
-
-  get connectable() {
-    return true;
-  }
-  containedByBounds!: (_: Bound) => boolean;
-  getNearestPoint!: (_: IVec) => IVec;
-  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  boxSelect!: (bound: Bound) => boolean;
-  hitTest(x: number, y: number): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    return bound.isPointInBound([x, y], 0);
-  }
+export function makeEmbedModel<
+  Props extends object,
+  T extends Constructor<BaseBlockModel<Props>> = Constructor<
+    BaseBlockModel<Props>
+  >,
+>(SuperClass: T) {
+  return makeSelectableInEdgeless<Props & EdgelessSelectableProps>(
+    SuperClass as Constructor<BaseBlockModel<Props & EdgelessSelectableProps>>
+  );
 }
+
+export type EmbedBlockModel<Props = object> = BaseBlockModel<EmbedProps<Props>>;

--- a/packages/blocks/src/_common/embed-block-helper/types.ts
+++ b/packages/blocks/src/_common/embed-block-helper/types.ts
@@ -1,10 +1,10 @@
 import type { BlockServiceConstructor } from '@blocksuite/block-std';
 import type {
-  BaseBlockModel,
   BaseBlockTransformer,
   InternalPrimitives,
 } from '@blocksuite/store';
 
+import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
 import type { EmbedBlockModel } from './embed-block-model.js';
 
 export type EmbedBlockGeneratorOptions<
@@ -27,12 +27,4 @@ export type EmbedBlockGeneratorOptions<
   };
 };
 
-export type EmbedProps<Props = object> = Props & {
-  rotate: number;
-  xywh: string;
-  index: string;
-};
-
-export type BaseEmbedBlockModel<Props extends object = object> = BaseBlockModel<
-  EmbedProps<Props>
->;
+export type EmbedProps<Props = object> = Props & EdgelessSelectableProps;

--- a/packages/blocks/src/embed-github-block/embed-github-model.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-model.ts
@@ -1,6 +1,8 @@
-import { EmbedBlockModel } from '../_common/embed-block-helper/index.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
+import { BaseBlockModel } from '@blocksuite/store';
+
+import { makeEmbedModel } from '../_common/embed-block-helper/index.js';
 import type { EmbedGithubBlockProps } from './types.js';
 
-@EdgelessSelectableMixin
-export class EmbedGithubBlockModel extends EmbedBlockModel<EmbedGithubBlockProps> {}
+export class EmbedGithubBlockModel extends makeEmbedModel<EmbedGithubBlockProps>(
+  BaseBlockModel
+) {}

--- a/packages/blocks/src/embed-html-block/embed-html-model.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-model.ts
@@ -1,10 +1,12 @@
-import { EmbedBlockModel } from '../_common/embed-block-helper/index.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
+import { BaseBlockModel } from '@blocksuite/store';
+
+import { makeEmbedModel } from '../_common/embed-block-helper/index.js';
 
 export type EmbedHtmlBlockProps = {
   html?: string;
   design?: string;
 };
 
-@EdgelessSelectableMixin
-export class EmbedHtmlBlockModel extends EmbedBlockModel<EmbedHtmlBlockProps> {}
+export class EmbedHtmlBlockModel extends makeEmbedModel<EmbedHtmlBlockProps>(
+  BaseBlockModel
+) {}

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -6,7 +6,11 @@ import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import { getBlockElementByPath } from '../_common/utils/index.js';
 import { FRAME_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import { Bound, type SerializedXYWH } from '../surface-block/index.js';
+import {
+  Bound,
+  type HitTestOptions,
+  type SerializedXYWH,
+} from '../surface-block/index.js';
 import type { FrameBlockComponent } from './frame-block.js';
 
 type FrameBlockProps = {
@@ -40,7 +44,7 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(
 ) {
   override flavour!: EdgelessBlockType.FRAME;
   override batch = FRAME_BATCH;
-  override hitTest(x: number, y: number): boolean {
+  override hitTest(x: number, y: number, _: HitTestOptions): boolean {
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointOnBound([x, y]);
     if (hit) return true;

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,7 +1,7 @@
 import type { Text } from '@blocksuite/store';
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
 import { type SerializedXYWH } from '../surface-block/index.js';
 
@@ -33,7 +33,7 @@ export const FrameBlockSchema = defineBlockSchema({
   },
 });
 
-export class FrameBlockModel extends makeSelectableInEdgeless<FrameBlockProps>(
+export class FrameBlockModel extends selectable<FrameBlockProps>(
   BaseBlockModel
 ) {
   override flavour!: EdgelessBlockType.FRAME;

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -4,7 +4,7 @@ import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import { FRAME_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import { type SerializedXYWH } from '../surface-block/index.js';
+import { Bound, type SerializedXYWH } from '../surface-block/index.js';
 
 type FrameBlockProps = {
   title: Text;
@@ -37,4 +37,15 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(
 ) {
   override flavour!: EdgelessBlockType.FRAME;
   override batch = FRAME_BATCH;
+  override hitTest(x: number, y: number): boolean {
+    const bound = Bound.deserialize(this.xywh);
+    const hit = bound.isPointOnBound([x, y]);
+    if (hit) return true;
+    const titleBound = block.titleBound;
+    return titleBound.isPointInBound([x, y], 0);
+  }
+
+  override boxSelect(bound: Bound): boolean {
+    return Bound.deserialize(this.xywh).isIntersectWithBound(bound);
+  }
 }

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,31 +1,26 @@
-import { assertExists } from '@blocksuite/global/utils';
 import type { Text } from '@blocksuite/store';
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { getBlockElementByPath } from '../_common/utils/query.js';
-import { FRAME_BATCH } from '../surface-block/batch.js';
+import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import type {
-  HitTestOptions,
-  IEdgelessElement,
-} from '../surface-block/elements/edgeless-element.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
-import {
-  Bound,
-  type IVec,
-  linePolygonIntersects,
-  type PointLocation,
-  type SerializedXYWH,
-} from '../surface-block/index.js';
-import type { FrameBlockComponent } from './frame-block.js';
+import { type SerializedXYWH } from '../surface-block/index.js';
+
+type FrameBlockProps = {
+  title: Text;
+  background: string;
+  xywh: SerializedXYWH;
+  index: string;
+  rotate: number;
+};
 
 export const FrameBlockSchema = defineBlockSchema({
   flavour: 'affine:frame',
-  props: internal => ({
+  props: (internal): FrameBlockProps => ({
     title: internal.Text(),
     background: '--affine-palette-transparent',
     xywh: `[0,0,100,100]`,
     index: 'a0',
+    rotate: 0,
   }),
   metadata: {
     version: 1,
@@ -38,65 +33,8 @@ export const FrameBlockSchema = defineBlockSchema({
   },
 });
 
-type Props = {
-  title: Text;
-  background: string;
-  xywh: SerializedXYWH;
-  index: string;
-};
-
-@EdgelessSelectableMixin
-export class FrameBlockModel
-  extends BaseBlockModel<Props>
-  implements IEdgelessElement
-{
+export class FrameBlockModel extends makeSelectableInEdgeless<FrameBlockProps>(
+  BaseBlockModel
+) {
   override flavour!: EdgelessBlockType.FRAME;
-
-  get connectable() {
-    return true;
-  }
-
-  get batch() {
-    return FRAME_BATCH;
-  }
-
-  get rotate() {
-    return 0;
-  }
-
-  get elementBound() {
-    return Bound.deserialize(this.xywh);
-  }
-
-  containedByBounds(bound: Bound): boolean {
-    return bound.contains(Bound.deserialize(this.xywh));
-  }
-  getNearestPoint(_: IVec): IVec {
-    throw new Error('Function not implemented.');
-  }
-  intersectWithLine(start: IVec, end: IVec): PointLocation[] | null {
-    return linePolygonIntersects(
-      start,
-      end,
-      Bound.deserialize(this.xywh).points
-    );
-  }
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  hitTest(x: number, y: number, _: HitTestOptions): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    const hit = bound.isPointOnBound([x, y]);
-    if (hit) return true;
-
-    assertExists(this.page.root);
-    const block = getBlockElementByPath([
-      this.page.root?.id,
-      this.id,
-    ]) as FrameBlockComponent;
-    if (!block) return false;
-    const titleBound = block.titleBound;
-    return titleBound.isPointInBound([x, y], 0);
-  }
-  boxSelect(bound: Bound): boolean {
-    return Bound.deserialize(this.xywh).isIntersectWithBound(bound);
-  }
 }

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -10,7 +10,6 @@ type FrameBlockProps = {
   background: string;
   xywh: SerializedXYWH;
   index: string;
-  rotate: number;
 };
 
 export const FrameBlockSchema = defineBlockSchema({
@@ -20,7 +19,6 @@ export const FrameBlockSchema = defineBlockSchema({
     background: '--affine-palette-transparent',
     xywh: `[0,0,100,100]`,
     index: 'a0',
-    rotate: 0,
   }),
   metadata: {
     version: 1,

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,10 +1,13 @@
+import { assertExists } from '@blocksuite/global/utils';
 import type { Text } from '@blocksuite/store';
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { getBlockElementByPath } from '../_common/utils/index.js';
 import { FRAME_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
 import { Bound, type SerializedXYWH } from '../surface-block/index.js';
+import type { FrameBlockComponent } from './frame-block.js';
 
 type FrameBlockProps = {
   title: Text;
@@ -41,6 +44,12 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointOnBound([x, y]);
     if (hit) return true;
+    assertExists(this.page.root);
+    const block = getBlockElementByPath([
+      this.page.root?.id,
+      this.id,
+    ]) as FrameBlockComponent;
+    if (!block) return false;
     const titleBound = block.titleBound;
     return titleBound.isPointInBound([x, y], 0);
   }

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -2,6 +2,7 @@ import type { Text } from '@blocksuite/store';
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { FRAME_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
 import { type SerializedXYWH } from '../surface-block/index.js';
 
@@ -35,4 +36,5 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(
   BaseBlockModel
 ) {
   override flavour!: EdgelessBlockType.FRAME;
+  override batch = FRAME_BATCH;
 }

--- a/packages/blocks/src/image-block/image-model.ts
+++ b/packages/blocks/src/image-block/image-model.ts
@@ -1,6 +1,6 @@
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
 import { type SerializedXYWH } from '../surface-block/index.js';
 import { ImageBlockTransformer } from './image-transformer.js';
@@ -36,7 +36,7 @@ export const ImageBlockSchema = defineBlockSchema({
   toModel: () => new ImageBlockModel(),
 });
 
-export class ImageBlockModel extends makeSelectableInEdgeless<ImageBlockProps>(
+export class ImageBlockModel extends selectable<ImageBlockProps>(
   BaseBlockModel
 ) {
   override flavour!: EdgelessBlockType.IMAGE;

--- a/packages/blocks/src/image-block/image-model.ts
+++ b/packages/blocks/src/image-block/image-model.ts
@@ -1,15 +1,8 @@
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { BLOCK_BATCH } from '../surface-block/batch.js';
+import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
-import type { PointLocation } from '../surface-block/index.js';
-import {
-  Bound,
-  type IEdgelessElement,
-  type IVec,
-  type SerializedXYWH,
-} from '../surface-block/index.js';
+import { type SerializedXYWH } from '../surface-block/index.js';
 import { ImageBlockTransformer } from './image-transformer.js';
 
 export type ImageBlockProps = {
@@ -18,7 +11,7 @@ export type ImageBlockProps = {
   width?: number;
   height?: number;
   index: string;
-  xywh?: SerializedXYWH;
+  xywh: SerializedXYWH;
   rotate: number;
 };
 
@@ -43,13 +36,9 @@ export const ImageBlockSchema = defineBlockSchema({
   toModel: () => new ImageBlockModel(),
 });
 
-@EdgelessSelectableMixin
-export class ImageBlockModel
-  extends BaseBlockModel<ImageBlockProps>
-  implements IEdgelessElement
-{
-  elementBound!: Bound;
-  override xywh!: SerializedXYWH;
+export class ImageBlockModel extends makeSelectableInEdgeless<ImageBlockProps>(
+  BaseBlockModel
+) {
   override flavour!: EdgelessBlockType.IMAGE;
 
   constructor() {
@@ -74,23 +63,5 @@ export class ImageBlockModel
 
       this.page.blob.decreaseRef(blobId);
     });
-  }
-
-  get batch() {
-    return BLOCK_BATCH;
-  }
-
-  get connectable() {
-    return true;
-  }
-  containedByBounds!: (_: Bound) => boolean;
-  getNearestPoint!: (_: IVec) => IVec;
-  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  boxSelect!: (bound: Bound) => boolean;
-
-  hitTest(x: number, y: number): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    return bound.isPointInBound([x, y], 0);
   }
 }

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -1,7 +1,7 @@
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { NOTE_WIDTH } from '../_common/consts.js';
-import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import {
   DEFAULT_NOTE_COLOR,
   NOTE_SHADOWS,
@@ -70,8 +70,6 @@ type NoteEdgelessProps = {
   collapsedHeight?: number;
 };
 
-export class NoteBlockModel extends makeSelectableInEdgeless<NoteProps>(
-  BaseBlockModel
-) {
+export class NoteBlockModel extends selectable<NoteProps>(BaseBlockModel) {
   override flavour!: EdgelessBlockType.NOTE;
 }

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -1,37 +1,27 @@
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { NOTE_WIDTH } from '../_common/consts.js';
+import { makeSelectableInEdgeless } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import {
   DEFAULT_NOTE_COLOR,
   NOTE_SHADOWS,
 } from '../_common/edgeless/note/consts.js';
-import { BLOCK_BATCH } from '../surface-block/batch.js';
 import type { EdgelessBlockType } from '../surface-block/edgeless-types.js';
-import type {
-  HitTestOptions,
-  IEdgelessElement,
-} from '../surface-block/elements/edgeless-element.js';
-import { EdgelessSelectableMixin } from '../surface-block/elements/selectable.js';
-import type { StrokeStyle } from '../surface-block/index.js';
-import {
-  Bound,
-  type IVec,
-  type PointLocation,
-  type SerializedXYWH,
-} from '../surface-block/index.js';
+import { type SerializedXYWH, StrokeStyle } from '../surface-block/index.js';
 
 export const NoteBlockSchema = defineBlockSchema({
   flavour: 'affine:note',
-  props: () => ({
+  props: (): NoteProps => ({
     xywh: `[0,0,${NOTE_WIDTH},95]`,
     background: DEFAULT_NOTE_COLOR,
     index: 'a0',
     hidden: false,
+    rotate: 0,
     edgeless: {
       style: {
         borderRadius: 8,
         borderSize: 4,
-        borderStyle: 'solid',
+        borderStyle: StrokeStyle.Solid,
         shadowType: NOTE_SHADOWS[1],
       },
     },
@@ -63,6 +53,7 @@ export const NoteBlockSchema = defineBlockSchema({
 type NoteProps = {
   xywh: SerializedXYWH;
   background: string;
+  rotate: number;
   index: string;
   hidden: boolean;
   edgeless: NoteEdgelessProps;
@@ -75,38 +66,12 @@ type NoteEdgelessProps = {
     borderStyle: StrokeStyle;
     shadowType: string;
   };
-  collapse: boolean;
-  collapsedHeight: number;
+  collapse?: boolean;
+  collapsedHeight?: number;
 };
 
-@EdgelessSelectableMixin
-export class NoteBlockModel
-  extends BaseBlockModel<NoteProps>
-  implements IEdgelessElement
-{
+export class NoteBlockModel extends makeSelectableInEdgeless<NoteProps>(
+  BaseBlockModel
+) {
   override flavour!: EdgelessBlockType.NOTE;
-  elementBound!: Bound;
-
-  get connectable() {
-    return true;
-  }
-
-  get batch() {
-    return BLOCK_BATCH;
-  }
-
-  get rotate() {
-    return 0;
-  }
-
-  containedByBounds!: (_: Bound) => boolean;
-  getNearestPoint!: (_: IVec) => IVec;
-  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
-  getRelativePointLocation!: (_: IVec) => PointLocation;
-  boxSelect!: (bound: Bound) => boolean;
-
-  hitTest(x: number, y: number, _: HitTestOptions): boolean {
-    const bound = Bound.deserialize(this.xywh);
-    return bound.isPointInBound([x, y], 0);
-  }
 }

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -16,7 +16,6 @@ export const NoteBlockSchema = defineBlockSchema({
     background: DEFAULT_NOTE_COLOR,
     index: 'a0',
     hidden: false,
-    rotate: 0,
     edgeless: {
       style: {
         borderRadius: 8,
@@ -53,7 +52,6 @@ export const NoteBlockSchema = defineBlockSchema({
 type NoteProps = {
   xywh: SerializedXYWH;
   background: string;
-  rotate: number;
   index: string;
   hidden: boolean;
   edgeless: NoteEdgelessProps;

--- a/packages/blocks/src/surface-block/elements/text/text-element.ts
+++ b/packages/blocks/src/surface-block/elements/text/text-element.ts
@@ -8,11 +8,12 @@ import {
   getPointsFromBoundsWithRotation,
   linePolygonIntersects,
   pointInPolygon,
+  polygonGetPointTangent,
   polygonNearestPoint,
   rotatePoints,
 } from '../../utils/math-utils.js';
+import { PointLocation } from '../../utils/point-location.js';
 import { type IVec } from '../../utils/vec.js';
-import { EdgelessSelectableMixin } from '../selectable.js';
 import { SurfaceElement } from '../surface-element.js';
 import type { IText, ITextDelta, ITextLocalRecord } from './types.js';
 import {
@@ -25,10 +26,23 @@ import {
   wrapText,
 } from './utils.js';
 
-@EdgelessSelectableMixin
 export class TextElement extends SurfaceElement<IText> {
   get text() {
     return this.yMap.get('text') as IText['text'];
+  }
+
+  override getRelativePointLocation(relativePoint: IVec): PointLocation {
+    const bound = Bound.deserialize(this.xywh);
+    const point = bound.getRelativePoint(relativePoint);
+    const rotatePoint = rotatePoints(
+      [point],
+      bound.center,
+      this.rotate ?? 0
+    )[0];
+    const points = rotatePoints(bound.points, bound.center, this.rotate ?? 0);
+    const tangent = polygonGetPointTangent(points, rotatePoint);
+
+    return new PointLocation(rotatePoint, tangent);
   }
 
   get color() {

--- a/packages/global/src/utils/index.ts
+++ b/packages/global/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './assert.js';
 export * from './disposable.js';
 export * from './function.js';
 export * from './slot.js';
+export * from './types.js';

--- a/packages/global/src/utils/types.ts
+++ b/packages/global/src/utils/types.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Constructor<T = object> = new (...args: any[]) => T;

--- a/packages/lit/src/with-disposable.ts
+++ b/packages/lit/src/with-disposable.ts
@@ -1,4 +1,4 @@
-import { DisposableGroup } from '@blocksuite/global/utils';
+import { type Constructor, DisposableGroup } from '@blocksuite/global/utils';
 import type { LitElement } from 'lit';
 
 // See https://lit.dev/docs/composition/mixins/#mixins-in-typescript
@@ -7,9 +7,6 @@ export declare class DisposableClass {
   readonly disposables: DisposableGroup;
   protected _disposables: DisposableGroup;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Constructor<T = object> = new (...args: any[]) => T;
 
 /**
  * Mixin that adds a `_disposables: DisposableGroup` property to the class.


### PR DESCRIPTION
Before:
```ts
@EdgelessSelectableMixin
export class NoteBlockModel
  extends BaseBlockModel<NoteProps>
  implements IEdgelessElement
{
  override flavour!: EdgelessBlockType.NOTE;
  elementBound!: Bound;

  get connectable() {
    return true;
  }

  get batch() {
    return BLOCK_BATCH;
  }

  get rotate() {
    return 0;
  }

  containedByBounds!: (_: Bound) => boolean;
  getNearestPoint!: (_: IVec) => IVec;
  intersectWithLine!: (_: IVec, _1: IVec) => PointLocation[] | null;
  getRelativePointLocation!: (_: IVec) => PointLocation;
  boxSelect!: (bound: Bound) => boolean;

  hitTest(x: number, y: number, _: HitTestOptions): boolean {
    const bound = Bound.deserialize(this.xywh);
    return bound.isPointInBound([x, y], 0);
  }
}
```

After:
```ts
export class NoteBlockModel
  extends selectable<NoteProps>(BaseBlockModel) {
}
```