### PR TITLE
chore: remove redundant import

### DIFF
--- a/packages/presets/src/editors/affine-doc-editor.ts
+++ b/packages/presets/src/editors/affine-doc-editor.ts
@@ -1,6 +1,3 @@
-import '../fragments/doc-title/doc-title';
-import '../fragments/page-meta-tags/page-meta-tags';
-
 import { DocEditorBlockSpecs } from '@blocksuite/blocks';
 import { noop } from '@blocksuite/global/utils';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';


### PR DESCRIPTION
Using `noop(DocTitle)` should be adequate for prevent tree-shaking. cc @AyushAgrawal-A2 