### PR TITLE
fix: markdown table view format workaround

### DIFF
--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -19,11 +19,14 @@ import {
 import { nanoid } from '@blocksuite/store';
 import { ASTWalker, BaseAdapter } from '@blocksuite/store';
 import { sha } from '@blocksuite/store';
-import type { Heading, Root, RootContentMap } from 'mdast';
+import format from 'date-fns/format';
+import type { Heading, Root, RootContentMap, TableRow } from 'mdast';
 import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
 import { unified } from 'unified';
 
+import type { SerializedCells } from '../../database-block/database-model.js';
+import type { Column } from '../../database-block/types.js';
 import { getFilenameFromContentDisposition } from '../utils/header-value-parser.js';
 import { remarkGfm } from './gfm.js';
 
@@ -82,7 +85,7 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
       assets
     );
     return {
-      file: this._astToMardown(ast),
+      file: this._astToMarkdown(ast),
       assetsIds,
     };
   }
@@ -104,7 +107,7 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
         assets
       );
       sliceAssetsIds.push(...assetsIds);
-      buffer += this._astToMardown(ast);
+      buffer += this._astToMarkdown(ast);
     }
     const markdown =
       buffer.match(/\n/g)?.length === 1 ? buffer.trimEnd() : buffer;
@@ -445,6 +448,129 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
               'children'
             )
             .closeNode();
+          break;
+        }
+        case 'affine:database': {
+          const rows: TableRow[] = [];
+          const columns = o.node.props.columns as Array<Column>;
+          const children = o.node.children;
+          const cells = o.node.props.cells as SerializedCells;
+          const createAstCell = (
+            children: Record<string, string | undefined | unknown>[]
+          ) => ({
+            type: 'tableCell',
+            children,
+          });
+          const mdAstCells = Array.prototype.map.call(children, v =>
+            Array.prototype.map.call(columns, col => {
+              const cell = cells[v.id]?.[col.id];
+              let r;
+              if (cell || col.type === 'title') {
+                switch (col.type) {
+                  case 'link':
+                  case 'progress':
+                  case 'number':
+                    r = createAstCell([
+                      {
+                        type: 'text',
+                        value: cell.value,
+                      },
+                    ]);
+                    break;
+                  case 'rich-text':
+                    r = createAstCell([
+                      {
+                        type: 'text',
+                        value: cell.value?.toString(),
+                      },
+                    ]);
+                    break;
+                  case 'title':
+                    r = createAstCell([
+                      {
+                        type: 'text',
+                        value: v.props.text.delta
+                          .map((v: { insert: string }) => v.insert)
+                          .join(''),
+                      },
+                    ]);
+                    break;
+                  case 'date':
+                    r = createAstCell([
+                      {
+                        type: 'text',
+                        value: format(
+                          new Date(cell.value as number),
+                          'yyyy-MM-dd'
+                        ),
+                      },
+                    ]);
+                    break;
+                  case 'select': {
+                    const value = col.data.options.find(
+                      (opt: Record<string, string>) => opt.id === cell.value
+                    )?.value;
+                    r = createAstCell([{ type: 'text', value }]);
+                    break;
+                  }
+                  case 'multi-select': {
+                    const value = Array.prototype.map
+                      .call(
+                        cell.value,
+                        val =>
+                          col.data.options.find(
+                            (opt: Record<string, string>) => val === opt.id
+                          ).value
+                      )
+                      .filter(Boolean)
+                      .join(',');
+
+                    r = createAstCell([{ type: 'text', value }]);
+                    break;
+                  }
+                  case 'checkbox': {
+                    r = createAstCell([{ type: 'text', value: cell.value }]);
+                    break;
+                  }
+                  default:
+                    r = createAstCell([{ type: 'text', value: '' }]);
+                }
+              } else {
+                r = createAstCell([{ type: 'text', value: '' }]);
+              }
+              return r;
+            })
+          );
+
+          // Handle first row.
+          if (Array.isArray(columns)) {
+            rows.push({
+              type: 'tableRow',
+              children: Array.prototype.map.call(columns, v =>
+                createAstCell([
+                  {
+                    type: 'text',
+                    value: v.name,
+                  },
+                ])
+              ) as [],
+            });
+          }
+
+          // Handle 2-... rows
+          Array.prototype.forEach.call(mdAstCells, children => {
+            rows.push({ type: 'tableRow', children });
+          });
+
+          context
+            .openNode({
+              type: 'table',
+              children: rows,
+            })
+            .closeNode();
+
+          context.skipAllChildren();
+          break;
         }
       }
     });
