### PR TITLE
fix(edgeless): console error on block delete

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/page-block/edgeless/components/note-slicer/index.ts
@@ -155,7 +155,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
       buildPath(block)
     ) as NoteBlockComponent;
 
-    assertExists(noteBlockElement);
+    if (!noteBlockElement) return null;
 
     const {
       raw: { clientX, clientY },

--- a/packages/blocks/src/surface-block/grid.ts
+++ b/packages/blocks/src/surface-block/grid.ts
@@ -1,5 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
-
 import type { EdgelessElement } from '../_common/types.js';
 import { GRID_SIZE, type IBound } from './consts.js';
 import { compare } from './managers/group-manager.js';
@@ -71,7 +69,7 @@ export class GridManager<T extends EdgelessElement> {
 
   remove(element: T) {
     const grids = this._elementToGrids.get(element);
-    assertExists(grids);
+    if (!grids) return;
 
     for (const grid of grids) {
       grid.delete(element);


### PR DESCRIPTION
to fix console error from:
1. note-slicer on deleting top level note block
2. GridManager on deleting image/bookmark block inside top level note

https://github.com/toeverything/blocksuite/assets/54364088/a9c8aaa2-a2c6-460e-a8fb-688902e9b851