### PR TITLE
refactor:  optimize the implementation of isNativeTextInVText

### DIFF
--- a/packages/inline/src/utils/guard.ts
+++ b/packages/inline/src/utils/guard.ts
@@ -1,10 +1,7 @@
 import { VElement, VLine } from '../components/index.js';
 
 export function isNativeTextInVText(text: unknown): text is Text {
-  return (
-    text instanceof Text &&
-    (text.parentElement?.dataset.vText === 'true' ?? false)
-  );
+  return text instanceof Text && text.parentElement?.dataset.vText === 'true';
 }
 
 export function isVElement(element: unknown): element is HTMLElement {


### PR DESCRIPTION
Current implementation will cause warning that is `The "??" operator here will always return the left operand`.