### PR TITLE
revert: fix DOMException on encountering {} in markdown

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -144,8 +144,5 @@ export default defineConfig({
         },
       });
     },
-    attrs: {
-      disable: true,
-    },
   },
 });

--- a/packages/inline/src/services/range.ts
+++ b/packages/inline/src/services/range.ts
@@ -317,26 +317,32 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
    * there are three cases when the inline ranage of this Editor is not null:
    * (In the following, "|" mean anchor and focus, each line is a separate Editor)
    * 1. anchor and focus are in this Editor
+   *    ```
    *    aaaaaa
    *    b|bbbb|b
    *    cccccc
-   *    the inline ranage of second Editor is {index: 1, length: 4}, the others are null
+   *    ```
+   *    the inline ranage of second Editor is `{index: 1, length: 4}`, the others are null
    * 2. anchor and focus one in this Editor, one in another Editor
+   *    ```
    *    aaa|aaa    aaaaaa
    *    bbbbb|b or bbbbb|b
    *    cccccc     cc|cccc
+   *    ```
    *    2.1
-   *        the inline ranage of first Editor is {index: 3, length: 3}, the second is {index: 0, length: 5},
+   *        the inline ranage of first Editor is `{index: 3, length: 3}`, the second is `{index: 0, length: 5}`,
    *        the third is null
    *    2.2
-   *        the inline ranage of first Editor is null, the second is {index: 5, length: 1},
-   *        the third is {index: 0, length: 2}
+   *        the inline ranage of first Editor is null, the second is `{index: 5, length: 1}`,
+   *        the third is `{index: 0, length: 2}`
    * 3. anchor and focus are in another Editor
+   *    ```
    *    aa|aaaa
    *    bbbbbb
    *    cccc|cc
-   *    the inline range of first Editor is {index: 2, length: 4},
-   *    the second is {index: 0, length: 6}, the third is {index: 0, length: 4}
+   *    ```
+   *    the inline range of first Editor is `{index: 2, length: 4}`,
+   *    the second is `{index: 0, length: 6}`, the third is `{index: 0, length: 4}`
    */
   toInlineRange = (range: Range): InlineRange | null => {
     const { rootElement, yText } = this.editor;


### PR DESCRIPTION
This reverts 2be59aa30320d9ef1817af1dacfc261047da5396
https://github.com/toeverything/blocksuite/pull/5683