### PR TITLE
feat(inline): support nested contenteditable

### DIFF
--- a/packages/inline/src/inline-editor.ts
+++ b/packages/inline/src/inline-editor.ts
@@ -49,6 +49,7 @@ export class InlineEditor<
 
   private readonly _yText: Y.Text;
   private _rootElement: InlineRootElement<TextAttributes> | null = null;
+  private _eventSource: HTMLElement | null = null;
   private _isReadonly = false;
 
   private _eventService: EventService<TextAttributes> =
@@ -102,6 +103,11 @@ export class InlineEditor<
   get rootElement() {
     assertExists(this._rootElement);
     return this._rootElement;
+  }
+
+  get eventSource() {
+    assertExists(this._eventSource);
+    return this._eventSource;
   }
 
   get eventService() {
@@ -208,12 +214,14 @@ export class InlineEditor<
     this.slots.inlineRangeUpdate.on(this.rangeService.onInlineRangeUpdated);
   }
 
-  mount(rootElement: HTMLElement) {
+  mount(rootElement: HTMLElement, eventSource: HTMLElement = rootElement) {
     const inlineRoot = rootElement as InlineRootElement<TextAttributes>;
     inlineRoot.inlineEditor = this;
     this._rootElement = inlineRoot;
+    this._eventSource = eventSource;
     render(nothing, this._rootElement);
     this._rootElement.contentEditable = 'true';
+    this._eventSource.contentEditable = 'true';
     this._rootElement.dataset.vRoot = 'true';
 
     this._bindYTextObserver();

--- a/packages/inline/src/services/event.ts
+++ b/packages/inline/src/services/event.ts
@@ -25,6 +25,7 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
   }
 
   mount = () => {
+    const eventSource = this.editor.eventSource;
     const rootElement = this.editor.rootElement;
 
     if (!this.inlineRangeProvider) {
@@ -36,24 +37,24 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
     }
 
     this.editor.disposables.addFromEvent(
-      rootElement,
+      eventSource,
       'beforeinput',
       this._onBeforeInput
     );
     this.editor.disposables.addFromEvent(
-      rootElement,
+      eventSource,
       'compositionstart',
       this._onCompositionStart
     );
     this.editor.disposables.addFromEvent(
-      rootElement,
+      eventSource,
       'compositionend',
       (event: CompositionEvent) => {
         this._onCompositionEnd(event).catch(console.error);
       }
     );
     this.editor.disposables.addFromEvent(
-      rootElement,
+      eventSource,
       'keydown',
       this._onKeyDown
     );

--- a/packages/playground/examples/inline/test-page.ts
+++ b/packages/playground/examples/inline/test-page.ts
@@ -143,7 +143,9 @@ export class TestRichText extends ShadowlessElement {
   undoManager!: Y.UndoManager;
 
   override firstUpdated() {
-    this.inlineEditor.mount(this._container);
+    this.contentEditable = 'true';
+    this.style.outline = 'none';
+    this.inlineEditor.mount(this._container, this);
 
     const keydownHandler = createInlineKeyDownHandler(this.inlineEditor, {
       inputRule: {
@@ -167,7 +169,7 @@ export class TestRichText extends ShadowlessElement {
         },
       },
     });
-    this._container.addEventListener('keydown', keydownHandler);
+    this.addEventListener('keydown', keydownHandler);
 
     this.inlineEditor.slots.textChange.on(() => {
       const el = this.querySelector('.y-text');
@@ -232,8 +234,8 @@ export class TestRichText extends ShadowlessElement {
         }
       </style>
       <div class="rich-text-container"></div>
-      <div class="v-range"></div>
-      <div class="y-text"></div>`;
+      <div contenteditable="false" class="v-range"></div>
+      <div contenteditable="false" class="y-text"></div>`;
   }
 }
 


### PR DESCRIPTION
The nesting of contenteditable elements can cause the lower-level contenteditable elements to be unable to listen to the events necessary for content synchronization (beforeinput, composition, keydown). Therefore, the inline editor needs to support listening to related events in elements outside of the rootElement.