### PR TITLE
fix(edgeless): wrong display in canvas editor when setting text-align to right

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -4,7 +4,16 @@
     "scope-enum": [
       2,
       "always",
-      ["page", "edgeless", "database", "store", "std", "presets", "playground"]
+      [
+        "page",
+        "edgeless",
+        "database",
+        "store",
+        "std",
+        "presets",
+        "playground",
+        "inline"
+      ]
     ]
   }
 }

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-text-editor.ts
@@ -62,6 +62,12 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       word-break: keep-all !important;
       overflow-wrap: normal !important;
     }
+
+    /* We cannot add styles directly from the top, as this would cause a shift in the inline elements inside. */
+    /* https://github.com/toeverything/blocksuite/issues/5723 */
+    .edgeless-text-editor rich-text v-text {
+      text-align: var(--text-align);
+    }
   `;
 
   @query('rich-text')
@@ -421,9 +427,10 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
           ? '50%'
           : `calc(100% - ${EdgelessTextEditor.HORIZONTAL_PADDING}px)`;
 
+    this.style.setProperty('--text-align', textAlign);
+
     return html`<div
       style=${styleMap({
-        textAlign,
         fontFamily: wrapFontFamily(fontFamily),
         minWidth: hasMaxWidth ? `${rect.width}px` : 'none',
         maxWidth: hasMaxWidth ? `${w}px` : 'none',

--- a/packages/inline/src/components/v-line.ts
+++ b/packages/inline/src/components/v-line.ts
@@ -91,6 +91,8 @@ export class VLine extends LitElement {
       // this padding is used to make cursor can be placed at the
       // start and end of the line when the first and last element is embed element
       padding: '0 0.5px',
+      // https://github.com/toeverything/blocksuite/issues/5723
+      textAlign: 'left',
     })}>${renderElements}</div>`;
   }
 

--- a/packages/inline/src/components/v-line.ts
+++ b/packages/inline/src/components/v-line.ts
@@ -91,8 +91,6 @@ export class VLine extends LitElement {
       // this padding is used to make cursor can be placed at the
       // start and end of the line when the first and last element is embed element
       padding: '0 0.5px',
-      // https://github.com/toeverything/blocksuite/issues/5723
-      textAlign: 'left',
     })}>${renderElements}</div>`;
   }
 

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -23,6 +23,10 @@ import {
 import { assertStoreMatchJSX } from './utils/asserts.js';
 import { scoped, test } from './utils/playwright.js';
 
+test.use({
+  ignoreHTTPSErrors: true,
+});
+
 const inputUrl = 'http://localhost';
 
 const createBookmarkBlockBySlashMenu = async (page: Page) => {

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -23,11 +23,18 @@ import {
 import { assertStoreMatchJSX } from './utils/asserts.js';
 import { scoped, test } from './utils/playwright.js';
 
-test.use({
-  ignoreHTTPSErrors: true,
-});
-
 const inputUrl = 'http://localhost';
+
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    'https://affine-worker.toeverything.workers.dev/api/linkPreview',
+    async route => {
+      await route.fulfill({
+        json: {},
+      });
+    }
+  );
+});
 
 const createBookmarkBlockBySlashMenu = async (page: Page) => {
   await enterPlaygroundRoom(page);

--- a/tests/export.spec.ts
+++ b/tests/export.spec.ts
@@ -20,6 +20,18 @@ import {
   waitNextFrame,
 } from './utils/actions/index.js';
 import { test } from './utils/playwright.js';
+
+test.beforeEach(async ({ page }) => {
+  await page.route(
+    'https://affine-worker.toeverything.workers.dev/api/linkPreview',
+    async route => {
+      await route.fulfill({
+        json: {},
+      });
+    }
+  );
+});
+
 test('export html title', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyEdgelessState(page);


### PR DESCRIPTION
Close #5723

before:

https://github.com/toeverything/blocksuite/assets/50035259/2d37f6f6-3a75-4881-aefa-967c712f67af

after:

https://github.com/toeverything/blocksuite/assets/50035259/d9f4a8cd-7cb0-4eb1-8a9b-cc19726b882d

