### PR TITLE
refactor: rename `EditorContainer` and `BlockSuiteRoot`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "pnpm --filter @blocksuite/playground dev",
     "dev:docs": "pnpm --filter @blocksuite/docs dev",
     "lint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ ./ --max-warnings=0",
+    "lint:fix": "pnpm lint --fix",
     "lit-lint": "pnpm lit-analyzer --strict=false --rules.no-incompatible-property-type=error --rules.no-incompatible-type-binding=off --rules.no-invalid-css=off --rules.no-invalid-tag-name=off \"packages/**/*.ts\"",
     "test": "playwright test",
     "coverage:report": "nyc report -t .nyc_output --report-dir .coverage --reporter=html",

--- a/packages/block-std/src/event/control/pointer.ts
+++ b/packages/block-std/src/event/control/pointer.ts
@@ -18,24 +18,24 @@ export class PointerControl {
 
   listen() {
     this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.root,
+      this._dispatcher.host,
       'pointerdown',
       this._down
     );
     this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.root,
+      this._dispatcher.host,
       'pointermove',
       this._moveOn
     );
     this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.root,
+      this._dispatcher.host,
       'pointerout',
       this._out
     );
   }
 
   private get _rect() {
-    return this._dispatcher.root.getBoundingClientRect();
+    return this._dispatcher.host.getBoundingClientRect();
   }
 
   private _reset = () => {

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -95,7 +95,7 @@ export class UIEventDispatcher {
     this.disposables.dispose();
   }
 
-  get root() {
+  get host() {
     return this.std.host;
   }
 
@@ -235,7 +235,7 @@ export class UIEventDispatcher {
   private _bindEvents() {
     bypassEventNames.forEach(eventName => {
       this.disposables.addFromEvent(
-        this.root,
+        this.host,
         toLowerCase(eventName),
         event => {
           this.run(

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -96,7 +96,7 @@ export class UIEventDispatcher {
   }
 
   get root() {
-    return this.std.root;
+    return this.std.host;
   }
 
   run(name: EventName, context: UIEventStateContext, scope?: EventScope) {

--- a/packages/block-std/src/provider/block-std-provider.ts
+++ b/packages/block-std/src/provider/block-std-provider.ts
@@ -8,7 +8,7 @@ import { SpecStore } from '../spec/index.js';
 import { ViewStore } from '../view/index.js';
 
 export interface BlockStdProviderOptions {
-  root: HTMLElement;
+  host: HTMLElement;
   workspace: Workspace;
   page: Page;
 }
@@ -19,13 +19,13 @@ export class BlockStdProvider {
   readonly event: UIEventDispatcher;
   readonly selection: SelectionManager;
   readonly command: CommandManager;
-  readonly root: HTMLElement;
+  readonly host: HTMLElement;
   readonly spec: SpecStore;
   readonly view: ViewStore;
   readonly clipboard: Clipboard;
 
   constructor(options: BlockStdProviderOptions) {
-    this.root = options.root;
+    this.host = options.host;
     this.workspace = options.workspace;
     this.page = options.page;
     this.event = new UIEventDispatcher(this);

--- a/packages/block-std/src/view/view-store.ts
+++ b/packages/block-std/src/view/view-store.ts
@@ -66,7 +66,7 @@ export class ViewStore {
     if (this._cachedPath.has(node)) {
       return this._cachedPath.get(node) as NodeView[];
     }
-    const root = this.std.root;
+    const root = this.std.host;
 
     const iterate = (
       node: Node | null,
@@ -114,7 +114,7 @@ export class ViewStore {
         children,
       };
     };
-    const firstBlock = this.std.root.firstElementChild;
+    const firstBlock = this.std.host.firstElementChild;
     assertExists(firstBlock);
 
     const tree = {
@@ -308,7 +308,7 @@ export class ViewStore {
   };
 
   mount() {
-    this._observer.observe(this.std.root, observeOptions);
+    this._observer.observe(this.std.host, observeOptions);
   }
 
   unmount() {

--- a/packages/block-std/src/view/view-store.ts
+++ b/packages/block-std/src/view/view-store.ts
@@ -66,13 +66,13 @@ export class ViewStore {
     if (this._cachedPath.has(node)) {
       return this._cachedPath.get(node) as NodeView[];
     }
-    const root = this.std.host;
+    const host = this.std.host;
 
     const iterate = (
       node: Node | null,
       path: Array<NodeView>
     ): Array<NodeView> => {
-      if (!node || node === root) return path;
+      if (!node || node === host) return path;
       const nodeView = this.getNodeView(node);
       if (!nodeView) {
         return path;

--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -50,7 +50,7 @@ export class FileDropManager {
     }
 
     this._blockService.disposables.addFromEvent(
-      this._blockService.std.root,
+      this._blockService.std.host,
       'drop',
       this.onDrop
     );

--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -704,10 +704,10 @@ export const createPopup = (
     middleware?: Array<Middleware | null | undefined | false>;
   }
 ) => {
-  const root = document.querySelector('editor-host');
-  assertExists(root);
+  const host = document.querySelector('editor-host');
+  assertExists(host);
 
-  const modal = createModal(root);
+  const modal = createModal(host);
   autoUpdate(target, content, () => {
     computePosition(target, content, {
       middleware: options?.middleware ?? [shift({ crossAxis: true })],

--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -704,7 +704,7 @@ export const createPopup = (
     middleware?: Array<Middleware | null | undefined | false>;
   }
 ) => {
-  const root = document.querySelector('block-suite-root');
+  const root = document.querySelector('editor-host');
   assertExists(root);
 
   const modal = createModal(root);

--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -29,9 +29,9 @@ import { bracketPairs } from './bracket-pairs.js';
 import { hardEnter, onBackspace, onForwardDelete } from './legacy.js';
 
 export const bindContainerHotkey = (blockElement: BlockElement) => {
-  const selection = blockElement.root.selection;
+  const selection = blockElement.host.selection;
   const model = blockElement.model;
-  const root = blockElement.root;
+  const root = blockElement.host;
   const leftBrackets = bracketPairs.map(pair => pair.left);
 
   const _selectBlock = () => {
@@ -394,7 +394,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
   }
 
   function tryConvertToLinkedPage() {
-    const pageBlock = blockElement.root.view.viewFromPath(
+    const pageBlock = blockElement.host.view.viewFromPath(
       'block',
       buildPath(model.page.root)
     );

--- a/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/virgo/nodes/link-node/link-popup/link-popup.ts
@@ -65,7 +65,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
       });
     }
 
-    const parent = this.blockElement.root.page.getParent(
+    const parent = this.blockElement.host.page.getParent(
       this.blockElement.model
     );
     assertExists(parent);
@@ -155,8 +155,8 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
   private _isBookmarkAllowed() {
     const blockElement = this.blockElement;
-    const schema = blockElement.root.page.schema;
-    const parent = blockElement.root.page.getParent(blockElement.model);
+    const schema = blockElement.host.page.schema;
+    const parent = blockElement.host.page.getParent(blockElement.model);
     assertExists(parent);
     const bookmarkSchema = schema.flavourSchemaMap.get('affine:bookmark');
     assertExists(bookmarkSchema);
@@ -214,11 +214,11 @@ export class LinkPopup extends WithDisposable(LitElement) {
       url: this.currentLink,
       title: this.currentText,
     };
-    const page = blockElement.root.page;
+    const page = blockElement.host.page;
     const parent = page.getParent(blockElement.model);
     assertExists(parent);
     const index = parent.children.indexOf(blockElement.model);
-    blockElement.root.page.addBlock(
+    blockElement.host.page.addBlock(
       'affine:bookmark',
       props,
       parent,

--- a/packages/blocks/src/_common/components/toast.ts
+++ b/packages/blocks/src/_common/components/toast.ts
@@ -35,7 +35,7 @@ const createToastContainer = () => {
   `;
   const template = html`<div class="toast-container" style="${styles}"></div>`;
   const element = htmlToElement<HTMLDivElement>(template);
-  const container = document.body.querySelector('editor-container');
+  const container = document.body.querySelector('affine-editor-container');
   assertExists(container);
   container.appendChild(element);
   return element;

--- a/packages/blocks/src/_common/configs/move-block.ts
+++ b/packages/blocks/src/_common/configs/move-block.ts
@@ -3,7 +3,7 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { BlockElement } from '@blocksuite/lit';
 
 const getSelection = (blockComponent: BlockElement) =>
-  blockComponent.root.selection;
+  blockComponent.host.selection;
 
 function getBlockSelectionBySide(blockElement: BlockElement, tail: boolean) {
   const selection = getSelection(blockElement);
@@ -18,7 +18,7 @@ function getTextSelection(blockElement: BlockElement) {
 }
 
 const pathToBlock = (blockElement: BlockElement, path: string[]) =>
-  blockElement.root.view.viewFromPath('block', path);
+  blockElement.host.view.viewFromPath('block', path);
 
 interface MoveBlockConfig {
   name: string;
@@ -51,7 +51,7 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
           true
         );
         blockElement.updateComplete.then(() => {
-          const rangeManager = blockElement.root.rangeManager;
+          const rangeManager = blockElement.host.rangeManager;
           assertExists(rangeManager);
           rangeManager.syncTextSelectionToRange(textSelection);
         });
@@ -100,7 +100,7 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
         page.moveBlocks([currentModel], parentModel, nextSiblingModel, false);
         blockElement.updateComplete.then(() => {
           // `textSelection` will not change so we need wo sync it manually
-          const rangeManager = blockElement.root.rangeManager;
+          const rangeManager = blockElement.host.rangeManager;
           assertExists(rangeManager);
           rangeManager.syncTextSelectionToRange(textSelection);
         });

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -1,7 +1,7 @@
 import './database-convert-view.js';
 
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { html, type TemplateResult } from 'lit';
 
 import { matchFlavours } from '../../../_common/utils/model.js';
@@ -18,9 +18,9 @@ export interface QuickActionConfig {
   disabledToolTip?: string;
   icon: TemplateResult<1>;
   hotkey?: string;
-  showWhen: (root: BlockSuiteRoot) => boolean;
-  enabledWhen: (root: BlockSuiteRoot) => boolean;
-  action: (root: BlockSuiteRoot) => void;
+  showWhen: (root: EditorHost) => boolean;
+  enabledWhen: (root: EditorHost) => boolean;
+  action: (root: EditorHost) => void;
 }
 
 export const quickActionConfig: QuickActionConfig[] = [

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -18,9 +18,9 @@ export interface QuickActionConfig {
   disabledToolTip?: string;
   icon: TemplateResult<1>;
   hotkey?: string;
-  showWhen: (root: EditorHost) => boolean;
-  enabledWhen: (root: EditorHost) => boolean;
-  action: (root: EditorHost) => void;
+  showWhen: (host: EditorHost) => boolean;
+  enabledWhen: (host: EditorHost) => boolean;
+  action: (host: EditorHost) => void;
 }
 
 export const quickActionConfig: QuickActionConfig[] = [

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -32,8 +32,8 @@ export const quickActionConfig: QuickActionConfig[] = [
     hotkey: undefined,
     showWhen: () => true,
     enabledWhen: () => true,
-    action: root => {
-      copyBlocksInPage(root);
+    action: host => {
+      copyBlocksInPage(host);
       toast('Copied to clipboard');
     },
   },
@@ -44,8 +44,8 @@ export const quickActionConfig: QuickActionConfig[] = [
       'Contains Block types that cannot be converted to Database',
     icon: DatabaseTableViewIcon20,
     hotkey: `Mod-g`,
-    showWhen: root => {
-      const selectedModels = getSelectedContentModels(root, ['text', 'block']);
+    showWhen: host => {
+      const selectedModels = getSelectedContentModels(host, ['text', 'block']);
 
       if (selectedModels.length === 0) {
         return false;
@@ -58,8 +58,8 @@ export const quickActionConfig: QuickActionConfig[] = [
 
       return true;
     },
-    enabledWhen: root => {
-      const selectedModels = getSelectedContentModels(root, ['text', 'block']);
+    enabledWhen: host => {
+      const selectedModels = getSelectedContentModels(host, ['text', 'block']);
 
       if (selectedModels.length === 0) {
         return false;
@@ -69,10 +69,10 @@ export const quickActionConfig: QuickActionConfig[] = [
         DATABASE_CONVERT_WHITE_LIST.includes(block.flavour)
       );
     },
-    action: root => {
+    action: host => {
       createSimplePortal({
         template: html`<database-convert-view
-          .root=${root}
+          .host=${host}
         ></database-convert-view>`,
       });
     },

--- a/packages/blocks/src/_common/configs/quick-action/database-convert-view.ts
+++ b/packages/blocks/src/_common/configs/quick-action/database-convert-view.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { WithDisposable } from '@blocksuite/lit';
 import { css, html, LitElement, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -156,7 +156,7 @@ export class DatabaseConvertView extends WithDisposable(LitElement) {
   `;
 
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   get page() {
     return this.root.page;

--- a/packages/blocks/src/_common/configs/quick-action/database-convert-view.ts
+++ b/packages/blocks/src/_common/configs/quick-action/database-convert-view.ts
@@ -156,14 +156,14 @@ export class DatabaseConvertView extends WithDisposable(LitElement) {
   `;
 
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   get page() {
-    return this.root.page;
+    return this.host.page;
   }
 
   private _convertToDatabase(viewType: DataViewTypes) {
-    const selectedModels = getSelectedContentModels(this.root, [
+    const selectedModels = getSelectedContentModels(this.host, [
       'text',
       'block',
     ]);
@@ -187,7 +187,7 @@ export class DatabaseConvertView extends WithDisposable(LitElement) {
     databaseModel.applyColumnUpdate();
     this.page.moveBlocks(selectedModels, databaseModel);
 
-    const selectionManager = this.root.selection;
+    const selectionManager = this.host.selection;
     selectionManager.clear();
 
     this.remove();

--- a/packages/blocks/src/_common/configs/text-format/config.ts
+++ b/packages/blocks/src/_common/configs/text-format/config.ts
@@ -20,8 +20,8 @@ export interface TextFormatConfig {
   name: string;
   icon: TemplateResult<1>;
   hotkey?: string;
-  activeWhen: (root: EditorHost) => boolean;
-  action: (root: EditorHost) => void;
+  activeWhen: (host: EditorHost) => boolean;
+  action: (host: EditorHost) => void;
 }
 
 export const textFormatConfigs: TextFormatConfig[] = [

--- a/packages/blocks/src/_common/configs/text-format/config.ts
+++ b/packages/blocks/src/_common/configs/text-format/config.ts
@@ -30,9 +30,9 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Bold',
     icon: BoldIcon,
     hotkey: 'Mod-b',
-    activeWhen: root => commonActiveWhen(root, 'bold'),
-    action: root => {
-      handleCommonStyle(root, 'bold');
+    activeWhen: host => commonActiveWhen(host, 'bold'),
+    action: host => {
+      handleCommonStyle(host, 'bold');
     },
   },
   {
@@ -40,9 +40,9 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Italic',
     icon: ItalicIcon,
     hotkey: 'Mod-i',
-    activeWhen: root => commonActiveWhen(root, 'italic'),
-    action: root => {
-      handleCommonStyle(root, 'italic');
+    activeWhen: host => commonActiveWhen(host, 'italic'),
+    action: host => {
+      handleCommonStyle(host, 'italic');
     },
   },
   {
@@ -50,9 +50,9 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Underline',
     icon: UnderlineIcon,
     hotkey: 'Mod-u',
-    activeWhen: root => commonActiveWhen(root, 'underline'),
-    action: root => {
-      handleCommonStyle(root, 'underline');
+    activeWhen: host => commonActiveWhen(host, 'underline'),
+    action: host => {
+      handleCommonStyle(host, 'underline');
     },
   },
   {
@@ -60,9 +60,9 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Strikethrough',
     icon: StrikethroughIcon,
     hotkey: 'Mod-shift-s',
-    activeWhen: root => commonActiveWhen(root, 'strike'),
-    action: root => {
-      handleCommonStyle(root, 'strike');
+    activeWhen: host => commonActiveWhen(host, 'strike'),
+    action: host => {
+      handleCommonStyle(host, 'strike');
     },
   },
   {
@@ -70,9 +70,9 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Code',
     icon: CodeIcon,
     hotkey: 'Mod-e',
-    activeWhen: root => commonActiveWhen(root, 'code'),
-    action: root => {
-      handleCommonStyle(root, 'code');
+    activeWhen: host => commonActiveWhen(host, 'code'),
+    action: host => {
+      handleCommonStyle(host, 'code');
     },
   },
   {
@@ -80,7 +80,7 @@ export const textFormatConfigs: TextFormatConfig[] = [
     name: 'Link',
     icon: LinkIcon,
     hotkey: 'Mod-k',
-    activeWhen: root => commonActiveWhen(root, 'link'),
+    activeWhen: host => commonActiveWhen(host, 'link'),
     action: () => {
       const selection = document.getSelection();
       if (!selection || selection.rangeCount === 0) return;

--- a/packages/blocks/src/_common/configs/text-format/config.ts
+++ b/packages/blocks/src/_common/configs/text-format/config.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { VIRGO_ROOT_ATTR, type VirgoRootElement } from '@blocksuite/virgo';
 import type { TemplateResult } from 'lit';
 
@@ -20,8 +20,8 @@ export interface TextFormatConfig {
   name: string;
   icon: TemplateResult<1>;
   hotkey?: string;
-  activeWhen: (root: BlockSuiteRoot) => boolean;
-  action: (root: BlockSuiteRoot) => void;
+  activeWhen: (root: EditorHost) => boolean;
+  action: (root: EditorHost) => void;
 }
 
 export const textFormatConfigs: TextFormatConfig[] = [

--- a/packages/blocks/src/_common/configs/text-format/utils.ts
+++ b/packages/blocks/src/_common/configs/text-format/utils.ts
@@ -46,10 +46,10 @@ function getCombinedFormatFromVEditors(
   });
 }
 
-function getCombinedFormat(root: EditorHost): AffineTextAttributes {
+function getCombinedFormat(host: EditorHost): AffineTextAttributes {
   let result: AffineTextAttributes = {};
 
-  root.std.command
+  host.std.command
     .pipe()
     .withHost()
     .try(chain => [
@@ -118,7 +118,7 @@ function getCombinedFormat(root: EditorHost): AffineTextAttributes {
       // native selection, corresponding to `formatNative` command
       chain.inline(() => {
         const selectedVEditors = Array.from<VirgoRootElement>(
-          root.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
+          host.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
         )
           .filter(el => {
             const selection = document.getSelection();
@@ -149,13 +149,13 @@ function getCombinedFormat(root: EditorHost): AffineTextAttributes {
 }
 
 export function handleCommonStyle(
-  root: EditorHost,
+  host: EditorHost,
   key: Extract<
     keyof AffineTextAttributes,
     'bold' | 'italic' | 'underline' | 'strike' | 'code'
   >
 ) {
-  const active = commonActiveWhen(root, key);
+  const active = commonActiveWhen(host, key);
   const payload: {
     styles: AffineTextAttributes;
     mode?: 'replace' | 'merge';
@@ -164,7 +164,7 @@ export function handleCommonStyle(
       [key]: active ? null : true,
     },
   };
-  root.std.command
+  host.std.command
     .pipe()
     .withHost()
     .try(chain => [
@@ -175,15 +175,15 @@ export function handleCommonStyle(
     .run();
 }
 
-export function commonActiveWhen(root: EditorHost, key: string) {
-  const format = getCombinedFormat(root);
+export function commonActiveWhen(host: EditorHost, key: string) {
+  const format = getCombinedFormat(host);
   return key in format;
 }
 
-export function isFormatSupported(root: EditorHost) {
+export function isFormatSupported(host: EditorHost) {
   let result = false;
 
-  root.std.command
+  host.std.command
     .pipe()
     .withHost()
     .try(chain => [
@@ -243,7 +243,7 @@ export function isFormatSupported(root: EditorHost) {
       // native selection, corresponding to `formatNative` command
       chain.inline(() => {
         const selectedVEditors = Array.from<VirgoRootElement>(
-          root.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
+          host.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
         )
           .filter(el => {
             const selection = document.getSelection();

--- a/packages/blocks/src/_common/configs/text-format/utils.ts
+++ b/packages/blocks/src/_common/configs/text-format/utils.ts
@@ -51,7 +51,7 @@ function getCombinedFormat(root: EditorHost): AffineTextAttributes {
 
   root.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .try(chain => [
       // text selection, corresponding to `formatText` command
       chain
@@ -166,7 +166,7 @@ export function handleCommonStyle(
   };
   root.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .try(chain => [
       chain.getTextSelection().formatText(payload),
       chain.getBlockSelections().formatBlock(payload),
@@ -185,7 +185,7 @@ export function isFormatSupported(root: EditorHost) {
 
   root.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .try(chain => [
       // text selection, corresponding to `formatText` command
       chain

--- a/packages/blocks/src/_common/configs/text-format/utils.ts
+++ b/packages/blocks/src/_common/configs/text-format/utils.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement, BlockSuiteRoot } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import {
   VIRGO_ROOT_ATTR,
   type VirgoRootElement,
@@ -46,7 +46,7 @@ function getCombinedFormatFromVEditors(
   });
 }
 
-function getCombinedFormat(root: BlockSuiteRoot): AffineTextAttributes {
+function getCombinedFormat(root: EditorHost): AffineTextAttributes {
   let result: AffineTextAttributes = {};
 
   root.std.command
@@ -149,7 +149,7 @@ function getCombinedFormat(root: BlockSuiteRoot): AffineTextAttributes {
 }
 
 export function handleCommonStyle(
-  root: BlockSuiteRoot,
+  root: EditorHost,
   key: Extract<
     keyof AffineTextAttributes,
     'bold' | 'italic' | 'underline' | 'strike' | 'code'
@@ -175,12 +175,12 @@ export function handleCommonStyle(
     .run();
 }
 
-export function commonActiveWhen(root: BlockSuiteRoot, key: string) {
+export function commonActiveWhen(root: EditorHost, key: string) {
   const format = getCombinedFormat(root);
   return key in format;
 }
 
-export function isFormatSupported(root: BlockSuiteRoot) {
+export function isFormatSupported(root: EditorHost) {
   let result = false;
 
   root.std.command

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -15,14 +15,14 @@ export class EmbedBlockElement<
   WidgetName extends string = string,
 > extends BlockElement<Model, Service, WidgetName> {
   protected get _isInSurface() {
-    const parent = this.root.querySelector('affine-edgeless-page');
+    const parent = this.host.querySelector('affine-edgeless-page');
     return !!parent;
   }
 
   get surface() {
     if (!this._isInSurface) return null;
 
-    return this.root.querySelector('affine-surface');
+    return this.host.querySelector('affine-surface');
   }
 
   get bound(): Bound {

--- a/packages/blocks/src/_common/theme/utils.ts
+++ b/packages/blocks/src/_common/theme/utils.ts
@@ -5,7 +5,7 @@ import type { ThemeObserver } from './theme-observer.js';
 
 function getClosestEditorContainer(element: Element) {
   const container = element.closest(
-    'editor-container'
+    'affine-editor-container'
   ) as unknown as Element & {
     themeObserver: ThemeObserver;
   };

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement, BlockSuiteRoot } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { VIRGO_ROOT_ATTR } from '@blocksuite/virgo';
 
@@ -190,13 +190,13 @@ export function getEditorContainer(page: Page): AbstractEditor {
   );
   const pageBlock = getBlockElementByModel(page.root);
   // EditorContainer
-  const editorContainer = pageBlock?.closest('editor-container');
+  const editorContainer = pageBlock?.closest('affine-editor-container');
   assertExists(editorContainer);
   return editorContainer as AbstractEditor;
 }
 
 function getClosestEditorContainer(ele: Element) {
-  const editorContainer = ele.closest('editor-container');
+  const editorContainer = ele.closest('affine-editor-container');
   assertExists(editorContainer);
   return editorContainer as AbstractEditor;
 }
@@ -210,7 +210,7 @@ export function isPageMode(page: Page) {
 }
 
 export function getLitRoot() {
-  const root = document.querySelector<BlockSuiteRoot>('block-suite-root');
+  const root = document.querySelector<EditorHost>('editor-host');
   assertExists(root);
   return root;
 }
@@ -329,7 +329,7 @@ export function getModelByElement(element: Element): BaseBlockModel {
 }
 
 export function isInsidePageTitle(element: unknown): boolean {
-  const editor = document.querySelector('editor-container');
+  const editor = document.querySelector('affine-editor-container');
   const titleElement = (editor ?? document).querySelector(
     '[data-block-is-title="true"]'
   );
@@ -339,7 +339,7 @@ export function isInsidePageTitle(element: unknown): boolean {
 }
 
 export function isInsideEdgelessTextEditor(element: unknown): boolean {
-  const editor = document.querySelector('editor-container');
+  const editor = document.querySelector('affine-editor-container');
   const textElement = getEdgelessCanvasTextEditor(editor ?? document);
   if (!textElement) return false;
 

--- a/packages/blocks/src/_common/widgets/block-hub/components/block-hub.ts
+++ b/packages/blocks/src/_common/widgets/block-hub/components/block-hub.ts
@@ -90,13 +90,13 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
   private _lastDraggingFlavour: string | null = null;
   private _timer: number | null = null;
   private _rafID: number = 0;
-  private _root: EditorHost;
+  private _host: EditorHost;
 
   static override styles = styles;
 
-  constructor(root: EditorHost) {
+  constructor(host: EditorHost) {
     super();
-    this._root = root;
+    this._host = host;
   }
 
   override connectedCallback() {
@@ -106,13 +106,13 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     disposables.addFromEvent(this, 'dragstart', this._onDragStart);
     disposables.addFromEvent(this, 'drag', this._onDrag);
     disposables.addFromEvent(this, 'dragend', this._onDragEnd);
-    disposables.addFromEvent(this._root, 'dragover', this._onDragOver);
-    disposables.addFromEvent(this._root, 'drop', this._onDrop);
+    disposables.addFromEvent(this._host, 'dragover', this._onDragOver);
+    disposables.addFromEvent(this._host, 'drop', this._onDrop);
     disposables.addFromEvent(this, 'mousedown', this._onMouseDown);
 
     if (IS_FIREFOX) {
       disposables.addFromEvent(
-        this._root,
+        this._host,
         'dragover',
         this._onDragOverDocument
       );
@@ -193,13 +193,13 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
   }
 
   private get _isPageMode() {
-    return isPageMode(this._root.page);
+    return isPageMode(this._host.page);
   }
 
   private get _pageBlockElement() {
     const pageElement = this._isPageMode
-      ? (getDocPage(this._root.page) as DocPageBlockComponent)
-      : (getEdgelessPage(this._root.page) as EdgelessPageBlockComponent);
+      ? (getDocPage(this._host.page) as DocPageBlockComponent)
+      : (getEdgelessPage(this._host.page) as EdgelessPageBlockComponent);
     return pageElement;
   }
 
@@ -214,7 +214,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
     if (this._isPageMode) {
       const closestNoteBlock = getClosestNoteBlock(
-        this._root.page,
+        this._host.page,
         this._pageBlockElement,
         point
       );
@@ -347,7 +347,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       if (x >= min.x && x <= max.x && y >= min.y) {
         const lastBlock = this._pageBlockElement.model.lastChild();
         if (lastBlock) {
-          const lastElement = this._root.view.viewFromPath('block', [
+          const lastElement = this._host.view.viewFromPath('block', [
             lastBlock.id,
           ]);
           element = lastElement;
@@ -435,7 +435,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     assertExists(e.dataTransfer);
     if (!e.dataTransfer.getData('affine/block-hub')) return;
 
-    const page = this._root.page;
+    const page = this._host.page;
     const point = this._indicator?.rect?.min ?? new Point(e.clientX, e.clientY);
     const lastModelState = this._lastDroppingTarget;
     const lastType = this._lastDroppingType;
@@ -455,7 +455,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
         }))
       );
     } else if (props.flavour === 'affine:bookmark') {
-      const url = await toggleBookmarkCreateModal(this._root);
+      const url = await toggleBookmarkCreateModal(this._host);
       url &&
         models.push({
           flavour: 'affine:bookmark',
@@ -509,7 +509,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
     let noteId;
     if (focusId && parentModel) {
-      const targetNoteBlock = this._root.view.viewFromPath(
+      const targetNoteBlock = this._host.view.viewFromPath(
         'block',
         buildPath(parentModel)
       );
@@ -549,7 +549,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       flavour: blockHubElement.getAttribute('affine-flavour') ?? '',
       type: affineType ?? undefined,
     };
-    const page = this._root.page;
+    const page = this._host.page;
     const models = [];
 
     if (data.flavour === 'affine:image' && data.type === 'image') {
@@ -560,7 +560,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
         }))
       );
     } else if (data.flavour === 'affine:bookmark') {
-      const url = await toggleBookmarkCreateModal(this._root);
+      const url = await toggleBookmarkCreateModal(this._host);
       url &&
         models.push({
           flavour: 'affine:bookmark',

--- a/packages/blocks/src/_common/widgets/block-hub/components/block-hub.ts
+++ b/packages/blocks/src/_common/widgets/block-hub/components/block-hub.ts
@@ -1,6 +1,6 @@
 import { IS_FIREFOX } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement, query, queryAll, state } from 'lit/decorators.js';
@@ -90,11 +90,11 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
   private _lastDraggingFlavour: string | null = null;
   private _timer: number | null = null;
   private _rafID: number = 0;
-  private _root: BlockSuiteRoot;
+  private _root: EditorHost;
 
   static override styles = styles;
 
-  constructor(root: BlockSuiteRoot) {
+  constructor(root: EditorHost) {
     super();
     this._root = root;
   }

--- a/packages/blocks/src/_common/widgets/block-hub/index.ts
+++ b/packages/blocks/src/_common/widgets/block-hub/index.ts
@@ -13,7 +13,7 @@ export class BlockHubWidget extends WidgetElement {
   override connectedCallback() {
     super.connectedCallback();
 
-    const blockHub = new BlockHub(this.root);
+    const blockHub = new BlockHub(this.host);
     document.body.appendChild(blockHub);
 
     this.disposables.add(() => blockHub.remove());

--- a/packages/blocks/src/_common/widgets/doc-dragging-area/index.ts
+++ b/packages/blocks/src/_common/widgets/doc-dragging-area/index.ts
@@ -166,7 +166,7 @@ export class AffineDocDraggingAreaWidget extends WidgetElement<DocPageBlockCompo
 
     const getAllNodeFromTree = (): BlockElement[] => {
       const blockElement: BlockElement[] = [];
-      this.root.view.walkThrough(node => {
+      this.host.view.walkThrough(node => {
         const view = node.view;
         if (!(view instanceof BlockElement)) {
           return true;
@@ -186,7 +186,7 @@ export class AffineDocDraggingAreaWidget extends WidgetElement<DocPageBlockCompo
 
     const elements = getAllNodeFromTree();
 
-    const rootRect = this.root.getBoundingClientRect();
+    const rootRect = this.host.getBoundingClientRect();
     return elements.map(element => {
       const bounding = element.getBoundingClientRect();
       return {
@@ -214,12 +214,12 @@ export class AffineDocDraggingAreaWidget extends WidgetElement<DocPageBlockCompo
       this._allBlocksWithRect,
       userRect
     ).map(blockPath => {
-      return this.root.selection.getInstance('block', {
+      return this.host.selection.getInstance('block', {
         path: blockPath,
       });
     });
 
-    this.root.selection.setGroup('note', selections);
+    this.host.selection.setGroup('note', selections);
   }
 
   private _clearRaf() {

--- a/packages/blocks/src/_common/widgets/doc-page-meta-data/index.ts
+++ b/packages/blocks/src/_common/widgets/doc-page-meta-data/index.ts
@@ -12,13 +12,13 @@ export class DocPageMetaDataWidget extends WidgetElement {
   override connectedCallback() {
     super.connectedCallback();
 
-    this.root.updateComplete.then(() => {
+    this.host.updateComplete.then(() => {
       const pageElement = getDocPage(this.page);
       assertExists(pageElement);
 
       const pageMetaData = new PageMetaData(this.page, pageElement);
 
-      const pageTitleContainer = this.root.querySelector(
+      const pageTitleContainer = this.host.querySelector(
         '.affine-doc-page-block-title-container'
       );
       assertExists(pageTitleContainer);

--- a/packages/blocks/src/_common/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/_common/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -42,7 +42,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }> = [];
 
   private get _selectionManager() {
-    return this.root.selection;
+    return this.host.selection;
   }
 
   private get _container() {
@@ -88,7 +88,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     });
 
     this._remoteColorManager = new RemoteColorManager(
-      this.root.page.workspace.awarenessStore
+      this.host.page.workspace.awarenessStore
     );
   }
 
@@ -113,7 +113,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     const container = this._container;
     const containerRect = this._containerRect;
     if (textSelection) {
-      const rangeManager = this.root.rangeManager;
+      const rangeManager = this.host.rangeManager;
       assertExists(rangeManager);
       const range = rangeManager.textSelectionToRange(textSelection);
 
@@ -138,7 +138,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
       }
     } else if (blockSelections.length > 0) {
       return blockSelections.flatMap(blockSelection => {
-        const blockElement = this.root.view.viewFromPath(
+        const blockElement = this.host.view.viewFromPath(
           'block',
           blockSelection.path
         );
@@ -180,7 +180,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     const containerRect = this._containerRect;
 
     if (textSelection) {
-      const rangeManager = this.root.rangeManager;
+      const rangeManager = this.host.rangeManager;
       assertExists(rangeManager);
       const range = rangeManager.pointToRange({
         path: textSelection.to
@@ -215,7 +215,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     } else if (blockSelections.length > 0) {
       const lastBlockSelection = blockSelections[blockSelections.length - 1];
 
-      const blockElement = this.root.view.viewFromPath(
+      const blockElement = this.host.view.viewFromPath(
         'block',
         lastBlockSelection.path
       );

--- a/packages/blocks/src/_common/widgets/drag-handle/index.ts
+++ b/packages/blocks/src/_common/widgets/drag-handle/index.ts
@@ -124,9 +124,9 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   get selectedBlocks() {
-    return this.root.selection.find('text')
-      ? this.root.selection.filter('text')
-      : this.root.selection.filter('block');
+    return this.host.selection.find('text')
+      ? this.host.selection.filter('text')
+      : this.host.selection.filter('block');
   }
 
   clearRaf() {
@@ -309,7 +309,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       width = Math.max(width, element.getBoundingClientRect().width);
       const container = document.createElement('div');
       container.classList.add('affine-block-element');
-      render(this.root.renderModel(element.model), container);
+      render(this.host.renderModel(element.model), container);
       fragment.appendChild(container);
     });
 
@@ -382,7 +382,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   private _getBlockElementFromViewStore(path: string[]) {
-    return this.root.view.viewFromPath('block', path);
+    return this.host.view.viewFromPath('block', path);
   }
 
   private get _viewportOffset() {
@@ -602,7 +602,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   private _setSelectedBlocks(blockElements: BlockElement[], noteId?: string) {
-    const { selection } = this.root;
+    const { selection } = this.host;
     const selections = blockElements.map(blockElement =>
       selection.getInstance('block', {
         path: blockElement.path,
@@ -626,8 +626,8 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   private get _rangeManager() {
-    assertExists(this.root.rangeManager);
-    return this.root.rangeManager;
+    assertExists(this.host.rangeManager);
+    return this.host.rangeManager;
   }
 
   private _removeHoverRect() {
@@ -679,7 +679,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       return;
     }
 
-    const blockId = closestBlockElement.getAttribute(this.root.blockIdAttr);
+    const blockId = closestBlockElement.getAttribute(this.host.blockIdAttr);
     const blockPath = closestBlockElement.path;
     assertExists(blockId);
     assertExists(blockPath);
@@ -763,7 +763,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       return;
     }
 
-    const { selection } = this.root;
+    const { selection } = this.host;
     const selectedBlocks = this.selectedBlocks;
 
     // Should clear selection if current block is the first selected block

--- a/packages/blocks/src/_common/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/_common/widgets/drag-handle/utils.ts
@@ -270,7 +270,7 @@ export const getDropResult = (
   let dropIndicator = null;
 
   const target = captureEventTarget(event.target);
-  const rootElement = target?.closest('block-suite-root');
+  const rootElement = target?.closest('editor-host');
   const offset = {
     x: rootElement?.getBoundingClientRect().left ?? 0,
     y: rootElement?.getBoundingClientRect().top ?? 0,

--- a/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/_common/widgets/edgeless-remote-selection/index.ts
@@ -217,7 +217,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlo
     this._updateRemoteRects();
 
     this._remoteColorManager = new RemoteColorManager(
-      this.root.page.workspace.awarenessStore
+      this.host.page.workspace.awarenessStore
     );
   }
 

--- a/packages/blocks/src/_common/widgets/format-bar/components/action-items.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/action-items.ts
@@ -8,7 +8,7 @@ export const ActionItems = (formatBar: AffineFormatBarWidget) => {
     return null;
   }
 
-  const root = formatBar.root;
+  const root = formatBar.host;
   return quickActionConfig
     .filter(({ showWhen }) => showWhen(root))
     .map(({ id, name, icon, action, enabledWhen, disabledToolTip }) => {

--- a/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
@@ -39,7 +39,7 @@ const updateHighlight = (
   };
   root.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .try(chain => [
       chain.getTextSelection().formatText(payload),
       chain.getBlockSelections().formatBlock(payload),

--- a/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
@@ -24,7 +24,7 @@ let lastUsedColor: string | null = null;
 let lastUsedHighlightType: HighlightType = HighlightType.Background;
 
 const updateHighlight = (
-  root: EditorHost,
+  host: EditorHost,
   color: string | null,
   highlightType: HighlightType
 ) => {
@@ -39,7 +39,7 @@ const updateHighlight = (
       background: highlightType === HighlightType.Background ? color : null,
     },
   };
-  root.std.command
+  host.std.command
     .pipe()
     .withHost()
     .try(chain => [

--- a/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
@@ -66,7 +66,7 @@ const HighlightPanel = (
           text="${name}"
           data-testid="${color ?? 'unset'}"
           @click="${() => {
-            updateHighlight(formatBar.root, color, HighlightType.Foreground);
+            updateHighlight(formatBar.host, color, HighlightType.Foreground);
             formatBar.requestUpdate();
           }}"
         >
@@ -86,7 +86,7 @@ const HighlightPanel = (
           style="padding-left: 4px; justify-content: flex-start; gap: 8px;"
           text="${name}"
           @click="${() => {
-            updateHighlight(formatBar.root, color, HighlightType.Background);
+            updateHighlight(formatBar.host, color, HighlightType.Background);
             formatBar.requestUpdate();
           }}"
         >
@@ -102,7 +102,7 @@ const HighlightPanel = (
 };
 
 export const HighlightButton = (formatBar: AffineFormatBarWidget) => {
-  const root = formatBar.blockElement.root;
+  const root = formatBar.blockElement.host;
 
   const { setFloating, setReference } = whenHover(isHover => {
     if (!isHover) {

--- a/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/highlight/highlight-button.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { computePosition, flip, shift } from '@floating-ui/dom';
 import { html } from 'lit';
 
@@ -22,7 +22,7 @@ let lastUsedColor: string | null = null;
 let lastUsedHighlightType: HighlightType = HighlightType.Background;
 
 const updateHighlight = (
-  root: BlockSuiteRoot,
+  root: EditorHost,
   color: string | null,
   highlightType: HighlightType
 ) => {

--- a/packages/blocks/src/_common/widgets/format-bar/components/inline-items.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/inline-items.ts
@@ -6,7 +6,7 @@ import type { AffineFormatBarWidget } from '../format-bar.js';
 import { HighlightButton } from './highlight/highlight-button.js';
 
 export const InlineItems = (formatBar: AffineFormatBarWidget) => {
-  const root = formatBar.root;
+  const root = formatBar.host;
 
   if (!isFormatSupported(root)) {
     return null;

--- a/packages/blocks/src/_common/widgets/format-bar/components/paragraph-button.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/components/paragraph-button.ts
@@ -130,7 +130,7 @@ export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
 
   const paragraphPanel = ParagraphPanel({
     selectedBlockElements,
-    page: formatBar.root.page,
+    page: formatBar.host.page,
     ref: setFloating,
   });
 

--- a/packages/blocks/src/_common/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/format-bar.ts
@@ -40,7 +40,7 @@ export class AffineFormatBarWidget extends WidgetElement {
   private _customElements: HTMLDivElement[] = [];
 
   private get _selectionManager() {
-    return this.root.selection;
+    return this.host.selection;
   }
 
   private _dragging = false;
@@ -134,14 +134,14 @@ export class AffineFormatBarWidget extends WidgetElement {
     });
 
     this.disposables.add(
-      this.root.event.add('dragStart', () => {
+      this.host.event.add('dragStart', () => {
         this._dragging = true;
         this.requestUpdate();
       })
     );
 
     this.disposables.add(
-      this.root.event.add('dragEnd', () => {
+      this.host.event.add('dragEnd', () => {
         this._dragging = false;
         this.requestUpdate();
       })
@@ -149,7 +149,7 @@ export class AffineFormatBarWidget extends WidgetElement {
 
     // calculate placement
     this.disposables.add(
-      this.root.event.add('pointerUp', ctx => {
+      this.host.event.add('pointerUp', ctx => {
         if (this.displayType === 'text' || this.displayType === 'native') {
           const range = this.nativeRange;
           assertExists(range);
@@ -179,12 +179,12 @@ export class AffineFormatBarWidget extends WidgetElement {
     // listen to selection change
     this.disposables.add(
       this._selectionManager.slots.changed.on(async () => {
-        await this.root.updateComplete;
+        await this.host.updateComplete;
         const textSelection = pageElement.selection.find('text');
         const blockSelections = pageElement.selection.filter('block');
 
         if (textSelection) {
-          const block = this.root.view.viewFromPath(
+          const block = this.host.view.viewFromPath(
             'block',
             textSelection.path
           );
@@ -194,9 +194,9 @@ export class AffineFormatBarWidget extends WidgetElement {
             block.model.role === 'content'
           ) {
             this._displayType = 'text';
-            assertExists(pageElement.root.rangeManager);
+            assertExists(pageElement.host.rangeManager);
 
-            this.root.std.command
+            this.host.std.command
               .pipe()
               .withHost()
               .getTextSelection()
@@ -217,7 +217,7 @@ export class AffineFormatBarWidget extends WidgetElement {
           this._selectedBlockElements = blockSelections
             .map(selection => {
               const path = selection.path;
-              return this.blockElement.root.view.viewFromPath('block', path);
+              return this.blockElement.host.view.viewFromPath('block', path);
             })
             .filter((el): el is BlockElement => !!el);
         } else {
@@ -228,7 +228,7 @@ export class AffineFormatBarWidget extends WidgetElement {
       })
     );
     this.disposables.addFromEvent(document, 'selectionchange', () => {
-      const databaseSelection = this.root.selection.find('database');
+      const databaseSelection = this.host.selection.find('database');
       const reset = () => {
         this._reset();
         this.requestUpdate();

--- a/packages/blocks/src/_common/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/_common/widgets/format-bar/format-bar.ts
@@ -198,7 +198,7 @@ export class AffineFormatBarWidget extends WidgetElement {
 
             this.root.std.command
               .pipe()
-              .withRoot()
+              .withHost()
               .getTextSelection()
               .getSelectedBlocks({
                 types: ['text'],

--- a/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
@@ -1,4 +1,4 @@
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { html, nothing } from 'lit';
 import { ref, type RefOrCallback } from 'lit/directives/ref.js';
 
@@ -34,7 +34,7 @@ export function ImageOptionsTemplate({
   /**
    * @deprecated
    */
-  root: BlockSuiteRoot;
+  root: EditorHost;
 }) {
   const supportAttachment =
     model.page.schema.flavourSchemaMap.has('affine:attachment');

--- a/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/_common/widgets/image-toolbar/image-options.ts
@@ -25,7 +25,7 @@ export function ImageOptionsTemplate({
   model,
   blob,
   abortController,
-  root,
+  host,
 }: {
   ref?: RefOrCallback;
   model: ImageBlockModel;
@@ -34,7 +34,7 @@ export function ImageOptionsTemplate({
   /**
    * @deprecated
    */
-  root: EditorHost;
+  host: EditorHost;
 }) {
   const supportAttachment =
     model.page.schema.flavourSchemaMap.has('affine:attachment');
@@ -125,7 +125,7 @@ export function ImageOptionsTemplate({
           @click="${() => {
             if (!blob) return;
             abortController.abort();
-            openLeditsEditor(model, blob, root);
+            openLeditsEditor(model, blob, host);
           }}"
         >
           ${HighLightDuotoneIcon}

--- a/packages/blocks/src/_common/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/_common/widgets/image-toolbar/index.ts
@@ -22,7 +22,7 @@ export class AffineImageToolbarWidget extends WidgetElement<ImageBlockComponent>
           model: imageBlock.model,
           blob: imageBlock.blob,
           abortController,
-          root: this.blockElement.root,
+          host: this.blockElement.root,
         }),
         computePosition: {
           referenceElement: imageContainer,

--- a/packages/blocks/src/_common/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/_common/widgets/image-toolbar/index.ts
@@ -22,7 +22,7 @@ export class AffineImageToolbarWidget extends WidgetElement<ImageBlockComponent>
           model: imageBlock.model,
           blob: imageBlock.blob,
           abortController,
-          host: this.blockElement.root,
+          host: this.blockElement.host,
         }),
         computePosition: {
           referenceElement: imageContainer,

--- a/packages/blocks/src/_common/widgets/linked-page/index.ts
+++ b/packages/blocks/src/_common/widgets/linked-page/index.ts
@@ -112,13 +112,13 @@ export class AffineLinkedPageWidget extends WidgetElement {
     const eventState = ctx.get('keyboardState');
     const event = eventState.raw;
     if (isControlledKeyboardEvent(event) || event.key.length !== 1) return;
-    const text = this.root.selection.value.find(selection =>
+    const text = this.host.selection.value.find(selection =>
       selection.is('text')
     );
     if (!text) {
       return;
     }
-    const model = this.root.page.getBlockById(text.blockId);
+    const model = this.host.page.getBlockById(text.blockId);
     if (!model) {
       return;
     }

--- a/packages/blocks/src/_common/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/_common/widgets/slash-menu/config.ts
@@ -81,7 +81,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           action: ({ pageElement }) => {
             pageElement.root.std.command
               .pipe()
-              .withRoot()
+              .withHost()
               .tryAll(chain => [
                 chain.getTextSelection(),
                 chain.getBlockSelections(),
@@ -162,7 +162,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
         action: ({ pageElement }) => {
           pageElement.root.std.command
             .pipe()
-            .withRoot()
+            .withHost()
             .tryAll(chain => [
               chain.getTextSelection(),
               chain.getBlockSelections(),

--- a/packages/blocks/src/_common/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/_common/widgets/slash-menu/config.ts
@@ -79,7 +79,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
             return true;
           },
           action: ({ pageElement }) => {
-            pageElement.root.std.command
+            pageElement.host.std.command
               .pipe()
               .withHost()
               .tryAll(chain => [
@@ -160,7 +160,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           return true;
         },
         action: ({ pageElement }) => {
-          pageElement.root.std.command
+          pageElement.host.std.command
             .pipe()
             .withHost()
             .tryAll(chain => [
@@ -282,7 +282,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           if (!parent) {
             return;
           }
-          const url = await toggleBookmarkCreateModal(pageElement.root);
+          const url = await toggleBookmarkCreateModal(pageElement.host);
           if (!url) return;
           const props = {
             flavour: 'affine:bookmark',
@@ -306,7 +306,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           if (!parent) return;
           const file = await openFileOrFiles();
           if (!file) return;
-          const service = pageElement.root.spec.getService('affine:attachment');
+          const service = pageElement.host.spec.getService('affine:attachment');
           assertExists(service);
           assertInstanceOf(service, AttachmentService);
           const maxFileSize = service.maxFileSize;

--- a/packages/blocks/src/_common/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/_common/widgets/slash-menu/index.ts
@@ -121,13 +121,13 @@ export class AffineSlashMenuWidget extends WidgetElement {
     const event = eventState.raw;
     const triggerKey = this.options.isTriggerKey(event);
     if (triggerKey === false) return;
-    const text = this.root.selection.value.find(selection =>
+    const text = this.host.selection.value.find(selection =>
       selection.is('text')
     );
     if (!text) {
       return;
     }
-    const model = this.root.page.getBlockById(text.blockId);
+    const model = this.host.page.getBlockById(text.blockId);
     if (!model) {
       return;
     }

--- a/packages/blocks/src/_legacy/clipboard/edgeless-clipboard.ts
+++ b/packages/blocks/src/_legacy/clipboard/edgeless-clipboard.ts
@@ -177,7 +177,7 @@ export class EdgelessClipboard implements Clipboard {
     if (state.editing) {
       // use build-in cut handler in rich-text when cut in surface text element
       if (isCanvasElementWithText(elements[0])) return;
-      deleteModelsByTextSelection(this._edgeless.root);
+      deleteModelsByTextSelection(this._edgeless.host);
       return;
     }
 
@@ -203,7 +203,7 @@ export class EdgelessClipboard implements Clipboard {
     if (state.editing) {
       // use build-in copy handler in rich-text when copy in surface text element
       if (isCanvasElementWithText(elements[0])) return;
-      await copyBlocksInPage(this._edgeless.root);
+      await copyBlocksInPage(this._edgeless.host);
       return;
     }
     const data = await prepareClipboardData(elements);
@@ -258,7 +258,7 @@ export class EdgelessClipboard implements Clipboard {
 
   private async _pasteInTextNote(e: ClipboardEvent) {
     const attachmentService =
-      this._edgeless.root.spec.getService('affine:attachment');
+      this._edgeless.host.spec.getService('affine:attachment');
     assertExists(attachmentService);
     assertInstanceOf(attachmentService, AttachmentService);
     const maxFileSize = attachmentService.maxFileSize;
@@ -272,11 +272,11 @@ export class EdgelessClipboard implements Clipboard {
     }
     this._page.captureSync();
 
-    deleteModelsByTextSelection(this._edgeless.root);
+    deleteModelsByTextSelection(this._edgeless.host);
 
     const textSelection = this.textSelection;
     assertExists(textSelection);
-    const selectedModels = getSelectedContentModels(this._edgeless.root, [
+    const selectedModels = getSelectedContentModels(this._edgeless.host, [
       'text',
     ]);
 

--- a/packages/blocks/src/_legacy/clipboard/page-clipboard.ts
+++ b/packages/blocks/src/_legacy/clipboard/page-clipboard.ts
@@ -59,7 +59,7 @@ export class PageClipboard implements Clipboard {
 
     let blocks = [];
     const focusedBlockModel = deleteModelsByTextSelection(
-      this._ele.root,
+      this._ele.host,
       textSelection
     );
     // This assert is unreliable
@@ -69,7 +69,7 @@ export class PageClipboard implements Clipboard {
       blocks = await textedClipboardData2Blocks(this._page, e.clipboardData);
     } else {
       const attachmentService =
-        this._ele.root.spec.getService('affine:attachment');
+        this._ele.host.spec.getService('affine:attachment');
       assertExists(attachmentService);
       assertInstanceOf(attachmentService, AttachmentService);
       const maxFileSize = attachmentService.maxFileSize;
@@ -102,7 +102,7 @@ export class PageClipboard implements Clipboard {
   };
 
   private async _copyBlocksInPage() {
-    return await copyBlocksInPage(this._ele.root);
+    return await copyBlocksInPage(this._ele.host);
   }
 
   private _onCut = async (ctx: UIEventStateContext) => {
@@ -112,7 +112,7 @@ export class PageClipboard implements Clipboard {
     if (textSelection) {
       e.preventDefault();
       await this._onCopy(ctx);
-      deleteModelsByTextSelection(this._ele.root, textSelection);
+      deleteModelsByTextSelection(this._ele.host, textSelection);
       return;
     }
     const blockSelections = this._ele.selection.filter('block');

--- a/packages/blocks/src/_legacy/clipboard/utils/commons.ts
+++ b/packages/blocks/src/_legacy/clipboard/utils/commons.ts
@@ -189,13 +189,13 @@ async function createPageClipboardItems(
   return [textClipboardItem, htmlClipboardItem, pageClipboardItem];
 }
 
-export async function copyBlocksInPage(root: EditorHost) {
-  const selectedModels = getSelectedContentModels(root, [
+export async function copyBlocksInPage(host: EditorHost) {
+  const selectedModels = getSelectedContentModels(host, [
     'text',
     'block',
     'image',
   ]);
-  const textSelection = root.selection.find('text');
+  const textSelection = host.selection.find('text');
   const clipboardItems = await createPageClipboardItems(
     selectedModels,
     textSelection

--- a/packages/blocks/src/_legacy/clipboard/utils/commons.ts
+++ b/packages/blocks/src/_legacy/clipboard/utils/commons.ts
@@ -1,5 +1,5 @@
 import type { TextSelection } from '@blocksuite/block-std';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { BaseBlockModel, type Page } from '@blocksuite/store';
 
 import {
@@ -189,7 +189,7 @@ async function createPageClipboardItems(
   return [textClipboardItem, htmlClipboardItem, pageClipboardItem];
 }
 
-export async function copyBlocksInPage(root: BlockSuiteRoot) {
+export async function copyBlocksInPage(root: EditorHost) {
   const selectedModels = getSelectedContentModels(root, [
     'text',
     'block',

--- a/packages/blocks/src/_legacy/clipboard/utils/operation.ts
+++ b/packages/blocks/src/_legacy/clipboard/utils/operation.ts
@@ -1,11 +1,11 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 
 import { getVirgoByModel } from '../../../_common/utils/query.js';
 import { getSelectedContentModels } from '../../../page-block/utils/selection.js';
 
 export function deleteModelsByTextSelection(
-  root: BlockSuiteRoot,
+  root: EditorHost,
   textSelection = root.selection.find('text')
 ) {
   assertExists(textSelection);

--- a/packages/blocks/src/_legacy/clipboard/utils/operation.ts
+++ b/packages/blocks/src/_legacy/clipboard/utils/operation.ts
@@ -5,12 +5,12 @@ import { getVirgoByModel } from '../../../_common/utils/query.js';
 import { getSelectedContentModels } from '../../../page-block/utils/selection.js';
 
 export function deleteModelsByTextSelection(
-  root: EditorHost,
-  textSelection = root.selection.find('text')
+  host: EditorHost,
+  textSelection = host.selection.find('text')
 ) {
   assertExists(textSelection);
-  const page = root.page;
-  const selectedModels = getSelectedContentModels(root, ['text']);
+  const page = host.page;
+  const selectedModels = getSelectedContentModels(host, ['text']);
 
   if (selectedModels.length === 0) {
     return null;

--- a/packages/blocks/src/_legacy/service/json2block.ts
+++ b/packages/blocks/src/_legacy/service/json2block.ts
@@ -197,7 +197,7 @@ export async function json2block(
     if (lastMergedModel) {
       asyncGetBlockElementByModel(lastMergedModel).then(element => {
         if (element) {
-          const selectionManager = element.root.selection;
+          const selectionManager = element.host.selection;
           const blockSelection = selectionManager?.getInstance('block', {
             path: element.path ?? [],
           });

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -143,8 +143,8 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
 
           // If start dragging from the attachment element
           // Set selection and take over dragStart event to start dragging
-          this.root.selection.set([
-            this.root.selection.getInstance('block', {
+          this.host.selection.set([
+            this.host.selection.getInstance('block', {
               path: attachmentBlock.path,
             }),
           ]);
@@ -179,7 +179,7 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
   }
 
   private _focusAttachment() {
-    const selectionManager = this.root.selection;
+    const selectionManager = this.host.selection;
     const blockSelection = selectionManager.getInstance('block', {
       path: this.path,
     });

--- a/packages/blocks/src/attachment-block/attachment-service.ts
+++ b/packages/blocks/src/attachment-block/attachment-service.ts
@@ -24,7 +24,7 @@ export class AttachmentService extends BlockService<AttachmentBlockModel> {
     this.fileDropManager = new FileDropManager(this, this.fileDropRule);
 
     this.disposables.addFromEvent(
-      this.std.root,
+      this.std.host,
       'dragover',
       this.fileDropManager.onDragOver
     );

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -51,7 +51,7 @@ export class BookmarkBlockComponent extends BlockElement<BookmarkBlockModel> {
   }
 
   override render() {
-    const parent = this.root.page.getParent(this.model);
+    const parent = this.host.page.getParent(this.model);
     const isInSurface = parent?.flavour === 'affine:surface';
 
     if (isInSurface) {

--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -172,7 +172,7 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
   }
 
   private _onCardClick() {
-    const selectionManager = this.bookmark.root.selection;
+    const selectionManager = this.bookmark.host.selection;
     const blockSelection = selectionManager.getInstance('block', {
       path: this.bookmark.path,
     });

--- a/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-toolbar.ts
@@ -45,7 +45,7 @@ export class BookmarkToolbar extends WithDisposable(LitElement) {
   onSelected?: ToolbarActionCallback & MenuActionCallback;
 
   @property({ attribute: false })
-  root!: HTMLElement;
+  host!: HTMLElement;
 
   @property({ attribute: false })
   abortController!: AbortController;

--- a/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
@@ -96,9 +96,9 @@ export class BookmarkCreateModal extends WithDisposable(ShadowlessElement) {
 }
 
 export async function toggleBookmarkCreateModal(
-  root: EditorHost
+  host: EditorHost
 ): Promise<null | string> {
-  root.selection.clear();
+  host.selection.clear();
   const bookmarkCreateModal = new BookmarkCreateModal();
   return new Promise(resolve => {
     bookmarkCreateModal.onConfirm = url => {

--- a/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
@@ -1,4 +1,4 @@
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
@@ -96,7 +96,7 @@ export class BookmarkCreateModal extends WithDisposable(ShadowlessElement) {
 }
 
 export async function toggleBookmarkCreateModal(
-  root: BlockSuiteRoot
+  root: EditorHost
 ): Promise<null | string> {
   root.selection.clear();
   const bookmarkCreateModal = new BookmarkCreateModal();

--- a/packages/blocks/src/bookmark-block/components/modal/bookmark-edit-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/modal/bookmark-edit-modal.ts
@@ -108,7 +108,7 @@ export class BookmarkEditModal extends WithDisposable(ShadowlessElement) {
 }
 
 export function toggleBookmarkEditModal(bookmark: BookmarkBlockComponent) {
-  bookmark.root.selection.clear();
+  bookmark.host.selection.clear();
   const modal = new BookmarkEditModal();
   modal.bookmark = bookmark;
   document.body.appendChild(modal);

--- a/packages/blocks/src/bookmark-block/doc-bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/doc-bookmark-block.ts
@@ -33,7 +33,7 @@ export class DocBookmarkBlockComponent extends WithDisposable(
   }
 
   get root() {
-    return this.block.root;
+    return this.block.host;
   }
 
   override connectedCallback() {
@@ -97,7 +97,7 @@ export class DocBookmarkBlockComponent extends WithDisposable(
         <bookmark-toolbar
           .model=${this.model}
           .onSelected=${this._onToolbarSelected}
-          .root=${this}
+          .host=${this}
           .abortController=${abortController}
           .std=${this.block.std}
         ></bookmark-toolbar>`,

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -297,7 +297,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
     bindContainerHotkey(this);
 
-    const selectionManager = this.root.selection;
+    const selectionManager = this.host.selection;
     const INDENT_SYMBOL = '  ';
     const LINE_BREAK_SYMBOL = '\n';
     const allIndexOf = (

--- a/packages/blocks/src/database-block/common/datasource/all-page-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/all-page-datasource.ts
@@ -1,5 +1,5 @@
 import { assertExists, Slot } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Page, Workspace } from '@blocksuite/store';
 
 import type { InsertToPosition } from '../../types.js';
@@ -60,7 +60,7 @@ export class AllPageDatasource extends BaseDataSource {
     return Object.keys(this.propertiesMap);
   }
 
-  constructor(root: BlockSuiteRoot, _config: AllPageDatasourceConfig) {
+  constructor(root: EditorHost, _config: AllPageDatasourceConfig) {
     super();
     this.workspace = root.page.workspace;
     root.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);

--- a/packages/blocks/src/database-block/common/datasource/all-page-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/all-page-datasource.ts
@@ -60,10 +60,10 @@ export class AllPageDatasource extends BaseDataSource {
     return Object.keys(this.propertiesMap);
   }
 
-  constructor(root: EditorHost, _config: AllPageDatasourceConfig) {
+  constructor(host: EditorHost, _config: AllPageDatasourceConfig) {
     super();
-    this.workspace = root.page.workspace;
-    root.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);
+    this.workspace = host.page.workspace;
+    host.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);
   }
 
   public cellChangeValue(

--- a/packages/blocks/src/database-block/common/datasource/block-renderer.ts
+++ b/packages/blocks/src/database-block/common/datasource/block-renderer.ts
@@ -1,4 +1,4 @@
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import { css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -45,7 +45,7 @@ export class BlockRenderer
   public view!: DataViewTableManager | DataViewKanbanManager;
   @property({ attribute: false })
   public rowId!: string;
-  root?: BlockSuiteRoot;
+  root?: EditorHost;
 
   get model() {
     return this.root?.page.getBlockById(this.rowId);
@@ -53,7 +53,7 @@ export class BlockRenderer
 
   public override connectedCallback() {
     super.connectedCallback();
-    this.root = this.closest('block-suite-root') ?? undefined;
+    this.root = this.closest('editor-host') ?? undefined;
     this._disposables.addFromEvent(
       this,
       'keydown',

--- a/packages/blocks/src/database-block/common/datasource/database-block-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/database-block-datasource.ts
@@ -1,6 +1,6 @@
 import type { Disposable } from '@blocksuite/global/utils';
 import { assertExists, Slot } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { Text, type Y } from '@blocksuite/store';
 
@@ -35,7 +35,7 @@ export class DatabaseBlockDatasource extends BaseDataSource {
   }
 
   constructor(
-    private root: BlockSuiteRoot,
+    private root: EditorHost,
     config: DatabaseBlockDatasourceConfig
   ) {
     super();

--- a/packages/blocks/src/database-block/common/datasource/database-block-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/database-block-datasource.ts
@@ -35,11 +35,11 @@ export class DatabaseBlockDatasource extends BaseDataSource {
   }
 
   constructor(
-    private root: EditorHost,
+    private host: EditorHost,
     config: DatabaseBlockDatasourceConfig
   ) {
     super();
-    this._model = root.page.workspace
+    this._model = host.page.workspace
       .getPage(config.pageId)
       ?.getBlockById(config.blockId) as DatabaseBlockModel;
     this._model.childrenUpdated.pipe(this.slots.update);
@@ -125,7 +125,7 @@ export class DatabaseBlockDatasource extends BaseDataSource {
       const model = this.getModelById(rowId);
       if (model) {
         return {
-          result: this.root.renderModel(model),
+          result: this.host.renderModel(model),
           model,
         };
       }

--- a/packages/blocks/src/database-block/common/datasource/datasource-manager.ts
+++ b/packages/blocks/src/database-block/common/datasource/datasource-manager.ts
@@ -1,4 +1,4 @@
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 
 import type { DatabaseBlockModel } from '../../database-model.js';
 import { AllPageDatasource } from './all-page-datasource.js';
@@ -15,12 +15,12 @@ import { TagsDatasource } from './tags-datasource.js';
 
 const datasourceMap: {
   [K in DataSourceConfig['type']]: {
-    title: (root: BlockSuiteRoot, config: GetConfig<K>) => string;
-    constructor: new (root: BlockSuiteRoot, config: GetConfig<K>) => DataSource;
+    title: (root: EditorHost, config: GetConfig<K>) => string;
+    constructor: new (root: EditorHost, config: GetConfig<K>) => DataSource;
   };
 } = {
   'database-block': {
-    title: (root: BlockSuiteRoot, config: DatabaseBlockDatasourceConfig) => {
+    title: (root: EditorHost, config: DatabaseBlockDatasourceConfig) => {
       const dbblock = root.page.workspace
         .getPage(config.pageId)
         ?.getBlockById(config.blockId) as DatabaseBlockModel;
@@ -29,26 +29,26 @@ const datasourceMap: {
     constructor: DatabaseBlockDatasource,
   },
   'all-pages': {
-    title: (_root: BlockSuiteRoot, _config: AllPageDatasourceConfig) => {
+    title: (_root: EditorHost, _config: AllPageDatasourceConfig) => {
       return 'All Pages';
     },
     constructor: AllPageDatasource,
   },
   tags: {
-    title: (_root: BlockSuiteRoot, _config: TagsDatasourceConfig) => {
+    title: (_root: EditorHost, _config: TagsDatasourceConfig) => {
       return 'Tags';
     },
     constructor: TagsDatasource,
   },
 };
 export const createDatasource = (
-  root: BlockSuiteRoot,
+  root: EditorHost,
   config: DataSourceConfig
 ): DataSource => {
   return new datasourceMap[config.type].constructor(root, config as never);
 };
 export const getDatasourceTitle = (
-  root: BlockSuiteRoot,
+  root: EditorHost,
   config: DataSourceConfig
 ): string => {
   return datasourceMap[config.type].title(root, config as never);

--- a/packages/blocks/src/database-block/common/datasource/datasource-manager.ts
+++ b/packages/blocks/src/database-block/common/datasource/datasource-manager.ts
@@ -15,13 +15,13 @@ import { TagsDatasource } from './tags-datasource.js';
 
 const datasourceMap: {
   [K in DataSourceConfig['type']]: {
-    title: (root: EditorHost, config: GetConfig<K>) => string;
-    constructor: new (root: EditorHost, config: GetConfig<K>) => DataSource;
+    title: (host: EditorHost, config: GetConfig<K>) => string;
+    constructor: new (host: EditorHost, config: GetConfig<K>) => DataSource;
   };
 } = {
   'database-block': {
-    title: (root: EditorHost, config: DatabaseBlockDatasourceConfig) => {
-      const dbblock = root.page.workspace
+    title: (host: EditorHost, config: DatabaseBlockDatasourceConfig) => {
+      const dbblock = host.page.workspace
         .getPage(config.pageId)
         ?.getBlockById(config.blockId) as DatabaseBlockModel;
       return dbblock?.title.toString() ?? '';
@@ -29,27 +29,27 @@ const datasourceMap: {
     constructor: DatabaseBlockDatasource,
   },
   'all-pages': {
-    title: (_root: EditorHost, _config: AllPageDatasourceConfig) => {
+    title: (_host: EditorHost, _config: AllPageDatasourceConfig) => {
       return 'All Pages';
     },
     constructor: AllPageDatasource,
   },
   tags: {
-    title: (_root: EditorHost, _config: TagsDatasourceConfig) => {
+    title: (_host: EditorHost, _config: TagsDatasourceConfig) => {
       return 'Tags';
     },
     constructor: TagsDatasource,
   },
 };
 export const createDatasource = (
-  root: EditorHost,
+  host: EditorHost,
   config: DataSourceConfig
 ): DataSource => {
-  return new datasourceMap[config.type].constructor(root, config as never);
+  return new datasourceMap[config.type].constructor(host, config as never);
 };
 export const getDatasourceTitle = (
-  root: EditorHost,
+  host: EditorHost,
   config: DataSourceConfig
 ): string => {
-  return datasourceMap[config.type].title(root, config as never);
+  return datasourceMap[config.type].title(host, config as never);
 };

--- a/packages/blocks/src/database-block/common/datasource/tags-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/tags-datasource.ts
@@ -82,10 +82,10 @@ export class TagsDatasource extends BaseDataSource {
     return Object.keys(this.propertiesMap);
   }
 
-  constructor(root: EditorHost, _config: TagsDatasourceConfig) {
+  constructor(host: EditorHost, _config: TagsDatasourceConfig) {
     super();
-    this.meta = root.page.workspace.meta;
-    root.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);
+    this.meta = host.page.workspace.meta;
+    host.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);
   }
 
   public cellChangeValue(

--- a/packages/blocks/src/database-block/common/datasource/tags-datasource.ts
+++ b/packages/blocks/src/database-block/common/datasource/tags-datasource.ts
@@ -1,5 +1,5 @@
 import { assertExists, Slot } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Workspace } from '@blocksuite/store';
 import { nanoid } from '@blocksuite/store';
 
@@ -82,7 +82,7 @@ export class TagsDatasource extends BaseDataSource {
     return Object.keys(this.propertiesMap);
   }
 
-  constructor(root: BlockSuiteRoot, _config: TagsDatasourceConfig) {
+  constructor(root: EditorHost, _config: TagsDatasourceConfig) {
     super();
     this.meta = root.page.workspace.meta;
     root.page.workspace.meta.pageMetasUpdated.pipe(this.slots.update);

--- a/packages/blocks/src/database-block/common/header-area/text.ts
+++ b/packages/blocks/src/database-block/common/header-area/text.ts
@@ -284,7 +284,7 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
     }
 
     // TODO: replace this dom operation
-    const rootEl = document.querySelector('block-suite-root');
+    const rootEl = document.querySelector('editor-host');
     assertExists(rootEl);
     rootEl.std.clipboard.writeToClipboard(async items => {
       return {

--- a/packages/blocks/src/database-block/common/header/tools/expand/index.ts
+++ b/packages/blocks/src/database-block/common/header/tools/expand/index.ts
@@ -153,7 +153,7 @@ export class DatabaseBlockModalPreview extends WithDisposable(
 
   selectionUpdated: Slot<DataViewSelection | undefined> = new Slot();
   setSelection: (selection?: DataViewSelection) => void = selection => {
-    this.database.root.selection.set(
+    this.database.host.selection.set(
       selection
         ? [new DatabaseSelection({ path: this.path, viewSelection: selection })]
         : []
@@ -162,7 +162,7 @@ export class DatabaseBlockModalPreview extends WithDisposable(
   bindHotkey: (hotkeys: Record<string, UIEventHandler>) => Disposable =
     hotkeys => {
       return {
-        dispose: this.database.root.event.bindHotkey(hotkeys, {
+        dispose: this.database.host.event.bindHotkey(hotkeys, {
           path: [],
         }),
       };
@@ -172,7 +172,7 @@ export class DatabaseBlockModalPreview extends WithDisposable(
     handler
   ) => {
     return {
-      dispose: this.database.root.event.add(name, handler, {
+      dispose: this.database.host.event.add(name, handler, {
         path: [],
       }),
     };

--- a/packages/blocks/src/database-block/common/header/tools/expand/index.ts
+++ b/packages/blocks/src/database-block/common/header/tools/expand/index.ts
@@ -21,7 +21,7 @@ import { DatabaseSelection } from '../../../selection.js';
 export function showDatabasePreviewModal(database: DatabaseBlockComponent) {
   const viewComponent = new DatabaseBlockModalPreview();
   viewComponent.database = database;
-  const root = document.querySelector('block-suite-root');
+  const root = document.querySelector('editor-host');
   assertExists(root);
   const modal = createModal(root);
   const close = () => {

--- a/packages/blocks/src/database-block/common/header/tools/expand/table-full-screen-modal.ts
+++ b/packages/blocks/src/database-block/common/header/tools/expand/table-full-screen-modal.ts
@@ -28,7 +28,7 @@ export class DatabaseTableViewFullScreen extends BlockElement<DatabaseBlockModel
       <affine-database
         class="affine-block-element"
         .modalMode=${true}
-        .root=${this.root}
+        .host=${this.host}
         .model=${this.model}
       ></affine-database>
     `;

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -253,9 +253,9 @@ export class DatabaseBlockComponent extends BlockElement<DatabaseBlockModel> {
   private _dataSource?: DataSource;
   public get dataSource(): DataSource {
     if (!this._dataSource) {
-      this._dataSource = new DatabaseBlockDatasource(this.root, {
+      this._dataSource = new DatabaseBlockDatasource(this.host, {
         type: 'database-block',
-        pageId: this.root.page.id,
+        pageId: this.host.page.id,
         blockId: this.model.id,
       });
     }
@@ -329,21 +329,21 @@ export class DatabaseBlockComponent extends BlockElement<DatabaseBlockModel> {
   selectionUpdated = new Slot<DataViewSelection | undefined>();
 
   get getFlag() {
-    return this.root.page.awarenessStore.getFlag.bind(
-      this.root.page.awarenessStore
+    return this.host.page.awarenessStore.getFlag.bind(
+      this.host.page.awarenessStore
     );
   }
 
   _bindHotkey: DataViewProps['bindHotkey'] = hotkeys => {
     return {
-      dispose: this.root.event.bindHotkey(hotkeys, {
+      dispose: this.host.event.bindHotkey(hotkeys, {
         path: this.path,
       }),
     };
   };
   _handleEvent: DataViewProps['handleEvent'] = (name, handler) => {
     return {
-      dispose: this.root.event.add(name, handler, {
+      dispose: this.host.event.add(name, handler, {
         path: this.path,
       }),
     };

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -30,8 +30,8 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
     super.connectedCallback();
 
     this.handleEvent('click', () => {
-      this.root.selection.set([
-        this.root.selection.getInstance('block', {
+      this.host.selection.set([
+        this.host.selection.getInstance('block', {
           path: this.path,
         }),
       ]);

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -36,7 +36,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
 
   override connectedCallback() {
     super.connectedCallback();
-    const parent = this.root.page.getParent(this.model);
+    const parent = this.host.page.getParent(this.model);
     this._isInSurface = parent?.flavour === 'affine:surface';
   }
 
@@ -53,14 +53,14 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
       return html`<affine-edgeless-image
         .model=${this.model}
         .page=${this.page}
-        .root=${this.root}
+        .host=${this.host}
         .widgets=${this.widgets}
       ></affine-edgeless-image>`;
     } else {
       return html`<affine-page-image
         .model=${this.model}
         .page=${this.page}
-        .root=${this.root}
+        .host=${this.host}
         .widgets=${this.widgets}
       ></affine-page-image>`;
     }
@@ -286,8 +286,8 @@ export class ImageBlockPageComponent extends ImageBlock {
           if (!imageBlock || shouldResizeImage(imageBlock, target))
             return false;
 
-          this.root.selection.set([
-            this.root.selection.getInstance('block', {
+          this.host.selection.set([
+            this.host.selection.getInstance('block', {
               path: imageBlock.path,
             }),
           ]);
@@ -313,7 +313,7 @@ export class ImageBlockPageComponent extends ImageBlock {
     const embedResizeManager = new ImageResizeManager();
 
     this._disposables.add(
-      this.root.event.add('dragStart', ctx => {
+      this.host.event.add('dragStart', ctx => {
         const pointerState = ctx.get('pointerState');
         const target = pointerState.event.target;
         if (shouldResizeImage(this, target)) {
@@ -325,7 +325,7 @@ export class ImageBlockPageComponent extends ImageBlock {
       })
     );
     this._disposables.add(
-      this.root.event.add('dragMove', ctx => {
+      this.host.event.add('dragMove', ctx => {
         const pointerState = ctx.get('pointerState');
         if (this._isDragging) {
           embedResizeManager.onMove(pointerState);
@@ -335,7 +335,7 @@ export class ImageBlockPageComponent extends ImageBlock {
       })
     );
     this._disposables.add(
-      this.root.event.add('dragEnd', () => {
+      this.host.event.add('dragEnd', () => {
         if (this._isDragging) {
           this._isDragging = false;
           embedResizeManager.onEnd();
@@ -347,7 +347,7 @@ export class ImageBlockPageComponent extends ImageBlock {
   }
 
   private _handleSelection() {
-    const selection = this.root.selection;
+    const selection = this.host.selection;
     this._disposables.add(
       selection.slots.changed.on(selList => {
         const curr = selList.find(
@@ -388,7 +388,7 @@ export class ImageBlockPageComponent extends ImageBlock {
   }
 
   private _bindKeymap() {
-    const selection = this.root.selection;
+    const selection = this.host.selection;
     const addParagraph = () => {
       const parent = this.page.getParent(this.model);
       if (!parent) return;

--- a/packages/blocks/src/image-block/ledits/main.ts
+++ b/packages/blocks/src/image-block/ledits/main.ts
@@ -1,6 +1,6 @@
 // FIXME: this should be move to more appropriate place after extension system has completed
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 
 import type {
   AffineModalWidget,
@@ -15,7 +15,7 @@ function createGradioApp() {
   return app;
 }
 
-function getPageElement(root: BlockSuiteRoot) {
+function getPageElement(root: EditorHost) {
   assertExists(root.page.root?.id);
 
   const page = root.view.viewFromPath('block', [
@@ -28,7 +28,7 @@ function getPageElement(root: BlockSuiteRoot) {
 export function openLeditsEditor(
   model: ImageBlockModel,
   blob: Blob,
-  root: BlockSuiteRoot
+  root: EditorHost
 ) {
   const pageElement = getPageElement(root);
   const app = createGradioApp();

--- a/packages/blocks/src/image-block/ledits/main.ts
+++ b/packages/blocks/src/image-block/ledits/main.ts
@@ -15,11 +15,11 @@ function createGradioApp() {
   return app;
 }
 
-function getPageElement(root: EditorHost) {
-  assertExists(root.page.root?.id);
+function getPageElement(host: EditorHost) {
+  assertExists(host.page.root?.id);
 
-  const page = root.view.viewFromPath('block', [
-    root.page.root.id,
+  const page = host.view.viewFromPath('block', [
+    host.page.root.id,
   ]) as DocPageBlockComponent;
 
   return page;
@@ -28,9 +28,9 @@ function getPageElement(root: EditorHost) {
 export function openLeditsEditor(
   model: ImageBlockModel,
   blob: Blob,
-  root: EditorHost
+  host: EditorHost
 ) {
-  const pageElement = getPageElement(root);
+  const pageElement = getPageElement(host);
   const app = createGradioApp();
   const modal = (
     pageElement.widgetElements['affine-modal-widget'] as AffineModalWidget

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -30,7 +30,7 @@ export class ListBlockComponent extends BlockElement<ListBlockModel> {
   private _isCollapsedWhenReadOnly = !!this.model?.collapsed ?? false;
 
   private _select() {
-    const selection = this.root.selection;
+    const selection = this.host.selection;
     selection.update(selList => {
       return selList
         .filter(sel => !sel.is('text') && !sel.is('block'))

--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -655,10 +655,10 @@ export class KeymapController implements ReactiveController {
       if (!config.hotkey) return;
       this.host.bindHotKey({
         [config.hotkey]: ctx => {
-          if (!config.showWhen(this.host.root)) return;
+          if (!config.showWhen(this.host.host)) return;
 
           ctx.get('defaultState').event.preventDefault();
-          config.action(this.host.root);
+          config.action(this.host.host);
         },
       });
     });

--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -675,7 +675,7 @@ export class KeymapController implements ReactiveController {
 
             return this._std.command
               .pipe()
-              .withRoot()
+              .withHost()
               .tryAll(chain => [
                 chain.getTextSelection(),
                 chain.getBlockSelections(),

--- a/packages/blocks/src/page-block/clipboard/index.ts
+++ b/packages/blocks/src/page-block/clipboard/index.ts
@@ -105,7 +105,7 @@ export class ClipboardController implements ReactiveController {
   private _copySelected = (event: ClipboardEvent, onCopy?: () => void) => {
     return this._std.command
       .pipe()
-      .withRoot()
+      .withHost()
       .with({ onCopy })
       .getSelectedModels()
       .copySelectedModels({ event });
@@ -125,7 +125,7 @@ export class ClipboardController implements ReactiveController {
     this._copySelected(e, () => {
       this._std.command
         .pipe()
-        .withRoot()
+        .withHost()
         .try(cmd => [
           cmd.getTextSelection().deleteText(),
           cmd.getBlockSelections().deleteSelectedModels(),

--- a/packages/blocks/src/page-block/clipboard/middlewares/copy.ts
+++ b/packages/blocks/src/page-block/clipboard/middlewares/copy.ts
@@ -1,6 +1,6 @@
 import type { TextRangePoint } from '@blocksuite/block-std';
 import { PathFinder } from '@blocksuite/block-std';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type {
   BaseBlockModel,
   BlockSnapshot,
@@ -21,7 +21,7 @@ const handlePoint = (
     model.text?.sliceToDelta(index, length + index);
 };
 
-const sliceText = (slots: JobSlots, std: BlockSuiteRoot['std']) => {
+const sliceText = (slots: JobSlots, std: EditorHost['std']) => {
   slots.afterExport.on(payload => {
     if (payload.type === 'block') {
       const snapshot = payload.snapshot;
@@ -40,7 +40,7 @@ const sliceText = (slots: JobSlots, std: BlockSuiteRoot['std']) => {
   });
 };
 
-export const copyMiddleware = (std: BlockSuiteRoot['std']): JobMiddleware => {
+export const copyMiddleware = (std: EditorHost['std']): JobMiddleware => {
   return ({ slots }) => {
     sliceText(slots, std);
   };

--- a/packages/blocks/src/page-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/page-block/clipboard/middlewares/paste.ts
@@ -5,7 +5,7 @@ import type {
 } from '@blocksuite/block-std';
 import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement, BlockSuiteRoot } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import type {
   BaseBlockModel,
   BlockSnapshot,
@@ -29,7 +29,7 @@ class PointState {
   readonly text: Text;
   readonly model: BaseBlockModel;
   constructor(
-    readonly std: BlockSuiteRoot['std'],
+    readonly std: EditorHost['std'],
     readonly point: TextRangePoint
   ) {
     this.block = this._blockFromPath(point.path);
@@ -54,7 +54,7 @@ class PasteTr {
   private readonly lastSnapshot: BlockSnapshot;
   private readonly lastIndex: number;
   constructor(
-    public readonly std: BlockSuiteRoot['std'],
+    public readonly std: EditorHost['std'],
     public readonly text: TextSelection,
     public readonly snapshot: SliceSnapshot
   ) {
@@ -215,7 +215,7 @@ function flatNote(snapshot: SliceSnapshot) {
   }
 }
 
-export const pasteMiddleware = (std: BlockSuiteRoot['std']): JobMiddleware => {
+export const pasteMiddleware = (std: EditorHost['std']): JobMiddleware => {
   return ({ slots }) => {
     let tr: PasteTr | undefined;
     slots.beforeImport.on(payload => {

--- a/packages/blocks/src/page-block/commands/block-crud/get-selected-blocks.ts
+++ b/packages/blocks/src/page-block/commands/block-crud/get-selected-blocks.ts
@@ -12,7 +12,7 @@ export const getSelectedBlocksCommand: Command<
   | 'currentTextSelection'
   | 'currentBlockSelections'
   | 'currentImageSelections'
-  | 'root',
+  | 'host',
   'selectedBlocks',
   {
     textSelection?: TextSelection;
@@ -22,17 +22,17 @@ export const getSelectedBlocksCommand: Command<
     types: Extract<BlockSuite.SelectionType, 'block' | 'text' | 'image'>[];
   }
 > = (ctx, next) => {
-  const { root, types } = ctx;
+  const { host, types } = ctx;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
 
   let dirtyResult: BlockElement[] = [];
 
   const textSelection = ctx.textSelection ?? ctx.currentTextSelection;
   if (types.includes('text') && textSelection) {
-    const rangeManager = root.rangeManager;
+    const rangeManager = host.rangeManager;
     assertExists(rangeManager);
     const range = rangeManager.textSelectionToRange(textSelection);
     if (!range) return;
@@ -49,7 +49,7 @@ export const getSelectedBlocksCommand: Command<
 
   const blockSelections = ctx.blockSelections ?? ctx.currentBlockSelections;
   if (types.includes('block') && blockSelections) {
-    const viewStore = root.view;
+    const viewStore = host.view;
     const selectedBlockElements = blockSelections.flatMap(selection => {
       const el = viewStore.viewFromPath('block', selection.path);
       return el ?? [];
@@ -59,7 +59,7 @@ export const getSelectedBlocksCommand: Command<
 
   const imageSelections = ctx.imageSelections ?? ctx.currentImageSelections;
   if (types.includes('image') && imageSelections) {
-    const viewStore = root.view;
+    const viewStore = host.view;
     const selectedBlockElements = imageSelections.flatMap(selection => {
       const el = viewStore.viewFromPath('block', selection.path);
       return el ?? [];

--- a/packages/blocks/src/page-block/commands/model-crud/get-selected-models.ts
+++ b/packages/blocks/src/page-block/commands/model-crud/get-selected-models.ts
@@ -5,7 +5,7 @@ import type { BaseBlockModel } from '@blocksuite/store';
 import { getSelectedContentModels } from '../../utils/index.js';
 
 export const getSelectedModelsCommand: Command<
-  'root',
+  'host',
   'selectedModels',
   {
     selectionType?: Extract<
@@ -14,14 +14,14 @@ export const getSelectedModelsCommand: Command<
     >[];
   }
 > = (ctx, next) => {
-  const { root } = ctx;
+  const { host } = ctx;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
 
   const selectionType = ctx.selectionType ?? ['block', 'text', 'image'];
-  const selectedModels = getSelectedContentModels(root, selectionType);
+  const selectedModels = getSelectedContentModels(host, selectionType);
 
   next({ selectedModels });
 };

--- a/packages/blocks/src/page-block/commands/text-crud/delete-text.ts
+++ b/packages/blocks/src/page-block/commands/text-crud/delete-text.ts
@@ -3,7 +3,7 @@ import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 
 export const deleteTextCommand: Command<
-  'currentTextSelection' | 'root',
+  'currentTextSelection' | 'host',
   never,
   {
     textSelection?: TextSelection;
@@ -15,16 +15,16 @@ export const deleteTextCommand: Command<
     '`textSelection` is required, you need to pass it in args or use `getTextSelection` command before adding this command to the pipeline.'
   );
 
-  const root = ctx.root;
+  const host = ctx.host;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
-  assertExists(root.rangeManager);
+  assertExists(host.rangeManager);
 
-  const range = root.rangeManager.textSelectionToRange(textSelection);
+  const range = host.rangeManager.textSelectionToRange(textSelection);
   if (!range) return;
-  const selectedElements = root.rangeManager.getSelectedBlockElementsByRange(
+  const selectedElements = host.rangeManager.getSelectedBlockElementsByRange(
     range,
     {
       mode: 'flat',

--- a/packages/blocks/src/page-block/commands/text-crud/format-block.ts
+++ b/packages/blocks/src/page-block/commands/text-crud/format-block.ts
@@ -8,7 +8,7 @@ import type { Flavour } from '../../../models.js';
 
 // for block selection
 export const formatBlockCommand: Command<
-  'currentBlockSelections' | 'root',
+  'currentBlockSelections' | 'host',
   never,
   {
     blockSelections?: BlockSelection[];
@@ -22,10 +22,10 @@ export const formatBlockCommand: Command<
     '`blockSelections` is required, you need to pass it in args or use `getBlockSelections` command before adding this command to the pipeline.'
   );
 
-  const root = ctx.root;
+  const host = ctx.host;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
 
   if (blockSelections.length === 0) return;
@@ -33,9 +33,9 @@ export const formatBlockCommand: Command<
   const styles = ctx.styles;
   const mode = ctx.mode ?? 'merge';
 
-  const success = root.std.command
+  const success = host.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .getSelectedBlocks({
       blockSelections,
       filter: el =>

--- a/packages/blocks/src/page-block/commands/text-crud/format-native.ts
+++ b/packages/blocks/src/page-block/commands/text-crud/format-native.ts
@@ -10,7 +10,7 @@ import type { Flavour } from '../../../models.js';
 
 // for native range
 export const formatNativeCommand: Command<
-  'root',
+  'host',
   never,
   {
     range?: Range;
@@ -18,10 +18,10 @@ export const formatNativeCommand: Command<
     mode?: 'replace' | 'merge';
   }
 > = (ctx, next) => {
-  const { root, styles, mode = 'merge' } = ctx;
+  const { host, styles, mode = 'merge' } = ctx;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
 
   let range = ctx.range;
@@ -33,7 +33,7 @@ export const formatNativeCommand: Command<
   if (!range) return;
 
   const selectedVEditors = Array.from<VirgoRootElement>(
-    root.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
+    host.querySelectorAll(`[${VIRGO_ROOT_ATTR}]`)
   )
     .filter(el => range?.intersectsNode(el))
     .filter(el => {

--- a/packages/blocks/src/page-block/commands/text-crud/format-text.ts
+++ b/packages/blocks/src/page-block/commands/text-crud/format-text.ts
@@ -9,7 +9,7 @@ import type { Flavour } from '../../../models.js';
 
 // for text selection
 export const formatTextCommand: Command<
-  'currentTextSelection' | 'root',
+  'currentTextSelection' | 'host',
   never,
   {
     textSelection?: TextSelection;
@@ -17,10 +17,10 @@ export const formatTextCommand: Command<
     mode?: 'replace' | 'merge';
   }
 > = (ctx, next) => {
-  const { root, styles, mode = 'merge' } = ctx;
+  const { host, styles, mode = 'merge' } = ctx;
   assertExists(
-    root,
-    '`root` is required, you need to use `withRoot` command before adding this command to the pipeline.'
+    host,
+    '`host` is required, you need to use `withHost` command before adding this command to the pipeline.'
   );
 
   const textSelection = ctx.textSelection ?? ctx.currentTextSelection;
@@ -29,9 +29,9 @@ export const formatTextCommand: Command<
     '`textSelection` is required, you need to pass it in args or use `getTextSelection` command before adding this command to the pipeline.'
   );
 
-  const success = root.std.command
+  const success = host.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .getSelectedBlocks({
       textSelection,
       filter: el =>
@@ -88,7 +88,7 @@ export const formatTextCommand: Command<
       });
 
       Promise.all(selectedBlocks.map(el => el.updateComplete)).then(() => {
-        root.rangeManager?.syncTextSelectionToRange(textSelection);
+        host.rangeManager?.syncTextSelectionToRange(textSelection);
       });
 
       next();

--- a/packages/blocks/src/page-block/commands/with-root.ts
+++ b/packages/blocks/src/page-block/commands/with-root.ts
@@ -1,10 +1,10 @@
 import type { Command } from '@blocksuite/block-std';
 import { assertInstanceOf } from '@blocksuite/global/utils';
-import { BlockSuiteRoot } from '@blocksuite/lit';
+import { EditorHost } from '@blocksuite/lit';
 
 export const withRootCommand: Command<never, 'root'> = (ctx, next) => {
   const root = ctx.std.root;
-  assertInstanceOf(root, BlockSuiteRoot);
+  assertInstanceOf(root, EditorHost);
 
   next({ root });
 };
@@ -12,7 +12,7 @@ export const withRootCommand: Command<never, 'root'> = (ctx, next) => {
 declare global {
   namespace BlockSuite {
     interface CommandData {
-      root?: BlockSuiteRoot;
+      root?: EditorHost;
     }
 
     interface Commands {

--- a/packages/blocks/src/page-block/commands/with-root.ts
+++ b/packages/blocks/src/page-block/commands/with-root.ts
@@ -2,21 +2,21 @@ import type { Command } from '@blocksuite/block-std';
 import { assertInstanceOf } from '@blocksuite/global/utils';
 import { EditorHost } from '@blocksuite/lit';
 
-export const withRootCommand: Command<never, 'root'> = (ctx, next) => {
-  const root = ctx.std.root;
-  assertInstanceOf(root, EditorHost);
+export const withHostCommand: Command<never, 'host'> = (ctx, next) => {
+  const host = ctx.std.host;
+  assertInstanceOf(host, EditorHost);
 
-  next({ root });
+  next({ host });
 };
 
 declare global {
   namespace BlockSuite {
     interface CommandData {
-      root?: EditorHost;
+      host?: EditorHost;
     }
 
     interface Commands {
-      withRoot: typeof withRootCommand;
+      withHost: typeof withHostCommand;
     }
   }
 }

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -379,7 +379,7 @@ export class DocPageBlockComponent extends BlockElement<
   override connectedCallback() {
     super.connectedCallback();
 
-    this.root.rangeManager?.rangeSynchronizer.setFilter(pageRangeSyncFilter);
+    this.host.rangeManager?.rangeSynchronizer.setFilter(pageRangeSyncFilter);
 
     this.gesture = new Gesture(this);
     this.keyboardManager = new PageKeyboardManager(this);
@@ -406,8 +406,8 @@ export class DocPageBlockComponent extends BlockElement<
 
     this.bindHotKey({
       ArrowUp: () => {
-        const view = this.root.view;
-        const selection = this.root.selection;
+        const view = this.host.view;
+        const selection = this.host.selection;
         const sel = selection.value.find(
           sel => sel.is('text') || sel.is('block')
         );
@@ -467,8 +467,8 @@ export class DocPageBlockComponent extends BlockElement<
         return true;
       },
       ArrowDown: () => {
-        const view = this.root.view;
-        const selection = this.root.selection;
+        const view = this.host.view;
+        const selection = this.host.selection;
         const sel = selection.value.find(
           sel => sel.is('text') || sel.is('block')
         );
@@ -571,8 +571,8 @@ export class DocPageBlockComponent extends BlockElement<
       }
 
       requestAnimationFrame(() => {
-        this.root.selection.setGroup('note', [
-          this.root.selection.getInstance('text', {
+        this.host.selection.setGroup('note', [
+          this.host.selection.getInstance('text', {
             from: {
               path: [this.model.id, noteId, paragraphId],
               index,

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -21,7 +21,7 @@ export class EdgelessPortalBase<
   edgeless!: EdgelessPageBlockComponent;
 
   protected renderModel(model: T) {
-    return this.surface.root.renderModel(this.surface.unwrap(model));
+    return this.surface.host.renderModel(this.surface.unwrap(model));
   }
 
   override connectedCallback(): void {

--- a/packages/blocks/src/page-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/page-block/edgeless/components/frame/frame-preview.ts
@@ -3,7 +3,7 @@ import {
   type Disposable,
   DisposableGroup,
 } from '@blocksuite/global/utils';
-import { type BlockSuiteRoot, WithDisposable } from '@blocksuite/lit';
+import { type EditorHost, WithDisposable } from '@blocksuite/lit';
 import type { Page, Y } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -93,7 +93,7 @@ export class FramePreview extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   surfaceWidth: number = DEFAULT_PREVIEW_CONTAINER_WIDTH;

--- a/packages/blocks/src/page-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/page-block/edgeless/components/frame/frame-preview.ts
@@ -93,7 +93,7 @@ export class FramePreview extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   @property({ attribute: false })
   surfaceWidth: number = DEFAULT_PREVIEW_CONTAINER_WIDTH;
@@ -386,8 +386,8 @@ export class FramePreview extends WithDisposable(LitElement) {
   }
 
   private _getCSSPropertyValue = (value: string) => {
-    const root = this.root;
-    this.root.updateComplete.then(() => {});
+    const root = this.host;
+    this.host.updateComplete.then(() => {});
     if (isCssVariable(value)) {
       const cssValue = getThemePropertyValue(root, value as CssVariableName);
       if (cssValue === undefined) {
@@ -509,9 +509,9 @@ export class FramePreview extends WithDisposable(LitElement) {
       >
         <surface-ref-portal
           .page=${this.page}
-          .root=${this.root}
+          .host=${this.host}
           .containerModel=${referencedModel}
-          .renderModel=${this.root.renderModel}
+          .renderModel=${this.host.renderModel}
         ></surface-ref-portal>
         <div class="surface-canvas-container">
           <!-- attach canvas here -->

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
@@ -109,7 +109,7 @@ export class EdgelessNoteMenu extends WithDisposable(LitElement) {
               .iconContainerPadding=${2}
               .tooltip=${'bookmark'}
               @click=${async () => {
-                const url = await toggleBookmarkCreateModal(this.edgeless.root);
+                const url = await toggleBookmarkCreateModal(this.edgeless.host);
                 if (!url) return;
 
                 const center = Vec.toVec(this.edgeless.surface.viewport.center);

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -260,7 +260,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
   get editorContainer(): EdtitorContainer {
     if (this._editorContainer) return this._editorContainer;
-    this._editorContainer = this.closest('editor-container');
+    this._editorContainer = this.closest('affine-editor-container');
     assertExists(this._editorContainer);
     return this._editorContainer;
   }
@@ -402,7 +402,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
   }
 
   /**
-   * Adds a new note with the given point on the editor-container.
+   * Adds a new note with the given point on the affine-editor-container.
    *
    * @param: point Point
    * @returns: The id of new note

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -896,13 +896,13 @@ export class EdgelessPageBlockComponent extends BlockElement<
   override connectedCallback() {
     super.connectedCallback();
     this._updateFrames();
-    this.root.rangeManager?.rangeSynchronizer.setFilter(pageRangeSyncFilter);
+    this.host.rangeManager?.rangeSynchronizer.setFilter(pageRangeSyncFilter);
 
     this.gesture = new Gesture(this);
     this.keyboardManager = new EdgelessPageKeyboardManager(this);
 
     this.handleEvent('selectionChange', () => {
-      const surface = this.root.selection.value.find(
+      const surface = this.host.selection.value.find(
         (sel): sel is SurfaceSelection => sel.is('surface')
       );
       if (!surface) return;
@@ -918,7 +918,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.mouseRoot = this.parentElement!;
     this.selectionManager = new EdgelessSelectionManager(this);
-    this.tools = new EdgelessToolsManager(this, this.root.event);
+    this.tools = new EdgelessToolsManager(this, this.host.event);
     this._initLocalRecordManager();
   }
 

--- a/packages/blocks/src/page-block/edgeless/services/selection-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/selection-manager.ts
@@ -89,7 +89,7 @@ export class EdgelessSelectionManager {
   }
 
   private get _selection() {
-    return this.container.root.selection;
+    return this.container.host.selection;
   }
 
   private _setState(selection: SurfaceSelection) {

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -347,7 +347,7 @@ export class EdgelessToolsManager {
     e.event.preventDefault();
     const pointerEventState = new PointerEventState({
       event: e.event as PointerEvent,
-      rect: this.dispatcher.root.getBoundingClientRect(),
+      rect: this.dispatcher.host.getBoundingClientRect(),
       startX: 0,
       startY: 0,
       last: null,

--- a/packages/blocks/src/page-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/page-block/keyboard/keyboard-manager.ts
@@ -47,7 +47,7 @@ export class PageKeyboardManager {
   }
 
   private get _selection() {
-    return this.pageElement.root.selection;
+    return this.pageElement.host.selection;
   }
 
   private get _currentSelection() {
@@ -100,7 +100,7 @@ export class PageKeyboardManager {
   ) {
     const current = selections[0];
     const first = this._page.getBlockById(current.blockId);
-    const firstElement = this.pageElement.root.view.viewFromPath(
+    const firstElement = this.pageElement.host.view.viewFromPath(
       'block',
       current.path
     );

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -42,7 +42,7 @@ export class PageService extends BlockService<PageBlockModel> {
       .add('formatBlock', formatBlockCommand)
       .add('formatNative', formatNativeCommand)
       .add('formatText', formatTextCommand)
-      .add('withRoot', withHostCommand);
+      .add('withHost', withHostCommand);
 
     this.loadFonts();
   }

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -16,7 +16,7 @@ import {
   getSelectedBlocksCommand,
   getSelectedModelsCommand,
   getTextSelectionCommand,
-  withRootCommand,
+  withHostCommand,
 } from './commands/index.js';
 import { FontLoader } from './font-loader/font-loader.js';
 import type { PageBlockModel } from './page-model.js';
@@ -42,7 +42,7 @@ export class PageService extends BlockService<PageBlockModel> {
       .add('formatBlock', formatBlockCommand)
       .add('formatNative', formatNativeCommand)
       .add('formatText', formatTextCommand)
-      .add('withRoot', withRootCommand);
+      .add('withRoot', withHostCommand);
 
     this.loadFonts();
   }

--- a/packages/blocks/src/page-block/text-selection/gesture.ts
+++ b/packages/blocks/src/page-block/text-selection/gesture.ts
@@ -25,7 +25,7 @@ export class Gesture {
   private _rafID = 0;
 
   private get _selectionManager() {
-    return this.pageElement.root.selection;
+    return this.pageElement.host.selection;
   }
 
   private get _viewportElement() {
@@ -36,8 +36,8 @@ export class Gesture {
   }
 
   private get _rangeManager() {
-    assertExists(this.pageElement.root.rangeManager);
-    return this.pageElement.root.rangeManager;
+    assertExists(this.pageElement.host.rangeManager);
+    return this.pageElement.host.rangeManager;
   }
 
   constructor(public pageElement: PageBlockComponent) {

--- a/packages/blocks/src/page-block/utils/operations/element/block-level.ts
+++ b/packages/blocks/src/page-block/utils/operations/element/block-level.ts
@@ -18,7 +18,7 @@ export function updateBlockElementType(
   if (blockElements.length === 0) {
     return [];
   }
-  const root = blockElements[0].root;
+  const root = blockElements[0].host;
   const page = blockElements[0].page;
   const hasSamePage = blockElements.every(block => block.page === page);
   if (!hasSamePage) {

--- a/packages/blocks/src/page-block/utils/selection.ts
+++ b/packages/blocks/src/page-block/utils/selection.ts
@@ -1,9 +1,9 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { type BaseBlockModel } from '@blocksuite/store';
 
 export function getSelectedContentModels(
-  root: BlockSuiteRoot,
+  root: EditorHost,
   types: Extract<BlockSuite.SelectionType, 'block' | 'text' | 'image'>[]
 ): BaseBlockModel[] {
   const result: BaseBlockModel[] = [];

--- a/packages/blocks/src/page-block/utils/selection.ts
+++ b/packages/blocks/src/page-block/utils/selection.ts
@@ -3,11 +3,11 @@ import type { EditorHost } from '@blocksuite/lit';
 import { type BaseBlockModel } from '@blocksuite/store';
 
 export function getSelectedContentModels(
-  root: EditorHost,
+  host: EditorHost,
   types: Extract<BlockSuite.SelectionType, 'block' | 'text' | 'image'>[]
 ): BaseBlockModel[] {
   const result: BaseBlockModel[] = [];
-  root.std.command
+  host.std.command
     .pipe()
     .withHost()
     .tryAll(chain => [

--- a/packages/blocks/src/page-block/utils/selection.ts
+++ b/packages/blocks/src/page-block/utils/selection.ts
@@ -9,7 +9,7 @@ export function getSelectedContentModels(
   const result: BaseBlockModel[] = [];
   root.std.command
     .pipe()
-    .withRoot()
+    .withHost()
     .tryAll(chain => [
       chain.getTextSelection(),
       chain.getBlockSelections(),

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -178,7 +178,7 @@ export class SurfaceBlockComponent extends BlockElement<
   }
 
   private get _isEdgeless() {
-    return !!this.root.querySelector('affine-edgeless-page');
+    return !!this.host.querySelector('affine-edgeless-page');
   }
 
   getBlocks<T extends EdgelessBlockType>(
@@ -260,7 +260,7 @@ export class SurfaceBlockComponent extends BlockElement<
   }
 
   getCSSPropertyValue = (value: string) => {
-    const root = this.root;
+    const root = this.host;
     if (isCssVariable(value)) {
       const cssValue = getThemePropertyValue(root, value as CssVariableName);
       if (cssValue === undefined) {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -306,7 +306,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
   }
 
   private _initHotkey() {
-    const selection = this.root.selection;
+    const selection = this.host.selection;
     const addParagraph = () => {
       if (!this.page.getParent(this.model)) return;
 
@@ -459,7 +459,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
   }
 
   private _initSelection() {
-    const selection = this.root.selection;
+    const selection = this.host.selection;
     this._disposables.add(
       selection.slots.changed.on(selList => {
         this._focused = selList.some(
@@ -622,7 +622,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
   };
 
   private _getCSSPropertyValue = (value: string) => {
-    const root = this.root;
+    const root = this.host;
     if (isCssVariable(value)) {
       const cssValue = getThemePropertyValue(root, value as CssVariableName);
       if (cssValue === undefined) {
@@ -727,7 +727,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
         ${flavourOrType === 'affine:frame' || flavourOrType === 'group'
           ? html`<surface-ref-portal
               .page=${this.page}
-              .root=${this.root}
+              .host=${this.host}
               .containerModel=${referencedModel}
               .renderModel=${this.renderModel}
             ></surface-ref-portal>`
@@ -815,7 +815,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
 
   private _shouldRender() {
     return (
-      !!this.root.querySelector('affine-doc-page') &&
+      !!this.host.querySelector('affine-doc-page') &&
       this.parentElement &&
       !this.parentElement.closest('affine-surface-ref')
     );

--- a/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
@@ -36,7 +36,7 @@ export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
   `;
 
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   @property({ attribute: false })
   page!: Page;
@@ -86,7 +86,7 @@ export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
           .index=${index}
           .model=${model}
           .page=${this.page}
-          .root=${this.root}
+          .host=${this.host}
           .renderModel=${this.renderModel}
         ></${tag}>`;
       }

--- a/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
@@ -3,7 +3,7 @@
 import './portal/image.js';
 import './portal/note.js';
 
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { css, type TemplateResult } from 'lit';
@@ -36,7 +36,7 @@ export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
   `;
 
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   page!: Page;

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -9,7 +9,7 @@ import type { TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import { WithDisposable } from '../with-disposable.js';
-import type { BlockSuiteRoot } from './lit-root.js';
+import type { EditorHost } from './lit-host.js';
 import { ShadowlessElement } from './shadowless-element.js';
 import type { WidgetElement } from './widget-element.js';
 
@@ -19,7 +19,7 @@ export class BlockElement<
   WidgetName extends string = string,
 > extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   model!: Model;

--- a/packages/lit/src/element/block-element.ts
+++ b/packages/lit/src/element/block-element.ts
@@ -19,7 +19,7 @@ export class BlockElement<
   WidgetName extends string = string,
 > extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   @property({ attribute: false })
   model!: Model;
@@ -65,13 +65,13 @@ export class BlockElement<
   get parentBlockElement() {
     const parentElement = this.parentElement;
     assertExists(parentElement);
-    const nodeView = this.root.view.getNodeView(parentElement);
+    const nodeView = this.host.view.getNodeView(parentElement);
     assertExists(nodeView);
     return nodeView.view as BlockElement;
   }
 
   get childBlockElements() {
-    const children = this.root.view.getChildren(this.path);
+    const children = this.host.view.getChildren(this.path);
     return children
       .filter(child => child.type === 'block')
       .map(child => child.view as BlockElement);
@@ -85,23 +85,23 @@ export class BlockElement<
     return Object.keys(this.widgets).reduce((mapping, key) => {
       return {
         ...mapping,
-        [key]: this.root.view.viewFromPath('widget', [...this.path, key]),
+        [key]: this.host.view.viewFromPath('widget', [...this.path, key]),
       };
     }, {});
   }
 
   get service(): Service | undefined {
-    return this.root.std.spec.getService(this.model.flavour) as
+    return this.host.std.spec.getService(this.model.flavour) as
       | Service
       | undefined;
   }
 
   get selection() {
-    return this.root.selection;
+    return this.host.selection;
   }
 
   get std() {
-    return this.root.std;
+    return this.host.std;
   }
 
   handleEvent = (
@@ -118,7 +118,7 @@ export class BlockElement<
           : undefined,
       path: options?.global || options?.flavour ? undefined : this.path,
     };
-    this._disposables.add(this.root.event.add(name, handler, config));
+    this._disposables.add(this.host.event.add(name, handler, config));
   };
 
   bindHotKey(
@@ -134,15 +134,15 @@ export class BlockElement<
           : undefined,
       path: options?.global || options?.flavour ? undefined : this.path,
     };
-    this._disposables.add(this.root.event.bindHotkey(keymap, config));
+    this._disposables.add(this.host.event.bindHotkey(keymap, config));
   }
 
   renderModel = (model: BaseBlockModel): TemplateResult => {
-    return this.root.renderModel(model);
+    return this.host.renderModel(model);
   };
 
   renderModelChildren = (model: BaseBlockModel): TemplateResult => {
-    return this.root.renderModelChildren(model);
+    return this.host.renderModelChildren(model);
   };
 
   protected override async getUpdateComplete(): Promise<boolean> {
@@ -154,7 +154,7 @@ export class BlockElement<
   override connectedCallback() {
     super.connectedCallback();
 
-    this.path = this.root.view.calculatePath(this);
+    this.path = this.host.view.calculatePath(this);
 
     this._disposables.add(
       this.model.propsUpdated.on(() => {
@@ -169,7 +169,7 @@ export class BlockElement<
     );
 
     this._disposables.add(
-      this.root.selection.slots.changed.on(selections => {
+      this.host.selection.slots.changed.on(selections => {
         const selection = selections.find(selection => {
           return PathFinder.equals(selection.path, this.path);
         });

--- a/packages/lit/src/element/index.ts
+++ b/packages/lit/src/element/index.ts
@@ -1,4 +1,4 @@
 export * from './block-element.js';
-export * from './lit-root.js';
+export * from './lit-host.js';
 export * from './shadowless-element.js';
 export * from './widget-element.js';

--- a/packages/lit/src/element/lit-host.ts
+++ b/packages/lit/src/element/lit-host.ts
@@ -30,7 +30,7 @@ import type { WidgetElement } from './widget-element.js';
 @customElement('editor-host')
 export class EditorHost extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
-  preset!: BlockSpec[];
+  specs!: BlockSpec[];
 
   @property({ attribute: false })
   page!: Page;
@@ -63,7 +63,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
 
   override willUpdate(changedProperties: PropertyValues) {
     if (changedProperties.has('preset')) {
-      this.std.spec.applySpecs(this.preset);
+      this.std.spec.applySpecs(this.specs);
     }
     super.willUpdate(changedProperties);
   }
@@ -99,7 +99,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
     this._registerView();
 
     this.std.mount();
-    this.std.spec.applySpecs(this.preset);
+    this.std.spec.applySpecs(this.specs);
     this.rangeManager = new RangeManager(this);
   }
 

--- a/packages/lit/src/element/lit-host.ts
+++ b/packages/lit/src/element/lit-host.ts
@@ -27,8 +27,8 @@ import type { BlockElement } from './block-element.js';
 import { ShadowlessElement } from './shadowless-element.js';
 import type { WidgetElement } from './widget-element.js';
 
-@customElement('block-suite-root')
-export class BlockSuiteRoot extends WithDisposable(ShadowlessElement) {
+@customElement('editor-host')
+export class EditorHost extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
   preset!: BlockSpec[];
 
@@ -249,7 +249,7 @@ function getChildren(
 
 declare global {
   interface HTMLElementTagNameMap {
-    'block-suite-root': BlockSuiteRoot;
+    'editor-host': EditorHost;
   }
 
   namespace BlockSuite {

--- a/packages/lit/src/element/lit-host.ts
+++ b/packages/lit/src/element/lit-host.ts
@@ -138,7 +138,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
       ? Object.entries(view.widgets).reduce((mapping, [key, tag]) => {
           const template = html`<${tag} ${unsafeStatic(
             this.widgetIdAttr
-          )}=${key} .root=${this} .page=${this.page}></${tag}>`;
+          )}=${key} .host=${this} .page=${this.page}></${tag}>`;
 
           return {
             ...mapping,
@@ -149,7 +149,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
 
     return html`<${tag}
       ${unsafeStatic(this.blockIdAttr)}=${model.id}
-      .root=${this}
+      .host=${this}
       .page=${this.page}
       .model=${model}
       .widgets=${widgets}

--- a/packages/lit/src/element/lit-host.ts
+++ b/packages/lit/src/element/lit-host.ts
@@ -92,7 +92,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
     super.connectedCallback();
 
     this.std = new BlockStdProvider({
-      root: this,
+      host: this,
       workspace: this.page.workspace,
       page: this.page,
     });

--- a/packages/lit/src/element/widget-element.ts
+++ b/packages/lit/src/element/widget-element.ts
@@ -7,13 +7,13 @@ import { property } from 'lit/decorators.js';
 
 import { WithDisposable } from '../with-disposable.js';
 import type { BlockElement } from './block-element.js';
-import type { BlockSuiteRoot } from './lit-root.js';
+import type { EditorHost } from './lit-host.js';
 
 export class WidgetElement<
   B extends BlockElement = BlockElement,
 > extends WithDisposable(LitElement) {
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   page!: Page;

--- a/packages/lit/src/element/widget-element.ts
+++ b/packages/lit/src/element/widget-element.ts
@@ -13,7 +13,7 @@ export class WidgetElement<
   B extends BlockElement = BlockElement,
 > extends WithDisposable(LitElement) {
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   @property({ attribute: false })
   page!: Page;
@@ -31,7 +31,7 @@ export class WidgetElement<
   get blockElement(): B {
     const parentElement = this.parentElement;
     assertExists(parentElement);
-    const nodeView = this.root.view.getNodeView(parentElement);
+    const nodeView = this.host.view.getNodeView(parentElement);
     assertExists(nodeView);
     return nodeView.view as B;
   }
@@ -42,7 +42,7 @@ export class WidgetElement<
   }
 
   get std() {
-    return this.root.std;
+    return this.host.std;
   }
 
   handleEvent = (
@@ -51,7 +51,7 @@ export class WidgetElement<
     options?: { global?: boolean }
   ) => {
     this._disposables.add(
-      this.root.event.add(name, handler, {
+      this.host.event.add(name, handler, {
         flavour: options?.global ? undefined : this.flavour,
       })
     );
@@ -62,7 +62,7 @@ export class WidgetElement<
     options?: { global: boolean }
   ) {
     this._disposables.add(
-      this.root.event.bindHotkey(keymap, {
+      this.host.event.bindHotkey(keymap, {
         flavour: options?.global ? undefined : this.flavour,
       })
     );
@@ -70,7 +70,7 @@ export class WidgetElement<
 
   override connectedCallback() {
     super.connectedCallback();
-    this.path = this.root.view.calculatePath(this);
+    this.path = this.host.view.calculatePath(this);
   }
 
   override render(): unknown {

--- a/packages/lit/src/utils/range-manager.ts
+++ b/packages/lit/src/utils/range-manager.ts
@@ -25,7 +25,7 @@ type RangeSnapshot = {
 export class RangeManager {
   readonly rangeSynchronizer = new RangeSynchronizer(this);
 
-  constructor(public root: EditorHost) {}
+  constructor(public host: EditorHost) {}
 
   get value() {
     return this._range;
@@ -39,7 +39,7 @@ export class RangeManager {
     this._isRangeReversed = false;
     window.getSelection()?.removeAllRanges();
     if (sync) {
-      this.root.selection.clear(['text']);
+      this.host.selection.clear(['text']);
     }
   }
 
@@ -63,7 +63,7 @@ export class RangeManager {
     }
 
     const { from, to } = selection;
-    const fromBlock = this.root.view.viewFromPath('block', from.path);
+    const fromBlock = this.host.view.viewFromPath('block', from.path);
     if (!fromBlock) {
       this.clearRange();
       return;
@@ -85,7 +85,7 @@ export class RangeManager {
       return null;
     }
 
-    const selectionManager = this.root.selection;
+    const selectionManager = this.host.selection;
     this._range = range;
     this._isRangeReversed = isRangeReversed;
 
@@ -133,8 +133,8 @@ export class RangeManager {
     const { mode = 'all', match = () => true } = options;
 
     let result = Array.from<BlockElement>(
-      this.root.querySelectorAll(
-        `[${this.root.blockIdAttr}]:not([data-queryable="false"])`
+      this.host.querySelectorAll(
+        `[${this.host.blockIdAttr}]:not([data-queryable="false"])`
       )
     ).filter(el => range.intersectsNode(el) && match(el));
 
@@ -147,7 +147,7 @@ export class RangeManager {
         ? range.startContainer
         : range.startContainer.parentElement;
     const firstElement = rangeStartElement?.closest(
-      `[${this.root.blockIdAttr}]`
+      `[${this.host.blockIdAttr}]`
     );
     assertExists(firstElement);
 
@@ -178,7 +178,7 @@ export class RangeManager {
 
   textSelectionToRange(selection: TextSelection): Range | null {
     const { from, to } = selection;
-    const fromBlock = this.root.view.viewFromPath('block', from.path);
+    const fromBlock = this.host.view.viewFromPath('block', from.path);
     if (!fromBlock) {
       return null;
     }
@@ -210,7 +210,7 @@ export class RangeManager {
   }
 
   private _calculateVirgo(point: TextRangePoint): [VEditor, VRange] | null {
-    const block = this.root.view.viewFromPath('block', point.path);
+    const block = this.host.view.viewFromPath('block', point.path);
     if (!block) {
       return null;
     }
@@ -354,6 +354,6 @@ export class RangeManager {
   }
 
   private _getBlock(element: HTMLElement) {
-    return element.closest(`[${this.root.blockIdAttr}]`) as BlockElement;
+    return element.closest(`[${this.host.blockIdAttr}]`) as BlockElement;
   }
 }

--- a/packages/lit/src/utils/range-manager.ts
+++ b/packages/lit/src/utils/range-manager.ts
@@ -9,7 +9,7 @@ import {
 } from '@blocksuite/virgo';
 
 import type { BlockElement } from '../element/block-element.js';
-import type { BlockSuiteRoot } from '../element/lit-root.js';
+import type { EditorHost } from '../element/lit-host.js';
 import { RangeSynchronizer } from './range-synchronizer.js';
 
 type RangeSnapshot = {
@@ -25,7 +25,7 @@ type RangeSnapshot = {
 export class RangeManager {
   readonly rangeSynchronizer = new RangeSynchronizer(this);
 
-  constructor(public root: BlockSuiteRoot) {}
+  constructor(public root: EditorHost) {}
 
   get value() {
     return this._range;

--- a/packages/lit/src/utils/range-synchronizer.ts
+++ b/packages/lit/src/utils/range-synchronizer.ts
@@ -31,34 +31,34 @@ export class RangeSynchronizer {
   }
 
   private get _selectionManager() {
-    return this.root.selection;
+    return this.host.selection;
   }
 
   private get _rangeManager() {
-    assertExists(this.root.rangeManager);
-    return this.root.rangeManager;
+    assertExists(this.host.rangeManager);
+    return this.host.rangeManager;
   }
 
   private _isComposing = false;
 
-  get root() {
-    return this.manager.root;
+  get host() {
+    return this.manager.host;
   }
 
   constructor(public manager: RangeManager) {
-    this.root.disposables.add(
+    this.host.disposables.add(
       this._selectionManager.slots.changed.on(this._onSelectionModelChanged)
     );
 
-    this.root.event.add('compositionStart', () => {
+    this.host.event.add('compositionStart', () => {
       this._isComposing = true;
     });
-    this.root.event.add('compositionEnd', () => {
+    this.host.event.add('compositionEnd', () => {
       this._isComposing = false;
     });
 
-    this.root.disposables.add(
-      this.root.event.add('selectionChange', () => {
+    this.host.disposables.add(
+      this.host.event.add('selectionChange', () => {
         const selection = window.getSelection();
         if (!selection) {
           this._selectionManager.clear();
@@ -85,7 +85,7 @@ export class RangeSynchronizer {
           return;
         }
 
-        if (range === null || range.intersectsNode(this.root)) {
+        if (range === null || range.intersectsNode(this.host)) {
           this._prevSelection = this._rangeManager.syncRangeToTextSelection(
             range,
             isRangeReversed
@@ -97,10 +97,10 @@ export class RangeSynchronizer {
       })
     );
 
-    this.root.disposables.add(
-      this.root.event.add('beforeInput', ctx => {
+    this.host.disposables.add(
+      this.host.event.add('beforeInput', ctx => {
         const event = ctx.get('defaultState').event as InputEvent;
-        if (this.root.page.readonly) return;
+        if (this.host.page.readonly) return;
 
         const current = this._selectionManager.find('text');
         if (!current) return;
@@ -137,7 +137,7 @@ export class RangeSynchronizer {
       this._prevSelection = text;
       this._rangeManager.syncTextSelectionToRange(text);
     });
-    this.root.disposables.add(() => {
+    this.host.disposables.add(() => {
       cancelAnimationFrame(rafId);
     });
   };
@@ -163,7 +163,7 @@ export class RangeSynchronizer {
 
     const endIsSelectedAll = to.length === endText.length;
 
-    this.root.page.transact(() => {
+    this.host.page.transact(() => {
       if (endIsSelectedAll && event.isComposing) {
         this._shamefullyResetIMERangeBeforeInput(startText, start, from);
       }
@@ -180,9 +180,9 @@ export class RangeSynchronizer {
         // delete from lowest to highest
         .reverse()
         .forEach(block => {
-          const parent = this.root.page.getParent(block.model);
+          const parent = this.host.page.getParent(block.model);
           assertExists(parent);
-          this.root.page.deleteBlock(block.model, {
+          this.host.page.deleteBlock(block.model, {
             bringChildrenTo: parent,
           });
         });

--- a/packages/lit/src/utils/v-range-provider.ts
+++ b/packages/lit/src/utils/v-range-provider.ts
@@ -12,7 +12,7 @@ import type { BlockElement } from '../element/block-element.js';
 export const getVRangeProvider: (
   element: BlockElement
 ) => VRangeProvider = element => {
-  const root = element.root;
+  const root = element.host;
   const selectionManager = root.selection;
   const rangeManager = root.rangeManager;
   const vRangeUpdatedSlot = new Slot<VRangeUpdatedProp>();

--- a/packages/playground/apps/default/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/default/components/quick-edgeless-menu.ts
@@ -25,7 +25,7 @@ import { NOTE_WIDTH } from '@blocksuite/blocks';
 import { MarkdownAdapter } from '@blocksuite/blocks';
 import type { ContentParser } from '@blocksuite/blocks/content-parser';
 import { ShadowlessElement } from '@blocksuite/lit';
-import type { EditorContainer } from '@blocksuite/presets';
+import type { AffineEditorContainer } from '@blocksuite/presets';
 import { Job, Utils, type Workspace } from '@blocksuite/store';
 import type { SlTab, SlTabGroup } from '@shoelace-style/shoelace';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
@@ -55,7 +55,7 @@ function getTabGroupTemplate({
   requestUpdate,
 }: {
   workspace: Workspace;
-  editor: EditorContainer;
+  editor: AffineEditorContainer;
   requestUpdate: () => void;
 }) {
   workspace.meta.pageMetasUpdated.on(requestUpdate);
@@ -131,7 +131,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   workspace!: Workspace;
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
 
   @property({ attribute: false })
   contentParser!: ContentParser;

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -157,7 +157,7 @@ async function main() {
   window.ContentParser = ContentParser;
   Object.defineProperty(globalThis, 'root', {
     get() {
-      return document.querySelector('block-suite-root') as BlockSuiteRoot;
+      return document.querySelector('editor-host') as BlockSuiteRoot;
     },
   });
 

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -155,7 +155,7 @@ async function main() {
   window.job = new Job({ workspace });
   window.Y = Workspace.Y;
   window.ContentParser = ContentParser;
-  Object.defineProperty(globalThis, 'root', {
+  Object.defineProperty(globalThis, 'host', {
     get() {
       return document.querySelector('editor-host') as EditorHost;
     },

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -6,7 +6,7 @@ import '@blocksuite/presets/themes/affine.css';
 
 import { ContentParser } from '@blocksuite/blocks/content-parser';
 import { AffineSchemas } from '@blocksuite/blocks/models';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { type DocProviderCreator, type Page, Text } from '@blocksuite/store';
 import { Job, Workspace } from '@blocksuite/store';
 
@@ -157,7 +157,7 @@ async function main() {
   window.ContentParser = ContentParser;
   Object.defineProperty(globalThis, 'root', {
     get() {
-      return document.querySelector('editor-host') as BlockSuiteRoot;
+      return document.querySelector('editor-host') as EditorHost;
     },
   });
 

--- a/packages/playground/apps/default/utils.ts
+++ b/packages/playground/apps/default/utils.ts
@@ -1,5 +1,5 @@
 import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
-import { EditorContainer } from '@blocksuite/presets';
+import { AffineEditorContainer } from '@blocksuite/presets';
 import type { BlobStorage, Page, Workspace } from '@blocksuite/store';
 import {
   createIndexeddbStorage,
@@ -72,7 +72,7 @@ export async function testIDBExistence() {
 export function createEditor(page: Page, element: HTMLElement) {
   const presets = getPlaygroundPresets();
 
-  const editor = new EditorContainer();
+  const editor = new AffineEditorContainer();
   editor.docSpecs = presets.docModePreset;
   editor.edgelessSpecs = presets.edgelessModePreset;
   editor.page = page;

--- a/packages/playground/apps/starter/components/custom-format-bar.ts
+++ b/packages/playground/apps/starter/components/custom-format-bar.ts
@@ -9,8 +9,8 @@ export function extendFormatBar() {
       element.textContent = '❤️';
       element.setAttribute('data-testid', 'custom-format-bar-element');
       element.addEventListener('click', () => {
-        const root = formatBar.root;
-        const selectionManager = root.selection;
+        const host = formatBar.host;
+        const selectionManager = host.selection;
         console.log('selections', selectionManager.value);
       });
 

--- a/packages/playground/apps/starter/components/custom-frame-panel.ts
+++ b/packages/playground/apps/starter/components/custom-frame-panel.ts
@@ -1,5 +1,5 @@
 import { WithDisposable } from '@blocksuite/lit';
-import type { EditorContainer } from '@blocksuite/presets';
+import type { AffineEditorContainer } from '@blocksuite/presets';
 import { registerFramePanelComponents } from '@blocksuite/presets';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -24,7 +24,7 @@ export class CustomFramePanel extends WithDisposable(LitElement) {
   private _show = false;
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
 
   private _renderPanel() {
     return html`<frame-panel .editor=${this.editor}></frame-panel>`;

--- a/packages/playground/apps/starter/components/custom-navigation-panel.ts
+++ b/packages/playground/apps/starter/components/custom-navigation-panel.ts
@@ -1,6 +1,6 @@
 import { registerTOCComponents } from '@blocksuite/blocks';
 import { WithDisposable } from '@blocksuite/lit';
-import type { EditorContainer } from '@blocksuite/presets';
+import type { AffineEditorContainer } from '@blocksuite/presets';
 import type { Page } from '@blocksuite/store';
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -27,7 +27,7 @@ export class CustomNavigationPanel extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
 
   private _renderPanel() {
     return html`<edgeless-toc-notes-panel

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -36,7 +36,7 @@ import {
   ShadowlessElement,
 } from '@blocksuite/lit';
 import type { AiPanel } from '@blocksuite/presets';
-import { EditorContainer } from '@blocksuite/presets';
+import { AffineEditorContainer } from '@blocksuite/presets';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { Utils, type Workspace } from '@blocksuite/store';
 import type { SlDropdown } from '@shoelace-style/shoelace';
@@ -51,7 +51,7 @@ import type { CustomFramePanel } from './custom-frame-panel.js';
 import type { CustomNavigationPanel } from './custom-navigation-panel.js';
 import type { SidePanel } from './side-panel';
 
-export function getSurfaceElementFromEditor(editor: EditorContainer) {
+export function getSurfaceElementFromEditor(editor: AffineEditorContainer) {
   const { page } = editor;
   const surfaceModel = page.getBlockByFlavour('affine:surface')[0];
   assertExists(surfaceModel);
@@ -194,7 +194,7 @@ export class DebugMenu extends ShadowlessElement {
   workspace!: Workspace;
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
 
   @property({ attribute: false })
   contentParser!: ContentParser;
@@ -300,8 +300,10 @@ export class DebugMenu extends ShadowlessElement {
   }
 
   private _switchEditorMode() {
-    const editor = document.querySelector<EditorContainer>('editor-container');
-    if (editor instanceof EditorContainer) {
+    const editor = document.querySelector<AffineEditorContainer>(
+      'affine-editor-container'
+    );
+    if (editor instanceof AffineEditorContainer) {
       const mode = editor.mode === 'page' ? 'edgeless' : 'page';
       editor.mode = mode;
     } else {
@@ -735,7 +737,7 @@ function createPageBlock(workspace: Workspace) {
 
 function PageList(
   workspace: Workspace,
-  editor: EditorContainer,
+  editor: AffineEditorContainer,
   requestUpdate: () => void
 ) {
   workspace.meta.pageMetasUpdated.on(requestUpdate);

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -148,10 +148,10 @@ function initStyleDebugMenu(styleMenu: Pane, style: CSSStyleDeclaration) {
     });
   }
 }
-export function getSelectedBlocks(root: EditorHost) {
+export function getSelectedBlocks(host: EditorHost) {
   let blocks: BlockElement[] = [];
 
-  root.std.command
+  host.std.command
     .pipe()
     .getBlockSelections()
     .inline((ctx, next) => {

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -32,7 +32,7 @@ import type { ContentParser } from '@blocksuite/blocks/content-parser';
 import { assertExists } from '@blocksuite/global/utils';
 import {
   type BlockElement,
-  type BlockSuiteRoot,
+  type EditorHost,
   ShadowlessElement,
 } from '@blocksuite/lit';
 import type { AiPanel } from '@blocksuite/presets';
@@ -148,7 +148,7 @@ function initStyleDebugMenu(styleMenu: Pane, style: CSSStyleDeclaration) {
     });
   }
 }
-export function getSelectedBlocks(root: BlockSuiteRoot) {
+export function getSelectedBlocks(root: EditorHost) {
   let blocks: BlockElement[] = [];
 
   root.std.command

--- a/packages/playground/apps/starter/data/multiple-editor.ts
+++ b/packages/playground/apps/starter/data/multiple-editor.ts
@@ -1,4 +1,4 @@
-import { EditorContainer } from '@blocksuite/presets';
+import { AffineEditorContainer } from '@blocksuite/presets';
 import { Text, type Workspace } from '@blocksuite/store';
 
 import { createEditor } from '../utils';
@@ -27,7 +27,7 @@ export const multiEditor: InitFn = async (workspace: Workspace, id: string) => {
     createEditor(page, app);
     app.style.display = 'flex';
     app.childNodes.forEach(node => {
-      if (node instanceof EditorContainer) {
+      if (node instanceof AffineEditorContainer) {
         node.style.flex = '1';
       }
     });

--- a/packages/playground/apps/starter/env.d.ts
+++ b/packages/playground/apps/starter/env.d.ts
@@ -1,5 +1,6 @@
 import type { TestUtils } from '@blocksuite/blocks';
 import type { ContentParser } from '@blocksuite/blocks/content-parser';
+import type { EditorHost } from '@blocksuite/lit';
 import type { AffineEditorContainer } from '@blocksuite/presets';
 import type {
   BlockSchema,
@@ -21,6 +22,7 @@ declare global {
     Y: typeof Workspace.Y;
     std: typeof std;
     testUtils: TestUtils;
+    host: EditorHost;
 
     // TODO: remove this when provider support subdocument
     subdocProviders: Map<string, DocProvider[]>;

--- a/packages/playground/apps/starter/env.d.ts
+++ b/packages/playground/apps/starter/env.d.ts
@@ -1,6 +1,6 @@
 import type { TestUtils } from '@blocksuite/blocks';
 import type { ContentParser } from '@blocksuite/blocks/content-parser';
-import type { EditorContainer } from '@blocksuite/presets';
+import type { AffineEditorContainer } from '@blocksuite/presets';
 import type {
   BlockSchema,
   DocProvider,
@@ -12,7 +12,7 @@ import type { z } from 'zod';
 
 declare global {
   interface Window {
-    editor: EditorContainer;
+    editor: AffineEditorContainer;
     page: Page;
     workspace: Workspace;
     blockSchemas: z.infer<typeof BlockSchema>[];

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -115,7 +115,7 @@ async function main() {
   window.ContentParser = ContentParser;
   Object.defineProperty(globalThis, 'root', {
     get() {
-      return document.querySelector('block-suite-root') as BlockSuiteRoot;
+      return document.querySelector('editor-host') as BlockSuiteRoot;
     },
   });
 

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -113,7 +113,7 @@ async function main() {
   window.blockSchemas = AffineSchemas;
   window.Y = Workspace.Y;
   window.ContentParser = ContentParser;
-  Object.defineProperty(globalThis, 'root', {
+  Object.defineProperty(globalThis, 'host', {
     get() {
       return document.querySelector('editor-host') as EditorHost;
     },

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -8,7 +8,7 @@ import '@blocksuite/presets/themes/affine.css';
 import { TestUtils } from '@blocksuite/blocks';
 import { ContentParser } from '@blocksuite/blocks/content-parser';
 import { AffineSchemas } from '@blocksuite/blocks/models';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { AiPanel } from '@blocksuite/presets';
 import type { DocProvider, Page } from '@blocksuite/store';
 import { Job, Workspace } from '@blocksuite/store';
@@ -115,7 +115,7 @@ async function main() {
   window.ContentParser = ContentParser;
   Object.defineProperty(globalThis, 'root', {
     get() {
-      return document.querySelector('editor-host') as BlockSuiteRoot;
+      return document.querySelector('editor-host') as EditorHost;
     },
   });
 

--- a/packages/playground/apps/starter/utils.ts
+++ b/packages/playground/apps/starter/utils.ts
@@ -3,7 +3,7 @@ import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
 import * as globalUtils from '@blocksuite/global/utils';
 import { assertExists } from '@blocksuite/global/utils';
 import * as editor from '@blocksuite/presets';
-import { EditorContainer } from '@blocksuite/presets';
+import { AffineEditorContainer } from '@blocksuite/presets';
 import type {
   BlobStorage,
   DocProviderCreator,
@@ -174,7 +174,7 @@ export function createWorkspaceOptions(): WorkspaceOptions {
 }
 
 export function createEditor(page: Page, element: HTMLElement) {
-  const editor = new EditorContainer();
+  const editor = new AffineEditorContainer();
   editor.page = page;
   element.append(editor);
 

--- a/packages/presets/src/editors/doc-editor.ts
+++ b/packages/presets/src/editors/doc-editor.ts
@@ -1,16 +1,12 @@
 import { DocEditorBlockSpecs } from '@blocksuite/blocks';
 import { noop } from '@blocksuite/global/utils';
-import {
-  BlockSuiteRoot,
-  ShadowlessElement,
-  WithDisposable,
-} from '@blocksuite/lit';
+import { EditorHost, ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { createRef, type Ref, ref } from 'lit/directives/ref.js';
 
-noop(BlockSuiteRoot);
+noop(EditorHost);
 
 @customElement('doc-editor')
 export class DocEditor extends WithDisposable(ShadowlessElement) {
@@ -20,7 +16,7 @@ export class DocEditor extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
   preset = DocEditorBlockSpecs;
 
-  root: Ref<BlockSuiteRoot> = createRef<BlockSuiteRoot>();
+  root: Ref<EditorHost> = createRef<EditorHost>();
 
   override render() {
     return html`
@@ -42,11 +38,11 @@ export class DocEditor extends WithDisposable(ShadowlessElement) {
           }
         }
       </style>
-      <block-suite-root
+      <editor-host
         ${ref(this.root)}
         .page=${this.page}
         .preset=${this.preset}
-      ></block-suite-root>
+      ></editor-host>
     `;
   }
 }

--- a/packages/presets/src/editors/doc-editor.ts
+++ b/packages/presets/src/editors/doc-editor.ts
@@ -14,9 +14,9 @@ export class DocEditor extends WithDisposable(ShadowlessElement) {
   page!: Page;
 
   @property({ attribute: false })
-  preset = DocEditorBlockSpecs;
+  specs = DocEditorBlockSpecs;
 
-  root: Ref<EditorHost> = createRef<EditorHost>();
+  host: Ref<EditorHost> = createRef<EditorHost>();
 
   override render() {
     return html`
@@ -39,9 +39,9 @@ export class DocEditor extends WithDisposable(ShadowlessElement) {
         }
       </style>
       <editor-host
-        ${ref(this.root)}
+        ${ref(this.host)}
         .page=${this.page}
-        .preset=${this.preset}
+        .specs=${this.specs}
       ></editor-host>
     `;
   }

--- a/packages/presets/src/editors/edgeless-editor.ts
+++ b/packages/presets/src/editors/edgeless-editor.ts
@@ -1,16 +1,12 @@
 import { EdgelessEditorBlockSpecs } from '@blocksuite/blocks';
 import { noop } from '@blocksuite/global/utils';
-import {
-  BlockSuiteRoot,
-  ShadowlessElement,
-  WithDisposable,
-} from '@blocksuite/lit';
+import { EditorHost, ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { createRef, type Ref, ref } from 'lit/directives/ref.js';
 
-noop(BlockSuiteRoot);
+noop(EditorHost);
 
 @customElement('edgeless-editor')
 export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
@@ -20,7 +16,7 @@ export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
   @property({ attribute: false })
   preset = EdgelessEditorBlockSpecs;
 
-  root: Ref<BlockSuiteRoot> = createRef<BlockSuiteRoot>();
+  root: Ref<EditorHost> = createRef<EditorHost>();
 
   override render() {
     return html`
@@ -42,11 +38,11 @@ export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
           }
         }
       </style>
-      <block-suite-root
+      <editor-host
         ${ref(this.root)}
         .page=${this.page}
         .preset=${this.preset}
-      ></block-suite-root>
+      ></editor-host>
     `;
   }
 }

--- a/packages/presets/src/editors/edgeless-editor.ts
+++ b/packages/presets/src/editors/edgeless-editor.ts
@@ -14,9 +14,9 @@ export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
   page!: Page;
 
   @property({ attribute: false })
-  preset = EdgelessEditorBlockSpecs;
+  specs = EdgelessEditorBlockSpecs;
 
-  root: Ref<EditorHost> = createRef<EditorHost>();
+  host: Ref<EditorHost> = createRef<EditorHost>();
 
   override render() {
     return html`
@@ -39,9 +39,9 @@ export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
         }
       </style>
       <editor-host
-        ${ref(this.root)}
+        ${ref(this.host)}
         .page=${this.page}
-        .preset=${this.preset}
+        .specs=${this.specs}
       ></editor-host>
     `;
   }

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -67,8 +67,8 @@ export class AffineEditorContainer
 
   get root() {
     return this.mode === 'page'
-      ? this._docPage?.root
-      : this._edgelessPage?.root;
+      ? this._docPage?.host
+      : this._edgelessPage?.host;
   }
 
   readonly themeObserver = new ThemeObserver();

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -36,8 +36,8 @@ function forwardSlot<T extends Record<string, Slot<any>>>(
   });
 }
 
-@customElement('editor-container')
-export class EditorContainer
+@customElement('affine-editor-container')
+export class AffineEditorContainer
   extends WithDisposable(ShadowlessElement)
   implements AbstractEditor
 {
@@ -162,6 +162,6 @@ export class EditorContainer
 
 declare global {
   interface HTMLElementTagNameMap {
-    'editor-container': EditorContainer;
+    'affine-editor-container': AffineEditorContainer;
   }
 }

--- a/packages/presets/src/editors/index.ts
+++ b/packages/presets/src/editors/index.ts
@@ -1,4 +1,4 @@
-import './editor-container.js';
+import './affine-editor-container.js';
 import './simple-affine-editor.js';
 
 export * from './doc-editor.js';

--- a/packages/presets/src/editors/index.ts
+++ b/packages/presets/src/editors/index.ts
@@ -1,4 +1,4 @@
-import './affine-editor-container.js';
+import './editor-container.js';
 import './simple-affine-editor.js';
 
 export * from './doc-editor.js';

--- a/packages/presets/src/editors/simple-affine-editor.ts
+++ b/packages/presets/src/editors/simple-affine-editor.ts
@@ -4,7 +4,7 @@ import { Schema, Workspace } from '@blocksuite/store';
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { AffineEditorContainer } from './affine-editor-container.js';
+import { AffineEditorContainer } from './editor-container.js';
 
 /**
  * This is the editor component to be used out-of-the-box.

--- a/packages/presets/src/editors/simple-affine-editor.ts
+++ b/packages/presets/src/editors/simple-affine-editor.ts
@@ -4,7 +4,7 @@ import { Schema, Workspace } from '@blocksuite/store';
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { EditorContainer } from './editor-container.js';
+import { AffineEditorContainer } from './affine-editor-container.js';
 
 /**
  * This is the editor component to be used out-of-the-box.
@@ -33,7 +33,7 @@ export class SimpleAffineEditor extends LitElement {
   }
 
   override connectedCallback() {
-    const editor = new EditorContainer();
+    const editor = new AffineEditorContainer();
     editor.page = this.page;
     this.appendChild(editor);
   }

--- a/packages/presets/src/fragments/ai-panel/ai-panel.ts
+++ b/packages/presets/src/fragments/ai-panel/ai-panel.ts
@@ -1,5 +1,5 @@
 import {
-  type BlockSuiteRoot,
+  type EditorHost,
   ShadowlessElement,
   WithDisposable,
 } from '@blocksuite/lit';
@@ -8,7 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EditorContainer } from '../../index.js';
+import type { AffineEditorContainer } from '../../index.js';
 import { GPTAPI, type GPTAPIPayloadMap } from './actions/index.js';
 import { EditorWithAI } from './api.js';
 import { LANGUAGE, TONE } from './config.js';
@@ -76,7 +76,7 @@ export class AiPanel extends WithDisposable(ShadowlessElement) {
   private _result = '';
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
   editorWithAI?: EditorWithAI;
   get api() {
     if (!this.editorWithAI) {
@@ -90,7 +90,7 @@ export class AiPanel extends WithDisposable(ShadowlessElement) {
   }
 
   get root() {
-    return this.editor.root as BlockSuiteRoot;
+    return this.editor.root as EditorHost;
   }
 
   public override connectedCallback() {

--- a/packages/presets/src/fragments/ai-panel/api.ts
+++ b/packages/presets/src/fragments/ai-panel/api.ts
@@ -5,10 +5,10 @@ import {
   loadImages,
 } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Workspace } from '@blocksuite/store';
 
-import type { EditorContainer } from '../../editors/index.js';
+import type { AffineEditorContainer } from '../../editors/index.js';
 import { GPTAPI, type GPTAPIPayloadMap } from './actions/index.js';
 import { demoScript } from './demo-script.js';
 import {
@@ -29,12 +29,12 @@ export class EditorWithAI {
   get workspace(): Workspace {
     return this.editor.page.workspace;
   }
-  get root(): BlockSuiteRoot {
+  get root(): EditorHost {
     assertExists(this.editor.root);
     return this.editor.root;
   }
 
-  constructor(private editor: EditorContainer) {}
+  constructor(private editor: AffineEditorContainer) {}
 
   makeItReal = async () => {
     const png = await selectedToPng(this.editor);

--- a/packages/presets/src/fragments/ai-panel/utils/markdown-utils.ts
+++ b/packages/presets/src/fragments/ai-panel/utils/markdown-utils.ts
@@ -1,9 +1,9 @@
 import { MarkdownAdapter } from '@blocksuite/blocks';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { Job, type Slice } from '@blocksuite/store';
 
-export async function getMarkdownFromSlice(root: BlockSuiteRoot, slice: Slice) {
+export async function getMarkdownFromSlice(root: EditorHost, slice: Slice) {
   const job = new Job({ workspace: root.std.page.workspace });
   const snapshot = await job.sliceToSnapshot(slice);
   const markdownAdapter = new MarkdownAdapter();
@@ -16,7 +16,7 @@ export async function getMarkdownFromSlice(root: BlockSuiteRoot, slice: Slice) {
 }
 
 export async function insertFromMarkdown(
-  root: BlockSuiteRoot,
+  root: EditorHost,
   markdown: string,
   parent?: string,
   index?: number

--- a/packages/presets/src/fragments/ai-panel/utils/markdown-utils.ts
+++ b/packages/presets/src/fragments/ai-panel/utils/markdown-utils.ts
@@ -3,8 +3,8 @@ import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { Job, type Slice } from '@blocksuite/store';
 
-export async function getMarkdownFromSlice(root: EditorHost, slice: Slice) {
-  const job = new Job({ workspace: root.std.page.workspace });
+export async function getMarkdownFromSlice(host: EditorHost, slice: Slice) {
+  const job = new Job({ workspace: host.std.page.workspace });
   const snapshot = await job.sliceToSnapshot(slice);
   const markdownAdapter = new MarkdownAdapter();
   const markdown = await markdownAdapter.fromSliceSnapshot({
@@ -16,15 +16,15 @@ export async function getMarkdownFromSlice(root: EditorHost, slice: Slice) {
 }
 
 export async function insertFromMarkdown(
-  root: EditorHost,
+  host: EditorHost,
   markdown: string,
   parent?: string,
   index?: number
 ) {
-  const job = new Job({ workspace: root.std.page.workspace });
+  const job = new Job({ workspace: host.std.page.workspace });
   const markdownAdapter = new MarkdownAdapter();
   const { blockVersions, workspaceVersion, pageVersion } =
-    root.std.page.workspace.meta;
+    host.std.page.workspace.meta;
   if (!blockVersions || !workspaceVersion || !pageVersion)
     throw new Error(
       'Need blockVersions, workspaceVersion, pageVersion meta information to get slice'
@@ -36,8 +36,8 @@ export async function insertFromMarkdown(
     blockVersions,
     pageVersion,
     workspaceVersion,
-    workspaceId: root.std.page.workspace.id,
-    pageId: root.std.page.id,
+    workspaceId: host.std.page.workspace.id,
+    pageId: host.std.page.id,
   };
 
   const snapshots = (await markdownAdapter.toSliceSnapshot(payload)).content[0]
@@ -47,7 +47,7 @@ export async function insertFromMarkdown(
   snapshots.forEach(async (blockSnapshot, i) => {
     const model = await job.snapshotToBlock(
       blockSnapshot,
-      root.std.page,
+      host.std.page,
       parent,
       (index ?? 0) + i
     );

--- a/packages/presets/src/fragments/ai-panel/utils/mind-map-utils.ts
+++ b/packages/presets/src/fragments/ai-panel/utils/mind-map-utils.ts
@@ -6,7 +6,7 @@ import {
   StrokeStyle,
 } from '@blocksuite/blocks';
 
-import type { EditorContainer } from '../../../editors/index.js';
+import type { AffineEditorContainer } from '../../../editors/index.js';
 
 interface Position {
   x: number;
@@ -52,7 +52,7 @@ export const DEFAULT_CONNECTOR_PROPS = {
   rearEndpointStyle: ConnectorEndpointStyle.None,
 };
 
-export function getEdgelessPageBlockFromEditor(editor: EditorContainer) {
+export function getEdgelessPageBlockFromEditor(editor: AffineEditorContainer) {
   const edgelessPage = editor.getElementsByTagName('affine-edgeless-page')[0];
   if (!edgelessPage) {
     alert('Please switch to edgeless mode');

--- a/packages/presets/src/fragments/ai-panel/utils/selection-utils.ts
+++ b/packages/presets/src/fragments/ai-panel/utils/selection-utils.ts
@@ -6,10 +6,10 @@ import type { AffineEditorContainer } from '../../../editors/index.js';
 import { getMarkdownFromSlice } from './markdown-utils.js';
 import { getEdgelessPageBlockFromEditor } from './mind-map-utils.js';
 
-export function hasSelectedTextContent(root: EditorHost) {
+export function hasSelectedTextContent(host: EditorHost) {
   let result = false;
 
-  root.std.command
+  host.std.command
     .pipe()
     .getBlockSelections()
     .inline((ctx, next) => {
@@ -36,10 +36,10 @@ export function hasSelectedTextContent(root: EditorHost) {
   return result;
 }
 
-export async function getSelectedTextSlice(root: EditorHost) {
+export async function getSelectedTextSlice(host: EditorHost) {
   let models: BaseBlockModel[] = [];
 
-  root.std.command
+  host.std.command
     .pipe()
     .getBlockSelections()
     .inline((ctx, next) => {
@@ -64,13 +64,13 @@ export async function getSelectedTextSlice(root: EditorHost) {
     })
     .run();
 
-  return Slice.fromModels(root.std.page, models);
+  return Slice.fromModels(host.std.page, models);
 }
 
-export async function getSelectedBlocks(root: EditorHost) {
+export async function getSelectedBlocks(host: EditorHost) {
   let blocks: BlockElement[] = [];
 
-  root.std.command
+  host.std.command
     .pipe()
     .getBlockSelections()
     .inline((ctx, next) => {
@@ -118,9 +118,9 @@ export async function selectedToPng(editor: AffineEditorContainer) {
   return (await selectedToCanvas(editor))?.toDataURL('image/png');
 }
 
-export async function getSelectedTextContent(root: EditorHost) {
-  const slice = await getSelectedTextSlice(root);
-  return await getMarkdownFromSlice(root, slice);
+export async function getSelectedTextContent(host: EditorHost) {
+  const slice = await getSelectedTextSlice(host);
+  return await getMarkdownFromSlice(host, slice);
 }
 
 export const stopPropagation = (e: Event) => {

--- a/packages/presets/src/fragments/ai-panel/utils/selection-utils.ts
+++ b/packages/presets/src/fragments/ai-panel/utils/selection-utils.ts
@@ -1,12 +1,12 @@
 import { BlocksUtils } from '@blocksuite/blocks';
-import type { BlockElement, BlockSuiteRoot } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import { type BaseBlockModel, Slice } from '@blocksuite/store';
 
-import type { EditorContainer } from '../../../editors/index.js';
+import type { AffineEditorContainer } from '../../../editors/index.js';
 import { getMarkdownFromSlice } from './markdown-utils.js';
 import { getEdgelessPageBlockFromEditor } from './mind-map-utils.js';
 
-export function hasSelectedTextContent(root: BlockSuiteRoot) {
+export function hasSelectedTextContent(root: EditorHost) {
   let result = false;
 
   root.std.command
@@ -36,7 +36,7 @@ export function hasSelectedTextContent(root: BlockSuiteRoot) {
   return result;
 }
 
-export async function getSelectedTextSlice(root: BlockSuiteRoot) {
+export async function getSelectedTextSlice(root: EditorHost) {
   let models: BaseBlockModel[] = [];
 
   root.std.command
@@ -67,7 +67,7 @@ export async function getSelectedTextSlice(root: BlockSuiteRoot) {
   return Slice.fromModels(root.std.page, models);
 }
 
-export async function getSelectedBlocks(root: BlockSuiteRoot) {
+export async function getSelectedBlocks(root: EditorHost) {
   let blocks: BlockElement[] = [];
 
   root.std.command
@@ -96,7 +96,7 @@ export async function getSelectedBlocks(root: BlockSuiteRoot) {
   return blocks;
 }
 
-export async function selectedToCanvas(editor: EditorContainer) {
+export async function selectedToCanvas(editor: AffineEditorContainer) {
   const edgelessPage = getEdgelessPageBlockFromEditor(editor);
   const { notes, frames, shapes, images } = BlocksUtils.splitElements(
     edgelessPage.selectionManager.elements
@@ -114,11 +114,11 @@ export async function selectedToCanvas(editor: EditorContainer) {
   return canvas;
 }
 
-export async function selectedToPng(editor: EditorContainer) {
+export async function selectedToPng(editor: AffineEditorContainer) {
   return (await selectedToCanvas(editor))?.toDataURL('image/png');
 }
 
-export async function getSelectedTextContent(root: BlockSuiteRoot) {
+export async function getSelectedTextContent(root: EditorHost) {
   const slice = await getSelectedTextSlice(root);
   return await getMarkdownFromSlice(root, slice);
 }

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -88,7 +88,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: EditorHost;
+  editorHost!: EditorHost;
 
   @property({ attribute: false })
   changeEditorMode!: (mode: 'page' | 'edgeless') => void;
@@ -107,7 +107,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
   fitPadding!: number[];
 
   @property({ attribute: false })
-  host!: Document | HTMLElement;
+  domHost!: Document | HTMLElement;
 
   @query('.frame-list-container')
   frameListContainer!: HTMLElement;
@@ -287,7 +287,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
       width,
       container: this,
       doc: this.ownerDocument,
-      host: this.host ?? this.ownerDocument,
+      domHost: this.domHost ?? this.ownerDocument,
       start: {
         x: e.detail.clientX,
         y: e.detail.clientY,
@@ -297,7 +297,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
       frameElementHeight: this._frameElementHeight,
       edgeless: this.edgeless,
       page: this.page,
-      editorHost: this.root,
+      editorHost: this.editorHost,
       onDragEnd: insertIdx => {
         this._dragging = false;
         this.insertIndex = undefined;
@@ -358,7 +358,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
           data-frame-id=${frameItem.frame.id}
           .edgeless=${this.edgeless}
           .page=${this.page}
-          .root=${this.root}
+          .root=${this.editorHost}
           .frame=${frameItem.frame}
           .cardIndex=${idx}
           .frameIndex=${frameItem.frameIndex}

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -297,7 +297,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
       frameElementHeight: this._frameElementHeight,
       edgeless: this.edgeless,
       page: this.page,
-      root: this.root,
+      editorHost: this.root,
       onDragEnd: insertIdx => {
         this._dragging = false;
         this.insertIndex = undefined;

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -9,7 +9,7 @@ import {
   saveViewportToSession,
 } from '@blocksuite/blocks';
 import { DisposableGroup } from '@blocksuite/global/utils';
-import { type BlockSuiteRoot, WithDisposable } from '@blocksuite/lit';
+import { type EditorHost, WithDisposable } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
@@ -88,7 +88,7 @@ export class FramePanelBody extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   changeEditorMode!: (mode: 'page' | 'edgeless') => void;

--- a/packages/presets/src/fragments/frame-panel/card/frame-card.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card.ts
@@ -123,7 +123,7 @@ export class FrameCard extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: EditorHost;
+  host!: EditorHost;
 
   @property({ attribute: false })
   cardIndex!: number;
@@ -283,7 +283,7 @@ export class FrameCard extends WithDisposable(LitElement) {
           ? nothing
           : html`<frame-preview
               .edgeless=${this.edgeless}
-              .root=${this.root}
+              .host=${this.host}
               .page=${this.page}
               .frame=${this.frame}
             ></frame-preview>`}

--- a/packages/presets/src/fragments/frame-panel/card/frame-card.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card.ts
@@ -7,7 +7,7 @@ import {
   once,
 } from '@blocksuite/blocks';
 import { DisposableGroup } from '@blocksuite/global/utils';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import { WithDisposable } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
@@ -123,7 +123,7 @@ export class FrameCard extends WithDisposable(LitElement) {
   page!: Page;
 
   @property({ attribute: false })
-  root!: BlockSuiteRoot;
+  root!: EditorHost;
 
   @property({ attribute: false })
   cardIndex!: number;

--- a/packages/presets/src/fragments/frame-panel/frame-panel.ts
+++ b/packages/presets/src/fragments/frame-panel/frame-panel.ts
@@ -109,7 +109,7 @@ export class FramePanel extends WithDisposable(LitElement) {
         class="frame-panel-body"
         .edgeless=${this.edgeless}
         .page=${this.page}
-        .root=${this.root}
+        .editorHost=${this.root}
         .changeEditorMode=${this._changeEditorMode}
         .fitPadding=${this.fitPadding}
       ></frame-panel-body>

--- a/packages/presets/src/fragments/frame-panel/frame-panel.ts
+++ b/packages/presets/src/fragments/frame-panel/frame-panel.ts
@@ -2,12 +2,12 @@ import './header/frame-panel-header.js';
 import './body/frame-panel-body.js';
 
 import { FramePreview } from '@blocksuite/blocks';
-import { type BlockSuiteRoot, WithDisposable } from '@blocksuite/lit';
+import { type EditorHost, WithDisposable } from '@blocksuite/lit';
 import { baseTheme } from '@toeverything/theme';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import type { EditorContainer } from '../../index.js';
+import type { AffineEditorContainer } from '../../index.js';
 import { FramePanelBody } from './body/frame-panel-body.js';
 import { FrameCard } from './card/frame-card.js';
 import { FrameCardTitle } from './card/frame-card-title.js';
@@ -53,7 +53,7 @@ export class FramePanel extends WithDisposable(LitElement) {
   static override styles = styles;
 
   @property({ attribute: false })
-  editor!: EditorContainer;
+  editor!: AffineEditorContainer;
 
   @property({ attribute: false })
   fitPadding: number[] = [50, 380, 50, 50];
@@ -63,7 +63,7 @@ export class FramePanel extends WithDisposable(LitElement) {
   }
 
   get root() {
-    return this.editor.root as BlockSuiteRoot;
+    return this.editor.root as EditorHost;
   }
 
   get edgeless() {

--- a/packages/presets/src/fragments/frame-panel/utils/drag.ts
+++ b/packages/presets/src/fragments/frame-panel/utils/drag.ts
@@ -29,7 +29,7 @@ export function startDragging(
     frameListContainer: HTMLElement;
     frameElementHeight: number;
     doc: Document;
-    host: Document | HTMLElement;
+    domHost: Document | HTMLElement;
     container: FramePanelBody;
     start: {
       x: number;
@@ -42,7 +42,7 @@ export function startDragging(
 ) {
   const {
     doc,
-    host,
+    domHost,
     container,
     onDragMove,
     onDragEnd,
@@ -61,7 +61,7 @@ export function startDragging(
 
       el.edgeless = edgeless;
       el.page = page;
-      el.root = editorHost;
+      el.host = editorHost;
       el.frame = frame.frame;
 
       el.cardIndex = frame.cardIndex;
@@ -152,7 +152,7 @@ export function startDragging(
     onDragEnd?.(idx);
   };
 
-  once(host as Document, 'mouseup', dragEnd);
+  once(domHost as Document, 'mouseup', dragEnd);
 }
 
 function createMaskElement(doc: Document) {

--- a/packages/presets/src/fragments/frame-panel/utils/drag.ts
+++ b/packages/presets/src/fragments/frame-panel/utils/drag.ts
@@ -37,7 +37,7 @@ export function startDragging(
     };
     edgeless: EdgelessPageBlockComponent | null;
     page: Page;
-    root: EditorHost;
+    editorHost: EditorHost;
   }
 ) {
   const {
@@ -52,7 +52,7 @@ export function startDragging(
     start,
     edgeless,
     page,
-    root,
+    editorHost,
   } = options;
   const cardElements = frames
     .slice(frames.length - 2, frames.length)
@@ -61,7 +61,7 @@ export function startDragging(
 
       el.edgeless = edgeless;
       el.page = page;
-      el.root = root;
+      el.root = editorHost;
       el.frame = frame.frame;
 
       el.cardIndex = frame.cardIndex;

--- a/packages/presets/src/fragments/frame-panel/utils/drag.ts
+++ b/packages/presets/src/fragments/frame-panel/utils/drag.ts
@@ -4,7 +4,7 @@ import {
   on,
   once,
 } from '@blocksuite/blocks';
-import type { BlockSuiteRoot } from '@blocksuite/lit';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 
 import type { FramePanelBody } from '../body/frame-panel-body.js';
@@ -37,7 +37,7 @@ export function startDragging(
     };
     edgeless: EdgelessPageBlockComponent | null;
     page: Page;
-    root: BlockSuiteRoot;
+    root: EditorHost;
   }
 ) {
   const {

--- a/packages/presets/tests/env.d.ts
+++ b/packages/presets/tests/env.d.ts
@@ -1,14 +1,14 @@
 import type { Page, Workspace } from '@blocksuite/store';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import type { EditorContainer } from '../src/index.js';
+import type { AffineEditorContainer } from '../src/index.js';
 
 declare global {
-  const editor: EditorContainer;
+  const editor: AffineEditorContainer;
   const page: Page;
   const workspace: Workspace;
   interface Window {
-    editor: EditorContainer;
+    editor: AffineEditorContainer;
     page: Page;
     workspace: Workspace;
   }

--- a/packages/presets/tests/utils/edgeless.ts
+++ b/packages/presets/tests/utils/edgeless.ts
@@ -3,9 +3,9 @@ import type { SurfaceBlockComponent } from '@blocksuite/blocks';
 import type { Page } from '@blocksuite/store';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import type { EditorContainer } from '../../src/index.js';
+import type { AffineEditorContainer } from '../../src/index.js';
 
-export function getSurface(page: Page, editor: EditorContainer) {
+export function getSurface(page: Page, editor: AffineEditorContainer) {
   const surfaceModel = page.getBlockByFlavour('affine:surface');
 
   return editor.root!.view.viewFromPath('block', [

--- a/packages/presets/tests/utils/setup.ts
+++ b/packages/presets/tests/utils/setup.ts
@@ -9,7 +9,7 @@ import {
 import { createMemoryStorage, Generator, Schema } from '@blocksuite/store';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { EditorContainer } from '../../src/index.js';
+import { AffineEditorContainer } from '../../src/index.js';
 
 function createWorkspaceOptions() {
   const providerCreators: DocProviderCreator[] = [];
@@ -52,7 +52,7 @@ async function initWorkspace(workspace: Workspace) {
 }
 
 function createEditor(page: Page, element: HTMLElement) {
-  const editor = new EditorContainer();
+  const editor = new AffineEditorContainer();
   editor.page = page;
   element.append(editor);
 

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -61,7 +61,7 @@ export class Page extends Space<FlatBlockMap> {
      * Note that at this moment, the whole block tree may not be fully initialized yet.
      */
     rootAdded: new Slot<BaseBlockModel>(),
-    rootDeleted: new Slot<string | string[]>(),
+    rootDeleted: new Slot<string>(),
     blockUpdated: new Slot<
       | {
           type: 'add';

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -645,8 +645,8 @@ test.describe('slash menu with customize menu', () => {
           r: Symbol.for(''),
         }) as const;
 
-      const editor = document.querySelector('editor-container');
-      if (!editor) throw new Error("Can't find editor-container");
+      const editor = document.querySelector('affine-editor-container');
+      if (!editor) throw new Error("Can't find affine-editor-container");
 
       const SlashMenuWidget = window.$blocksuite.blocks.AffineSlashMenuWidget;
       class CustomSlashMenu extends SlashMenuWidget {
@@ -691,8 +691,8 @@ test.describe('slash menu with customize menu', () => {
           r: Symbol.for(''),
         }) as const;
 
-      const editor = document.querySelector('editor-container');
-      if (!editor) throw new Error("Can't find editor-container");
+      const editor = document.querySelector('affine-editor-container');
+      if (!editor) throw new Error("Can't find affine-editor-container");
       const SlashMenuWidget = window.$blocksuite.blocks.AffineSlashMenuWidget;
 
       class CustomSlashMenu extends SlashMenuWidget {

--- a/tests/utils/actions/block.ts
+++ b/tests/utils/actions/block.ts
@@ -14,7 +14,7 @@ export async function updateBlockType(
   await page.evaluate(
     ([flavour, type]) => {
       const blocks: BlockElement[] = [];
-      window.root.std.command
+      window.host.std.command
         .pipe()
         .withHost()
         .tryAll(chain => [chain.getTextSelection(), chain.getBlockSelections()])

--- a/tests/utils/actions/block.ts
+++ b/tests/utils/actions/block.ts
@@ -16,7 +16,7 @@ export async function updateBlockType(
       const blocks: BlockElement[] = [];
       window.root.std.command
         .pipe()
-        .withRoot()
+        .withHost()
         .tryAll(chain => [chain.getTextSelection(), chain.getBlockSelections()])
         .getSelectedBlocks({
           types: ['text', 'block'],

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -147,10 +147,10 @@ export async function cutByKeyboard(page: Page) {
 export async function pasteByKeyboard(page: Page, forceFocus = true) {
   if (forceFocus) {
     const isEditorActive = await page.evaluate(
-      () => document.activeElement?.closest('editor-container')
+      () => document.activeElement?.closest('affine-editor-container')
     );
     if (!isEditorActive) {
-      await page.click('editor-container');
+      await page.click('affine-editor-container');
     }
   }
 

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -85,7 +85,7 @@ async function initEmptyEditor({
           throw new Error('Cannot find app root element(#app).');
         }
         const createEditor = () => {
-          const editor = document.createElement('editor-container');
+          const editor = document.createElement('affine-editor-container');
           editor.page = page;
           editor.autofocus = true;
           editor.slots.pageLinkClicked.on(({ pageId }) => {
@@ -140,7 +140,7 @@ async function initEmptyEditor({
 }
 
 export const getEditorLocator = (page: Page) => {
-  return page.locator('editor-container').nth(currentEditorIndex);
+  return page.locator('affine-editor-container').nth(currentEditorIndex);
 };
 export const getBlockHub = (page: Page) => {
   return page.locator('affine-block-hub').nth(currentEditorIndex);
@@ -599,7 +599,7 @@ export async function focusRichText(
 export async function focusRichTextEnd(page: Page, i = 0) {
   await page.evaluate(
     ([i]) => {
-      const editor = document.querySelectorAll('editor-container')[i];
+      const editor = document.querySelectorAll('affine-editor-container')[i];
       const richTexts = Array.from(editor.querySelectorAll('rich-text'));
 
       richTexts[i].vEditor?.focusEnd();
@@ -1104,8 +1104,8 @@ export async function initImageState(page: Page) {
 
 export async function getCurrentEditorPageId(page: Page) {
   return await page.evaluate(index => {
-    const editor = document.querySelectorAll('editor-container')[index];
-    if (!editor) throw new Error("Can't find editor-container");
+    const editor = document.querySelectorAll('affine-editor-container')[index];
+    if (!editor) throw new Error("Can't find affine-editor-container");
     const pageId = editor.page.id;
     return pageId;
   }, currentEditorIndex);
@@ -1118,7 +1118,7 @@ export async function getCurrentHTMLTheme(page: Page) {
 
 export async function getCurrentEditorTheme(page: Page) {
   const mode = await page
-    .locator('editor-container')
+    .locator('affine-editor-container')
     .first()
     .evaluate(ele => {
       return (ele as unknown as Element & { themeObserver: ThemeObserver })
@@ -1132,7 +1132,7 @@ export async function getCurrentThemeCSSPropertyValue(
   property: CssVariableName
 ) {
   const value = await page
-    .locator('editor-container')
+    .locator('affine-editor-container')
     .evaluate((ele, property: CssVariableName) => {
       return (ele as unknown as Element & { themeObserver: ThemeObserver })
         .themeObserver.cssVariables?.[property];

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -186,7 +186,7 @@ export async function assertTextContain(page: Page, text: string, i = 0) {
 
 export async function assertRichTexts(page: Page, texts: string[]) {
   const actualTexts = await page.evaluate(index => {
-    const editor = document.querySelectorAll('editor-container')[index];
+    const editor = document.querySelectorAll('affine-editor-container')[index];
     const richTexts = Array.from(
       editor?.querySelectorAll<RichText>('rich-text') ?? []
     );
@@ -300,7 +300,9 @@ export async function assertRichTextVRange(
 ) {
   const actual = await page.evaluate(
     ([richTextIndex, index]) => {
-      const editor = document.querySelectorAll('editor-container')[index];
+      const editor = document.querySelectorAll('affine-editor-container')[
+        index
+      ];
       const richText = editor?.querySelectorAll('rich-text')[richTextIndex];
       const vEditor = richText.vEditor;
       return vEditor?.getVRange();
@@ -385,7 +387,7 @@ export async function assertRichTextModelType(
 
 export async function assertTextFormats(page: Page, resultObj: unknown[]) {
   const actual = await page.evaluate(index => {
-    const editor = document.querySelectorAll('editor-container')[index];
+    const editor = document.querySelectorAll('affine-editor-container')[index];
     const elements = editor?.querySelectorAll('rich-text');
     return Array.from(elements).map(el => {
       const vEditor = el.vEditor;
@@ -504,7 +506,7 @@ export async function assertBlockProps(
 
 export async function assertBlockTypes(page: Page, blockTypes: string[]) {
   const actual = await page.evaluate(index => {
-    const editor = document.querySelectorAll('editor-container')[index];
+    const editor = document.querySelectorAll('affine-editor-container')[index];
     const elements = editor?.querySelectorAll('[data-block-id]');
     return (
       Array.from(elements)
@@ -636,7 +638,7 @@ export async function assertClipItems(
   // FIXME: use original clipboard API
   // const clipItems = await page.evaluate(() => {
   //   return document
-  //     .getElementsByTagName('editor-container')[0]
+  //     .getElementsByTagName('affine-editor-container')[0]
   //     .clipboard['_copy']['_getClipItems']();
   // });
   // const actual = clipItems.find(item => item.mimeType === key)?.data;

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -28,7 +28,7 @@ declare global {
     page: Page;
     debugMenu: DebugMenu;
     editor: AffineEditorContainer;
-    root: EditorHost;
+    host: EditorHost;
     testUtils: TestUtils;
 
     // TODO: remove this when provider support subdocument

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -3,7 +3,7 @@ import type { ContentParser } from '../../packages/blocks/src/content-parser.js'
 import type { TestUtils } from '../../packages/blocks/src/index.js';
 import type { BlockSuiteRoot } from '../../packages/lit/src/index.js';
 import type { DebugMenu } from '../../packages/playground/apps/starter/components/debug-menu.js';
-import type { EditorContainer } from '../../packages/presets/src/index.js';
+import type { AffineEditorContainer } from '../../packages/presets/src/index.js';
 import type {
   BaseBlockModel,
   Page,
@@ -27,7 +27,7 @@ declare global {
     blockSchema: Record<string, typeof BaseBlockModel>;
     page: Page;
     debugMenu: DebugMenu;
-    editor: EditorContainer;
+    editor: AffineEditorContainer;
     root: BlockSuiteRoot;
     testUtils: TestUtils;
 

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import type { ContentParser } from '../../packages/blocks/src/content-parser.js';
 import type { TestUtils } from '../../packages/blocks/src/index.js';
-import type { BlockSuiteRoot } from '../../packages/lit/src/index.js';
+import type { EditorHost } from '../../packages/lit/src/index.js';
 import type { DebugMenu } from '../../packages/playground/apps/starter/components/debug-menu.js';
 import type { AffineEditorContainer } from '../../packages/presets/src/index.js';
 import type {
@@ -28,7 +28,7 @@ declare global {
     page: Page;
     debugMenu: DebugMenu;
     editor: AffineEditorContainer;
-    root: BlockSuiteRoot;
+    root: EditorHost;
     testUtils: TestUtils;
 
     // TODO: remove this when provider support subdocument

--- a/tests/utils/playwright.ts
+++ b/tests/utils/playwright.ts
@@ -83,8 +83,9 @@ if (scope) {
     }
     const focusInSecondEditor = await page.evaluate(
       ([currentEditorIndex]) => {
-        const editor =
-          document.querySelectorAll('editor-container')[currentEditorIndex];
+        const editor = document.querySelectorAll('affine-editor-container')[
+          currentEditorIndex
+        ];
         const selection = getSelection();
         if (!selection || selection.rangeCount === 0) {
           return true;
@@ -101,7 +102,7 @@ if (scope) {
     await enterPlaygroundRoom(page);
     await initEmptyParagraphState(page);
     const count = await page.evaluate(() => {
-      return document.querySelectorAll('editor-container').length;
+      return document.querySelectorAll('affine-editor-container').length;
     });
 
     expect(count).toBe(2);


### PR DESCRIPTION
* `EditorContainer` -> `AffineEditorContainer`
* `BlockSuiteRoot` -> `EditorHost`
* `withRoot` -> `withHost`
* `blockElement.root` -> `blockElement.host`
* `window.root` -> `window.host` (playground console only)