### PR TITLE
fix(edgeless): correct overlay position after #5791

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -100,6 +100,8 @@ export class EmbedBlockElement<
       assertExists(embedPortal);
       const dragPreviewEl = embedPortal.cloneNode() as HTMLElement;
       dragPreviewEl.style.transform = '';
+      dragPreviewEl.style.left = '0';
+      dragPreviewEl.style.top = '0';
       render(
         blockComponent.host.renderModel(blockComponent.model),
         dragPreviewEl

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -91,6 +91,8 @@ export class BookmarkBlockComponent extends BlockElement<
       assertExists(bookmarkPortal);
       const dragPreviewEl = bookmarkPortal.cloneNode() as HTMLElement;
       dragPreviewEl.style.transform = '';
+      dragPreviewEl.style.left = '0';
+      dragPreviewEl.style.top = '0';
       render(
         blockComponent.host.renderModel(blockComponent.model),
         dragPreviewEl

--- a/packages/blocks/src/note-block/note-block.ts
+++ b/packages/blocks/src/note-block/note-block.ts
@@ -51,6 +51,8 @@ export class NoteBlockComponent extends BlockElement<NoteBlockModel> {
       assertExists(notePortal);
       const dragPreviewEl = notePortal.cloneNode() as HTMLElement;
       dragPreviewEl.style.transform = '';
+      dragPreviewEl.style.left = '0';
+      dragPreviewEl.style.top = '0';
       const noteBackground = notePortal.querySelector('.note-background');
       assertExists(noteBackground);
       const noteBackgroundClone = noteBackground.cloneNode();

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -106,6 +106,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
 
     .more-actions-container {
       display: none;
+      position: absolute;
       width: 164px;
       padding: 8px;
       justify-content: center;

--- a/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
@@ -224,7 +224,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
     ) as HTMLElement;
     assertExists(noteContainer);
     const [baseX, baseY, noteWidth] = deserializeXYWH(note.xywh);
-    const transformX = baseX * this._zoom;
+    const transformX = baseX;
     const transformY = this.edgelessPage.surface.toModelCoord(
       gapRect.x - edgelessRect.x,
       gapRect.y - edgelessRect.y + gapRect.height / 2


### PR DESCRIPTION
Due to the change in rendering style of edgeless block portal items in #5791, overlay position calculation needs to be updated.
Affected items:
- drag preview of top-level blocks in edgeless
- note slicer (on zoom in/out)
- more menu (on edgeless surface pan)


https://github.com/toeverything/blocksuite/assets/54364088/e1b75899-7e4a-401b-8963-c7ed95f25e3d

