### PR TITLE
feat(presets): support double click to disable note sorting and fix typo

### DIFF
--- a/packages/playground/apps/starter/components/custom-outline-panel.ts
+++ b/packages/playground/apps/starter/components/custom-outline-panel.ts
@@ -6,10 +6,10 @@ import {
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-@customElement('custom-toc-outline-panel')
-export class CustomTOCOutlinePanel extends WithDisposable(LitElement) {
+@customElement('custom-outline-panel')
+export class CustomOutlinePanel extends WithDisposable(LitElement) {
   static override styles = css`
-    .custom-toc-outline-container {
+    .custom-outline-container {
       position: absolute;
       top: 0;
       right: 0;
@@ -52,9 +52,7 @@ export class CustomTOCOutlinePanel extends WithDisposable(LitElement) {
     return html`
       ${this._show
         ? html`
-            <div class="custom-toc-outline-container">
-              ${this._renderPanel()}
-            </div>
+            <div class="custom-outline-container">${this._renderPanel()}</div>
           `
         : null}
     `;
@@ -63,6 +61,6 @@ export class CustomTOCOutlinePanel extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'custom-toc-outline-panel': CustomTOCOutlinePanel;
+    'custom-outline-panel': CustomOutlinePanel;
   }
 }

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -50,7 +50,7 @@ import type { Pane } from 'tweakpane';
 
 import { extendFormatBar } from './custom-format-bar.js';
 import type { CustomFramePanel } from './custom-frame-panel.js';
-import type { CustomTOCOutlinePanel } from './custom-toc-outline-panel.js';
+import type { CustomOutlinePanel } from './custom-outline-panel.js';
 import type { LeftSidePanel } from './left-side-panel';
 import type { PagesPanel } from './pages-panel';
 import type { SidePanel } from './side-panel';
@@ -204,7 +204,7 @@ export class DebugMenu extends ShadowlessElement {
   contentParser!: ContentParser;
 
   @property({ attribute: false })
-  tocOutlinePanel!: CustomTOCOutlinePanel;
+  outlinePanel!: CustomOutlinePanel;
 
   @property({ attribute: false })
   framePanel!: CustomFramePanel;
@@ -321,8 +321,8 @@ export class DebugMenu extends ShadowlessElement {
     }
   }
 
-  private _toggleTOCOutlinePanel() {
-    this.tocOutlinePanel.toggleDisplay();
+  private _toggleOutlinePanel() {
+    this.outlinePanel.toggleDisplay();
   }
 
   private _toggleFramePanel() {
@@ -684,7 +684,7 @@ export class DebugMenu extends ShadowlessElement {
               <sl-menu-item @click=${this._switchOffsetMode}>
                 Switch Offset Mode
               </sl-menu-item>
-              <sl-menu-item @click=${this._toggleTOCOutlinePanel}>
+              <sl-menu-item @click=${this._toggleOutlinePanel}>
                 Toggle TOC Outline Panel
               </sl-menu-item>
               <sl-menu-item @click=${this._toggleFramePanel}>

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -204,7 +204,7 @@ export class DebugMenu extends ShadowlessElement {
   contentParser!: ContentParser;
 
   @property({ attribute: false })
-  navigationPanel!: CustomTOCOutlinePanel;
+  tocOutlinePanel!: CustomTOCOutlinePanel;
 
   @property({ attribute: false })
   framePanel!: CustomFramePanel;
@@ -321,8 +321,8 @@ export class DebugMenu extends ShadowlessElement {
     }
   }
 
-  private _toggleNavigationPanel() {
-    this.navigationPanel.toggleDisplay();
+  private _toggleTOCOutlinePanel() {
+    this.tocOutlinePanel.toggleDisplay();
   }
 
   private _toggleFramePanel() {
@@ -684,7 +684,7 @@ export class DebugMenu extends ShadowlessElement {
               <sl-menu-item @click=${this._switchOffsetMode}>
                 Switch Offset Mode
               </sl-menu-item>
-              <sl-menu-item @click=${this._toggleNavigationPanel}>
+              <sl-menu-item @click=${this._toggleTOCOutlinePanel}>
                 Toggle TOC Outline Panel
               </sl-menu-item>
               <sl-menu-item @click=${this._toggleFramePanel}>

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -58,7 +58,7 @@ function subscribePage(workspace: Workspace) {
     debugMenu.editor = editor;
     debugMenu.mode = defaultMode;
     debugMenu.contentParser = contentParser;
-    debugMenu.navigationPanel = tocOutlinePanel;
+    debugMenu.tocOutlinePanel = tocOutlinePanel;
     debugMenu.framePanel = framePanel;
     debugMenu.copilotPanel = copilotPanelPanel;
     debugMenu.sidePanel = sidePanel;

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -14,7 +14,7 @@ import type { DocProvider, Page } from '@blocksuite/store';
 import { Job, Workspace } from '@blocksuite/store';
 
 import { CustomFramePanel } from './components/custom-frame-panel';
-import { CustomTOCOutlinePanel } from './components/custom-toc-outline-panel.js';
+import { CustomOutlinePanel } from './components/custom-outline-panel.js';
 import { DebugMenu } from './components/debug-menu.js';
 import { LeftSidePanel } from './components/left-side-panel';
 import { PagesPanel } from './components/pages-panel';
@@ -47,7 +47,7 @@ function subscribePage(workspace: Workspace) {
     const editor = createEditor(page, app);
     const contentParser = new ContentParser(page);
     const debugMenu = new DebugMenu();
-    const tocOutlinePanel = new CustomTOCOutlinePanel();
+    const outlinePanel = new CustomOutlinePanel();
     const framePanel = new CustomFramePanel();
     const copilotPanelPanel = new CopilotPanel();
     const sidePanel = new SidePanel();
@@ -58,20 +58,20 @@ function subscribePage(workspace: Workspace) {
     debugMenu.editor = editor;
     debugMenu.mode = defaultMode;
     debugMenu.contentParser = contentParser;
-    debugMenu.tocOutlinePanel = tocOutlinePanel;
+    debugMenu.outlinePanel = outlinePanel;
     debugMenu.framePanel = framePanel;
     debugMenu.copilotPanel = copilotPanelPanel;
     debugMenu.sidePanel = sidePanel;
     debugMenu.leftSidePanel = leftSidePanel;
     debugMenu.pagesPanel = pagesPanel;
 
-    tocOutlinePanel.editor = editor;
+    outlinePanel.editor = editor;
     copilotPanelPanel.editor = editor;
     framePanel.editor = editor;
     pagesPanel.editor = editor;
 
     document.body.appendChild(debugMenu);
-    document.body.appendChild(tocOutlinePanel);
+    document.body.appendChild(outlinePanel);
     document.body.appendChild(sidePanel);
     document.body.appendChild(leftSidePanel);
     document.body.appendChild(framePanel);

--- a/packages/presets/src/fragments/toc-panel/toc-panel.ts
+++ b/packages/presets/src/fragments/toc-panel/toc-panel.ts
@@ -139,6 +139,7 @@ export class TOCPanel extends WithDisposable(LitElement) {
           .mode=${this.mode}
           .showPreviewIcon=${this.showPreviewIcon}
           .enableNotesSorting=${this.enableNotesSorting}
+          .toggleNotesSorting=${this._toggleNotesSorting}
         >
         </toc-panel-body>
       </div>


### PR DESCRIPTION
1. Support double click at blank area to disable note sorting option.
2. Fix highlight mask disappeared after mode switched.
3. Fix typo.