### PR TITLE
refactor: support multiple-editors

### DIFF
--- a/packages/block-std/src/event/control/clipboard.ts
+++ b/packages/block-std/src/event/control/clipboard.ts
@@ -16,12 +16,7 @@ export class ClipboardControl {
   }
 
   private _cut = (event: ClipboardEvent) => {
-    // if (
-    //   !event.target ||
-    //   !this._dispatcher.host.contains(event.target as Node)
-    // ) {
-    //   return;
-    // }
+    if (!this._dispatcher.focus) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,
@@ -33,12 +28,7 @@ export class ClipboardControl {
   };
 
   private _copy = (event: ClipboardEvent) => {
-    // if (
-    //   !event.target ||
-    //   !this._dispatcher.host.contains(event.target as Node)
-    // ) {
-    //   return;
-    // }
+    if (!this._dispatcher.focus) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,
@@ -50,12 +40,7 @@ export class ClipboardControl {
   };
 
   private _paste = (event: ClipboardEvent) => {
-    // if (
-    //   !event.target ||
-    //   !this._dispatcher.host.contains(event.target as Node)
-    // ) {
-    //   return;
-    // }
+    if (!this._dispatcher.focus) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,

--- a/packages/block-std/src/event/control/clipboard.ts
+++ b/packages/block-std/src/event/control/clipboard.ts
@@ -16,7 +16,7 @@ export class ClipboardControl {
   }
 
   private _cut = (event: ClipboardEvent) => {
-    if (!this._dispatcher.focus) return;
+    if (!this._dispatcher.isActive) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,
@@ -28,7 +28,7 @@ export class ClipboardControl {
   };
 
   private _copy = (event: ClipboardEvent) => {
-    if (!this._dispatcher.focus) return;
+    if (!this._dispatcher.isActive) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,
@@ -40,7 +40,7 @@ export class ClipboardControl {
   };
 
   private _paste = (event: ClipboardEvent) => {
-    if (!this._dispatcher.focus) return;
+    if (!this._dispatcher.isActive) return;
 
     const clipboardEventState = new ClipboardEventState({
       event,

--- a/packages/block-std/src/event/control/clipboard.ts
+++ b/packages/block-std/src/event/control/clipboard.ts
@@ -16,6 +16,13 @@ export class ClipboardControl {
   }
 
   private _cut = (event: ClipboardEvent) => {
+    // if (
+    //   !event.target ||
+    //   !this._dispatcher.host.contains(event.target as Node)
+    // ) {
+    //   return;
+    // }
+
     const clipboardEventState = new ClipboardEventState({
       event,
     });
@@ -26,6 +33,13 @@ export class ClipboardControl {
   };
 
   private _copy = (event: ClipboardEvent) => {
+    // if (
+    //   !event.target ||
+    //   !this._dispatcher.host.contains(event.target as Node)
+    // ) {
+    //   return;
+    // }
+
     const clipboardEventState = new ClipboardEventState({
       event,
     });
@@ -36,6 +50,13 @@ export class ClipboardControl {
   };
 
   private _paste = (event: ClipboardEvent) => {
+    // if (
+    //   !event.target ||
+    //   !this._dispatcher.host.contains(event.target as Node)
+    // ) {
+    //   return;
+    // }
+
     const clipboardEventState = new ClipboardEventState({
       event,
     });

--- a/packages/block-std/src/event/control/keyboard.ts
+++ b/packages/block-std/src/event/control/keyboard.ts
@@ -46,7 +46,7 @@ export class KeyboardControl {
   }
 
   private _down = (event: KeyboardEvent) => {
-    if (!this._dispatcher.focus) return;
+    if (!this._dispatcher.isActive) return;
 
     const keyboardEventState = new KeyboardEventState({
       event,
@@ -59,7 +59,7 @@ export class KeyboardControl {
   };
 
   private _up = (event: KeyboardEvent) => {
-    if (!this._dispatcher.focus) return;
+    if (!this._dispatcher.isActive) return;
 
     const keyboardEventState = new KeyboardEventState({
       event,

--- a/packages/block-std/src/event/control/keyboard.ts
+++ b/packages/block-std/src/event/control/keyboard.ts
@@ -46,6 +46,8 @@ export class KeyboardControl {
   }
 
   private _down = (event: KeyboardEvent) => {
+    if (!this._dispatcher.focus) return;
+
     const keyboardEventState = new KeyboardEventState({
       event,
       composing: this.composition,
@@ -57,6 +59,8 @@ export class KeyboardControl {
   };
 
   private _up = (event: KeyboardEvent) => {
+    if (!this._dispatcher.focus) return;
+
     const keyboardEventState = new KeyboardEventState({
       event,
       composing: this.composition,

--- a/packages/block-std/src/event/control/pointer.ts
+++ b/packages/block-std/src/event/control/pointer.ts
@@ -50,6 +50,8 @@ export class PointerControl {
   }
 
   private _down = (event: PointerEvent) => {
+    this._dispatcher.focus = true;
+
     if (
       this._lastPointerDownEvent &&
       event.timeStamp - this._lastPointerDownEvent.timeStamp < 500 &&

--- a/packages/block-std/src/event/control/pointer.ts
+++ b/packages/block-std/src/event/control/pointer.ts
@@ -90,7 +90,6 @@ export class PointerControl {
   };
 
   private _up = (event: PointerEvent) => {
-    if (!this._dispatcher.isActive) return;
     const pointerEventState = new PointerEventState({
       event,
       rect: this._rect,

--- a/packages/block-std/src/event/control/pointer.ts
+++ b/packages/block-std/src/event/control/pointer.ts
@@ -50,7 +50,7 @@ export class PointerControl {
   }
 
   private _down = (event: PointerEvent) => {
-    this._dispatcher.focus = true;
+    this._dispatcher.activate();
 
     if (
       this._lastPointerDownEvent &&
@@ -90,6 +90,7 @@ export class PointerControl {
   };
 
   private _up = (event: PointerEvent) => {
+    if (!this._dispatcher.isActive) return;
     const pointerEventState = new PointerEventState({
       event,
       rect: this._rect,

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -82,12 +82,17 @@ export class RangeControl {
         ? range.startContainer
         : range.startContainer.parentElement;
     if (!startElement) return;
-
     if (
       startElement === document.documentElement ||
       startElement === document.body
     )
       return;
+
+    const endElement =
+      range.endContainer instanceof Element
+        ? range.endContainer
+        : range.endContainer.parentElement;
+    if (!endElement) return;
 
     if (startElement.closest('.blocksuite-portal')) return;
     if (startElement.closest('affine-menu')) return;
@@ -100,14 +105,11 @@ export class RangeControl {
     // @ts-ignore
     const viewport = pageBlock.viewportElement;
     assertExists(viewport);
-
-    if (!viewport.contains(range.startContainer)) {
-      console.log(startElement);
+    if (!viewport.contains(startElement)) {
       this._dispatcher.focus = false;
       return;
     }
-    if (!viewport.contains(range.endContainer)) {
-      console.log(startElement);
+    if (!viewport.contains(endElement)) {
       this._dispatcher.focus = false;
       return;
     }

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -55,12 +55,10 @@ export class RangeControl {
   };
 
   private _selectionChange = (event: Event) => {
-    const prevFocus = this._dispatcher.focus;
-
+    const prevIsActive = this._dispatcher.isActive;
     this._checkSelectionSource();
-
-    if (!this._dispatcher.focus) {
-      if (prevFocus) this._dispatcher.std.selection.clear();
+    if (!this._dispatcher.isActive) {
+      if (prevIsActive) this._dispatcher.std.selection.clear();
       return;
     }
 
@@ -99,17 +97,17 @@ export class RangeControl {
     if (!endElement) return;
 
     if (startElement.closest('.blocksuite-overlay')) return;
-
+    const prevIsActive = this._dispatcher.isActive;
     if (!viewport.contains(startElement)) {
-      this._dispatcher.focus = false;
+      if (prevIsActive) this._dispatcher.deactivate();
       return;
     }
     if (!viewport.contains(endElement)) {
-      this._dispatcher.focus = false;
+      if (prevIsActive) this._dispatcher.deactivate();
       return;
     }
 
-    this._dispatcher.focus = true;
+    this._dispatcher.activate();
   };
 
   private _buildScope = (eventName: EventName) => {

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -55,9 +55,12 @@ export class RangeControl {
   };
 
   private _selectionChange = (event: Event) => {
+    const prevFocus = this._dispatcher.focus;
+
     this._checkSelectionSource();
+
     if (!this._dispatcher.focus) {
-      this._dispatcher.std.selection.clear();
+      if (prevFocus) this._dispatcher.std.selection.clear();
       return;
     }
 

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -55,12 +55,9 @@ export class RangeControl {
   };
 
   private _selectionChange = (event: Event) => {
-    const prevIsActive = this._dispatcher.isActive;
     this._checkSelectionSource();
-    if (!this._dispatcher.isActive) {
-      if (prevIsActive) this._dispatcher.std.selection.clear();
-      return;
-    }
+
+    if (!this._dispatcher.isActive) return;
 
     const scope = this._buildScope('selectionChange');
 
@@ -84,11 +81,19 @@ export class RangeControl {
         ? range.startContainer
         : range.startContainer.parentElement;
     if (!startElement) return;
+
     if (
       startElement === document.documentElement ||
       startElement === document.body
     )
       return;
+
+    if (startElement.closest('.blocksuite-overlay')) return;
+
+    if (!viewport.contains(startElement)) {
+      this._dispatcher.deactivate();
+      return;
+    }
 
     const endElement =
       range.endContainer instanceof Element
@@ -96,14 +101,8 @@ export class RangeControl {
         : range.endContainer.parentElement;
     if (!endElement) return;
 
-    if (startElement.closest('.blocksuite-overlay')) return;
-    const prevIsActive = this._dispatcher.isActive;
-    if (!viewport.contains(startElement)) {
-      if (prevIsActive) this._dispatcher.deactivate();
-      return;
-    }
     if (!viewport.contains(endElement)) {
-      if (prevIsActive) this._dispatcher.deactivate();
+      this._dispatcher.deactivate();
       return;
     }
 

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -55,6 +55,11 @@ export class RangeControl {
   };
 
   private _selectionChange = (event: Event) => {
+    // if (!this._checkSelectionSource()) {
+    //   this._dispatcher.std.selection.clear();
+    //   return;
+    // }
+
     const scope = this._buildScope('selectionChange');
 
     this._dispatcher.run('selectionChange', this._createContext(event), scope);
@@ -63,6 +68,19 @@ export class RangeControl {
   private _createContext(event: Event) {
     return UIEventStateContext.from(new UIEventState(event));
   }
+
+  // private _checkSelectionSource = () => {
+  //   const selection = document.getSelection();
+  //   if (!selection || !selection.rangeCount) return true;
+
+  //   const range = selection.getRangeAt(0);
+  //   if (!range) return true;
+
+  //   if (!this._dispatcher.std.host.contains(range.startContainer)) return false;
+  //   if (!this._dispatcher.std.host.contains(range.endContainer)) return false;
+
+  //   return true;
+  // };
 
   private _buildScope = (eventName: EventName) => {
     let scope: EventScope | undefined;

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -57,7 +57,7 @@ export class RangeControl {
   private _selectionChange = (event: Event) => {
     this._checkSelectionSource();
     if (!this._dispatcher.focus) {
-      // this._dispatcher.std.selection.clear();
+      this._dispatcher.std.selection.clear();
       return;
     }
 

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -95,9 +95,7 @@ export class RangeControl {
         : range.endContainer.parentElement;
     if (!endElement) return;
 
-    if (startElement.closest('.blocksuite-portal')) return;
-    if (startElement.closest('.blocksuite-modal')) return;
-    if (startElement.closest('.default-toolbar')) return;
+    if (startElement.closest('.blocksuite-overlay')) return;
 
     if (!viewport.contains(startElement)) {
       // console.log(startElement);

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -90,6 +90,8 @@ export class RangeControl {
       return;
 
     if (startElement.closest('.blocksuite-portal')) return;
+    if (startElement.closest('affine-menu')) return;
+    if (startElement.closest('affine-multi-tag-select')) return;
 
     const pageBlock = this._dispatcher.std.view.viewFromPath('block', [
       this._dispatcher.std.page.root?.id ?? '',
@@ -100,10 +102,12 @@ export class RangeControl {
     assertExists(viewport);
 
     if (!viewport.contains(range.startContainer)) {
+      console.log(startElement);
       this._dispatcher.focus = false;
       return;
     }
     if (!viewport.contains(range.endContainer)) {
+      console.log(startElement);
       this._dispatcher.focus = false;
       return;
     }

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -98,16 +98,10 @@ export class RangeControl {
     if (startElement.closest('.blocksuite-overlay')) return;
 
     if (!viewport.contains(startElement)) {
-      // console.log(startElement);
-      throw new Error('startElement not in viewport');
-
       this._dispatcher.focus = false;
       return;
     }
     if (!viewport.contains(endElement)) {
-      // console.log(endElement);
-      throw new Error('startElement not in viewport');
-
       this._dispatcher.focus = false;
       return;
     }

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -1,5 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
-
 import { UIEventState, UIEventStateContext } from '../base.js';
 import type {
   EventName,
@@ -73,6 +71,9 @@ export class RangeControl {
   }
 
   private _checkSelectionSource = () => {
+    const viewport = this._dispatcher.viewportElement;
+    if (!viewport) return;
+
     const selection = document.getSelection();
     if (!selection || !selection.rangeCount) return;
     const range = selection.getRangeAt(0);
@@ -98,20 +99,17 @@ export class RangeControl {
     if (startElement.closest('.blocksuite-modal')) return;
     if (startElement.closest('.default-toolbar')) return;
 
-    const pageBlock = this._dispatcher.std.view.viewFromPath('block', [
-      this._dispatcher.std.page.root?.id ?? '',
-    ]);
-    if (!pageBlock) return;
-    // @ts-ignore
-    const viewport = pageBlock.viewportElement;
-    assertExists(viewport);
     if (!viewport.contains(startElement)) {
       // console.log(startElement);
+      throw new Error('startElement not in viewport');
+
       this._dispatcher.focus = false;
       return;
     }
     if (!viewport.contains(endElement)) {
       // console.log(endElement);
+      throw new Error('startElement not in viewport');
+
       this._dispatcher.focus = false;
       return;
     }

--- a/packages/block-std/src/event/control/range.ts
+++ b/packages/block-std/src/event/control/range.ts
@@ -95,8 +95,8 @@ export class RangeControl {
     if (!endElement) return;
 
     if (startElement.closest('.blocksuite-portal')) return;
-    if (startElement.closest('affine-menu')) return;
-    if (startElement.closest('affine-multi-tag-select')) return;
+    if (startElement.closest('.blocksuite-modal')) return;
+    if (startElement.closest('.default-toolbar')) return;
 
     const pageBlock = this._dispatcher.std.view.viewFromPath('block', [
       this._dispatcher.std.page.root?.id ?? '',
@@ -106,10 +106,12 @@ export class RangeControl {
     const viewport = pageBlock.viewportElement;
     assertExists(viewport);
     if (!viewport.contains(startElement)) {
+      // console.log(startElement);
       this._dispatcher.focus = false;
       return;
     }
     if (!viewport.contains(endElement)) {
+      // console.log(endElement);
       this._dispatcher.focus = false;
       return;
     }

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -68,7 +68,7 @@ export type EventScope = {
 export class UIEventDispatcher {
   disposables = new DisposableGroup();
 
-  private static _focus = true;
+  focus = false;
 
   private _handlersMap = Object.fromEntries(
     eventNames.map((name): [EventName, Array<EventHandlerRunner>] => [name, []])
@@ -84,14 +84,6 @@ export class UIEventDispatcher {
     this._keyboardControl = new KeyboardControl(this);
     this._rangeControl = new RangeControl(this);
     this._clipboardControl = new ClipboardControl(this);
-  }
-
-  get focus() {
-    return UIEventDispatcher._focus;
-  }
-
-  set focus(value) {
-    UIEventDispatcher._focus = value;
   }
 
   private _viewportElement: HTMLElement | null = null;

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -1,4 +1,4 @@
-import { DisposableGroup } from '@blocksuite/global/utils';
+import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 
 import { PathFinder } from '../utils/index.js';
 import type { UIEventHandler } from './base.js';
@@ -92,6 +92,20 @@ export class UIEventDispatcher {
 
   set focus(value) {
     UIEventDispatcher._focus = value;
+  }
+
+  private _viewportElement: HTMLElement | null = null;
+
+  get viewportElement() {
+    if (this._viewportElement) return this._viewportElement;
+    const pageElement = this.std.view.viewFromPath('block', [
+      this.std.page.root?.id ?? '',
+    ]);
+    assertExists(pageElement);
+    // @ts-ignore
+    this._viewportElement = pageElement.viewportElement as HTMLElement | null;
+    assertExists(this._viewportElement);
+    return this._viewportElement;
   }
 
   mount() {

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -68,8 +68,6 @@ export type EventScope = {
 export class UIEventDispatcher {
   disposables = new DisposableGroup();
 
-  focus = false;
-
   private _handlersMap = Object.fromEntries(
     eventNames.map((name): [EventName, Array<EventHandlerRunner>] => [name, []])
   ) as Record<EventName, Array<EventHandlerRunner>>;
@@ -85,6 +83,20 @@ export class UIEventDispatcher {
     this._rangeControl = new RangeControl(this);
     this._clipboardControl = new ClipboardControl(this);
   }
+
+  private static _activeDispatcher: UIEventDispatcher | null = null;
+
+  get isActive() {
+    return UIEventDispatcher._activeDispatcher === this;
+  }
+
+  activate = () => {
+    UIEventDispatcher._activeDispatcher = this;
+  };
+
+  deactivate = () => {
+    UIEventDispatcher._activeDispatcher = null;
+  };
 
   private _viewportElement: HTMLElement | null = null;
 

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -68,6 +68,8 @@ export type EventScope = {
 export class UIEventDispatcher {
   disposables = new DisposableGroup();
 
+  private static _focus = true;
+
   private _handlersMap = Object.fromEntries(
     eventNames.map((name): [EventName, Array<EventHandlerRunner>] => [name, []])
   ) as Record<EventName, Array<EventHandlerRunner>>;
@@ -82,6 +84,14 @@ export class UIEventDispatcher {
     this._keyboardControl = new KeyboardControl(this);
     this._rangeControl = new RangeControl(this);
     this._clipboardControl = new ClipboardControl(this);
+  }
+
+  get focus() {
+    return UIEventDispatcher._focus;
+  }
+
+  set focus(value) {
+    UIEventDispatcher._focus = value;
   }
 
   mount() {

--- a/packages/block-std/src/event/dispatcher.ts
+++ b/packages/block-std/src/event/dispatcher.ts
@@ -91,11 +91,18 @@ export class UIEventDispatcher {
   }
 
   activate = () => {
+    const prevDispatcher = UIEventDispatcher._activeDispatcher;
+    if (prevDispatcher === this) return;
     UIEventDispatcher._activeDispatcher = this;
+    prevDispatcher?.std.selection.clear();
   };
 
   deactivate = () => {
+    const prevDispatcher = UIEventDispatcher._activeDispatcher;
+    if (!prevDispatcher) return;
+    if (prevDispatcher !== this) return;
     UIEventDispatcher._activeDispatcher = null;
+    prevDispatcher.std.selection.clear();
   };
 
   private _viewportElement: HTMLElement | null = null;

--- a/packages/blocks/src/_common/components/drag-indicator.ts
+++ b/packages/blocks/src/_common/components/drag-indicator.ts
@@ -35,7 +35,10 @@ export class DragIndicator extends LitElement {
       height: `${height}px`,
       transform: `translate(${left}px, ${top}px)`,
     });
-    return html`<div class="affine-drag-indicator" style=${style}></div>`;
+    return html`<div
+      class="affine-drag-indicator blocksuite-overlay"
+      style=${style}
+    ></div>`;
   }
 }
 

--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -669,6 +669,7 @@ declare global {
 }
 export const createModal = (container: HTMLElement = document.body) => {
   const div = document.createElement('div');
+  div.classList.add('blocksuite-modal');
   div.style.position = 'fixed';
   div.style.left = '0';
   div.style.top = '0';

--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -669,7 +669,7 @@ declare global {
 }
 export const createModal = (container: HTMLElement = document.body) => {
   const div = document.createElement('div');
-  div.classList.add('blocksuite-modal');
+  div.classList.add('blocksuite-overlay');
   div.style.position = 'fixed';
   div.style.left = '0';
   div.style.top = '0';

--- a/packages/blocks/src/_common/components/portal.ts
+++ b/packages/blocks/src/_common/components/portal.ts
@@ -58,7 +58,7 @@ export class Portal extends LitElement {
           ...(typeof this.shadowDom !== 'boolean' ? this.shadowDom : {}),
         })
       : portalRoot;
-    portalRoot.classList.add('blocksuite-portal');
+    portalRoot.classList.add('blocksuite-portal', 'blocksuite-overlay');
     this.container.append(portalRoot);
     this._portalRoot = portalRoot;
     return renderRoot;

--- a/packages/blocks/src/_common/components/rich-text/inline/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/inline/nodes/link-node/link-popup/link-popup.ts
@@ -99,7 +99,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
       Object.values(domRects).forEach(domRect => {
         const mockSelection = document.createElement('div');
-        mockSelection.classList.add('mock-selection');
+        mockSelection.classList.add('mock-selection blocksuite-overlay');
         mockSelection.style.left = `${domRect.left}px`;
         mockSelection.style.top = `${domRect.top}px`;
         mockSelection.style.width = `${domRect.width}px`;
@@ -383,7 +383,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
           : this._editTemplate();
 
     return html`
-      <div class="overlay-root">
+      <div class="overlay-root blocksuite-overlay">
         ${mask}
         <div class="popup-container" @keydown=${this._onKeydown}>
           ${popover}

--- a/packages/blocks/src/_common/components/rich-text/inline/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/components/rich-text/inline/nodes/link-node/link-popup/link-popup.ts
@@ -99,7 +99,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
       Object.values(domRects).forEach(domRect => {
         const mockSelection = document.createElement('div');
-        mockSelection.classList.add('mock-selection blocksuite-overlay');
+        mockSelection.classList.add('mock-selection', 'blocksuite-overlay');
         mockSelection.style.left = `${domRect.left}px`;
         mockSelection.style.top = `${domRect.top}px`;
         mockSelection.style.width = `${domRect.width}px`;

--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -259,7 +259,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         const inlineEditor = _getInlineEditor();
         const inilneRange = inlineEditor.getInlineRange();
         assertExists(inilneRange);
-        handleIndent(model.page, model, inilneRange.index);
+        handleIndent(blockElement.host, model, inilneRange.index);
         _preventDefault(ctx);
 
         return true;
@@ -271,7 +271,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         })
       ).selectedModels;
       if (!models) return;
-      handleMultiBlockIndent(blockElement.page, models);
+      handleMultiBlockIndent(blockElement.host, models);
       return true;
     },
     'Mod-Backspace': ctx => {
@@ -298,7 +298,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         const inlineRange = inlineEditor.getInlineRange();
         assertExists(inlineRange);
         if (inlineRange.index === 0) {
-          handleRemoveAllIndent(model.page, model, inlineRange.index);
+          handleRemoveAllIndent(blockElement.host, model, inlineRange.index);
           _preventDefault(ctx);
         }
 
@@ -311,7 +311,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         })
       ).selectedModels;
       if (!models) return;
-      handleRemoveAllIndentForMultiBlocks(blockElement.page, models);
+      handleRemoveAllIndentForMultiBlocks(blockElement.host, models);
       return true;
     },
     'Shift-Tab': ctx => {
@@ -337,7 +337,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         const inlineEditor = _getInlineEditor();
         const inlineRange = inlineEditor.getInlineRange();
         assertExists(inlineRange);
-        handleUnindent(model.page, model, inlineRange.index);
+        handleUnindent(blockElement.host, model, inlineRange.index);
         _preventDefault(ctx);
 
         return true;
@@ -349,7 +349,7 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
         })
       ).selectedModels;
       if (!models) return;
-      handleMultiBlockOutdent(blockElement.page, models);
+      handleMultiBlockOutdent(blockElement.host, models);
       return true;
     },
     Backspace: ctx => {
@@ -464,7 +464,11 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
       title: pageName,
     })
       .then(page => {
-        insertLinkedNode({ model: blockElement.model, pageId: page.id });
+        insertLinkedNode({
+          editorHost: blockElement.host,
+          model: blockElement.model,
+          pageId: page.id,
+        });
       })
       .catch(e => console.error(e));
     return true;

--- a/packages/blocks/src/_common/components/rich-text/keymap/legacy.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/legacy.ts
@@ -89,7 +89,7 @@ export function hardEnter(
     // After
     // - line1
     // - | <-- will unindent the block
-    handleUnindent(page, model, range.index);
+    handleUnindent(editorHost, model, range.index);
     return KEYBOARD_PREVENT_DEFAULT;
   }
 
@@ -99,7 +99,7 @@ export function hardEnter(
     if (matchFlavours(model, ['affine:code'])) {
       if (shortKey) {
         // shortKey+Enter to exit the block
-        handleBlockEndEnter(page, model);
+        handleBlockEndEnter(editorHost, model);
         return KEYBOARD_PREVENT_DEFAULT;
       }
 
@@ -126,12 +126,12 @@ export function hardEnter(
     // - line1
     // - | <-- will unindent the block
     model.text.delete(range.index - 1, 1);
-    handleBlockEndEnter(page, model);
+    handleBlockEndEnter(editorHost, model);
     return KEYBOARD_PREVENT_DEFAULT;
   }
 
   if (isEnd || shortKey) {
-    handleBlockEndEnter(page, model);
+    handleBlockEndEnter(editorHost, model);
     return KEYBOARD_PREVENT_DEFAULT;
   }
 
@@ -141,7 +141,7 @@ export function hardEnter(
     return KEYBOARD_PREVENT_DEFAULT;
   }
 
-  handleBlockSplit(page, model, range.index, range.length)?.catch(
+  handleBlockSplit(editorHost, model, range.index, range.length)?.catch(
     console.error
   );
   return KEYBOARD_PREVENT_DEFAULT;

--- a/packages/blocks/src/_common/components/rich-text/markdown/block.ts
+++ b/packages/blocks/src/_common/components/rich-text/markdown/block.ts
@@ -83,7 +83,7 @@ export function tryConvertBlock(
 
     const codeBlock = page.getBlockById(codeId);
     assertExists(codeBlock);
-    asyncSetInlineRange(codeBlock, { index: 0, length: 0 }).catch(
+    asyncSetInlineRange(element.host, codeBlock, { index: 0, length: 0 }).catch(
       console.error
     );
 

--- a/packages/blocks/src/_common/components/rich-text/markdown/utils.ts
+++ b/packages/blocks/src/_common/components/rich-text/markdown/utils.ts
@@ -52,7 +52,7 @@ export function convertToList(
     });
 
     const id = page.addBlock('affine:list', blockProps, parent, index);
-    asyncFocusRichText(page, id)?.catch(console.error);
+    asyncFocusRichText(element.host, page, id)?.catch(console.error);
   }
   return true;
 }
@@ -85,7 +85,7 @@ export function convertToParagraph(
     });
 
     const id = page.addBlock('affine:paragraph', blockProps, parent, index);
-    asyncFocusRichText(page, id)?.catch(console.error);
+    asyncFocusRichText(element.host, page, id)?.catch(console.error);
   } else if (
     matchFlavours(model, ['affine:paragraph']) &&
     model['type'] !== type
@@ -94,7 +94,7 @@ export function convertToParagraph(
     page.captureSync();
 
     model.text?.delete(0, prefix.length + 1);
-    const inlineEditor = getInlineEditorByModel(model);
+    const inlineEditor = getInlineEditorByModel(element.host, model);
     if (inlineEditor) {
       inlineEditor.setInlineRange({
         index: 0,
@@ -133,10 +133,12 @@ export function convertToDivider(
 
     const nextBlock = parent.children[index + 1];
     if (nextBlock) {
-      asyncFocusRichText(page, nextBlock.id)?.catch(console.error);
+      asyncFocusRichText(element.host, page, nextBlock.id)?.catch(
+        console.error
+      );
     } else {
       const nextId = page.addBlock('affine:paragraph', {}, parent);
-      asyncFocusRichText(page, nextId)?.catch(console.error);
+      asyncFocusRichText(element.host, page, nextId)?.catch(console.error);
     }
   }
   return true;

--- a/packages/blocks/src/_common/components/toast.ts
+++ b/packages/blocks/src/_common/components/toast.ts
@@ -33,7 +33,10 @@ const createToastContainer = () => {
     flex-direction: column-reverse;
     align-items: center;
   `;
-  const template = html`<div class="toast-container" style="${styles}"></div>`;
+  const template = html`<div
+    class="toast-container blocksuite-overlay"
+    style="${styles}"
+  ></div>`;
   const element = htmlToElement<HTMLDivElement>(template);
   const container = document.body.querySelector('affine-editor-container');
   assertExists(container);

--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -1,4 +1,5 @@
 import { assertExists, sleep } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import { BaseBlockModel } from '@blocksuite/store';
 import { css, unsafeCSS } from 'lit';
 
@@ -209,6 +210,7 @@ export const createKeydownObserver = ({
  * Remove specified text from the current range.
  */
 export function cleanSpecifiedTail(
+  editorHost: EditorHost,
   inlineEditorOrModel: AffineInlineEditor | BaseBlockModel,
   str: string
 ) {
@@ -218,7 +220,7 @@ export function cleanSpecifiedTail(
   }
   const inlineEditor =
     inlineEditorOrModel instanceof BaseBlockModel
-      ? getInlineEditorByModel(inlineEditorOrModel)
+      ? getInlineEditorByModel(editorHost, inlineEditorOrModel)
       : inlineEditorOrModel;
   assertExists(inlineEditor, 'Inline editor not found');
 

--- a/packages/blocks/src/_common/utils/filesys.ts
+++ b/packages/blocks/src/_common/utils/filesys.ts
@@ -172,7 +172,7 @@ export async function openFileOrFiles({
   return new Promise(resolve => {
     // Append a new `<input type="file" multiple? />` and hide it.
     const input = document.createElement('input');
-    input.classList.add('affine-upload-input');
+    input.classList.add('affine-upload-input', 'blocksuite-overlay');
     input.style.display = 'none';
     input.type = 'file';
     if (multiple) {

--- a/packages/blocks/src/_common/utils/selection.ts
+++ b/packages/blocks/src/_common/utils/selection.ts
@@ -29,10 +29,11 @@ declare global {
 }
 
 export async function asyncSetInlineRange(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   inlineRange: InlineRange
 ) {
-  const richText = await asyncGetRichTextByModel(model);
+  const richText = await asyncGetRichTextByModel(editorHost, model);
   if (!richText) {
     return;
   }
@@ -44,6 +45,7 @@ export async function asyncSetInlineRange(
 }
 
 export function asyncFocusRichText(
+  editorHost: EditorHost,
   page: Page,
   id: string,
   inlineRange: InlineRange = { index: 0, length: 0 }
@@ -51,7 +53,7 @@ export function asyncFocusRichText(
   const model = page.getBlockById(id);
   assertExists(model);
   if (matchFlavours(model, ['affine:divider'])) return;
-  return asyncSetInlineRange(model, inlineRange);
+  return asyncSetInlineRange(editorHost, model, inlineRange);
 }
 
 function caretRangeFromPoint(clientX: number, clientY: number): Range | null {

--- a/packages/blocks/src/_legacy/content-parser/index.ts
+++ b/packages/blocks/src/_legacy/content-parser/index.ts
@@ -1,10 +1,11 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 
 import {
   getBlockComponentByModel,
   getEditorContainer,
-  isPageMode,
+  isInsideDocEditor,
   matchFlavours,
   type TopLevelBlockModel,
 } from '../../_common/utils/index.js';
@@ -22,16 +23,19 @@ import { FileExporter } from './file-exporter/file-exporter.js';
 type Html2CanvasFunction = typeof import('html2canvas').default;
 
 export class ContentParser {
+  private _host: EditorHost;
   private _page: Page;
   private _imageProxyEndpoint?: string;
 
   constructor(
+    host: EditorHost,
     page: Page,
     options: {
       /** API endpoint used for cross-domain image export */
       imageProxyEndpoint?: string;
     } = {}
   ) {
+    this._host = host;
     this._page = page;
     this._imageProxyEndpoint = options?.imageProxyEndpoint;
     // FIXME: this hard-coded config should be removed, see https://github.com/toeverything/blocksuite/issues/3506
@@ -47,7 +51,7 @@ export class ContentParser {
 
   private async _checkReady() {
     const pathname = location.pathname;
-    const pageMode = isPageMode(this._page);
+    const pageMode = isInsideDocEditor(this._host);
 
     const promise = new Promise((resolve, reject) => {
       let count = 0;
@@ -59,7 +63,9 @@ export class ContentParser {
           reject(e);
         }
         const root = this._page.root;
-        const pageBlock = root ? getBlockComponentByModel(root) : null;
+        const pageBlock = root
+          ? getBlockComponentByModel(this._host, root)
+          : null;
         const imageCard = pageBlock?.querySelector('affine-image-block-card');
         const isReady =
           !imageCard || imageCard.getAttribute('imageState') === '0';
@@ -188,15 +194,15 @@ export class ContentParser {
     if (!root) return;
 
     const pathname = location.pathname;
-    const pageMode = isPageMode(this._page);
-    const editorContainer = getEditorContainer(this._page);
+    const pageMode = isInsideDocEditor(this._host);
+    const editorContainer = getEditorContainer(this._host);
     const containerComputedStyle = window.getComputedStyle(editorContainer);
 
     const html2canvas = (element: HTMLElement) =>
       this._html2canvas(element, {
         backgroundColor: containerComputedStyle.backgroundColor,
       });
-    const container = document.querySelector(
+    const container = editorContainer.querySelector(
       '.affine-block-children-container'
     );
 
@@ -295,9 +301,9 @@ export class ContentParser {
     if (!(html2canvas instanceof Function)) return;
 
     const pathname = location.pathname;
-    const pageMode = isPageMode(this._page);
+    const pageMode = isInsideDocEditor(this._host);
 
-    const editorContainer = getEditorContainer(this._page);
+    const editorContainer = getEditorContainer(this._host);
     const pageContainer = editorContainer.querySelector(
       '.affine-doc-page-block-container'
     );
@@ -383,7 +389,10 @@ export class ContentParser {
   }
 
   private _checkCanContinueToCanvas(pathName: string, pageMode: boolean) {
-    if (location.pathname !== pathName || isPageMode(this._page) !== pageMode) {
+    if (
+      location.pathname !== pathName ||
+      isInsideDocEditor(this._host) !== pageMode
+    ) {
       throw new Error('Unable to export content to canvas');
     }
   }
@@ -391,13 +400,14 @@ export class ContentParser {
   private async _toCanvas(): Promise<HTMLCanvasElement | void> {
     await this._checkReady();
 
-    if (isPageMode(this._page)) {
+    if (isInsideDocEditor(this._host)) {
       return await this._docToCanvas();
     } else {
       const root = this._page.root;
       if (!root) return;
 
       const edgeless = getBlockComponentByModel(
+        this._host,
         root
       ) as EdgelessPageBlockComponent;
       const bound = edgeless.getElementsBound();

--- a/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/modal/bookmark-create-modal.ts
@@ -61,7 +61,7 @@ export class BookmarkCreateModal extends WithDisposable(ShadowlessElement) {
   };
 
   override render() {
-    return html`<div class="bookmark-modal">
+    return html`<div class="bookmark-modal blocksuite-overlay">
       <div class="bookmark-modal-mask" @click=${this._onCancel}></div>
       <div class="bookmark-modal-wrapper" style="width:480px">
         <icon-button

--- a/packages/blocks/src/bookmark-block/components/modal/bookmark-edit-modal.ts
+++ b/packages/blocks/src/bookmark-block/components/modal/bookmark-edit-modal.ts
@@ -58,7 +58,7 @@ export class BookmarkEditModal extends WithDisposable(ShadowlessElement) {
     const title =
       this.bookmarkModel.title ?? this.bookmarkModel.title ?? 'Bookmark';
 
-    return html`<div class="bookmark-modal">
+    return html`<div class="bookmark-modal blocksuite-overlay">
       <div class="bookmark-modal-mask" @click=${() => this.remove()}></div>
       <div
         class="bookmark-modal-wrapper"

--- a/packages/blocks/src/database-block/common/detail/layout.ts
+++ b/packages/blocks/src/database-block/common/detail/layout.ts
@@ -6,6 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { createModal } from '../../../_common/components/menu/index.js';
 import { CrossIcon } from '../../../_common/icons/index.js';
+import type { PageBlockComponent } from '../../../index.js';
 import type { DataViewManager } from '../data-view-manager.js';
 import { RecordDetail } from './detail.js';
 
@@ -88,14 +89,12 @@ class SideLayoutModal extends ShadowlessElement {
 }
 
 export const popSideDetail = (ops: {
+  pageElement: PageBlockComponent | null;
   view: DataViewManager;
   rowId: string;
   onClose?: () => void;
 }) => {
-  //FIXME: to make widget path work
-  const page =
-    document.querySelector('affine-doc-page') ??
-    document.querySelector('affine-edgeless-page');
+  const page = ops.pageElement;
   assertExists(page);
   const block = findFirstBlockParent(page) ?? page;
   const modal = createModal(page);

--- a/packages/blocks/src/database-block/common/header/tools/add-row/add-row.ts
+++ b/packages/blocks/src/database-block/common/header/tools/add-row/add-row.ts
@@ -172,6 +172,7 @@ declare global {
 }
 const createDropPreview = () => {
   const div = document.createElement('div');
+  div.classList.add('blocksuite-overlay');
   div.setAttribute('data-is-drop-preview', 'true');
   div.style.pointerEvents = 'none';
   div.style.position = 'fixed';
@@ -195,6 +196,7 @@ const createDropPreview = () => {
 
 const createDragPreview = () => {
   const preview = new NewRecordPreview();
+  preview.classList.add('blocksuite-overlay');
   document.body.append(preview);
   return {
     display(x: number, y: number) {

--- a/packages/blocks/src/database-block/common/literal/define.ts
+++ b/packages/blocks/src/database-block/common/literal/define.ts
@@ -168,6 +168,7 @@ literalMatcher.register(tDate.create(), {
   view: createUniComponentFromWebComponent(DateLiteral),
   popEdit: (position, { value, onChange }) => {
     const input = document.createElement('input');
+    input.classList.add('blocksuite-overlay');
     input.type = 'date';
     input.click();
     input.valueAsNumber = value as number;

--- a/packages/blocks/src/database-block/kanban/card.ts
+++ b/packages/blocks/src/database-block/kanban/card.ts
@@ -9,6 +9,7 @@ import { html } from 'lit/static-html.js';
 
 import { positionToVRect } from '../../_common/components/menu/index.js';
 import { MoreHorizontalIcon, NewEditIcon } from '../../_common/icons/index.js';
+import { getPageByElement } from '../../_common/utils/query.js';
 import { popSideDetail } from '../common/detail/layout.js';
 import type {
   DataViewKanbanColumnManager,
@@ -156,7 +157,9 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
       if (selection) {
         selection.selection = undefined;
       }
+      const pageElement = getPageByElement(this);
       popSideDetail({
+        pageElement,
         view: this.view,
         rowId: this.cardId,
         onClose: () => {
@@ -263,8 +266,9 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
   private clickEdit = (e: MouseEvent) => {
     e.stopPropagation();
     const selection = this.getSelection();
+    const pageElement = getPageByElement(this);
     if (selection) {
-      openDetail(this.cardId, selection);
+      openDetail(pageElement, this.cardId, selection);
     }
   };
 
@@ -286,7 +290,8 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
           },
         ],
       };
-      popCardMenu(ele, this.cardId, selection);
+      const pageElement = getPageByElement(this);
+      popCardMenu(pageElement, ele, this.cardId, selection);
     }
   };
   private contextMenu = (e: MouseEvent) => {
@@ -303,7 +308,13 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
           },
         ],
       };
-      popCardMenu(positionToVRect(e.x, e.y), this.cardId, selection);
+      const pageElement = getPageByElement(this);
+      popCardMenu(
+        pageElement,
+        positionToVRect(e.x, e.y),
+        this.cardId,
+        selection
+      );
     }
   };
 }

--- a/packages/blocks/src/database-block/kanban/controller/drag.ts
+++ b/packages/blocks/src/database-block/kanban/controller/drag.ts
@@ -162,7 +162,7 @@ const createDragPreview = (card: KanbanCard, x: number, y: number) => {
   kanbanCard.isFocus = true;
   kanbanCard.style.backgroundColor = 'var(--affine-background-primary-color)';
   div.append(kanbanCard);
-  div.className = 'with-data-view-css-variable';
+  div.className = 'with-data-view-css-variable blocksuite-overlay';
   div.style.width = `${card.getBoundingClientRect().width}px`;
   div.style.position = 'fixed';
   // div.style.pointerEvents = 'none';

--- a/packages/blocks/src/database-block/kanban/menu.ts
+++ b/packages/blocks/src/database-block/kanban/menu.ts
@@ -9,16 +9,19 @@ import {
   MoveLeftIcon,
   MoveRightIcon,
 } from '../../_common/icons/index.js';
+import type { PageBlockComponent } from '../../index.js';
 import { popSideDetail } from '../common/detail/layout.js';
 import type { KanbanSelectionController } from './controller/selection.js';
 
 export const openDetail = (
+  pageElement: PageBlockComponent | null,
   rowId: string,
   selection: KanbanSelectionController
 ) => {
   const old = selection.selection;
   selection.selection = undefined;
   popSideDetail({
+    pageElement,
     view: selection.view,
     rowId: rowId,
     onClose: () => {
@@ -28,6 +31,7 @@ export const openDetail = (
 };
 
 export const popCardMenu = (
+  pageElement: PageBlockComponent | null,
   ele: ReferenceElement,
   rowId: string,
   selection: KanbanSelectionController
@@ -38,7 +42,7 @@ export const popCardMenu = (
       name: 'Expand Card',
       icon: ExpandFullIcon,
       select: () => {
-        openDetail(rowId, selection);
+        openDetail(pageElement, rowId, selection);
       },
     },
     {

--- a/packages/blocks/src/database-block/table/components/column-header/vertical-indicator.ts
+++ b/packages/blocks/src/database-block/table/components/column-header/vertical-indicator.ts
@@ -160,6 +160,7 @@ type VerticalIndicator = {
 export const getVerticalIndicator = (): VerticalIndicator => {
   if (!preview) {
     const dragBar = new TableVerticalIndicator();
+    dragBar.classList.add('blocksuite-overlay');
     preview = {
       display(
         width: number,

--- a/packages/blocks/src/database-block/table/components/menu.ts
+++ b/packages/blocks/src/database-block/table/components/menu.ts
@@ -8,16 +8,19 @@ import {
   MoveLeftIcon,
   MoveRightIcon,
 } from '../../../_common/icons/index.js';
+import type { PageBlockComponent } from '../../../page-block/types.js';
 import { popSideDetail } from '../../common/detail/layout.js';
 import type { TableSelectionController } from '../controller/selection.js';
 
 export const openDetail = (
+  pageElement: PageBlockComponent | null,
   rowId: string,
   selection: TableSelectionController
 ) => {
   const old = selection.selection;
   selection.selection = undefined;
   popSideDetail({
+    pageElement,
     view: selection.host.view,
     rowId: rowId,
     onClose: () => {
@@ -27,6 +30,7 @@ export const openDetail = (
 };
 
 export const popRowMenu = (
+  pageElement: PageBlockComponent | null,
   ele: ReferenceElement,
   rowId: string,
   selection: TableSelectionController
@@ -37,7 +41,7 @@ export const popRowMenu = (
       name: 'Expand Row',
       icon: ExpandFullIcon,
       select: () => {
-        openDetail(rowId, selection);
+        openDetail(pageElement, rowId, selection);
       },
     },
     // {

--- a/packages/blocks/src/database-block/table/components/row.ts
+++ b/packages/blocks/src/database-block/table/components/row.ts
@@ -10,7 +10,10 @@ import {
   MoreHorizontalIcon,
   NewEditIcon,
 } from '../../../_common/icons/index.js';
-import type { TableViewSelection } from '../../../_common/utils/index.js';
+import {
+  getPageByElement,
+  type TableViewSelection,
+} from '../../../_common/utils/index.js';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../consts.js';
 import type { DataViewTableManager } from '../table-view-manager.js';
 import { openDetail, popRowMenu } from './menu.js';
@@ -132,7 +135,8 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
       },
       isEditing: false,
     };
-    popRowMenu(positionToVRect(e.x, e.y), this.rowId, selection);
+    const pageElement = getPageByElement(this);
+    popRowMenu(pageElement, positionToVRect(e.x, e.y), this.rowId, selection);
   };
 
   public override connectedCallback() {
@@ -206,7 +210,8 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
               },
               isEditing: false,
             });
-            openDetail(this.rowId, this.selectionController);
+            const pageElement = getPageByElement(this);
+            openDetail(pageElement, this.rowId, this.selectionController);
           };
           const openMenu = (e: MouseEvent) => {
             if (!this.selectionController) {
@@ -224,7 +229,8 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
               },
               isEditing: false,
             });
-            popRowMenu(ele, this.rowId, this.selectionController);
+            const pageElement = getPageByElement(this);
+            popRowMenu(pageElement, ele, this.rowId, this.selectionController);
           };
           return html`
             <div>

--- a/packages/blocks/src/database-block/table/controller/drag.ts
+++ b/packages/blocks/src/database-block/table/controller/drag.ts
@@ -162,7 +162,7 @@ const createDragPreview = (row: TableRow, x: number, y: number) => {
   cloneRow.rowIndex = row.rowIndex;
   cloneRow.rowId = row.rowId;
   div.append(cloneRow);
-  div.className = 'with-data-view-css-variable';
+  div.className = 'with-data-view-css-variable blocksuite-overlay';
   div.style.width = `${row.getBoundingClientRect().width}px`;
   div.style.position = 'fixed';
   div.style.pointerEvents = 'none';
@@ -184,6 +184,7 @@ const createDragPreview = (row: TableRow, x: number, y: number) => {
 };
 const createDropPreview = () => {
   const div = document.createElement('div');
+  div.classList.add('blocksuite-overlay');
   div.setAttribute('data-is-drop-preview', 'true');
   div.style.pointerEvents = 'none';
   div.style.position = 'fixed';

--- a/packages/blocks/src/database-block/table/controller/hotkeys.ts
+++ b/packages/blocks/src/database-block/table/controller/hotkeys.ts
@@ -1,5 +1,6 @@
 import type { ReactiveController } from 'lit';
 
+import { getPageByElement } from '../../../_common/utils/query.js';
 import { popRowMenu } from '../components/menu.js';
 import type { DataViewTable } from '../table-view.js';
 
@@ -227,7 +228,8 @@ export class TableHotkeysController implements ReactiveController {
           );
           if (cell) {
             context.get('keyboardState').raw.preventDefault();
-            popRowMenu(cell, cell.rowId, this.selectionController);
+            const pageElement = getPageByElement(cell);
+            popRowMenu(pageElement, cell, cell.rowId, this.selectionController);
           }
         },
       })

--- a/packages/blocks/src/image-block/doc-image-block.ts
+++ b/packages/blocks/src/image-block/doc-image-block.ts
@@ -340,7 +340,7 @@ export class ImageBlockPageComponent extends BlockElement<ImageBlockModel> {
         parent,
         index + 1
       );
-      asyncFocusRichText(model.page, id)?.catch(console.error);
+      asyncFocusRichText(this.host, model.page, id)?.catch(console.error);
     }
   }
 

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -82,7 +82,7 @@ export class DocPageBlockComponent extends BlockElement<
     }
 
     /* Extra small devices (phones, 640px and down) */
-    @media screen and (max-width: 640px) {
+    @container viewport (width <= 640px) {
       .affine-doc-page-block-container {
         padding-left: ${PAGE_BLOCK_CHILD_PADDING}px;
         padding-right: ${PAGE_BLOCK_CHILD_PADDING}px;
@@ -206,7 +206,9 @@ export class DocPageBlockComponent extends BlockElement<
       this._getDefaultNoteBlock(),
       0
     );
-    asyncFocusRichText(this.page, newFirstParagraphId)?.catch(console.error);
+    asyncFocusRichText(this.host, this.page, newFirstParagraphId)?.catch(
+      console.error
+    );
   };
 
   focusFirstParagraph = () => {
@@ -215,7 +217,9 @@ export class DocPageBlockComponent extends BlockElement<
       matchFlavours(block, ['affine:paragraph', 'affine:list', 'affine:code'])
     );
     if (firstText) {
-      asyncFocusRichText(this.page, firstText.id)?.catch(console.error);
+      asyncFocusRichText(this.host, this.page, firstText.id)?.catch(
+        console.error
+      );
     } else {
       const newFirstParagraphId = this.page.addBlock(
         'affine:paragraph',
@@ -223,7 +227,9 @@ export class DocPageBlockComponent extends BlockElement<
         defaultNote,
         0
       );
-      asyncFocusRichText(this.page, newFirstParagraphId)?.catch(console.error);
+      asyncFocusRichText(this.host, this.page, newFirstParagraphId)?.catch(
+        console.error
+      );
     }
   };
 

--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -36,13 +36,16 @@ const PAGE_BLOCK_CHILD_PADDING = 24;
 
 function testClickOnBlankArea(
   state: PointerEventState,
+  viewportLeft: number,
   viewportWidth: number,
   pageWidth: number,
   paddingLeft: number,
   paddingRight: number
 ) {
-  const blankLeft = (viewportWidth - pageWidth) / 2 + paddingLeft;
-  const blankRight = (viewportWidth - pageWidth) / 2 + pageWidth - paddingRight;
+  const blankLeft =
+    viewportLeft + (viewportWidth - pageWidth) / 2 + paddingLeft;
+  const blankRight =
+    viewportLeft + (viewportWidth - pageWidth) / 2 + pageWidth - paddingRight;
 
   if (state.raw.clientX < blankLeft || state.raw.clientX > blankRight) {
     return true;
@@ -362,6 +365,7 @@ export class DocPageBlockComponent extends BlockElement<
       );
       const isClickOnBlankArea = testClickOnBlankArea(
         event,
+        this.viewport.left,
         this.viewport.clientWidth,
         this.pageBlockContainer.clientWidth,
         parseFloat(paddingLeft),

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -252,7 +252,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
 
     return html`
       <div
-        class="edgeless-block-portal-note"
+        class="edgeless-block-portal-note blocksuite-overlay"
         style=${styleMap(style)}
         data-model-height="${bound.h}"
         @mouseleave=${this._leaved}

--- a/packages/blocks/src/page-block/edgeless/components/note-slicer/slicer-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-slicer/slicer-button.ts
@@ -165,7 +165,9 @@ export class PopupNoteSlicerButton extends WithDisposable(LitElement) {
   }
 
   override render() {
-    return html`<button class="slicer-button">${CutIcon}</button>`;
+    return html`<button class="slicer-button blocksuite-overlay">
+      ${CutIcon}
+    </button>`;
   }
 }
 

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-element.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-element.ts
@@ -246,10 +246,26 @@ export class EdgelessShapeToolElement extends WithDisposable(LitElement) {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._disposables.addFromEvent(window, 'mousemove', this._onMouseMove);
-    this._disposables.addFromEvent(window, 'touchmove', this._touchMove);
-    this._disposables.addFromEvent(window, 'mouseup', this._onMouseUp);
-    this._disposables.addFromEvent(window, 'touchend', this._onTouchEnd);
+    this._disposables.addFromEvent(
+      this.edgeless.host,
+      'mousemove',
+      this._onMouseMove
+    );
+    this._disposables.addFromEvent(
+      this.edgeless.host,
+      'touchmove',
+      this._touchMove
+    );
+    this._disposables.addFromEvent(
+      this.edgeless.host,
+      'mouseup',
+      this._onMouseUp
+    );
+    this._disposables.addFromEvent(
+      this.edgeless.host,
+      'touchend',
+      this._onTouchEnd
+    );
   }
 
   override updated(changedProperties: PropertyValues<this>) {

--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -4,6 +4,7 @@ import type {
   UIEventStateContext,
 } from '@blocksuite/block-std';
 import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import {
   type BlockSnapshot,
@@ -22,7 +23,7 @@ import { groupBy } from '../../../_common/utils/iterable.js';
 import {
   buildPath,
   getEditorContainer,
-  isPageMode,
+  isInsideDocEditor,
 } from '../../../_common/utils/query.js';
 import { isUrlInClipboard } from '../../../_common/utils/url.js';
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
@@ -668,6 +669,7 @@ export class EdgelessClipboardController extends PageClipboard {
     nodes?: TopLevelBlockModel[],
     canvasElements: CanvasElement[] = []
   ): Promise<HTMLCanvasElement | undefined> {
+    const host = edgeless.host;
     const root = this.page.root;
     if (!root) return;
 
@@ -675,10 +677,10 @@ export class EdgelessClipboardController extends PageClipboard {
     if (!(html2canvas instanceof Function)) return;
 
     const pathname = location.pathname;
-    const pageMode = isPageMode(this.page);
+    const pageMode = isInsideDocEditor(host);
 
-    const editorContainer = getEditorContainer(this.page);
-    const container = document.querySelector(
+    const editorContainer = getEditorContainer(host);
+    const container = editorContainer.querySelector(
       '.affine-block-children-container'
     );
     if (!container) return;
@@ -786,7 +788,7 @@ export class EdgelessClipboardController extends PageClipboard {
         }
       }
 
-      this._checkCanContinueToCanvas(pathname, pageMode);
+      this._checkCanContinueToCanvas(host, pathname, pageMode);
     }
 
     const surfaceCanvas = edgeless.surface.viewport.getCanvasByBound(
@@ -798,8 +800,15 @@ export class EdgelessClipboardController extends PageClipboard {
     return canvas;
   }
 
-  private _checkCanContinueToCanvas(pathName: string, pageMode: boolean) {
-    if (location.pathname !== pathName || isPageMode(this.page) !== pageMode) {
+  private _checkCanContinueToCanvas(
+    host: EditorHost,
+    pathName: string,
+    pageMode: boolean
+  ) {
+    if (
+      location.pathname !== pathName ||
+      isInsideDocEditor(host) !== pageMode
+    ) {
       throw new Error('Unable to export content to canvas');
     }
   }

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -112,13 +112,13 @@ export class EdgelessPageBlockComponent extends BlockElement<
       contain: size layout style;
     }
 
-    @media screen and (max-width: 1200px) {
+    @container viewport (width <= 1200px) {
       edgeless-zoom-toolbar {
         display: none;
       }
     }
 
-    @media screen and (min-width: 1200px) {
+    @container viewport (width >= 1200px) {
       zoom-bar-toggle-button {
         display: none;
       }
@@ -559,7 +559,9 @@ export class EdgelessPageBlockComponent extends BlockElement<
       this.updateComplete
         .then(() => {
           if (blockId) {
-            asyncFocusRichText(this.page, blockId)?.catch(console.error);
+            asyncFocusRichText(this.host, this.page, blockId)?.catch(
+              console.error
+            );
           } else if (point) {
             // Cannot reuse `handleNativeRangeClick` directly here,
             // since `retargetClick` will re-target to pervious editor

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -188,7 +188,7 @@ export class EdgelessToolsManager {
       if (
         !isInsideDocTitle(this.container.host, event.raw.target) &&
         !isDatabaseInput(event.raw.target) &&
-        !isInsideEdgelessTextEditor(event.raw.target)
+        !isInsideEdgelessTextEditor(this.container.host, event.raw.target)
       ) {
         event.raw.preventDefault();
       }
@@ -200,7 +200,7 @@ export class EdgelessToolsManager {
       if (
         !isInsideDocTitle(this.container.host, event.raw.target) &&
         !isDatabaseInput(event.raw.target) &&
-        !isInsideEdgelessTextEditor(event.raw.target)
+        !isInsideEdgelessTextEditor(this.container.host, event.raw.target)
       ) {
         event.raw.preventDefault();
       }
@@ -212,7 +212,7 @@ export class EdgelessToolsManager {
       if (
         !isInsideDocTitle(this.container.host, event.raw.target) &&
         !isDatabaseInput(event.raw.target) &&
-        !isInsideEdgelessTextEditor(event.raw.target)
+        !isInsideEdgelessTextEditor(this.container.host, event.raw.target)
       ) {
         event.raw.preventDefault();
       }
@@ -238,7 +238,7 @@ export class EdgelessToolsManager {
       if (
         !isInsideDocTitle(this.container.host, event.raw.target) &&
         !isDatabaseInput(event.raw.target) &&
-        !isInsideEdgelessTextEditor(event.raw.target)
+        !isInsideEdgelessTextEditor(this.container.host, event.raw.target)
       ) {
         event.raw.preventDefault();
       }

--- a/packages/blocks/src/page-block/utils/callback.ts
+++ b/packages/blocks/src/page-block/utils/callback.ts
@@ -9,10 +9,11 @@ import {
 } from '../../_common/utils/query.js';
 
 export async function onModelTextUpdated(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   callback?: (text: RichText) => void
 ) {
-  const richText = await asyncGetRichTextByModel(model);
+  const richText = await asyncGetRichTextByModel(editorHost, model);
   assertExists(richText, 'RichText is not ready yet.');
   await richText.updateComplete;
   const inlineEditor = richText.inlineEditor;

--- a/packages/blocks/src/page-block/utils/operations/element/block-level.ts
+++ b/packages/blocks/src/page-block/utils/operations/element/block-level.ts
@@ -18,7 +18,7 @@ export function updateBlockElementType(
   if (blockElements.length === 0) {
     return [];
   }
-  const root = blockElements[0].host;
+  const editorHost = blockElements[0].host;
   const page = blockElements[0].page;
   const hasSamePage = blockElements.every(block => block.page === page);
   if (!hasSamePage) {
@@ -39,7 +39,7 @@ export function updateBlockElementType(
     if (!model) {
       throw new Error('Failed to get model after merge code block!');
     }
-    asyncSetInlineRange(model, {
+    asyncSetInlineRange(editorHost, model, {
       index: model.text?.length ?? 0,
       length: 0,
     }).catch(console.error);
@@ -61,7 +61,7 @@ export function updateBlockElementType(
     if (!nextSibling) {
       nextSiblingId = page.addBlock('affine:paragraph', {}, parent);
     }
-    asyncFocusRichText(page, nextSiblingId)?.catch(console.error);
+    asyncFocusRichText(editorHost, page, nextSiblingId)?.catch(console.error);
     const newModel = page.getBlockById(id);
     if (!newModel) {
       throw new Error('Failed to get model after add divider block!');
@@ -88,8 +88,10 @@ export function updateBlockElementType(
   const firstNewModel = newModels[0];
   const lastNewModel = newModels[newModels.length - 1];
 
-  const allTextUpdated = newModels.map(model => onModelTextUpdated(model));
-  const selectionManager = root.selection;
+  const allTextUpdated = newModels.map(model =>
+    onModelTextUpdated(editorHost, model)
+  );
+  const selectionManager = editorHost.selection;
   const textSelection = selectionManager.find('text');
   const blockSelections = selectionManager.filter('block');
 

--- a/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
+++ b/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
@@ -514,7 +514,9 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
     if (isInsideDocEditor(this._editorHost)) {
       if (focusId) {
-        asyncFocusRichText(page, focusId)?.catch(console.error);
+        asyncFocusRichText(this._editorHost, page, focusId)?.catch(
+          console.error
+        );
       }
       return;
     }
@@ -610,7 +612,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
         defaultNoteBlock
       );
     });
-    lastId && (await asyncFocusRichText(page, lastId));
+    lastId && (await asyncFocusRichText(this._editorHost, page, lastId));
   };
 
   private _onClickOutside = (e: MouseEvent) => {

--- a/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
+++ b/packages/blocks/src/page-block/widgets/block-hub/components/block-hub.ts
@@ -674,7 +674,7 @@ export class BlockHub extends WithDisposable(ShadowlessElement) {
 
     return html`
       <div
-        class="block-hub-menu-container"
+        class="block-hub-menu-container blocksuite-overlay"
         @pointerdown=${stopPropagation}
         ?expanded=${this._expanded}
         style="bottom: ${BOTTOM_OFFSET}px; right: ${RIGHT_OFFSET}px;"

--- a/packages/blocks/src/page-block/widgets/linked-page/config.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/config.ts
@@ -1,4 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 import { type BaseBlockModel, type PageMeta } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
@@ -21,6 +22,7 @@ export type LinkedPageOptions = {
   ignoreBlockTypes: Flavour[];
   convertTriggerKey: boolean;
   getMenus: (ctx: {
+    editorHost: EditorHost;
     query: string;
     page: Page;
     pageMetas: PageMeta[];
@@ -47,13 +49,15 @@ const DEFAULT_PAGE_NAME = 'Untitled';
 const DISPLAY_NAME_LENGTH = 8;
 
 export function insertLinkedNode({
+  editorHost,
   model,
   pageId,
 }: {
+  editorHost: EditorHost;
   pageId: string;
   model: BaseBlockModel;
 }) {
-  const inlineEditor = getInlineEditorByModel(model);
+  const inlineEditor = getInlineEditorByModel(editorHost, model);
   assertExists(inlineEditor, 'Editor not found');
   const inlineRange = inlineEditor.getInlineRange();
   assertExists(inlineRange);
@@ -67,11 +71,12 @@ export function insertLinkedNode({
 }
 
 export const getMenus: (ctx: {
+  editorHost: EditorHost;
   query: string;
   page: Page;
   pageMetas: PageMeta[];
   model: BaseBlockModel;
-}) => LinkedPageGroup[] = ({ query, page, model, pageMetas }) => {
+}) => LinkedPageGroup[] = ({ editorHost, query, page, model, pageMetas }) => {
   const pageName = query || DEFAULT_PAGE_NAME;
   const displayPageName =
     pageName.slice(0, DISPLAY_NAME_LENGTH) +
@@ -91,6 +96,7 @@ export const getMenus: (ctx: {
         icon: PageIcon,
         action: () =>
           insertLinkedNode({
+            editorHost,
             model,
             pageId: page.id,
           }),
@@ -109,6 +115,7 @@ export const getMenus: (ctx: {
               title: pageName,
             });
             insertLinkedNode({
+              editorHost,
               model,
               pageId: newPage.id,
             });
@@ -130,6 +137,7 @@ export const getMenus: (ctx: {
               }
               const pageId = pageIds[0];
               insertLinkedNode({
+                editorHost,
                 model,
                 pageId: pageId,
               });

--- a/packages/blocks/src/page-block/widgets/linked-page/import-page/import-page.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/import-page/import-page.ts
@@ -264,7 +264,7 @@ export class ImportPage extends WithDisposable(LitElement) {
   override render() {
     if (this._loading) {
       return html`
-        <div class="overlay-mask"></div>
+        <div class="overlay-mask blocksuite-overlay"></div>
         <div class="container">
           <header
             class="loading-header"
@@ -283,7 +283,7 @@ export class ImportPage extends WithDisposable(LitElement) {
     }
     return html`
       <div
-        class="overlay-mask"
+        class="overlay-mask blocksuite-overlay"
         @click="${() => this.abortController.abort()}"
       ></div>
       <div class="container">

--- a/packages/blocks/src/page-block/widgets/linked-page/index.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/index.ts
@@ -40,7 +40,7 @@ export function showLinkedPagePopover({
   const disposables = new DisposableGroup();
   abortController.signal.addEventListener('abort', () => disposables.dispose());
 
-  const linkedPage = new LinkedPagePopover(model, abortController);
+  const linkedPage = new LinkedPagePopover(editorHost, model, abortController);
   linkedPage.options = options;
   linkedPage.triggerKey = triggerKey;
   // Mount
@@ -127,7 +127,7 @@ export class AffineLinkedPageWidget extends WidgetElement {
       return;
     }
     if (matchFlavours(model, this.options.ignoreBlockTypes)) return;
-    const inlineEditor = getInlineEditorByModel(model);
+    const inlineEditor = getInlineEditorByModel(this.host, model);
     if (!inlineEditor) return;
     const inlineRange = inlineEditor.getInlineRange();
     if (!inlineRange) return;

--- a/packages/blocks/src/page-block/widgets/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/linked-page-popover.ts
@@ -1,4 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import { WithDisposable } from '@blocksuite/lit';
 import { type BaseBlockModel } from '@blocksuite/store';
 import { html, LitElement } from 'lit';
@@ -49,6 +50,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
   private _updateActionList() {
     this._actionGroup = this.options.getMenus({
+      editorHost: this.editorHost,
       query: this._query,
       page: this._page,
       model: this.model,
@@ -64,6 +66,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
   }
 
   constructor(
+    private editorHost: EditorHost,
     private model: BaseBlockModel,
     private abortController = new AbortController()
   ) {
@@ -72,7 +75,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
   override connectedCallback() {
     super.connectedCallback();
-    const richText = getRichTextByModel(this.model);
+    const richText = getRichTextByModel(this.editorHost, this.model);
     assertExists(richText, 'RichText not found');
 
     // init
@@ -120,7 +123,11 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
       },
       onConfirm: () => {
         this.abortController.abort();
-        cleanSpecifiedTail(this.model, this.triggerKey + this._query);
+        cleanSpecifiedTail(
+          this.editorHost,
+          this.model,
+          this.triggerKey + this._query
+        );
         this._flattenActionList[this._activatedItemIndex]
           .action()
           ?.catch(console.error);
@@ -168,6 +175,7 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
                   @click=${() => {
                     this.abortController.abort();
                     cleanSpecifiedTail(
+                      this.editorHost,
                       this.model,
                       this.triggerKey + this._query
                     );

--- a/packages/blocks/src/page-block/widgets/linked-page/linked-page-popover.ts
+++ b/packages/blocks/src/page-block/widgets/linked-page/linked-page-popover.ts
@@ -155,7 +155,10 @@ export class LinkedPagePopover extends WithDisposable(LitElement) {
 
     // XXX This is a side effect
     let accIdx = 0;
-    return html`<div class="linked-page-popover" style="${style}">
+    return html`<div
+      class="linked-page-popover blocksuite-overlay"
+      style="${style}"
+    >
       ${this._actionGroup
         .filter(group => group.items.length)
         .map((group, idx) => {

--- a/packages/blocks/src/page-block/widgets/modal/custom-modal.ts
+++ b/packages/blocks/src/page-block/widgets/modal/custom-modal.ts
@@ -102,7 +102,7 @@ export class AffineCustomModal extends LitElement {
   override render() {
     const { options } = this;
 
-    return html`<div class="modal-background">
+    return html`<div class="modal-background blocksuite-overlay">
       <div class="modal-window">
         <div class="modal-main" ${ref(this.modalRef)}></div>
         <div class="modal-footer">

--- a/packages/blocks/src/page-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/config.ts
@@ -104,7 +104,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
                     );
                   }
                   const codeModel = newModels[0];
-                  onModelTextUpdated(codeModel, richText => {
+                  onModelTextUpdated(pageElement.host, codeModel, richText => {
                     const inlineEditor = richText.inlineEditor;
                     assertExists(inlineEditor);
                     inlineEditor.focusEnd();
@@ -123,13 +123,16 @@ export const menuGroups: SlashMenuOptions['menus'] = [
       .map(({ name, icon, id }) => ({
         name,
         icon,
-        action: ({ model }) => {
+        action: ({ pageElement, model }) => {
           if (!model.text) {
             return;
           }
           const len = model.text.length;
           if (!len) {
-            const inlineEditor = getInlineEditorByModel(model);
+            const inlineEditor = getInlineEditorByModel(
+              pageElement.host,
+              model
+            );
             assertExists(
               inlineEditor,
               "Can't set style mark! Inline editor not found"
@@ -189,7 +192,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
         icon: NewPageIcon,
         action: async ({ pageElement, model }) => {
           const newPage = await createDefaultPage(pageElement.page.workspace);
-          insertContent(model, REFERENCE_NODE, {
+          insertContent(pageElement.host, model, REFERENCE_NODE, {
             reference: {
               type: 'LinkedPage',
               pageId: newPage.id,
@@ -215,7 +218,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
         },
         action: ({ model, pageElement }) => {
           const triggerKey = '@';
-          insertContent(model, triggerKey);
+          insertContent(pageElement.host, model, triggerKey);
           assertExists(model.page.root);
           const widgetEle =
             pageElement.widgetElements['affine-linked-page-widget'];
@@ -320,34 +323,34 @@ export const menuGroups: SlashMenuOptions['menus'] = [
       {
         name: 'Today',
         icon: TodayIcon,
-        action: ({ model }) => {
+        action: ({ pageElement, model }) => {
           const date = new Date();
-          insertContent(model, formatDate(date));
+          insertContent(pageElement.host, model, formatDate(date));
         },
       },
       {
         name: 'Tomorrow',
         icon: TomorrowIcon,
-        action: ({ model }) => {
+        action: ({ pageElement, model }) => {
           // yyyy-mm-dd
           const date = new Date();
           date.setDate(date.getDate() + 1);
-          insertContent(model, formatDate(date));
+          insertContent(pageElement.host, model, formatDate(date));
         },
       },
       {
         name: 'Yesterday',
         icon: YesterdayIcon,
-        action: ({ model }) => {
+        action: ({ pageElement, model }) => {
           const date = new Date();
           date.setDate(date.getDate() - 1);
-          insertContent(model, formatDate(date));
+          insertContent(pageElement.host, model, formatDate(date));
         },
       },
       {
         name: 'Now',
         icon: NowIcon,
-        action: ({ model }) => {
+        action: ({ pageElement, model }) => {
           // For example 7:13 pm
           // https://stackoverflow.com/questions/8888491/how-do-you-display-javascript-datetime-in-12-hour-am-pm-format
           const date = new Date();
@@ -357,7 +360,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           hours = hours % 12;
           hours = hours ? hours : 12; // the hour '0' should be '12'
           const strTime = hours + ':' + minutes + ' ' + amOrPm;
-          insertContent(model, strTime);
+          insertContent(pageElement.host, model, strTime);
         },
       },
     ],

--- a/packages/blocks/src/page-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/index.ts
@@ -135,7 +135,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
     }
 
     if (matchFlavours(model, ['affine:code'])) return;
-    const inlineEditor = getInlineEditorByModel(model);
+    const inlineEditor = getInlineEditorByModel(this.host, model);
     if (!inlineEditor) return;
     inlineEditor.slots.inlineRangeApply.once(() => {
       const pageElement = this.blockElement;

--- a/packages/blocks/src/page-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/slash-menu-popover.ts
@@ -360,7 +360,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
       }
     );
 
-    return html`<div class="slash-menu-container">
+    return html`<div class="slash-menu-container blocksuite-overlay">
       <div
         class="overlay-mask"
         @click="${() => this.abortController.abort()}"

--- a/packages/blocks/src/page-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/slash-menu-popover.ts
@@ -62,6 +62,10 @@ export class SlashMenu extends WithDisposable(LitElement) {
 
   abortController = new AbortController();
 
+  get host() {
+    return this.pageElement.host;
+  }
+
   /**
    * Does not include the slash character
    */
@@ -76,7 +80,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
     });
     this._filterItems = this._updateItem('');
 
-    const richText = getRichTextByModel(this.model);
+    const richText = getRichTextByModel(this.host, this.model);
     if (!richText) {
       console.warn(
         'Slash Menu may not work properly! No rich text found for model',
@@ -254,7 +258,11 @@ export class SlashMenu extends WithDisposable(LitElement) {
     // Need to remove the search string
     // We must to do clean the slash string before we do the action
     // Otherwise, the action may change the model and cause the slash string to be changed
-    cleanSpecifiedTail(this.model, this.triggerKey + this._searchString);
+    cleanSpecifiedTail(
+      this.host,
+      this.model,
+      this.triggerKey + this._searchString
+    );
     this.abortController.abort();
 
     const { action } = this._filterItems[index];

--- a/packages/blocks/src/page-block/widgets/slash-menu/utils.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/utils.ts
@@ -1,3 +1,4 @@
+import type { EditorHost } from '@blocksuite/lit';
 import type { BaseBlockModel } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
@@ -61,6 +62,7 @@ export function collectGroupNames(menuItem: InternSlashItem[]) {
 }
 
 export function insertContent(
+  editorHost: EditorHost,
   model: BaseBlockModel,
   text: string,
   attributes?: AffineTextAttributes
@@ -68,7 +70,7 @@ export function insertContent(
   if (!model.text) {
     throw new Error("Can't insert text! Text not found");
   }
-  const inlineEditor = getInlineEditorByModel(model);
+  const inlineEditor = getInlineEditorByModel(editorHost, model);
   if (!inlineEditor) {
     throw new Error("Can't insert text! Inline editor not found");
   }

--- a/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/page-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -154,7 +154,7 @@ function SurfaceRefToolbarOptions(options: {
 
           if (!referencedModel) return;
 
-          edgelessToBlob(model.page, {
+          edgelessToBlob(blockElement.host, model.page, {
             surfaceRefBlock: blockElement,
             surfaceRenderer: blockElement.surfaceRenderer,
             edgelessElement: referencedModel,
@@ -180,7 +180,7 @@ function SurfaceRefToolbarOptions(options: {
         size="32px"
         ?hidden=${!hasValidReference}
         @click=${() => {
-          edgelessToBlob(model.page, {
+          edgelessToBlob(blockElement.host, model.page, {
             surfaceRefBlock: blockElement,
             surfaceRenderer: blockElement.surfaceRenderer,
             edgelessElement: blockElement.referenceModel as EdgelessElement,

--- a/packages/blocks/src/page-block/widgets/surface-ref-toolbar/utils.ts
+++ b/packages/blocks/src/page-block/widgets/surface-ref-toolbar/utils.ts
@@ -1,4 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
+import type { EditorHost } from '@blocksuite/lit';
 import type { Page } from '@blocksuite/store';
 
 import { type EdgelessElement } from '../../../_common/types.js';
@@ -9,6 +10,7 @@ import { Bound } from '../../../surface-block/utils/bound.js';
 import type { SurfaceRefBlockComponent } from '../../../surface-ref-block/surface-ref-block.js';
 
 export const edgelessToBlob = async (
+  host: EditorHost,
   page: Page,
   options: {
     surfaceRefBlock: SurfaceRefBlockComponent;
@@ -18,7 +20,7 @@ export const edgelessToBlob = async (
   }
 ): Promise<Blob> => {
   const { edgelessElement, blockContainer } = options;
-  const parser = new ContentParser(page);
+  const parser = new ContentParser(host, page);
   const bound = Bound.deserialize(edgelessElement.xywh);
   const isBlock = isTopLevelBlock(edgelessElement);
 

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -802,7 +802,7 @@ export class SurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel>
   viewInEdgeless() {
     if (!this._referencedModel) return;
 
-    const editorContainer = getEditorContainer(this.page);
+    const editorContainer = getEditorContainer(this.host);
 
     if (editorContainer.mode !== 'edgeless') {
       editorContainer.mode = 'edgeless';

--- a/packages/lit/src/utils/range-synchronizer.ts
+++ b/packages/lit/src/utils/range-synchronizer.ts
@@ -112,7 +112,7 @@ export class RangeSynchronizer {
   }
 
   private _onSelectionModelChanged = (selections: BaseSelection[]) => {
-    if (!this.host.event.focus) return;
+    if (!this.host.event.isActive) return;
     // wait for lit updated
     const rafId = requestAnimationFrame(() => {
       const text =

--- a/packages/lit/src/utils/range-synchronizer.ts
+++ b/packages/lit/src/utils/range-synchronizer.ts
@@ -112,6 +112,7 @@ export class RangeSynchronizer {
   }
 
   private _onSelectionModelChanged = (selections: BaseSelection[]) => {
+    if (!this.host.event.focus) return;
     // wait for lit updated
     const rafId = requestAnimationFrame(() => {
       const text =

--- a/packages/playground/apps/default/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/default/components/quick-edgeless-menu.ts
@@ -445,7 +445,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
           margin-right: 4px;
         }
       </style>
-      <div class="quick-edgeless-menu default">
+      <div class="quick-edgeless-menu default blocksuite-overlay">
         <div class="default-toolbar">
           <div class="top-container">
             <sl-dropdown placement="bottom" hoist>

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -40,7 +40,7 @@ function subscribePage(workspace: Workspace) {
     const page = workspace.getPage(pageId) as Page;
 
     const editor = createEditor(page, app);
-    const contentParser = new ContentParser(page);
+    const contentParser = new ContentParser(editor.host, page);
     const quickEdgelessMenu = new QuickEdgelessMenu();
     quickEdgelessMenu.workspace = workspace;
     quickEdgelessMenu.editor = editor;

--- a/packages/playground/apps/default/utils/notify.ts
+++ b/packages/playground/apps/default/utils/notify.ts
@@ -20,6 +20,7 @@ export function notify(
       ${escapeHtml(message)}
     `,
   });
+  alert.classList.add('blocksuite-overlay');
 
   document.body.append(alert);
   return alert.toast();

--- a/packages/playground/apps/starter/components/custom-frame-panel.ts
+++ b/packages/playground/apps/starter/components/custom-frame-panel.ts
@@ -55,7 +55,9 @@ export class CustomFramePanel extends WithDisposable(ShadowlessElement) {
   override render() {
     return html`
       ${this._show
-        ? html`<div class="custom-frame-container">${this._renderPanel()}</div>`
+        ? html`<div class="custom-frame-container blocksuite-overlay">
+            ${this._renderPanel()}
+          </div>`
         : nothing}
     `;
   }

--- a/packages/playground/apps/starter/components/custom-outline-panel.ts
+++ b/packages/playground/apps/starter/components/custom-outline-panel.ts
@@ -52,7 +52,9 @@ export class CustomOutlinePanel extends WithDisposable(LitElement) {
     return html`
       ${this._show
         ? html`
-            <div class="custom-outline-container">${this._renderPanel()}</div>
+            <div class="custom-outline-container blocksuite-overlay">
+              ${this._renderPanel()}
+            </div>
           `
         : null}
     `;

--- a/packages/playground/apps/starter/components/debug-menu.ts
+++ b/packages/playground/apps/starter/components/debug-menu.ts
@@ -618,7 +618,7 @@ export class DebugMenu extends ShadowlessElement {
           margin-right: 4px;
         }
       </style>
-      <div class="debug-menu default">
+      <div class="debug-menu default blocksuite-overlay">
         <div class="default-toolbar">
           <!-- undo/redo group -->
           <sl-button-group label="History">

--- a/packages/playground/apps/starter/components/left-side-panel.ts
+++ b/packages/playground/apps/starter/components/left-side-panel.ts
@@ -22,6 +22,7 @@ export class LeftSidePanel extends ShadowlessElement {
       this.currentContent.remove();
     }
     this.style.display = 'block';
+    ele.classList.add('blocksuite-overlay');
     this.currentContent = ele;
     this.append(ele);
   }

--- a/packages/playground/apps/starter/components/side-panel.ts
+++ b/packages/playground/apps/starter/components/side-panel.ts
@@ -21,6 +21,7 @@ export class SidePanel extends ShadowlessElement {
       this.currentContent.remove();
     }
     this.style.display = 'block';
+    ele.classList.add('blocksuite-overlay');
     this.currentContent = ele;
     this.append(ele);
   }

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -45,7 +45,7 @@ function subscribePage(workspace: Workspace) {
     const page = workspace.getPage(pageId) as Page;
 
     const editor = createEditor(page, app);
-    const contentParser = new ContentParser(page);
+    const contentParser = new ContentParser(editor.host, page);
     const debugMenu = new DebugMenu();
     const outlinePanel = new CustomOutlinePanel();
     const framePanel = new CustomFramePanel();

--- a/packages/playground/examples/multiple-editors/doc-doc/index.html
+++ b/packages/playground/examples/multiple-editors/doc-doc/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Doc+Doc Multiple-Editors Example</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        background-color: var(--affine-white-90);
+        transition: background-color 0.3s;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/playground/examples/multiple-editors/doc-doc/main.ts
+++ b/packages/playground/examples/multiple-editors/doc-doc/main.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import '@blocksuite/presets/themes/affine.css';
+
+import { createEmptyPage, DocEditor } from '@blocksuite/presets';
+
+const container = document.createElement('div');
+container.style.display = 'flex';
+container.style.height = '100%';
+container.style.width = '100%';
+document.body.appendChild(container);
+
+const page1 = createEmptyPage().init();
+const editor1 = new DocEditor();
+editor1.page = page1;
+editor1.style.flex = '1';
+editor1.style.borderRight = '1px solid #ccc';
+container.appendChild(editor1);
+
+const page2 = createEmptyPage().init();
+const editor2 = new DocEditor();
+editor2.page = page2;
+editor2.style.flex = '1';
+editor2.style.borderLeft = '1px solid #ccc';
+container.appendChild(editor2);

--- a/packages/playground/examples/multiple-editors/doc-edgeless/index.html
+++ b/packages/playground/examples/multiple-editors/doc-edgeless/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Doc+Edgeless Multiple-Editors Example</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        background-color: var(--affine-white-90);
+        transition: background-color 0.3s;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/playground/examples/multiple-editors/doc-edgeless/main.ts
+++ b/packages/playground/examples/multiple-editors/doc-edgeless/main.ts
@@ -16,13 +16,13 @@ document.body.appendChild(container);
 const page1 = createEmptyPage().init();
 const editor1 = new DocEditor();
 editor1.page = page1;
-editor1.style.flex = '1';
+editor1.style.flex = '2';
 editor1.style.borderRight = '1px solid #ccc';
 container.appendChild(editor1);
 
 const page2 = createEmptyPage().init();
 const editor2 = new EdgelessEditor();
 editor2.page = page2;
-editor2.style.flex = '2';
+editor2.style.flex = '3';
 editor2.style.borderLeft = '1px solid #ccc';
 container.appendChild(editor2);

--- a/packages/playground/examples/multiple-editors/doc-edgeless/main.ts
+++ b/packages/playground/examples/multiple-editors/doc-edgeless/main.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import '@blocksuite/presets/themes/affine.css';
+
+import {
+  createEmptyPage,
+  DocEditor,
+  EdgelessEditor,
+} from '@blocksuite/presets';
+
+const container = document.createElement('div');
+container.style.display = 'flex';
+container.style.height = '100%';
+container.style.width = '100%';
+document.body.appendChild(container);
+
+const page1 = createEmptyPage().init();
+const editor1 = new DocEditor();
+editor1.page = page1;
+editor1.style.flex = '1';
+editor1.style.borderRight = '1px solid #ccc';
+container.appendChild(editor1);
+
+const page2 = createEmptyPage().init();
+const editor2 = new EdgelessEditor();
+editor2.page = page2;
+editor2.style.flex = '2';
+editor2.style.borderLeft = '1px solid #ccc';
+container.appendChild(editor2);

--- a/packages/playground/examples/multiple-editors/edgeless-edgeless/index.html
+++ b/packages/playground/examples/multiple-editors/edgeless-edgeless/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Edgeless+Edgeless Multiple-Editors Example</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        background-color: var(--affine-white-90);
+        transition: background-color 0.3s;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/playground/examples/multiple-editors/edgeless-edgeless/main.ts
+++ b/packages/playground/examples/multiple-editors/edgeless-edgeless/main.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import '@blocksuite/presets/themes/affine.css';
+
+import { createEmptyPage, EdgelessEditor } from '@blocksuite/presets';
+
+const container = document.createElement('div');
+container.style.display = 'flex';
+container.style.height = '100%';
+container.style.width = '100%';
+document.body.appendChild(container);
+
+const page1 = createEmptyPage().init();
+const editor1 = new EdgelessEditor();
+editor1.page = page1;
+editor1.style.flex = '1';
+editor1.style.borderRight = '1px solid #ccc';
+container.appendChild(editor1);
+
+const page2 = createEmptyPage().init();
+const editor2 = new EdgelessEditor();
+editor2.page = page2;
+editor2.style.flex = '1';
+editor2.style.borderLeft = '1px solid #ccc';
+container.appendChild(editor2);

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -53,6 +53,18 @@ export default ({ mode }) => {
             __dirname,
             'examples/basic/edgeless/index.html'
           ),
+          'examples/multiple-editors/doc-doc': resolve(
+            __dirname,
+            'examples/multiple-editors/doc-doc/index.html'
+          ),
+          'examples/multiple-editors/doc-edgeless': resolve(
+            __dirname,
+            'examples/multiple-editors/doc-edgeless/index.html'
+          ),
+          'examples/multiple-editors/edgeless-edgeless': resolve(
+            __dirname,
+            'examples/multiple-editors/edgeless-edgeless/index.html'
+          ),
           'examples/inline': resolve(__dirname, 'examples/inline/index.html'),
           'examples/store': resolve(__dirname, 'examples/store/index.html'),
         },

--- a/packages/presets/src/editors/affine-doc-editor.ts
+++ b/packages/presets/src/editors/affine-doc-editor.ts
@@ -50,6 +50,8 @@ export class AffineDocEditor extends WithDisposable(ShadowlessElement) {
           overflow-x: hidden;
           overflow-y: auto;
           user-select: none;
+          container-name: viewport;
+          container-type: inline-size;
         }
 
         doc-editor {

--- a/packages/presets/src/editors/doc-editor.ts
+++ b/packages/presets/src/editors/doc-editor.ts
@@ -49,6 +49,8 @@ export class DocEditor extends WithDisposable(ShadowlessElement) {
           overflow-x: hidden;
           overflow-y: auto;
           user-select: none;
+          container-name: viewport;
+          container-type: inline-size;
         }
 
         .doc-editor-container {

--- a/packages/presets/src/editors/edgeless-editor.ts
+++ b/packages/presets/src/editors/edgeless-editor.ts
@@ -36,6 +36,8 @@ export class EdgelessEditor extends WithDisposable(ShadowlessElement) {
           overflow: hidden;
           font-family: var(--affine-font-family);
           background: var(--affine-background-primary-color);
+          container-name: viewport;
+          container-type: inline-size;
         }
         @media print {
           edgeless-editor {

--- a/packages/presets/src/fragments/copilot-panel/copilot-panel.ts
+++ b/packages/presets/src/fragments/copilot-panel/copilot-panel.ts
@@ -442,7 +442,10 @@ export class CopilotPanel extends WithDisposable(ShadowlessElement) {
   override render() {
     const panel = this.panels[this.currentPanel];
     return html`
-      <div style="display:flex;flex-direction: column;padding: 12px;">
+      <div
+        style="display:flex;flex-direction: column;padding: 12px;"
+        class="blocksuite-overlay"
+      >
         <div style="display:flex;align-items:center;justify-content:center;">
           <div
             style="display:flex;align-items:center;justify-content:center;cursor: pointer;user-select: none;width: max-content;padding: 4px; background-color: var(--affine-hover-color);border-radius: 12px;"

--- a/packages/presets/src/fragments/doc-title/doc-title.ts
+++ b/packages/presets/src/fragments/doc-title/doc-title.ts
@@ -51,7 +51,7 @@ export class DocTitle extends WithDisposable(ShadowlessElement) {
     }
 
     /* Extra small devices (phones, 640px and down) */
-    @media screen and (max-width: 640px) {
+    @container viewport (width <= 640px) {
       .doc-title-container {
         padding-left: ${PAGE_BLOCK_CHILD_PADDING}px;
         padding-right: ${PAGE_BLOCK_CHILD_PADDING}px;

--- a/packages/presets/src/fragments/page-meta-tags/backlink-popover.ts
+++ b/packages/presets/src/fragments/page-meta-tags/backlink-popover.ts
@@ -95,7 +95,6 @@ export class BacklinkButton extends WithDisposable(LitElement) {
     super.connectedCallback();
 
     this.tabIndex = 0;
-    this._disposables.addFromEvent(window, 'mousedown', this._onClickAway);
   }
 
   // Handle click outside
@@ -103,18 +102,18 @@ export class BacklinkButton extends WithDisposable(LitElement) {
     if (e.target === this) return;
     if (!this._showPopover) return;
     this._showPopover = false;
+    document.removeEventListener('mousedown', this._onClickAway);
   };
 
   onClick() {
     this._showPopover = !this._showPopover;
+    document.addEventListener('mousedown', this._onClickAway);
   }
 
   override render() {
     // Only show linked page backlinks
     const backlinks = this._backlinks;
-    if (!backlinks.length) {
-      return null;
-    }
+    if (!backlinks.length) return null;
 
     return html`
       <div class="btn" @click="${this.onClick}">

--- a/packages/presets/src/fragments/page-meta-tags/page-meta-tags.ts
+++ b/packages/presets/src/fragments/page-meta-tags/page-meta-tags.ts
@@ -51,7 +51,7 @@ export class PageMetaTags extends WithDisposable(LitElement) {
     }
 
     /* Extra small devices (phones, 640px and down) */
-    @media screen and (max-width: 640px) {
+    @container viewport (width <= 640px) {
       .page-meta-container {
         padding-left: ${PAGE_BLOCK_CHILD_PADDING}px;
         padding-right: ${PAGE_BLOCK_CHILD_PADDING}px;

--- a/tests/edgeless/shortcut.spec.ts
+++ b/tests/edgeless/shortcut.spec.ts
@@ -14,6 +14,7 @@ import {
   zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
+  clickView,
   enterPlaygroundRoom,
   focusRichText,
   initEmptyEdgelessState,
@@ -103,6 +104,8 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+
+    await clickView(page, [0, 0]);
     await zoomResetByKeyboard(page);
 
     await zoomOutByKeyboard(page);
@@ -119,6 +122,8 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+
+    await clickView(page, [0, 0]);
     await zoomResetByKeyboard(page);
     let zoom = await getZoomLevel(page);
     expect(zoom).toBe(100);
@@ -137,6 +142,8 @@ test.describe('zooming', () => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await switchEditorMode(page);
+
+    await clickView(page, [0, 0]);
     await zoomResetByKeyboard(page);
 
     await zoomInByKeyboard(page);

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -676,6 +676,7 @@ export async function shiftClickView(page: Page, point: [number, number]) {
 }
 
 export async function deleteAll(page: Page) {
+  await clickView(page, [0, 0]);
   await selectAllByKeyboard(page);
   await pressBackspace(page);
 }

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -106,7 +106,7 @@ async function initEmptyEditor({
         debugMenu.pagesPanel = pagesPanel;
         const leftSidePanel = document.createElement('left-side-panel');
         debugMenu.leftSidePanel = leftSidePanel;
-        debugMenu.contentParser = new window.ContentParser(page);
+        debugMenu.contentParser = new window.ContentParser(editor.host, page);
         document.body.appendChild(debugMenu);
         document.body.appendChild(leftSidePanel);
         window.debugMenu = debugMenu;


### PR DESCRIPTION
continuation of #5765 

closes #5625 
closes #5153



Changes:
1. Completed pending cleanup global querySelectors and events
2. UIEventDispatcher: 
   I tried moving events from document to editorHost, but there were few events which will originate from the document only. In multiple editor scenario each editor needs to be aware whether it is active or not, and respond to events only is it active.

   I have added a static field on UIEventDispatcher, which stores which dispatcher and thus which editor is active. It will run event handlers only if it is active.

   - The editor gets activated when the selection changes to an element inside the editor or the user clicks inside the editor.
   - The editor gets deactivated If there is a selection change to an element outside the editor.
   - There are a few overlays appended to document.body. I have added class "blocksuite-overlay" to these elements. If the user interacts with any such element the state will not change, i.e. the previous active editor which created the overlay will remain active.
4. For ease of testing of all three scenarios, added examples of independent multiple editors - doc-doc, doc-edgeless & edgeless-edgeless at
   - /examples/multiple-editors/doc-doc/
   - /examples/multiple-editors/doc-edgeless/
   - /examples/multiple-editors/edgeless-edgeless/