### PR TITLE
refactor: cleanup for multiple-editors

### DIFF
--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -1,12 +1,13 @@
 import type { BlockService } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 
 import {
   calcDropTarget,
   getClosestBlockElementByPoint,
   getModelByBlockComponent,
-  isPageMode,
+  isInsideDocEditor,
   matchFlavours,
   Point,
 } from '../../_common/utils/index.js';
@@ -57,8 +58,8 @@ export class FileDropManager {
     }
   }
 
-  get isPageMode(): boolean {
-    return isPageMode(this._blockService.page);
+  get editorHost(): EditorHost {
+    return this._blockService.std.host as EditorHost;
   }
 
   get type(): 'before' | 'after' {
@@ -74,7 +75,7 @@ export class FileDropManager {
 
     let targetModel = this._indicator.dropResult?.modelState.model || null;
 
-    if (!targetModel && this.isPageMode) {
+    if (!targetModel && isInsideDocEditor(this.editorHost)) {
       const lastNote = pageBlock.children[pageBlock.children.length - 1];
       if (!matchFlavours(lastNote, ['affine:note'])) {
         throw new Error('The last block is not a note block.');

--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -1,4 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import type {
   ClientRectObject,
@@ -668,7 +667,7 @@ declare global {
     'affine-menu': MenuComponent<unknown>;
   }
 }
-export const createModal = (container: HTMLElement) => {
+export const createModal = (container: HTMLElement = document.body) => {
   const div = document.createElement('div');
   div.style.position = 'fixed';
   div.style.left = '0';
@@ -706,10 +705,7 @@ export const createPopup = (
     middleware?: Array<Middleware | null | undefined | false>;
   }
 ) => {
-  const host = document.querySelector('editor-host');
-  assertExists(host);
-
-  const modal = createModal(host);
+  const modal = createModal();
   autoUpdate(target, content, () => {
     computePosition(target, content, {
       middleware: options?.middleware ?? [shift({ crossAxis: true })],

--- a/packages/blocks/src/_common/components/rich-text/inline/nodes/reference-node.ts
+++ b/packages/blocks/src/_common/components/rich-text/inline/nodes/reference-node.ts
@@ -13,8 +13,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { DocPageBlockComponent } from '../../../../../page-block/doc/doc-page-block.js';
 import { FontLinkedPageIcon, FontPageIcon } from '../../../../icons/index.js';
 import {
-  getBlockComponentByModel,
   getClosestBlockElementByElement,
+  getDocPageByElement,
   getModelByElement,
 } from '../../../../utils/index.js';
 import { DEFAULT_PAGE_NAME, REFERENCE_NODE } from '../../consts.js';
@@ -127,9 +127,9 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     const targetPageId = refMeta.id;
     const root = model.page.root;
     assertExists(root);
-    const element = getBlockComponentByModel(root) as DocPageBlockComponent;
-    assertExists(element);
-    element.slots.pageLinkClicked.emit({ pageId: targetPageId });
+    const docPageElement = getDocPageByElement(this) as DocPageBlockComponent;
+    assertExists(docPageElement);
+    docPageElement.slots.pageLinkClicked.emit({ pageId: targetPageId });
   }
 
   override render() {

--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -31,7 +31,7 @@ import { hardEnter, onBackspace, onForwardDelete } from './legacy.js';
 export const bindContainerHotkey = (blockElement: BlockElement) => {
   const selection = blockElement.host.selection;
   const model = blockElement.model;
-  const root = blockElement.host;
+  const editorHost = blockElement.host;
   const leftBrackets = bracketPairs.map(pair => pair.left);
 
   const _selectBlock = () => {
@@ -202,7 +202,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       }
 
       const state = ctx.get('keyboardState');
-      hardEnter(model, inlineRange, inlineEditor, state.raw);
+      hardEnter(editorHost, model, inlineRange, inlineEditor, state.raw);
       _preventDefault(ctx);
 
       return true;
@@ -214,7 +214,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       const inlineEditor = _getInlineEditor();
       const inlineRange = inlineEditor.getInlineRange();
       assertExists(inlineRange);
-      hardEnter(model, inlineRange, inlineEditor, state.raw, true);
+      hardEnter(editorHost, model, inlineRange, inlineEditor, state.raw, true);
       _preventDefault(ctx);
 
       return true;
@@ -247,7 +247,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       )
         return;
 
-      const textModels = getSelectedContentModels(root, ['text']);
+      const textModels = getSelectedContentModels(editorHost, ['text']);
       if (textModels.length === 1) {
         const inlineEditor = _getInlineEditor();
         const inilneRange = inlineEditor.getInlineRange();
@@ -258,7 +258,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         return true;
       }
 
-      const models = getSelectedContentModels(root, ['text', 'block']);
+      const models = getSelectedContentModels(editorHost, ['text', 'block']);
       handleMultiBlockIndent(blockElement.page, models);
       return true;
     },
@@ -276,7 +276,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       );
       if (!page) return;
 
-      const textModels = getSelectedContentModels(root, ['text']);
+      const textModels = getSelectedContentModels(editorHost, ['text']);
       if (textModels.length === 1) {
         const inlineEditor = _getInlineEditor();
         const inlineRange = inlineEditor.getInlineRange();
@@ -289,7 +289,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         return true;
       }
 
-      const models = getSelectedContentModels(root, ['text', 'block']);
+      const models = getSelectedContentModels(editorHost, ['text', 'block']);
       handleRemoveAllIndentForMultiBlocks(blockElement.page, models);
       return true;
     },
@@ -307,7 +307,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       );
       if (!page) return;
 
-      const textModels = getSelectedContentModels(root, ['text']);
+      const textModels = getSelectedContentModels(editorHost, ['text']);
       if (textModels.length === 1) {
         const inlineEditor = _getInlineEditor();
         const inlineRange = inlineEditor.getInlineRange();
@@ -318,7 +318,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         return true;
       }
 
-      const models = getSelectedContentModels(root, ['text', 'block']);
+      const models = getSelectedContentModels(editorHost, ['text', 'block']);
       handleMultiBlockOutdent(blockElement.page, models);
       return true;
     },
@@ -326,7 +326,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       if (!blockElement.selected?.is('text')) return;
       const state = ctx.get('keyboardState');
       const inlineEditor = _getInlineEditor();
-      if (!onBackspace(model, state.raw, inlineEditor)) {
+      if (!onBackspace(editorHost, model, state.raw, inlineEditor)) {
         _preventDefault(ctx);
       }
 
@@ -369,7 +369,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
 
         _preventDefault(ctx);
 
-        config.action(root);
+        config.action(editorHost);
         return true;
       },
     });
@@ -395,7 +395,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
     if (!blockElement.selected?.is('text')) return;
     const state = ctx.get('keyboardState');
     const inlineEditor = _getInlineEditor();
-    if (!onForwardDelete(model, state.raw, inlineEditor)) {
+    if (!onForwardDelete(editorHost, model, state.raw, inlineEditor)) {
       _preventDefault(ctx);
     }
     return true;

--- a/packages/blocks/src/_common/components/rich-text/keymap/legacy.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/legacy.ts
@@ -4,6 +4,7 @@ import {
   KEYBOARD_ALLOW_DEFAULT,
   KEYBOARD_PREVENT_DEFAULT,
 } from '@blocksuite/inline';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 
 import { matchFlavours } from '../../../../_common/utils/model.js';
@@ -42,6 +43,7 @@ export function onSoftEnter(
 }
 
 export function hardEnter(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   range: InlineRange,
   /**
@@ -76,7 +78,7 @@ export function hardEnter(
     // After
     // - list
     // |   <-- will replace with a new text block
-    handleLineStartBackspace(page, model);
+    handleLineStartBackspace(editorHost, model);
     return KEYBOARD_PREVENT_DEFAULT;
   }
   if (isEmptyList && isLastChild) {
@@ -158,6 +160,7 @@ function isSoftEnterable(model: BaseBlockModel) {
 }
 
 export function onBackspace(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   e: KeyboardEvent,
   inlineEditor: AffineInlineEditor
@@ -167,7 +170,7 @@ export function onBackspace(
       return KEYBOARD_ALLOW_DEFAULT;
     }
     e.stopPropagation();
-    handleLineStartBackspace(model.page, model);
+    handleLineStartBackspace(editorHost, model);
     return KEYBOARD_PREVENT_DEFAULT;
   }
   e.stopPropagation();
@@ -175,13 +178,14 @@ export function onBackspace(
 }
 
 export function onForwardDelete(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   e: KeyboardEvent,
   inlineEditor: AffineInlineEditor
 ) {
   e.stopPropagation();
   if (isCollapsedAtBlockEnd(inlineEditor)) {
-    handleLineEndForwardDelete(model.page, model);
+    handleLineEndForwardDelete(editorHost, model);
     return KEYBOARD_PREVENT_DEFAULT;
   }
   return KEYBOARD_ALLOW_DEFAULT;

--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -1,4 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { type BaseBlockModel } from '@blocksuite/store';
 import { Text } from '@blocksuite/store';
@@ -17,8 +18,6 @@ import {
 import {
   asyncFocusRichText,
   asyncSetInlineRange,
-} from '../../../_common/utils/selection.js';
-import {
   focusBlockByModel,
   focusTitle,
 } from '../../../_common/utils/selection.js';
@@ -371,12 +370,13 @@ export function handleRemoveAllIndentForMultiBlocks(
 
 // When deleting at line end of a code block,
 // do nothing
-function handleCodeBlockForwardDelete(_page: Page, model: ExtendedModel) {
+function handleCodeBlockForwardDelete(model: ExtendedModel) {
   if (!matchFlavours(model, ['affine:code'])) return false;
   return true;
 }
 
-function handleDatabaseBlockForwardDelete(page: Page, model: ExtendedModel) {
+function handleDatabaseBlockForwardDelete(model: ExtendedModel) {
+  const page = model.page;
   if (!isInsideBlockByFlavour(page, model, 'affine:database')) return false;
 
   return true;
@@ -384,7 +384,8 @@ function handleDatabaseBlockForwardDelete(page: Page, model: ExtendedModel) {
 
 // When deleting at line start of a list block,
 // switch it to normal paragraph block.
-function handleListBlockBackspace(page: Page, model: ExtendedModel) {
+function handleListBlockBackspace(model: ExtendedModel) {
+  const page = model.page;
   if (!matchFlavours(model, ['affine:list'])) return false;
 
   const parent = page.getParent(model);
@@ -427,8 +428,12 @@ function handleListBlockBackspace(page: Page, model: ExtendedModel) {
     - Line8
 - Line9
  */
-function handleListBlockForwardDelete(page: Page, model: ExtendedModel) {
+function handleListBlockForwardDelete(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
   if (!matchFlavours(model, ['affine:list'])) return false;
+  const page = model.page;
   const firstChild = model.firstChild();
   if (firstChild) {
     model.text?.join(firstChild.text as Text);
@@ -456,7 +461,7 @@ function handleListBlockForwardDelete(page: Page, model: ExtendedModel) {
         return true;
       }
     } else {
-      const nextBlock = getNextBlock(model);
+      const nextBlock = getNextBlock(editorHost, model);
       if (!nextBlock) {
         // do nothing
         return true;
@@ -536,7 +541,8 @@ function handleEmbedDividerCodeSibling(
   return true;
 }
 
-function handleNoPreviousSibling(page: Page, model: ExtendedModel) {
+function handleNoPreviousSibling(editorHost: EditorHost, model: ExtendedModel) {
+  const page = model.page;
   const text = model.text;
   const titleElement = document.querySelector(
     '.affine-doc-page-block-title'
@@ -564,16 +570,20 @@ function handleNoPreviousSibling(page: Page, model: ExtendedModel) {
   } else {
     text?.clear();
   }
-  focusTitle(page, title.length - textLength);
+  focusTitle(editorHost, title.length - textLength);
   return true;
 }
 
-function handleParagraphDeleteActions(page: Page, model: ExtendedModel) {
+function handleParagraphDeleteActions(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
+  const page = model.page;
   const parent = page.getParent(model);
   if (!parent) return false;
-  const previousSibling = getPreviousBlock(model);
+  const previousSibling = getPreviousBlock(editorHost, model);
   if (!previousSibling) {
-    return handleNoPreviousSibling(page, model);
+    return handleNoPreviousSibling(editorHost, model);
   } else if (
     matchFlavours(previousSibling, ['affine:paragraph', 'affine:list'])
   ) {
@@ -610,7 +620,11 @@ function handleParagraphDeleteActions(page: Page, model: ExtendedModel) {
   return false;
 }
 
-function handleParagraphBlockBackspace(page: Page, model: ExtendedModel) {
+function handleParagraphBlockBackspace(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
+  const page = model.page;
   if (!matchFlavours(model, ['affine:paragraph'])) return false;
 
   // When deleting at line start of a paragraph block,
@@ -632,7 +646,7 @@ function handleParagraphBlockBackspace(page: Page, model: ExtendedModel) {
   // - line1
   //   - line2|aaa
   //   - line3
-  const isHandled = handleParagraphDeleteActions(page, model);
+  const isHandled = handleParagraphDeleteActions(editorHost, model);
   if (isHandled) return true;
 
   // Before press backspace
@@ -648,7 +662,11 @@ function handleParagraphBlockBackspace(page: Page, model: ExtendedModel) {
   return true;
 }
 
-function handleParagraphBlockForwardDelete(page: Page, model: ExtendedModel) {
+function handleParagraphBlockForwardDelete(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
+  const page = model.page;
   function handleParagraphOrList(
     page: Page,
     model: ExtendedModel,
@@ -676,7 +694,7 @@ function handleParagraphBlockForwardDelete(page: Page, model: ExtendedModel) {
           return true;
         }
       } else {
-        const nextBlock = getNextBlock(model);
+        const nextBlock = getNextBlock(editorHost, model);
         if (
           !nextBlock ||
           !matchFlavours(nextBlock, ['affine:paragraph', 'affine:list'])
@@ -719,7 +737,7 @@ function handleParagraphBlockForwardDelete(page: Page, model: ExtendedModel) {
       page.deleteBlock(firstChild);
       return true;
     }
-    const nextBlock = getNextBlock(model);
+    const nextBlock = getNextBlock(editorHost, model);
     if (!firstChild && !nextBlock) return true;
     return (
       handleParagraphOrListChild(page, model, firstChild) ||
@@ -794,10 +812,13 @@ function handleUnknownBlockForwardDelete(model: ExtendedModel) {
   );
 }
 
-export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
+export function handleLineStartBackspace(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
   if (
-    handleListBlockBackspace(page, model) ||
-    handleParagraphBlockBackspace(page, model)
+    handleListBlockBackspace(model) ||
+    handleParagraphBlockBackspace(editorHost, model)
   ) {
     return;
   }
@@ -805,13 +826,16 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
   handleUnknownBlockBackspace(model);
 }
 
-export function handleLineEndForwardDelete(page: Page, model: ExtendedModel) {
+export function handleLineEndForwardDelete(
+  editorHost: EditorHost,
+  model: ExtendedModel
+) {
   if (
-    handleCodeBlockForwardDelete(page, model) ||
-    handleListBlockForwardDelete(page, model) ||
-    handleParagraphBlockForwardDelete(page, model)
+    handleCodeBlockForwardDelete(model) ||
+    handleListBlockForwardDelete(editorHost, model) ||
+    handleParagraphBlockForwardDelete(editorHost, model)
   ) {
-    handleDatabaseBlockForwardDelete(page, model);
+    handleDatabaseBlockForwardDelete(model);
     return;
   }
   handleUnknownBlockForwardDelete(model);

--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -510,11 +510,12 @@ function handleParagraphOrListSibling(
 }
 
 function handleEmbedDividerCodeSibling(
-  page: Page,
+  editorHost: EditorHost,
   model: ExtendedModel,
   previousSibling: ExtendedModel,
   parent: ExtendedModel
 ) {
+  const page = model.page;
   if (matchFlavours(previousSibling, ['affine:divider'])) {
     page.deleteBlock(previousSibling);
     return true;
@@ -531,7 +532,7 @@ function handleEmbedDividerCodeSibling(
   )
     return false;
 
-  focusBlockByModel(previousSibling);
+  focusBlockByModel(editorHost, previousSibling);
   if (!model.text?.length) {
     page.captureSync();
     page.deleteBlock(model, {
@@ -544,7 +545,7 @@ function handleEmbedDividerCodeSibling(
 function handleNoPreviousSibling(editorHost: EditorHost, model: ExtendedModel) {
   const page = model.page;
   const text = model.text;
-  const titleElement = document.querySelector(
+  const titleElement = editorHost.querySelector(
     '.affine-doc-page-block-title'
   ) as HTMLTextAreaElement | null;
   // Probably no title, e.g. in edgeless mode
@@ -608,12 +609,17 @@ function handleParagraphDeleteActions(
   // TODO handle in block service
   if (matchFlavours(parent, ['affine:database'])) {
     page.deleteBlock(model);
-    focusBlockByModel(previousSibling);
+    focusBlockByModel(editorHost, previousSibling);
     return true;
   } else if (matchFlavours(parent, ['affine:note'])) {
     return (
       handleParagraphOrListSibling(page, model, previousSibling, parent) ||
-      handleEmbedDividerCodeSibling(page, model, previousSibling, parent) ||
+      handleEmbedDividerCodeSibling(
+        editorHost,
+        model,
+        previousSibling,
+        parent
+      ) ||
       handleUnknownBlockBackspace(previousSibling)
     );
   }
@@ -758,7 +764,7 @@ function handleParagraphBlockForwardDelete(
         ])
       )
         return false;
-      focusBlockByModel(firstChild);
+      focusBlockByModel(editorHost, firstChild);
       return true;
     }
     function handleEmbedDividerCodeSibling(nextSibling: ExtendedModel | null) {
@@ -772,7 +778,7 @@ function handleParagraphBlockForwardDelete(
         !matchFlavours(nextSibling, ['affine:image', 'affine:code'])
       )
         return false;
-      focusBlockByModel(nextSibling);
+      focusBlockByModel(editorHost, nextSibling);
       return true;
     }
     return (

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -252,8 +252,8 @@ export function getLitRoot() {
 export function getViewportElement(editorHost: EditorHost) {
   if (isInsideDocEditor(editorHost)) return null;
   const page = editorHost.page;
-  assertExists(page);
-  const pageComponent = getBlockComponentByModel(page.root);
+  assertExists(page.root);
+  const pageComponent = editorHost.view.viewFromPath('block', [page.root.id]);
 
   if (
     !pageComponent ||

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -48,11 +48,10 @@ interface ContainerBlock {
  * NOTE: this method will skip the `affine:note` block
  */
 export function getNextBlock(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   map: Record<string, true> = {}
 ): BaseBlockModel | null {
-  const isPage = isPageMode(model.page);
-
   if (model.id in map) {
     throw new Error("Can't get next block! There's a loop in the block tree!");
   }
@@ -69,11 +68,11 @@ export function getNextBlock(
       // Assert nextSibling is not possible to be `affine:page`
       if (matchFlavours(nextSibling, ['affine:note'])) {
         // in edgeless mode, limit search for the next block within the same note
-        if (!isPage) {
+        if (isInsideEdgelessEditor(editorHost)) {
           return null;
         }
 
-        return getNextBlock(nextSibling);
+        return getNextBlock(editorHost, nextSibling);
       }
       return nextSibling;
     }
@@ -98,9 +97,10 @@ export function getNextBlock(
  *
  * NOTE: this method will just return blocks with `content` role
  */
-export function getPreviousBlock(model: BaseBlockModel): BaseBlockModel | null {
-  const isPage = isPageMode(model.page);
-
+export function getPreviousBlock(
+  editorHost: EditorHost,
+  model: BaseBlockModel
+): BaseBlockModel | null {
   const getPrev = (model: BaseBlockModel) => {
     const parent = model.page.getParent(model);
     if (!parent) return null;
@@ -115,7 +115,10 @@ export function getPreviousBlock(model: BaseBlockModel): BaseBlockModel | null {
     }
 
     // in edgeless mode, limit search for the previous block within the same note
-    if (!isPage && matchFlavours(parent, ['affine:note'])) {
+    if (
+      isInsideEdgelessEditor(editorHost) &&
+      matchFlavours(parent, ['affine:note'])
+    ) {
       return null;
     }
 
@@ -163,7 +166,10 @@ export function buildPath(model: BaseBlockModel | null): string[] {
   return path;
 }
 
-/** If it's not in the page mode, it will return `null` directly */
+/** If it's not in the page mode, it will return `null` directly
+ * Use `getDocPageByElement` or `getDocPageByEditorHost` instead.
+ * @deprecated
+ */
 export function getDocPage(page: Page): DocPageBlockComponent | null {
   const pageComponent = getBlockComponentByModel(page.root);
   if (pageComponent?.tagName !== 'AFFINE-DOC-PAGE') return null;
@@ -175,11 +181,29 @@ export function getDocPageByElement(element: Element) {
   return element.closest('affine-doc-page');
 }
 
-/** If it's not in the edgeless mode, it will return `null` directly */
+/** If it's not in the page mode, it will return `null` directly */
+export function getDocPageByEditorHost(editorHost: EditorHost) {
+  return editorHost.querySelector('affine-doc-page');
+}
+
+/** If it's not in the edgeless mode, it will return `null` directly
+ * Use `getEdgelessPageByElement` or `getEdgelessPageByEditorHost` instead.
+ * @deprecated
+ */
 export function getEdgelessPage(page: Page): EdgelessPageBlockComponent | null {
   const pageComponent = getBlockComponentByModel(page.root);
   if (pageComponent?.tagName !== 'AFFINE-EDGELESS-PAGE') return null;
   return pageComponent as EdgelessPageBlockComponent;
+}
+
+/** If it's not in the edgeless mode, it will return `null` directly */
+export function getEdgelessPageByElement(element: Element) {
+  return element.closest('affine-edgeless-page');
+}
+
+/** If it's not in the edgeless mode, it will return `null` directly */
+export function getEdgelessPageByEditorHost(editorHost: EditorHost) {
+  return editorHost.querySelector('affine-edgeless-page');
 }
 
 /** @deprecated */
@@ -190,9 +214,22 @@ export function getEditorContainer(page: Page): AbstractEditor {
   return editorContainer as AbstractEditor;
 }
 
+/**
+ * Note that this function is used for compatibility only, and may be removed in the future.
+ * Use `isInsideDocEditor` or `isInsideEdgelessEditor` instead.
+ * @deprecated
+ */
 export function isPageMode(page: Page) {
   const pageComponent = getBlockComponentByModel(page.root);
   return pageComponent?.tagName === 'AFFINE-DOC-PAGE';
+}
+
+export function isInsideDocEditor(host: EditorHost) {
+  return !!host.closest('doc-editor');
+}
+
+export function isInsideEdgelessEditor(host: EditorHost) {
+  return !!host.closest('edgeless-editor');
 }
 
 export function getLitRoot() {
@@ -212,10 +249,10 @@ export function getLitRoot() {
  * });
  * ```
  */
-export function getViewportElement(page: Page) {
-  const isPage = isPageMode(page);
-  if (!isPage) return null;
-  assertExists(page.root);
+export function getViewportElement(editorHost: EditorHost) {
+  if (isInsideDocEditor(editorHost)) return null;
+  const page = editorHost.page;
+  assertExists(page);
   const pageComponent = getBlockComponentByModel(page.root);
 
   if (

--- a/packages/blocks/src/_common/utils/selection.ts
+++ b/packages/blocks/src/_common/utils/selection.ts
@@ -1,6 +1,7 @@
 import { IS_FIREFOX } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
 import { type InlineRange, type VLine } from '@blocksuite/inline';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import type { DocPageBlockComponent } from '../../page-block/doc/doc-page-block.js';
@@ -9,7 +10,7 @@ import { matchFlavours } from './model.js';
 import {
   asyncGetRichTextByModel,
   getBlockComponentByModel,
-  getDocPage,
+  getDocPageByEditorHost,
   getDocPageByElement,
 } from './query.js';
 import { Rect } from './rect.js';
@@ -155,19 +156,19 @@ async function setNewTop(y: number, editableContainer: Element, zoom = 1) {
 /**
  * As the title is a text area, this function does not yet have support for `SelectionPosition`.
  */
-export function focusTitle(page: Page, index = Infinity, len = 0) {
+export function focusTitle(editorHost: EditorHost, index = Infinity, len = 0) {
   // TODO support SelectionPosition
-  const pageComponent = getDocPage(page);
-  if (!pageComponent) {
+  const docPageComponent = getDocPageByEditorHost(editorHost);
+  if (!docPageComponent) {
     throw new Error("Can't find page component!");
   }
-  if (!pageComponent.titleInlineEditor) {
+  if (!docPageComponent.titleInlineEditor) {
     throw new Error("Can't find title inline editor!");
   }
-  if (index > pageComponent.titleInlineEditor.yText.length) {
-    index = pageComponent.titleInlineEditor.yText.length;
+  if (index > docPageComponent.titleInlineEditor.yText.length) {
+    index = docPageComponent.titleInlineEditor.yText.length;
   }
-  pageComponent.titleInlineEditor.setInlineRange({ index, length: len });
+  docPageComponent.titleInlineEditor.setInlineRange({ index, length: len });
 }
 
 async function focusRichText(

--- a/packages/blocks/src/_common/utils/selection.ts
+++ b/packages/blocks/src/_common/utils/selection.ts
@@ -9,7 +9,7 @@ import type { SelectionPosition } from '../types.js';
 import { matchFlavours } from './model.js';
 import {
   asyncGetRichTextByModel,
-  getBlockComponentByModel,
+  buildPath,
   getDocPageByEditorHost,
   getDocPageByElement,
 } from './query.js';
@@ -215,6 +215,7 @@ async function focusRichText(
  * @deprecated Use `selectionManager.set` instead.
  */
 export function focusBlockByModel(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   position: SelectionPosition = 'end',
   zoom = 1
@@ -224,12 +225,12 @@ export function focusBlockByModel(
   }
 
   assertExists(model.page.root);
-  const pageBlock = getBlockComponentByModel(
-    model.page.root
-  ) as DocPageBlockComponent;
+  const pageBlock = editorHost.view.viewFromPath('block', [
+    model.page.root.id,
+  ]) as DocPageBlockComponent;
   assertExists(pageBlock);
 
-  const element = getBlockComponentByModel(model);
+  const element = editorHost.view.viewFromPath('block', buildPath(model));
   assertExists(element);
   const editableContainer = element?.querySelector('[contenteditable]');
   if (editableContainer) {

--- a/packages/blocks/src/_legacy/content-parser/index.ts
+++ b/packages/blocks/src/_legacy/content-parser/index.ts
@@ -114,7 +114,7 @@ export class ContentParser {
         }
         const root = this._page.root;
         const pageBlock = root ? getBlockComponentByModel(root) : null;
-        const imageCard = document.querySelector('affine-image-block-card');
+        const imageCard = pageBlock?.querySelector('affine-image-block-card');
         const isReady =
           !imageCard || imageCard.getAttribute('imageState') === '0';
         if (pageBlock && isReady) {

--- a/packages/blocks/src/bookmark-block/edgeless-bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/edgeless-bookmark-block.ts
@@ -4,6 +4,7 @@ import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { getEdgelessPageByElement } from '../_common/utils/query.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import type { BookmarkBlockComponent } from './bookmark-block.js';
 import type {
@@ -37,7 +38,7 @@ export class EdgelessBookmarkBlockComponent extends WithDisposable(
   }
 
   get edgeless() {
-    const edgeless = this.closest('affine-edgeless-page');
+    const edgeless = getEdgelessPageByElement(this);
     assertExists(edgeless);
     return edgeless;
   }

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,9 +1,9 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Text } from '@blocksuite/store';
 import { BaseBlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
-import { getBlockComponentByPath } from '../_common/utils/index.js';
 import { FRAME_BATCH } from '../surface-block/batch.js';
 import {
   Bound,
@@ -42,12 +42,17 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(
   BaseBlockModel
 ) {
   override batch = FRAME_BATCH;
-  override hitTest(x: number, y: number, _: HitTestOptions): boolean {
+  override hitTest(
+    x: number,
+    y: number,
+    _: HitTestOptions,
+    editorHost: EditorHost
+  ): boolean {
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointOnBound([x, y]);
     if (hit) return true;
     assertExists(this.page.root);
-    const block = getBlockComponentByPath([
+    const block = editorHost.view.viewFromPath('block', [
       this.page.root?.id,
       this.id,
     ]) as FrameBlockComponent;

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -7,7 +7,10 @@ import { html, render } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import { matchFlavours } from '../_common/utils/index.js';
+import {
+  getEdgelessPageByElement,
+  matchFlavours,
+} from '../_common/utils/index.js';
 import type { DragHandleOption } from '../page-block/widgets/drag-handle/config.js';
 import { AffineDragHandleWidget } from '../page-block/widgets/drag-handle/drag-handle.js';
 import {
@@ -141,7 +144,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
       const insideDragHandle = !!element?.closest('affine-drag-handle-widget');
       if (!insideDragHandle) return false;
 
-      const edgelessPage = blockComponent.closest('affine-edgeless-page');
+      const edgelessPage = getEdgelessPageByElement(blockComponent);
       const scale = edgelessPage ? edgelessPage.surface.viewport.zoom : 1;
       const width = blockComponent.getBoundingClientRect().width;
 

--- a/packages/blocks/src/image-block/image-service.ts
+++ b/packages/blocks/src/image-block/image-service.ts
@@ -1,11 +1,15 @@
 import { BlockService } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 
 import {
   FileDropManager,
   type FileDropOptions,
 } from '../_common/components/file-drop-manager.js';
-import { isPageMode, matchFlavours } from '../_common/utils/index.js';
+import {
+  isInsideEdgelessEditor,
+  matchFlavours,
+} from '../_common/utils/index.js';
 import type { DocPageBlockComponent } from '../page-block/doc/doc-page-block.js';
 import type { EdgelessPageBlockComponent } from '../page-block/edgeless/edgeless-page-block.js';
 import type { ImageBlockModel } from './image-model.js';
@@ -34,7 +38,7 @@ export class ImageService extends BlockService<ImageBlockModel> {
 
       if (targetModel && !matchFlavours(targetModel, ['affine:surface'])) {
         addSiblingImageBlock(imageFiles, this.maxFileSize, targetModel, place);
-      } else if (!isPageMode(this.page)) {
+      } else if (isInsideEdgelessEditor(this.std.host as EditorHost)) {
         const edgelessPage = this
           .pageBlockComponent as EdgelessPageBlockComponent;
         await edgelessPage.addImages(imageFiles, point);

--- a/packages/blocks/src/image-block/utils.ts
+++ b/packages/blocks/src/image-block/utils.ts
@@ -1,11 +1,12 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { Buffer } from 'buffer';
 
 import { humanFileSize } from '../_common/utils/math.js';
 import { toast } from './../_common/components/toast.js';
 import { downloadBlob } from './../_common/utils/filesys.js';
-import { getBlockComponentByModel } from './../_common/utils/query.js';
+import { buildPath } from './../_common/utils/query.js';
 import { ImageBlockModel, type ImageBlockProps } from './image-model.js';
 
 async function getImageBlob(model: ImageBlockModel) {
@@ -97,8 +98,8 @@ export async function downloadImage(model: ImageBlockModel) {
   downloadBlob(blob, 'image');
 }
 
-export function focusCaption(model: BaseBlockModel) {
-  const blockEle = getBlockComponentByModel(model);
+export function focusCaption(editorHost: EditorHost, model: BaseBlockModel) {
+  const blockEle = editorHost.view.viewFromPath('block', buildPath(model));
   assertExists(blockEle);
   const dom = blockEle.querySelector(
     '.affine-embed-wrapper-caption'

--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -1,13 +1,13 @@
 import type { BlockSelection, UIEventHandler } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import type { ReactiveController } from 'lit';
 import type { ReactiveControllerHost } from 'lit';
 
 import { moveBlockConfigs } from '../_common/configs/move-block.js';
 import { quickActionConfig } from '../_common/configs/quick-action/config.js';
 import { textConversionConfigs } from '../_common/configs/text-conversion.js';
-import { getBlockComponentByModel } from '../_common/utils/index.js';
+import { buildPath } from '../_common/utils/index.js';
 import { onModelElementUpdated } from '../page-block/utils/callback.js';
 import { updateBlockElementType } from '../page-block/utils/operations/element/block-level.js';
 import { ensureBlockInContainer } from './utils.js';
@@ -679,20 +679,27 @@ export class KeymapController implements ReactiveController {
                 }
 
                 const [codeModel] = newModels;
-                onModelElementUpdated(codeModel, () => {
-                  const codeElement = getBlockComponentByModel(codeModel);
-                  assertExists(codeElement);
-                  this._std.selection.setGroup('note', [
-                    this._std.selection.getInstance('text', {
-                      from: {
-                        path: codeElement.path,
-                        index: 0,
-                        length: codeModel.text?.length ?? 0,
-                      },
-                      to: null,
-                    }),
-                  ]);
-                }).catch(console.error);
+                onModelElementUpdated(
+                  this._std.host as EditorHost,
+                  codeModel,
+                  () => {
+                    const codeElement = this._std.view.viewFromPath(
+                      'block',
+                      buildPath(codeModel)
+                    );
+                    assertExists(codeElement);
+                    this._std.selection.setGroup('note', [
+                      this._std.selection.getInstance('text', {
+                        from: {
+                          path: codeElement.path,
+                          index: 0,
+                          length: codeModel.text?.length ?? 0,
+                        },
+                        to: null,
+                      }),
+                    ]);
+                  }
+                ).catch(console.error);
 
                 next();
               })

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -144,13 +144,13 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   private _surfaceRefReferenceSet = new Set<string>();
 
   private _initNoteHeightUpdate() {
-    const { page } = this.edgeless;
+    const { page, host } = this.edgeless;
     assertExists(page.root);
 
     const resetNoteResizeObserver = throttle(
       () => {
         requestConnectedFrame(() => {
-          this._noteResizeObserver.resetListener(page);
+          this._noteResizeObserver.resetListener(host);
         }, this);
       },
       16,
@@ -255,12 +255,12 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   override firstUpdated() {
     this._updateReference();
     const { _disposables, edgeless } = this;
-    const { page } = edgeless;
+    const { page, host } = edgeless;
 
     this._initNoteHeightUpdate();
 
     requestConnectedFrame(() => {
-      this._noteResizeObserver.resetListener(page);
+      this._noteResizeObserver.resetListener(host);
     }, this);
 
     _disposables.add(this._noteResizeObserver);

--- a/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
@@ -8,7 +8,6 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { EDGELESS_BLOCK_CHILD_PADDING } from '../../../../_common/consts.js';
 import {
   buildPath,
-  getBlockComponentByPath,
   getModelByBlockComponent,
   getRectByBlockElement,
   Point,
@@ -125,6 +124,10 @@ export class NoteSlicer extends WithDisposable(LitElement) {
     return this.edgelessPage?.surface?.viewport.zoom ?? 1;
   }
 
+  get editorHost() {
+    return this.edgelessPage.host;
+  }
+
   private _updateVisibility(e: PointerEventState) {
     const block = this.selection.elements[0];
 
@@ -145,7 +148,8 @@ export class NoteSlicer extends WithDisposable(LitElement) {
   }
 
   private _getEditingState(e: PointerEventState, block: NoteBlockModel) {
-    const noteBlockElement = getBlockComponentByPath(
+    const noteBlockElement = this.editorHost.view.viewFromPath(
+      'block',
       buildPath(block)
     ) as NoteBlockComponent;
 

--- a/packages/blocks/src/page-block/edgeless/components/text/edgeless-frame-title-editor.ts
+++ b/packages/blocks/src/page-block/edgeless/components/text/edgeless-frame-title-editor.ts
@@ -5,7 +5,6 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import type { RichText } from '../../../../_common/components/rich-text/rich-text.js';
-import { getBlockComponentByPath } from '../../../../_common/utils/index.js';
 import type {
   FrameBlockComponent,
   FrameBlockModel,
@@ -25,6 +24,10 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
   @property({ attribute: false })
   edgeless!: EdgelessPageBlockComponent;
 
+  get editorHost() {
+    return this.edgeless.host;
+  }
+
   get inlineEditor() {
     assertExists(this.richText.inlineEditor);
     return this.richText.inlineEditor;
@@ -35,7 +38,7 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
 
   get frameBlock() {
     assertExists(this.frameModel.page.root);
-    const block = getBlockComponentByPath([
+    const block = this.editorHost.view.viewFromPath('block', [
       this.frameModel.page.root.id,
       this.frameModel.id,
     ]) as FrameBlockComponent | null;

--- a/packages/blocks/src/page-block/edgeless/connector-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/connector-manager.ts
@@ -1180,9 +1180,14 @@ export class EdgelessConnectorManager extends ConnectorPathGenerator {
       // if not, check if in inside of the element
 
       if (
-        connectable.hitTest(point[0], point[1], {
-          ignoreTransparent: false,
-        })
+        connectable.hitTest(
+          point[0],
+          point[1],
+          {
+            ignoreTransparent: false,
+          },
+          this._edgeless.host
+        )
       ) {
         result = {
           id: connectable.id,

--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -20,8 +20,7 @@ import type {
 import { matchFlavours } from '../../../_common/utils/index.js';
 import { groupBy } from '../../../_common/utils/iterable.js';
 import {
-  getBlockComponentByModel,
-  getBlockComponentByPath,
+  buildPath,
   getEditorContainer,
   isPageMode,
 } from '../../../_common/utils/query.js';
@@ -140,9 +139,9 @@ export class EdgelessClipboardController extends PageClipboard {
         current = current.page.getParent(current);
       }
 
-      return getBlockComponentByPath(path);
+      return this.std.view.viewFromPath('block', path);
     } else {
-      return getBlockComponentByModel(model);
+      return this.std.view.viewFromPath('block', buildPath(model));
     }
   }
 

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/eraser-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/eraser-tool.ts
@@ -2,10 +2,7 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
 import type { Erasable, IPoint } from '../../../../_common/utils/index.js';
-import {
-  type EraserTool,
-  getBlockComponentByModel,
-} from '../../../../_common/utils/index.js';
+import { buildPath, type EraserTool } from '../../../../_common/utils/index.js';
 import {
   Bound,
   getStroke,
@@ -111,7 +108,10 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
           linePolygonIntersects(this._prevPoint, currentPoint, bound.points)
         ) {
           this._eraseTargets.add(erasable);
-          const ele = getBlockComponentByModel(erasable);
+          const ele = this._edgeless.host.view.viewFromPath(
+            'block',
+            buildPath(erasable)
+          );
           ele && ((<HTMLElement>ele).style.opacity = '0.3');
         }
       } else {
@@ -128,7 +128,10 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
   override beforeModeSwitch() {
     this._eraseTargets.forEach(erasable => {
       if (isTopLevelBlock(erasable)) {
-        const ele = getBlockComponentByModel(erasable);
+        const ele = this._edgeless.host.view.viewFromPath(
+          'block',
+          buildPath(erasable)
+        );
         ele && ((<HTMLElement>ele).style.opacity = '1');
       } else {
         this._edgeless.localRecord.update(erasable.id, { opacity: 1 });

--- a/packages/blocks/src/page-block/edgeless/utils/note-resize-observer.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/note-resize-observer.ts
@@ -1,10 +1,10 @@
 import { Slot, throttle } from '@blocksuite/global/utils';
-import type { Page } from '@blocksuite/store';
+import type { EditorHost } from '@blocksuite/lit';
 
 import { BLOCK_ID_ATTR } from '../../../_common/consts.js';
 import { almostEqual } from '../../../_common/utils/math.js';
 import { matchFlavours } from '../../../_common/utils/model.js';
-import { getBlockComponentByModel } from '../../../_common/utils/query.js';
+import { buildPath } from '../../../_common/utils/query.js';
 
 export class NoteResizeObserver {
   private _observer: ResizeObserver;
@@ -55,14 +55,20 @@ export class NoteResizeObserver {
     }
   };
 
-  resetListener(page: Page) {
+  resetListener(editorHost: EditorHost) {
+    const page = editorHost.page;
     const unCachedKeys = new Set(this._cachedElements.keys());
     page.root?.children.forEach(model => {
       if (!matchFlavours(model, ['affine:note'])) return;
 
       const blockId = model.id;
       unCachedKeys.delete(blockId);
-      const blockElement = getBlockComponentByModel(model);
+
+      const blockElement = editorHost.view.viewFromPath(
+        'block',
+        buildPath(model)
+      );
+
       const container = blockElement?.querySelector(
         '.affine-note-block-container'
       );

--- a/packages/blocks/src/page-block/utils/callback.ts
+++ b/packages/blocks/src/page-block/utils/callback.ts
@@ -1,11 +1,11 @@
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement } from '@blocksuite/lit';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
 import { type BaseBlockModel } from '@blocksuite/store';
 
 import type { RichText } from '../../_common/components/rich-text/rich-text.js';
 import {
-  asyncGetBlockComponentByModel,
   asyncGetRichTextByModel,
+  buildPath,
 } from '../../_common/utils/query.js';
 
 export async function onModelTextUpdated(
@@ -30,11 +30,19 @@ export async function onModelTextUpdated(
 // If you want to wait for the text elements,
 // please use `onModelTextUpdated`.
 export async function onModelElementUpdated(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   callback: (blockElement: BlockElement) => void
 ) {
-  const element = await asyncGetBlockComponentByModel(model);
-  if (element) {
-    callback(element);
-  }
+  const page = model.page;
+  assertExists(page.root);
+
+  const pageBlockElement = editorHost.view.viewFromPath('block', [
+    page.root.id,
+  ]);
+  if (!pageBlockElement) return;
+  await pageBlockElement.updateComplete;
+
+  const element = editorHost.view.viewFromPath('block', buildPath(model));
+  if (element) callback(element);
 }

--- a/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
+++ b/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
@@ -15,12 +15,12 @@ import {
   type DroppingType,
   type EditingState,
   getClosestBlockElementByPoint,
-  getDocPage,
-  getEdgelessPage,
+  getDocPageByEditorHost,
+  getEdgelessPageByEditorHost,
   getHoveringNote,
   getImageFilesFromLocal,
   getModelByBlockComponent,
-  isPageMode,
+  isInsideDocEditor,
   Point,
   Rect,
   stopPropagation,
@@ -95,13 +95,13 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
   private _lastDraggingFlavour: string | null = null;
   private _timer: number | null = null;
   private _rafID: number = 0;
-  private _host: EditorHost;
+  private _editorHost: EditorHost;
 
   static override styles = styles;
 
   constructor(host: EditorHost) {
     super();
-    this._host = host;
+    this._editorHost = host;
   }
 
   override connectedCallback() {
@@ -111,15 +111,15 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     disposables.addFromEvent(this, 'dragstart', this._onDragStart);
     disposables.addFromEvent(this, 'drag', this._onDrag);
     disposables.addFromEvent(this, 'dragend', this._onDragEnd);
-    disposables.addFromEvent(this._host, 'dragover', this._onDragOver);
-    disposables.addFromEvent(this._host, 'drop', (e: DragEvent) => {
+    disposables.addFromEvent(this._editorHost, 'dragover', this._onDragOver);
+    disposables.addFromEvent(this._editorHost, 'drop', (e: DragEvent) => {
       this._onDrop(e).catch(console.error);
     });
     disposables.addFromEvent(this, 'mousedown', this._onMouseDown);
 
     if (IS_FIREFOX) {
       disposables.addFromEvent(
-        this._host,
+        this._editorHost,
         'dragover',
         this._onDragOverDocument
       );
@@ -201,14 +201,12 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     if (!this._expanded) this._hideCardList();
   }
 
-  private get _isPageMode() {
-    return isPageMode(this._host.page);
-  }
-
   private get _pageBlockElement() {
-    const pageElement = this._isPageMode
-      ? (getDocPage(this._host.page) as DocPageBlockComponent)
-      : (getEdgelessPage(this._host.page) as EdgelessPageBlockComponent);
+    const pageElement = isInsideDocEditor(this._editorHost)
+      ? (getDocPageByEditorHost(this._editorHost) as DocPageBlockComponent)
+      : (getEdgelessPageByEditorHost(
+          this._editorHost
+        ) as EdgelessPageBlockComponent);
     return pageElement;
   }
 
@@ -221,9 +219,9 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       scale: number;
     };
 
-    if (this._isPageMode) {
+    if (isInsideDocEditor(this._editorHost)) {
       const closestNoteBlock = getClosestNoteBlock(
-        this._host.page,
+        this._editorHost,
         this._pageBlockElement,
         point
       );
@@ -356,7 +354,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       if (x >= min.x && x <= max.x && y >= min.y) {
         const lastBlock = this._pageBlockElement.model.lastChild();
         if (lastBlock) {
-          const lastElement = this._host.view.viewFromPath('block', [
+          const lastElement = this._editorHost.view.viewFromPath('block', [
             lastBlock.id,
           ]);
           element = lastElement;
@@ -444,7 +442,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     assertExists(e.dataTransfer);
     if (!e.dataTransfer.getData('affine/block-hub')) return;
 
-    const page = this._host.page;
+    const page = this._editorHost.page;
     const point = this._indicator?.rect?.min ?? new Point(e.clientX, e.clientY);
     const lastModelState = this._lastDroppingTarget;
     const lastType = this._lastDroppingType;
@@ -466,14 +464,14 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     ) {
       const imageFiles = await getImageFilesFromLocal();
 
-      const imageService = this._host.spec.getService('affine:image');
+      const imageService = this._editorHost.spec.getService('affine:image');
       assertExists(imageService);
       assertInstanceOf(imageService, ImageService);
       const maxFileSize = imageService.maxFileSize;
 
       addSiblingImageBlock(imageFiles, maxFileSize, lastModelState.model);
     } else if (props.flavour === 'affine:bookmark') {
-      const url = await toggleBookmarkCreateModal(this._host);
+      const url = await toggleBookmarkCreateModal(this._editorHost);
       url &&
         models.push({
           flavour: 'affine:bookmark',
@@ -514,7 +512,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       }
     }
 
-    if (this._isPageMode) {
+    if (isInsideDocEditor(this._editorHost)) {
       if (focusId) {
         asyncFocusRichText(page, focusId)?.catch(console.error);
       }
@@ -522,12 +520,12 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     }
 
     // In edgeless mode.
-    const pageBlock = getEdgelessPage(page);
-    assertExists(pageBlock);
+    const pageBlockElement = this
+      ._pageBlockElement as EdgelessPageBlockComponent;
 
     let noteId;
     if (focusId && parentModel) {
-      const targetNoteBlock = this._host.view.viewFromPath(
+      const targetNoteBlock = this._editorHost.view.viewFromPath(
         'block',
         buildPath(parentModel)
       );
@@ -535,7 +533,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       noteId = targetNoteBlock.model.id;
     } else {
       // Creates new note block on blank area.
-      const result = pageBlock.addNewNote(
+      const result = pageBlockElement.addNewNote(
         models,
         point,
         isDatabase ? { width: 752 } : undefined
@@ -551,7 +549,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
         service.initDatabaseBlock(page, model, model.id, 'table');
       }
     }
-    pageBlock.setSelection(noteId, true, focusId, point);
+    pageBlockElement.setSelection(noteId, true, focusId, point);
   };
 
   private _onClickCard = async (
@@ -567,7 +565,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
       flavour: blockHubElement.getAttribute('affine-flavour') ?? '',
       type: affineType ?? undefined,
     };
-    const page = this._host.page;
+    const page = this._editorHost.page;
     const models = [];
 
     const defaultNoteBlock =
@@ -581,7 +579,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
     if (data.flavour === 'affine:image' && data.type === 'image') {
       const imageFiles = await getImageFilesFromLocal();
 
-      const imageService = this._host.spec.getService('affine:image');
+      const imageService = this._editorHost.spec.getService('affine:image');
       assertExists(imageService);
       assertInstanceOf(imageService, ImageService);
       const maxFileSize = imageService.maxFileSize;
@@ -595,7 +593,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
       lastId = blockIds[blockIds.length - 1];
     } else if (data.flavour === 'affine:bookmark') {
-      const url = await toggleBookmarkCreateModal(this._host);
+      const url = await toggleBookmarkCreateModal(this._editorHost);
       url &&
         models.push({
           flavour: 'affine:bookmark',
@@ -667,7 +665,8 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
     const classes = classMap({
       'icon-expanded': this._expanded,
-      'new-icon-in-edgeless': !this._isPageMode && !this._expanded,
+      'new-icon-in-edgeless':
+        !isInsideDocEditor(this._editorHost) && !this._expanded,
       'new-icon': true,
     });
 

--- a/packages/blocks/src/page-block/widgets/doc-page-meta-data/doc-page-meta-data.ts
+++ b/packages/blocks/src/page-block/widgets/doc-page-meta-data/doc-page-meta-data.ts
@@ -2,7 +2,7 @@ import { assertExists } from '@blocksuite/global/utils';
 import { WidgetElement } from '@blocksuite/lit';
 import { customElement } from 'lit/decorators.js';
 
-import { getDocPage } from '../../../_common/utils/query.js';
+import { getDocPageByEditorHost } from '../../../_common/utils/query.js';
 import { PageMetaData } from './components/meta-data.js';
 
 export const AFFINE_DOC_PAGE_META_DATA = 'affine-page-meta-data-widget';
@@ -14,10 +14,10 @@ export class DocPageMetaDataWidget extends WidgetElement {
 
     this.host.updateComplete
       .then(() => {
-        const pageElement = getDocPage(this.page);
-        assertExists(pageElement);
+        const docPageElement = getDocPageByEditorHost(this.host);
+        assertExists(docPageElement);
 
-        const pageMetaData = new PageMetaData(this.page, pageElement);
+        const pageMetaData = new PageMetaData(this.page, docPageElement);
 
         const pageTitleContainer = this.host.querySelector(
           '.affine-doc-page-block-title-container'

--- a/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
@@ -17,8 +17,8 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { BLOCK_ID_ATTR } from '../../../_common/consts.js';
 import {
+  buildPath,
   type EdgelessTool,
-  getBlockComponentByModel,
   getBlockElementsExcludeSubtrees,
   getCurrentNativeRange,
   getModelByBlockComponent,
@@ -1123,7 +1123,9 @@ export class AffineDragHandleWidget extends WidgetElement<
       assertExists(parent);
       // Need to update selection when moving blocks successfully
       // Because the block path may be changed after moving
-      const parentElement = getBlockComponentByModel(parent);
+      const parentElement = this._getBlockElementFromViewStore(
+        buildPath(parent)
+      );
       if (parentElement) {
         const newSelectedBlocks = selectedBlocks
           .map(block => parentElement.path.concat(block.id))

--- a/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
@@ -22,7 +22,8 @@ import {
   getBlockElementsExcludeSubtrees,
   getCurrentNativeRange,
   getModelByBlockComponent,
-  isPageMode,
+  isInsideDocEditor,
+  isInsideEdgelessEditor,
   matchFlavours,
   Point,
   Rect,
@@ -142,7 +143,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   get anchorEdgelessElement(): TopLevelBlockModel | null {
-    if (isPageMode(this.page) || !this._anchorBlockId) return null;
+    if (isInsideDocEditor(this.host) || !this._anchorBlockId) return null;
     const { surface } = this.pageBlockElement as EdgelessPageBlockComponent;
     const edgelessElement = surface.pickById(this._anchorBlockId);
     return isTopLevelBlock(edgelessElement) ? edgelessElement : null;
@@ -161,7 +162,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   getDropResult = (state: PointerEventState): DropResult | null => {
     const point = getContainerOffsetPoint(state);
     const closestBlockElement = getClosestBlockByPoint(
-      this.page,
+      this.host,
       this.pageBlockElement,
       point
     );
@@ -263,13 +264,13 @@ export class AffineDragHandleWidget extends WidgetElement<
   ) => {
     const point = getContainerOffsetPoint(state);
     const closestNoteBlock = getClosestNoteBlock(
-      this.page,
+      this.host,
       this.pageBlockElement,
       point
     );
     if (
       !closestNoteBlock ||
-      isOutOfNoteBlock(this.page, closestNoteBlock, point, this.scale)
+      isOutOfNoteBlock(this.host, closestNoteBlock, point, this.scale)
     ) {
       this.resetDropResult();
     } else {
@@ -585,7 +586,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   private _showDragHandleOnTopLevelBlocks() {
-    if (isPageMode(this.page)) return;
+    if (isInsideDocEditor(this.host)) return;
     const edgelessPage = this.pageBlockElement as EdgelessPageBlockComponent;
 
     if (!this._anchorBlockPath) return;
@@ -708,7 +709,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   private _getHoverAreaRectTopLevelBlock(
     edgelessElement: TopLevelBlockModel
   ): Rect | null {
-    if (isPageMode(this.page)) return null;
+    if (isInsideDocEditor(this.host)) return null;
     const edgelessPage = this.pageBlockElement as EdgelessPageBlockComponent;
 
     const rect = getSelectedRect([edgelessElement]);
@@ -755,7 +756,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
     // When current page is edgeless page
     // We need to remain surface selection and set editing as true
-    if (!isPageMode(this.page)) {
+    if (isInsideEdgelessEditor(this.host)) {
       const surfaceElementId = noteId ? noteId : getNoteId(blockElements[0]);
       const surfaceSelection = selection.getInstance(
         'surface',
@@ -777,7 +778,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   private _canEditing = (noteBlock: BlockElement) => {
     if (noteBlock.page.id !== this.page.id) return false;
 
-    if (isPageMode(this.page)) return true;
+    if (isInsideDocEditor(this.host)) return true;
     const edgelessPage = this.pageBlockElement as EdgelessPageBlockComponent;
 
     const noteBlockId = noteBlock.path[noteBlock.path.length - 1];
@@ -788,7 +789,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   };
 
   private _checkTopLevelBlockSelection = () => {
-    if (this.page.readonly || isPageMode(this.page)) {
+    if (this.page.readonly || isInsideDocEditor(this.host)) {
       this._hide();
       return;
     }
@@ -839,7 +840,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
     const point = getContainerOffsetPoint(state);
     const closestBlockElement = getClosestBlockByPoint(
-      this.page,
+      this.host,
       this.pageBlockElement,
       point
     );
@@ -894,14 +895,14 @@ export class AffineDragHandleWidget extends WidgetElement<
     // When pointer out of note block hover area or inside database, should hide drag handle
     const point = getContainerOffsetPoint(state);
     const closestNoteBlock = getClosestNoteBlock(
-      this.page,
+      this.host,
       this.pageBlockElement,
       point
     ) as BlockElement | null;
     if (
       closestNoteBlock &&
       this._canEditing(closestNoteBlock) &&
-      !isOutOfNoteBlock(this.page, closestNoteBlock, point, this.scale)
+      !isOutOfNoteBlock(this.host, closestNoteBlock, point, this.scale)
     ) {
       this._pointerMoveOnBlock(state);
       return true;
@@ -1229,7 +1230,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
     // call default drag end handler if no option return true
     this._onDragEnd(state);
-    if (!isPageMode(this.page)) this._checkTopLevelBlockSelection();
+    if (isInsideEdgelessEditor(this.host)) this._checkTopLevelBlockSelection();
     return true;
   };
 
@@ -1366,7 +1367,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       this._onDragHandlePointerLeave
     );
 
-    if (isPageMode(this.page)) {
+    if (isInsideDocEditor(this.host)) {
       const docPage = this.pageBlockElement as DocPageBlockComponent;
 
       this._disposables.add(

--- a/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
@@ -4,8 +4,8 @@ import {
   type PointerEventState,
 } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import type { BlockElement } from '@blocksuite/lit';
-import type { BaseBlockModel, Page } from '@blocksuite/store';
+import type { BlockElement, EditorHost } from '@blocksuite/lit';
+import type { BaseBlockModel } from '@blocksuite/store';
 
 import {
   type BlockComponent,
@@ -15,7 +15,7 @@ import {
   getDropRectByPoint,
   getHoveringNote,
   getRectByBlockElement,
-  isPageMode,
+  isInsideDocEditor,
   matchFlavours,
   Point,
   Rect,
@@ -125,7 +125,7 @@ export const getContainerOffsetPoint = (state: PointerEventState) => {
 };
 
 export const isOutOfNoteBlock = (
-  page: Page,
+  editorHost: EditorHost,
   noteBlock: Element,
   point: Point,
   scale: number
@@ -134,7 +134,7 @@ export const isOutOfNoteBlock = (
   const rect = noteBlock.getBoundingClientRect();
   const padding = NOTE_CONTAINER_PADDING * scale;
   return rect
-    ? isPageMode(page)
+    ? isInsideDocEditor(editorHost)
       ? point.y < rect.top ||
         point.y > rect.bottom ||
         point.x > rect.right + padding
@@ -146,21 +146,21 @@ export const isOutOfNoteBlock = (
 };
 
 export const getClosestNoteBlock = (
-  page: Page,
+  editorHost: EditorHost,
   pageBlock: BlockComponent,
   point: Point
 ) => {
-  return isPageMode(page)
+  return isInsideDocEditor(editorHost)
     ? findClosestBlockElement(pageBlock, point, 'affine-note')
     : getHoveringNote(point)?.querySelector('affine-note');
 };
 
 export const getClosestBlockByPoint = (
-  page: Page,
+  editorHost: EditorHost,
   pageBlock: BlockComponent,
   point: Point
 ) => {
-  const closestNoteBlock = getClosestNoteBlock(page, pageBlock, point);
+  const closestNoteBlock = getClosestNoteBlock(editorHost, pageBlock, point);
   if (!closestNoteBlock || closestNoteBlock.closest('.affine-surface-ref'))
     return null;
   const noteRect = Rect.fromDOM(closestNoteBlock);

--- a/packages/blocks/src/page-block/widgets/image-toolbar/image-options.ts
+++ b/packages/blocks/src/page-block/widgets/image-toolbar/image-options.ts
@@ -21,12 +21,14 @@ import {
 } from '../../../image-block/utils.js';
 
 export function ImageOptionsTemplate({
+  editorHost,
   ref: containerRef,
   model,
   blob,
   abortController,
   host,
 }: {
+  editorHost: EditorHost;
   ref?: RefOrCallback;
   model: ImageBlockModel;
   blob?: Blob;
@@ -90,7 +92,7 @@ export function ImageOptionsTemplate({
         <icon-button
           size="32px"
           ?hidden=${readonly}
-          @click=${() => focusCaption(model)}
+          @click=${() => focusCaption(editorHost, model)}
         >
           ${CaptionIcon}
           <affine-tooltip tip-position="right">Caption</affine-tooltip>

--- a/packages/blocks/src/page-block/widgets/image-toolbar/image-toolbar.ts
+++ b/packages/blocks/src/page-block/widgets/image-toolbar/image-toolbar.ts
@@ -20,6 +20,7 @@ export class AffineImageToolbarWidget extends WidgetElement<ImageBlockComponent>
       if (!imageContainer) return null;
       return {
         template: ImageOptionsTemplate({
+          editorHost: this.host,
           model: imageBlock.model,
           blob: imageBlock.blob,
           abortController,

--- a/packages/blocks/src/page-block/widgets/linked-page/index.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/index.ts
@@ -4,8 +4,9 @@ import {
   DisposableGroup,
   throttle,
 } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import { WidgetElement } from '@blocksuite/lit';
-import { type BaseBlockModel } from '@blocksuite/store';
+import type { BaseBlockModel } from '@blocksuite/store';
 import { customElement } from 'lit/decorators.js';
 
 import { isControlledKeyboardEvent } from '../../../_common/utils/event.js';
@@ -20,6 +21,7 @@ import { getMenus, type LinkedPageOptions } from './config.js';
 import { LinkedPagePopover } from './linked-page-popover.js';
 
 export function showLinkedPagePopover({
+  editorHost,
   model,
   range,
   container = document.body,
@@ -27,6 +29,7 @@ export function showLinkedPagePopover({
   options,
   triggerKey,
 }: {
+  editorHost: EditorHost;
   model: BaseBlockModel;
   range: Range;
   container?: HTMLElement;
@@ -55,7 +58,7 @@ export function showLinkedPagePopover({
     linkedPage.updatePosition(position);
   }, 10);
   disposables.addFromEvent(window, 'resize', updatePosition);
-  const scrollContainer = getViewportElement(model.page);
+  const scrollContainer = getViewportElement(editorHost);
   if (scrollContainer) {
     // Note: in edgeless mode, the scroll container is not exist!
     disposables.addFromEvent(scrollContainer, 'scroll', updatePosition, {
@@ -98,15 +101,16 @@ export class AffineLinkedPageWidget extends WidgetElement {
     this.handleEvent('keyDown', this._onKeyDown);
   }
 
-  public showLinkedPage(model: BaseBlockModel, triggerKey: string) {
+  public showLinkedPage = (model: BaseBlockModel, triggerKey: string) => {
     const curRange = getCurrentNativeRange();
     showLinkedPagePopover({
+      editorHost: this.host,
       model,
       range: curRange,
       options: this.options,
       triggerKey,
     });
-  }
+  };
 
   private _onKeyDown = (ctx: UIEventStateContext) => {
     const eventState = ctx.get('keyboardState');

--- a/packages/blocks/src/page-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/config.ts
@@ -27,7 +27,6 @@ import {
 } from '../../../_common/icons/index.js';
 import {
   createDefaultPage,
-  getBlockComponentByModel,
   getCurrentNativeRange,
   getImageFilesFromLocal,
   getInlineEditorByModel,
@@ -205,12 +204,9 @@ export const menuGroups: SlashMenuOptions['menus'] = [
         name: 'Link Page',
         alias: ['dual link'],
         icon: DualLinkIcon,
-        showWhen: model => {
-          assertExists(model.page.root);
-          const pageBlock = getBlockComponentByModel(model.page.root);
-          assertExists(pageBlock);
+        showWhen: (_, pageElement) => {
           const linkedPageWidgetEle =
-            pageBlock.widgetElements['affine-linked-page-widget'];
+            pageElement.widgetElements['affine-linked-page-widget'];
           if (!linkedPageWidgetEle) return false;
           if (!('showLinkedPage' in linkedPageWidgetEle)) {
             console.warn(
@@ -220,13 +216,12 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           }
           return true;
         },
-        action: ({ model }) => {
+        action: ({ model, pageElement }) => {
           const triggerKey = '@';
           insertContent(model, triggerKey);
           assertExists(model.page.root);
-          const pageBlock = getBlockComponentByModel(model.page.root);
           const widgetEle =
-            pageBlock?.widgetElements['affine-linked-page-widget'];
+            pageElement.widgetElements['affine-linked-page-widget'];
           assertExists(widgetEle);
           // We have checked the existence of showLinkedPage method in the showWhen
           const linkedPageWidget = widgetEle as AffineLinkedPageWidget;

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -2,6 +2,7 @@ import '../_common/components/rich-text/rich-text.js';
 
 import { DisposableGroup } from '@blocksuite/global/utils';
 import type { InlineRangeProvider } from '@blocksuite/inline';
+import type { EditorHost } from '@blocksuite/lit';
 import { BlockElement, getInlineRangeProvider } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import { css, html, type TemplateResult } from 'lit';
@@ -16,7 +17,7 @@ import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../_common/consts.js';
 import {
   getThemeMode,
-  isPageMode,
+  isInsideEdgelessEditor,
   matchFlavours,
 } from '../_common/utils/index.js';
 import type { BlockHub } from '../page-block/widgets/block-hub/components/block-hub.js';
@@ -32,12 +33,16 @@ interface Style {
   [name: string]: string;
 }
 
-function TipsPlaceholder(model: BaseBlockModel, tipsPos: Style) {
+function TipsPlaceholder(
+  editorHost: EditorHost,
+  model: BaseBlockModel,
+  tipsPos: Style
+) {
   if (!matchFlavours(model, ['affine:paragraph'])) {
     throw new Error("TipsPlaceholder can't be used for this model");
   }
   if (model.type === 'text') {
-    if (!isPageMode(model.page)) {
+    if (isInsideEdgelessEditor(editorHost)) {
       return html`<div class="tips-placeholder" style=${styleMap(tipsPos)}>
         Type '/' for commands
       </div> `;
@@ -273,7 +278,11 @@ export class ParagraphBlockComponent extends BlockElement<ParagraphBlockModel> {
       };
     }
 
-    this._tipsPlaceholderTemplate = TipsPlaceholder(this.model, this.tipsPos);
+    this._tipsPlaceholderTemplate = TipsPlaceholder(
+      this.host,
+      this.model,
+      this.tipsPos
+    );
   };
 
   private _onFocusIn = () => {

--- a/packages/blocks/src/surface-block/elements/edgeless-element.ts
+++ b/packages/blocks/src/surface-block/elements/edgeless-element.ts
@@ -1,3 +1,5 @@
+import type { EditorHost } from '@blocksuite/lit';
+
 import type { Bound, IVec, PointLocation, SerializedXYWH } from '../index.js';
 import type { SurfaceBlockComponent } from '../surface-block.js';
 import type { IBrush } from './brush/types.js';
@@ -41,6 +43,7 @@ export interface IEdgelessElement {
     x: number,
     y: number,
     options: HitTestOptions,
+    editorHost: EditorHost,
     surface?: SurfaceBlockComponent
   ): boolean;
   boxSelect(bound: Bound): boolean;

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -877,13 +877,13 @@ export class SurfaceBlockComponent extends BlockElement<
     const pickBlock = () => {
       const candidates = this.layer.blocksGrid.search(hitTestBound);
       const picked = candidates.filter(element =>
-        element.hitTest(x, y, options)
+        element.hitTest(x, y, options, this.host)
       );
       return picked as EdgelessElement[];
     };
     const pickFrames = () => {
       return this.layer.frames.filter(frame =>
-        frame.hitTest(x, y, options)
+        frame.hitTest(x, y, options, this.host)
       ) as EdgelessElement[];
     };
 

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -15,6 +15,7 @@ import {
 import { getThemePropertyValue } from '../_common/theme/utils.js';
 import {
   type EdgelessElement,
+  isInsideEdgelessEditor,
   type ReorderingAction,
   requestConnectedFrame,
   type Selectable,
@@ -177,7 +178,7 @@ export class SurfaceBlockComponent extends BlockElement<
   }
 
   private get _isEdgeless() {
-    return !!this.host.querySelector('affine-edgeless-page');
+    return isInsideEdgelessEditor(this.host);
   }
 
   getBlocks<T extends EdgelessBlockType>(

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -20,7 +20,11 @@ import {
 import { getThemePropertyValue } from '../_common/theme/utils.js';
 import type { EdgelessElement, TopLevelBlockModel } from '../_common/types.js';
 import { stopPropagation } from '../_common/utils/event.js';
-import { buildPath, getEditorContainer } from '../_common/utils/query.js';
+import {
+  buildPath,
+  getEditorContainer,
+  isInsideDocEditor,
+} from '../_common/utils/query.js';
 import type { NoteBlockModel, SurfaceBlockModel } from '../models.js';
 import { ConnectorPathGenerator } from '../page-block/edgeless/connector-manager.js';
 import { getBackgroundGrid } from '../page-block/edgeless/utils/query.js';
@@ -825,7 +829,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
 
   private _shouldRender() {
     return (
-      !!this.host.querySelector('affine-doc-page') &&
+      isInsideDocEditor(this.host) &&
       this.parentElement &&
       !this.parentElement.closest('affine-surface-ref')
     );


### PR DESCRIPTION
Having global query functions, i.e. funtions having `document.querySelection`, prevents implementation of multiple-editors as the query result will always return element from first editor.

Changes:
- refactored utils and their usage, which directly / indirectly calls query on the document. `EditorHost` is used as the node for DOM queries instead.