### PR TITLE
feat(edgeless): update presentation setting labels

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
@@ -35,7 +35,7 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
       justify-content: space-between;
       align-items: center;
       height: 28px;
-      width: 254px;
+      width: 204px;
     }
 
     .text {
@@ -48,7 +48,7 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
   `;
 
   @state()
-  blackBackground = true;
+  blackBackground = false;
 
   @property({ attribute: false })
   popperShow = false;
@@ -77,11 +77,11 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
     const blackBackground = sessionStorage.getItem(
       PresentationConsts.BlackBackground
     );
-    this.blackBackground = blackBackground !== 'false';
+    this.blackBackground = blackBackground === 'true';
   }
 
   private _onBlackBackgroundChange = (checked: boolean) => {
-    this.blackBackground = !checked;
+    this.blackBackground = checked;
     this.edgeless.slots.navigatorSettingUpdated.emit({
       blackBackground: this.blackBackground,
     });
@@ -118,23 +118,23 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
         }}
       >
         <div class="item-container">
-          <div class="text title">Settings</div>
+          <div class="text title">Playback Settings</div>
         </div>
         <div class="item-container">
-          <div class="text">Hide toolbar while presenting</div>
+          <div class="text">Dark background</div>
+          <toggle-switch
+            .on=${this.blackBackground}
+            .onChange=${this._onBlackBackgroundChange}
+          >
+          </toggle-switch>
+        </div>
+        <div class="item-container">
+          <div class="text">Hide toolbar</div>
           <toggle-switch
             .on=${this.hideToolbar}
             .onChange=${(checked: boolean) => {
               this.onHideToolbarChange && this.onHideToolbarChange(checked);
             }}
-          >
-          </toggle-switch>
-        </div>
-        <div class="item-container">
-          <div class="text">Hide background while presenting</div>
-          <toggle-switch
-            .on=${!this.blackBackground}
-            .onChange=${this._onBlackBackgroundChange}
           >
           </toggle-switch>
         </div>

--- a/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
@@ -11,7 +11,7 @@ const styles = css`
     display: block;
     box-sizing: border-box;
     padding: 8px;
-    width: 290px;
+    width: 220px;
   }
 
   .frames-setting-menu-container {
@@ -51,7 +51,7 @@ const styles = css`
   }
 
   .frames-setting-menu-item .action-label {
-    width: 204px;
+    width: 138px;
     height: 20px;
     padding: 0 4px;
     font-size: 12px;
@@ -90,13 +90,13 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
     );
     const fillScreen = sessionStorage.getItem(PresentationConsts.FillScreen);
     const hideToolbar = sessionStorage.getItem(PresentationConsts.HideToolbar);
-    this.blackBackground = blackBackground !== 'false';
+    this.blackBackground = blackBackground === 'true';
     this.fillScreen = fillScreen === 'true';
     this.hideToolbar = hideToolbar === 'true';
   }
 
   private _onBlackBackgroundChange = (checked: boolean) => {
-    this.blackBackground = !checked;
+    this.blackBackground = checked;
     this.edgeless?.slots.navigatorSettingUpdated.emit({
       blackBackground: this.blackBackground,
     });
@@ -187,20 +187,20 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
         <div class="setting-label">Playback Settings</div>
       </div>
       <div class="frames-setting-menu-item action">
-        <div class="action-label">Hide toolbar while presenting</div>
+        <div class="action-label">Dark background</div>
         <div class="toggle-button">
           <toggle-switch
-            .on=${this.hideToolbar}
-            .onChange=${this._onHideToolBarChange}
+            .on=${this.blackBackground}
+            .onChange=${this._onBlackBackgroundChange}
           ></toggle-switch>
         </div>
       </div>
       <div class="frames-setting-menu-item action">
-        <div class="action-label">Hide background while presenting</div>
+        <div class="action-label">Hide toolbar</div>
         <div class="toggle-button">
           <toggle-switch
-            .on=${!this.blackBackground}
-            .onChange=${this._onBlackBackgroundChange}
+            .on=${this.hideToolbar}
+            .onChange=${this._onHideToolBarChange}
           ></toggle-switch>
         </div>
       </div>


### PR DESCRIPTION
The "Dark background" switch - when turned on, a black box is displayed - by default, it is not displayed. 
The "Hide toolbar" switch - when turned on, the toolbar is hidden - by default, it is displayed.