### PR TITLE
fix(page): unable to add trailing paragraph on click in windows

### DIFF
--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -38,14 +38,11 @@ function testClickOnBlankArea(
   state: PointerEventState,
   viewportWidth: number,
   pageWidth: number,
-  pageStyle: CSSStyleDeclaration
+  paddingLeft: number,
+  paddingRight: number
 ) {
-  const blankLeft =
-    viewportWidth - pageWidth + parseFloat(pageStyle.paddingLeft);
-  const blankRight =
-    (viewportWidth - pageWidth) / 2 +
-    pageWidth -
-    parseFloat(pageStyle.paddingRight);
+  const blankLeft = (viewportWidth - pageWidth) / 2 + paddingLeft;
+  const blankRight = (viewportWidth - pageWidth) / 2 + pageWidth - paddingRight;
 
   if (state.raw.clientX < blankLeft || state.raw.clientX > blankRight) {
     return true;
@@ -351,11 +348,15 @@ export class DocPageBlockComponent extends BlockElement<
         return;
       }
 
+      const { paddingLeft, paddingRight } = window.getComputedStyle(
+        this.pageBlockContainer
+      );
       const isClickOnBlankArea = testClickOnBlankArea(
         event,
         this.viewport.clientWidth,
         this.pageBlockContainer.clientWidth,
-        window.getComputedStyle(this.pageBlockContainer)
+        parseFloat(paddingLeft),
+        parseFloat(paddingRight)
       );
       if (isClickOnBlankArea) return;
 


### PR DESCRIPTION
before:

https://github.com/toeverything/blocksuite/assets/15389209/e12764bd-5a73-4101-bb50-025daf1b4602



after:


https://github.com/toeverything/blocksuite/assets/15389209/403dce25-9bcc-4737-be2f-f3d4a5207452
