### PR TITLE
fix(database): date cell cannot display date picker again

### DIFF
--- a/packages/blocks/src/database-block/common/columns/date/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/date/cell-renderer.ts
@@ -45,7 +45,6 @@ export class DateCell extends BaseCellRenderer<number> {
     }
     return html` <input
       type="date"
-      disabled
       value="${value}"
       class="affine-database-date date"
     />`;


### PR DESCRIPTION
part of: #5798

> It is hard to edit the field after it has a value. It seems the element with the value doesn't have an action to select a new date, so I need to click around it on the element "below" it.