### PR TITLE
fix: drag handle ui bugs

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -383,7 +383,7 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
     return html` <style>
         :host {
           position: absolute;
-          z-index: 1;
+          z-index: 3;
           left: ${this.left}px;
           top: ${this.top}px;
         }

--- a/packages/blocks/src/page-block/widgets/drag-handle/components/drag-preview.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/components/drag-preview.ts
@@ -17,12 +17,10 @@ export class DragPreview extends ShadowlessElement {
   override render() {
     return html`<style>
       affine-drag-preview {
-        --x: 0px;
-        --y: 0px;
-        height: auto;
-        display: block;
-        position: absolute;
         box-sizing: border-box;
+        position: absolute;
+        display: block;
+        height: auto;
         font-family: ${baseTheme.fontSansFamily};
         font-size: var(--affine-font-base);
         line-height: var(--affine-line-height);
@@ -30,37 +28,16 @@ export class DragPreview extends ShadowlessElement {
         font-weight: 400;
         top: 0;
         left: 0;
+        transform-origin: 0 0;
         opacity: 0.5;
-        cursor: none;
         user-select: none;
         pointer-events: none;
         caret-color: transparent;
-        transform-origin: 0 0;
         z-index: 3;
       }
 
-      affine-drag-preview > .affine-block-element {
-        pointer-events: none;
-        background-color: transparent;
-      }
-
-      affine-drag-preview > .affine-block-element:first-child > *:first-child {
-        margin-top: 0;
-      }
-
       .affine-drag-preview-grabbing * {
-        cursor: grabbing;
-      }
-
-      affine-drag-preview.grabbing:after {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 24px;
-        height: 24px;
-        transform: translate(var(--x), var(--y));
+        cursor: grabbing !important;
       }
     </style>`;
   }

--- a/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
@@ -416,12 +416,8 @@ export function convertDragPreviewEdgelessToDoc({
     : parentBlock.children.indexOf(targetBlock);
 
   const blockModel = blockComponent.model;
-  const blockProps = getBlockProps(blockModel);
-  delete blockProps.width;
-  delete blockProps.height;
-  delete blockProps.xywh;
-  delete blockProps.zIndex;
-
+  const { width, height, xywh, rotate, zIndex, ...blockProps } =
+    getBlockProps(blockModel);
   page.addBlock(blockModel.flavour, blockProps, parentBlock, parentIndex);
   page.deleteBlock(blockModel);
   return true;

--- a/tests/drag.spec.ts
+++ b/tests/drag.spec.ts
@@ -777,7 +777,7 @@ test('should create preview when dragging', async ({ page }) => {
     undefined,
     async () => {
       await expect(dragPreview).toBeVisible();
-      await expect(dragPreview.locator('.affine-block-element')).toHaveCount(2);
+      await expect(dragPreview.locator('[data-block-id]')).toHaveCount(2);
     }
   );
 });


### PR DESCRIPTION
Bugs fixed:
- drag handle showing after block is deleted
- drag handle showing over pop-up menu
- drag handle disappears on failed drop. need to deselect and select again to show drag handle.

added throttle to limit too many update