### PR TITLE
fix: forward specs to editor

### DIFF
--- a/packages/lit/src/element/lit-host.ts
+++ b/packages/lit/src/element/lit-host.ts
@@ -62,7 +62,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
   }
 
   override willUpdate(changedProperties: PropertyValues) {
-    if (changedProperties.has('preset')) {
+    if (changedProperties.has('specs')) {
       this.std.spec.applySpecs(this.specs);
     }
     super.willUpdate(changedProperties);

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -154,8 +154,14 @@ export class AffineEditorContainer
     return html`${keyed(
       this.model.id,
       this.mode === 'page'
-        ? html`<doc-editor .page=${this.page}></doc-editor>`
-        : html`<edgeless-editor .page=${this.page}></edgeless-editor>`
+        ? html`<doc-editor
+            .page=${this.page}
+            .specs=${this.docSpecs}
+          ></doc-editor>`
+        : html`<edgeless-editor
+            .page=${this.page}
+            .specs=${this.edgelessSpecs}
+          ></edgeless-editor>`
     )}`;
   }
 }


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/pull/5158#issuecomment-1865840827 https://github.com/toeverything/blocksuite/pull/5657

This pull request fixes an issue with forwarding specs in the editor container.

Previously, the specs were not being properly forwarded to the doc-editor and edgeless-editor components.
