### PR TITLE
fix(edgeless): wrong size display when dragging after changing the font size

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -405,7 +405,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   private _onDragStart = () => {
     this.edgeless.slots.elementResizeStart.emit();
     this.setToolbarVisible(false);
-    this._updateResizeManagerState(false);
+    this._updateResizeManagerState(true);
   };
 
   private _onDragMove = (

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -448,10 +448,11 @@ test('auto wrap text in shape', async ({ page }) => {
   selectedRect = await getEdgelessSelectedRect(page);
   expect(selectedRect.width).toBe(lastWidth);
   expect(selectedRect.height).toBeGreaterThanOrEqual(lastHeight);
+  lastWidth = selectedRect.width;
   lastHeight = selectedRect.height;
 
   // increase width to make text not wrap
-  await resizeElementByHandle(page, { x: 50, y: 10 }, 'bottom-right');
+  await resizeElementByHandle(page, { x: 50, y: -10 }, 'bottom-right');
   // the height of shape should be decreased because of long text not wrap
   selectedRect = await getEdgelessSelectedRect(page);
   expect(selectedRect.width).toBeGreaterThan(lastWidth);


### PR DESCRIPTION
To close #5731 

https://github.com/toeverything/blocksuite/assets/99816898/0cbcef5b-387b-400a-a494-1a30fe413820