@@ -789,7 +915,7 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
     return walker.walk(markdown, snapshot);
   };
 
-  private _astToMardown(ast: Root) {
+  private _astToMarkdown(ast: Root) {
     return unified()
       .use(remarkGfm)
       .use(remarkStringify, {

--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -461,84 +461,90 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
             type: 'tableCell',
             children,
           });
-          const mdAstCells = Array.prototype.map.call(children, v =>
-            Array.prototype.map.call(columns, col => {
-              const cell = cells[v.id]?.[col.id];
-              let r;
-              if (cell || col.type === 'title') {
-                switch (col.type) {
-                  case 'link':
-                  case 'progress':
-                  case 'number':
-                    r = createAstCell([
-                      {
-                        type: 'text',
-                        value: cell.value,
-                      },
-                    ]);
-                    break;
-                  case 'rich-text':
-                    r = createAstCell([
-                      {
-                        type: 'text',
-                        value: cell.value?.toString(),
-                      },
-                    ]);
-                    break;
-                  case 'title':
-                    r = createAstCell([
-                      {
-                        type: 'text',
-                        value: v.props.text.delta
-                          .map((v: { insert: string }) => v.insert)
-                          .join(''),
-                      },
-                    ]);
-                    break;
-                  case 'date':
-                    r = createAstCell([
-                      {
-                        type: 'text',
-                        value: format(
-                          new Date(cell.value as number),
-                          'yyyy-MM-dd'
-                        ),
-                      },
-                    ]);
-                    break;
-                  case 'select': {
-                    const value = col.data.options.find(
-                      (opt: Record<string, string>) => opt.id === cell.value
-                    )?.value;
-                    r = createAstCell([{ type: 'text', value }]);
-                    break;
+          const mdAstCells = Array.prototype.map.call(
+            children,
+            (v: BlockSnapshot) =>
+              Array.prototype.map.call(columns, col => {
+                const cell = cells[v.id]?.[col.id];
+                let r;
+                if (cell || col.type === 'title') {
+                  switch (col.type) {
+                    case 'link':
+                    case 'progress':
+                    case 'number':
+                      r = createAstCell([
+                        {
+                          type: 'text',
+                          value: cell.value,
+                        },
+                      ]);
+                      break;
+                    case 'rich-text':
+                      r = createAstCell([
+                        {
+                          type: 'text',
+                          value: (cell.value as { delta: DeltaInsert[] }).delta
+                            .map(v => v.insert)
+                            .join(),
+                        },
+                      ]);
+                      break;
+                    case 'title':
+                      r = createAstCell([
+                        {
+                          type: 'text',
+                          value: (
+                            v.props.text as { delta: DeltaInsert[] }
+                          ).delta
+                            .map(v => v.insert)
+                            .join(''),
+                        },
+                      ]);
+                      break;
+                    case 'date':
+                      r = createAstCell([
+                        {
+                          type: 'text',
+                          value: format(
+                            new Date(cell.value as number),
+                            'yyyy-MM-dd'
+                          ),
+                        },
+                      ]);
+                      break;
+                    case 'select': {
+                      const value = col.data.options.find(
+                        (opt: Record<string, string>) => opt.id === cell.value
+                      )?.value;
+                      r = createAstCell([{ type: 'text', value }]);
+                      break;
+                    }
+                    case 'multi-select': {
+                      const value = Array.prototype.map
+                        .call(
+                          cell.value,
+                          val =>
+                            col.data.options.find(
+                              (opt: Record<string, string>) => val === opt.id
+                            ).value
+                        )
+                        .filter(Boolean)
+                        .join(',');
+                      r = createAstCell([{ type: 'text', value }]);
+                      break;
+                    }
+                    case 'checkbox': {
+                      r = createAstCell([{ type: 'text', value: cell.value }]);
+                      break;
+                    }
+                    default:
+                      r = createAstCell([{ type: 'text', value: '' }]);
                   }
-                  case 'multi-select': {
-                    const value = Array.prototype.map
-                      .call(
-                        cell.value,
-                        val =>
-                          col.data.options.find(
-                            (opt: Record<string, string>) => val === opt.id
-                          ).value
-                      )
-                      .filter(Boolean)
-                      .join(',');
-                    r = createAstCell([{ type: 'text', value }]);
-                    break;
-                  }
-                  case 'checkbox': {
-                    r = createAstCell([{ type: 'text', value: cell.value }]);
-                    break;
-                  }
-                  default:
-                    r = createAstCell([{ type: 'text', value: '' }]);
+                } else {
+                  r = createAstCell([{ type: 'text', value: '' }]);
                 }
-              } else {
-                r = createAstCell([{ type: 'text', value: '' }]);
-              }
-              return r;
-            })
+                return r;
+              })
           );
 
           // Handle first row.

--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -524,7 +524,6 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
                       )
                       .filter(Boolean)
                       .join(',');
-
                     r = createAstCell([{ type: 'text', value }]);
                     break;
                   }

--- a/packages/blocks/src/_common/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/_common/adapters/markdown.unit.spec.ts
@@ -1038,7 +1038,12 @@ hhh
             'block:O8dpIDiP7-': {
               columnId: 'block:O8dpIDiP7-',
               value: {
-                _yText: 'test1',
+                '$blocksuite:internal:text$': true,
+                delta: [
+                  {
+                    insert: 'test2',
+                  },
+                ],
               },
             },
             'block:U8lPD59MkF': {
@@ -1058,7 +1063,12 @@ hhh
             'block:O8dpIDiP7-': {
               columnId: 'block:O8dpIDiP7-',
               value: {
-                _yText: 'test2',
+                '$blocksuite:internal:text$': true,
+                delta: [
+                  {
+                    insert: 'test1',
+                  },
+                ],
               },
             },
             'block:5cglrBmAr3': {
@@ -1206,7 +1216,7 @@ hhh
       ],
     };
 
-    const md = `| Title  | Status      | Date       | Number | Progress | MultiSelect | RichText         | Link               | Checkbox |\n| ------ | ----------- | ---------- | ------ | -------- | ----------- | ---------------- | ------------------ | -------- |\n| Task 1 | TODO        | 2023-12-15 | 1      | 65       | test1,test2 | \\[object Object] | https://google.com | true     |\n| Task 2 | In Progress | 2023-12-20 |        |          |             | \\[object Object] |                    |          |\n`;
+    const md = `| Title  | Status      | Date       | Number | Progress | MultiSelect | RichText | Link               | Checkbox |\n| ------ | ----------- | ---------- | ------ | -------- | ----------- | -------- | ------------------ | -------- |\n| Task 1 | TODO        | 2023-12-15 | 1      | 65       | test1,test2 | test2    | https://google.com | true     |\n| Task 2 | In Progress | 2023-12-20 |        |          |             | test1    |                    |          |\n`;
     const mdAdapter = new MarkdownAdapter();
     const target = await mdAdapter.fromBlockSnapshot({
       snapshot: blockSnapshot,

--- a/packages/blocks/src/_common/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/_common/adapters/markdown.unit.spec.ts
@@ -1006,6 +1006,213 @@ hhh
     });
     expect(target.file).toBe(markdown);
   });
+
+  test('table', async () => {
+    const blockSnapshot: BlockSnapshot = {
+      type: 'block',
+      id: 'block:8Wb7CSJ9Qe',
+      flavour: 'affine:database',
+      props: {
+        cells: {
+          'block:P_-Wg7Rg9O': {
+            'block:qyo8q9VPWU': {
+              columnId: 'block:qyo8q9VPWU',
+              value: 'TKip9uc7Yx',
+            },
+            'block:5cglrBmAr3': {
+              columnId: 'block:5cglrBmAr3',
+              value: 1702598400000,
+            },
+            'block:8Fa0JQe7WY': {
+              columnId: 'block:8Fa0JQe7WY',
+              value: 1,
+            },
+            'block:5ej6StPuF_': {
+              columnId: 'block:5ej6StPuF_',
+              value: 65,
+            },
+            'block:DPhZ6JBziD': {
+              columnId: 'block:DPhZ6JBziD',
+              value: ['-2_QD3GZT1', '73UrEZWaKk'],
+            },
+            'block:O8dpIDiP7-': {
+              columnId: 'block:O8dpIDiP7-',
+              value: {
+                _yText: 'test1',
+              },
+            },
+            'block:U8lPD59MkF': {
+              columnId: 'block:U8lPD59MkF',
+              value: 'https://google.com',
+            },
+            'block:-DT7B0TafG': {
+              columnId: 'block:-DT7B0TafG',
+              value: true,
+            },
+          },
+          'block:0vhfgcHtPF': {
+            'block:qyo8q9VPWU': {
+              columnId: 'block:qyo8q9VPWU',
+              value: 'F2bgsaE3X2',
+            },
+            'block:O8dpIDiP7-': {
+              columnId: 'block:O8dpIDiP7-',
+              value: {
+                _yText: 'test2',
+              },
+            },
+            'block:5cglrBmAr3': {
+              columnId: 'block:5cglrBmAr3',
+              value: 1703030400000,
+            },
+          },
+          'block:b4_02QXMAM': {
+            'block:qyo8q9VPWU': {
+              columnId: 'block:qyo8q9VPWU',
+              value: 'y3O1A2IHHu',
+            },
+          },
+          'block:W_eirvg7EJ': {
+            'block:qyo8q9VPWU': {
+              columnId: 'block:qyo8q9VPWU',
+            },
+          },
+        },
+        columns: [
+          {
+            type: 'title',
+            name: 'Title',
+            data: {},
+            id: 'block:2VfUaitjf9',
+          },
+          {
+            type: 'select',
+            name: 'Status',
+            data: {
+              options: [
+                {
+                  id: 'TKip9uc7Yx',
+                  color: 'var(--affine-tag-white)',
+                  value: 'TODO',
+                },
+                {
+                  id: 'F2bgsaE3X2',
+                  color: 'var(--affine-tag-green)',
+                  value: 'In Progress',
+                },
+                {
+                  id: 'y3O1A2IHHu',
+                  color: 'var(--affine-tag-gray)',
+                  value: 'Done',
+                },
+              ],
+            },
+            id: 'block:qyo8q9VPWU',
+          },
+          {
+            type: 'date',
+            name: 'Date',
+            data: {},
+            id: 'block:5cglrBmAr3',
+          },
+          {
+            type: 'number',
+            name: 'Number',
+            data: {
+              decimal: 0,
+            },
+            id: 'block:8Fa0JQe7WY',
+          },
+          {
+            type: 'progress',
+            name: 'Progress',
+            data: {},
+            id: 'block:5ej6StPuF_',
+          },
+          {
+            type: 'multi-select',
+            name: 'MultiSelect',
+            data: {
+              options: [
+                {
+                  id: '73UrEZWaKk',
+                  value: 'test2',
+                  color: 'var(--affine-tag-purple)',
+                },
+                {
+                  id: '-2_QD3GZT1',
+                  value: 'test1',
+                  color: 'var(--affine-tag-teal)',
+                },
+              ],
+            },
+            id: 'block:DPhZ6JBziD',
+          },
+          {
+            type: 'rich-text',
+            name: 'RichText',
+            data: {},
+            id: 'block:O8dpIDiP7-',
+          },
+          {
+            type: 'link',
+            name: 'Link',
+            data: {},
+            id: 'block:U8lPD59MkF',
+          },
+          {
+            type: 'checkbox',
+            name: 'Checkbox',
+            data: {},
+            id: 'block:-DT7B0TafG',
+          },
+        ],
+      },
+      children: [
+        {
+          type: 'block',
+          id: 'block:P_-Wg7Rg9O',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Task 1',
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'block:0vhfgcHtPF',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Task 2',
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+
+    const md = `| Title  | Status      | Date       | Number | Progress | MultiSelect | RichText         | Link               | Checkbox |\n| ------ | ----------- | ---------- | ------ | -------- | ----------- | ---------------- | ------------------ | -------- |\n| Task 1 | TODO        | 2023-12-15 | 1      | 65       | test1,test2 | \\[object Object] | https://google.com | true     |\n| Task 2 | In Progress | 2023-12-20 |        |          |             | \\[object Object] |                    |          |\n`;
+    const mdAdapter = new MarkdownAdapter();
+    const target = await mdAdapter.fromBlockSnapshot({
+      snapshot: blockSnapshot,
+    });
+    expect(target.file).toBe(md);
+  });
 });
 
 describe('markdown to snapshot', () => {

--- a/packages/blocks/src/database-block/database-model.ts
+++ b/packages/blocks/src/database-block/database-model.ts
@@ -18,7 +18,7 @@ export type DatabaseBlockProps = {
   columns: Array<Column>;
 };
 
-type SerializedCells = {
+export type SerializedCells = {
   // row
   [key: string]: {
     // column


### PR DESCRIPTION
A workaround for incorrect exported markdown table format, relate to #4632, inline blocks have not been implemented.