### PR TITLE
feat: updated-twitter-icon

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -114,7 +114,12 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/toeverything/blocksuite' },
-      { icon: 'twitter', link: 'https://twitter.com/AffineDev' },
+      {
+        icon: {
+          svg: '<svg role="img" xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path fill="#777777" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/></svg>',
+        },
+        link: 'https://twitter.com/AffineDev',
+      },
     ],
 
     footer: {


### PR DESCRIPTION
I was assigned this [issue](https://github.com/toeverything/blocksuite/issues/5751).
On the doc website under navbar section the twitter logo was still the old one.
I have updated it to new icon.
Closes #5751.

![Screenshot 2023-12-18 135553](https://github.com/toeverything/blocksuite/assets/132576984/9ae4dfb5-99af-4790-864d-0f60b2bc3695)
