### PR TITLE
feat: add print formatter for the block model

### DIFF
--- a/packages/playground/apps/starter/env.d.ts
+++ b/packages/playground/apps/starter/env.d.ts
@@ -11,13 +11,13 @@ import type {
 import type { Job } from '@blocksuite/store';
 import type { z } from 'zod';
 
-type HTMLTemplate = [
-  string,
-  Record<string, unknown>,
-  ...(HTMLTemplate | string)[],
-];
-
 declare global {
+  type HTMLTemplate = [
+    string,
+    Record<string, unknown>,
+    ...(HTMLTemplate | string)[],
+  ];
+
   interface Window {
     editor: AffineEditorContainer;
     page: Page;

--- a/packages/playground/apps/starter/env.d.ts
+++ b/packages/playground/apps/starter/env.d.ts
@@ -11,6 +11,12 @@ import type {
 import type { Job } from '@blocksuite/store';
 import type { z } from 'zod';
 
+type HTMLTemplate = [
+  string,
+  Record<string, unknown>,
+  ...(HTMLTemplate | string)[],
+];
+
 declare global {
   interface Window {
     editor: AffineEditorContainer;
@@ -26,5 +32,11 @@ declare global {
 
     // TODO: remove this when provider support subdocument
     subdocProviders: Map<string, DocProvider[]>;
+
+    devtoolsFormatters: {
+      header: (obj: unknown, config: unknown) => null | HTMLTemplate;
+      hasBody: (obj: unknown, config: unknown) => boolean | null;
+      body: (obj: unknown, config: unknown) => null | HTMLTemplate;
+    }[];
   }
 }

--- a/packages/playground/apps/starter/utils.ts
+++ b/packages/playground/apps/starter/utils.ts
@@ -142,13 +142,13 @@ export function createEditor(page: Page, element: HTMLElement) {
   return editor;
 }
 
-const toStyledEntry = (key: string, value: string) => {
+function toStyledEntry(key: string, value: unknown) {
   return [
     ['span', { style: 'color: #c0c0c0' }, ` ${key}`],
     ['span', { style: 'color: #fff' }, `: `],
-    ['span', { style: 'color: rgb(92, 213, 251)' }, `'${value}'`],
+    ['span', { style: 'color: rgb(92, 213, 251)' }, `${JSON.stringify(value)}`],
   ];
-};
+}
 
 export const devtoolsFormatter = [
   {
@@ -185,7 +185,7 @@ export const devtoolsFormatter = [
         const propsArr = Object.entries(props).flatMap(([key]) => {
           return [
             // @ts-ignore
-            ...toStyledEntry(key, JSON.stringify(obj[key])),
+            ...toStyledEntry(key, obj[key]),
             ['div', {}, ''],
           ];
         });

--- a/packages/playground/apps/starter/utils.ts
+++ b/packages/playground/apps/starter/utils.ts
@@ -150,7 +150,7 @@ function toStyledEntry(key: string, value: unknown) {
   ];
 }
 
-export const devtoolsFormatter = [
+export const devtoolsFormatter: typeof window.devtoolsFormatters = [
   {
     header: function (obj: unknown) {
       if ('flavour' in (obj as store.BaseBlockModel)) {
@@ -163,7 +163,7 @@ export const devtoolsFormatter = [
           ['span', { style: 'color: #fff' }, `,`],
           ...toStyledEntry('id', obj.id),
           ['span', { style: 'color: #fff' }, `}`],
-        ];
+        ] as HTMLTemplate;
       }
 
       return null;
@@ -187,7 +187,7 @@ export const devtoolsFormatter = [
             // @ts-ignore
             ...toStyledEntry(key, obj[key]),
             ['div', {}, ''],
-          ];
+          ] as HTMLTemplate[];
         });
 
         return ['div', { style: 'padding-left: 1em' }, ...propsArr];
@@ -198,5 +198,4 @@ export const devtoolsFormatter = [
   },
 ];
 
-// @ts-ignore
 window.devtoolsFormatters = devtoolsFormatter;

--- a/packages/playground/apps/starter/utils.ts
+++ b/packages/playground/apps/starter/utils.ts
@@ -141,3 +141,62 @@ export function createEditor(page: Page, element: HTMLElement) {
 
   return editor;
 }
+
+const toStyledEntry = (key: string, value: string) => {
+  return [
+    ['span', { style: 'color: #c0c0c0' }, ` ${key}`],
+    ['span', { style: 'color: #fff' }, `: `],
+    ['span', { style: 'color: rgb(92, 213, 251)' }, `'${value}'`],
+  ];
+};
+
+export const devtoolsFormatter = [
+  {
+    header: function (obj: unknown) {
+      if ('flavour' in (obj as store.BaseBlockModel)) {
+        globalUtils.assertType<store.BaseBlockModel>(obj);
+        return [
+          'span',
+          { style: 'font-weight: bolder;' },
+          ['span', { style: 'color: #fff' }, `Block {`],
+          ...toStyledEntry('flavour', obj.flavour),
+          ['span', { style: 'color: #fff' }, `,`],
+          ...toStyledEntry('id', obj.id),
+          ['span', { style: 'color: #fff' }, `}`],
+        ];
+      }
+
+      return null;
+    },
+    hasBody: (obj: unknown) => {
+      if ('flavour' in (obj as store.BaseBlockModel)) {
+        return true;
+      }
+
+      return null;
+    },
+    body: (obj: unknown) => {
+      if ('flavour' in (obj as store.BaseBlockModel)) {
+        globalUtils.assertType<store.BaseBlockModel>(obj);
+
+        // @ts-ignore
+        const { props } = obj.page._blockTree.getBlock(obj.id)._parseYBlock();
+
+        const propsArr = Object.entries(props).flatMap(([key]) => {
+          return [
+            // @ts-ignore
+            ...toStyledEntry(key, JSON.stringify(obj[key])),
+            ['div', {}, ''],
+          ];
+        });
+
+        return ['div', { style: 'padding-left: 1em' }, ...propsArr];
+      }
+
+      return null;
+    },
+  },
+];
+
+// @ts-ignore
+window.devtoolsFormatters = devtoolsFormatter;


### PR DESCRIPTION
The block model is wrapped in a proxy which makes it difficult to print useful information in the console. The [Custom Formatters](https://firefox-source-docs.mozilla.org/devtools-user/custom_formatters/index.html) allow us to config how a variable can be printed in the console which can help us solve this problem. 

I wrote a small print formatter that can print all the props of the given block model. It should be sufficient in most cases.

Before:

![Screenshot 2024-01-01 at 10 31 25 PM](https://github.com/toeverything/blocksuite/assets/9301743/e5ec5a31-2ab5-4d0e-8da6-885e1036b98c)

After:
![Screenshot 2024-01-01 at 10 32 33 PM](https://github.com/toeverything/blocksuite/assets/9301743/4a02b5b8-7e99-4d91-874a-b74fba091dae)

**Note**: You need to check the `Enable custom formatters` in the Devtools preference to make it work.

<img width="419" alt="Screenshot 2024-01-01 at 10 34 26 PM" src="https://github.com/toeverything/blocksuite/assets/9301743/d222adf4-3395-4b64-9fe2-849000b3cb1c">