### PR TITLE
fix(edgeless): share page should be able to hide remote cursor

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-hover-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-hover-rect.ts
@@ -2,6 +2,7 @@ import { WithDisposable } from '@blocksuite/lit';
 import { css, html, LitElement } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
+import { requestConnectedFrame } from '../../../../_common/utils/event.js';
 import type { EdgelessPageBlockComponent } from '../../edgeless-page-block.js';
 import { isNoteBlock } from '../../utils/query.js';
 
@@ -42,21 +43,22 @@ export class EdgelessHoverRect extends WithDisposable(LitElement) {
   private _refreshHoverRect = () => {
     if (this.rAfId) cancelAnimationFrame(this.rAfId);
 
-    const hoverState = this.edgeless.tools.getHoverState();
-    if (!hoverState) {
-      this.rAfId = requestAnimationFrame(() => {
-        this.rect.style.removeProperty('visibility');
-      });
+    this.rAfId = requestConnectedFrame(() => {
+      const hoverState = this.edgeless.tools.getHoverState();
 
-      return;
-    }
+      if (!hoverState) {
+        this.rAfId = requestAnimationFrame(() => {
+          this.rect.style.removeProperty('visibility');
+        });
 
-    const { zoom } = this.edgeless.surface.viewport;
-    const { rect } = hoverState;
-    const element = hoverState.content;
-    const isNote = isNoteBlock(element);
+        return;
+      }
 
-    this.rAfId = requestAnimationFrame(() => {
+      const { zoom } = this.edgeless.surface.viewport;
+      const { rect } = hoverState;
+      const element = hoverState.content;
+      const isNote = isNoteBlock(element);
+
       this.rect.style.visibility = 'visible';
       this.rect.style.transform = `translate(${rect.x}px, ${rect.y}px)`;
       this.rect.style.width = `${rect.width}px`;
@@ -68,7 +70,7 @@ export class EdgelessHoverRect extends WithDisposable(LitElement) {
         ? 'var(--affine-hover-color)'
         : '';
       this.rAfId = null;
-    });
+    }, this);
   };
 
   protected override firstUpdated() {

--- a/packages/blocks/src/page-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/page-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -33,6 +33,8 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     }
   `;
 
+  static enable = true;
+
   private _remoteColorManager: RemoteColorManager | null = null;
 
   private _remoteSelections: Array<{
@@ -61,6 +63,9 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
 
   override connectedCallback() {
     super.connectedCallback();
+
+    if (!AffineDocRemoteSelectionWidget.enable) return;
+
     this.disposables.add(
       this._selectionManager.slots.remoteChanged.on(
         throttle((remoteSelections: Map<number, BaseSelection[]>) => {
@@ -239,7 +244,10 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }
 
   override render() {
-    if (this._remoteSelections.length === 0) {
+    if (
+      this._remoteSelections.length === 0 ||
+      !AffineDocRemoteSelectionWidget.enable
+    ) {
       return nothing;
     }
 

--- a/packages/blocks/src/page-block/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/page-block/widgets/edgeless-remote-selection/index.ts
@@ -1,7 +1,7 @@
 import { assertExists } from '@blocksuite/global/utils';
 import { WidgetElement } from '@blocksuite/lit';
 import type { UserInfo } from '@blocksuite/store';
-import { css, html } from 'lit';
+import { css, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -21,6 +21,7 @@ export const AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET =
 
 @customElement(AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET)
 export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlockComponent> {
+  static enable = true;
   static override styles = css`
     :host {
       pointer-events: none;
@@ -189,6 +190,8 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlo
   override connectedCallback() {
     super.connectedCallback();
 
+    if (!EdgelessRemoteSelectionWidget.enable) return;
+
     const { _disposables, surface, page, edgeless } = this;
 
     pickValues(edgeless.slots, [
@@ -223,6 +226,8 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<EdgelessPageBlo
   }
 
   override render() {
+    if (!EdgelessRemoteSelectionWidget.enable) return nothing;
+
     const { _remoteRects, _remoteCursors, _remoteColorManager } = this;
     assertExists(_remoteColorManager);
     const { zoom } = this.surface.viewport;

--- a/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -1,6 +1,6 @@
 import { WidgetElement } from '@blocksuite/lit';
 import { offset, shift } from '@floating-ui/dom';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -80,6 +80,8 @@ function SurfaceRefToolbarOptions(options: {
   const readonly = model.page.readonly;
   const hasValidReference = !!blockElement.referenceModel;
 
+  if (readonly) return nothing;
+
   return html`
     <style>
       :host {
@@ -122,7 +124,7 @@ function SurfaceRefToolbarOptions(options: {
 
     <div class="surface-ref-toolbar-container">
       <icon-button
-        ?hidden=${!hasValidReference}
+        ?hidden=${!hasValidReference || readonly}
         class="view-in-edgeless-button"
         text="View in Edgeless"
         width="fit-content"
@@ -131,6 +133,7 @@ function SurfaceRefToolbarOptions(options: {
       </icon-button>
       <div
         class="divider"
+        ?hidden=${readonly}
         style=${styleMap({
           display: hasValidReference ? undefined : 'none',
         })}

--- a/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -1,6 +1,6 @@
 import { WidgetElement } from '@blocksuite/lit';
 import { offset, shift } from '@floating-ui/dom';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -79,8 +79,6 @@ function SurfaceRefToolbarOptions(options: {
   const { blockElement, model, abortController } = options;
   const readonly = model.page.readonly;
   const hasValidReference = !!blockElement.referenceModel;
-
-  if (readonly) return nothing;
 
   return html`
     <style>


### PR DESCRIPTION
close #5662

The remote cursor can be hidden through `AffineDocRemoteSelectionWidget.enable = false` and `EdgelessRemoteSelectionWidget.enable = false`;