### PR TITLE
fix(edgeless): fix blur toolbar

### DIFF
--- a/packages/blocks/src/_common/icons/edgeless.ts
+++ b/packages/blocks/src/_common/icons/edgeless.ts
@@ -1834,9 +1834,9 @@ export const EdgelessEraserIcon = html`
 `;
 
 export const EdgelessTextIcon = html`<svg
-  width="53"
+  width="54"
   height="44"
-  viewBox="0 0 53 44"
+  viewBox="0 0 54 44"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/text/text-tool-button.ts
@@ -22,7 +22,7 @@ export class EdgelessTextToolButton extends WithDisposable(LitElement) {
     }
     .edgeless-text-button {
       position: relative;
-      width: 53px;
+      width: 54px;
       height: 44px;
       overflow-y: hidden;
     }


### PR DESCRIPTION
`transform` an element with odd sizes may cause blur. So, I updated the odd width to be an even number.
After fix:

https://github.com/toeverything/blocksuite/assets/21242087/757a9ca5-f21d-419d-8bb5-c34bb9d42349

