### PR TITLE
fix(edgeless): note background lost when copy as png

### DIFF
--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -747,7 +747,16 @@ export class EdgelessClipboardController extends PageClipboard {
       block: TopLevelBlockModel,
       isInFrame = false
     ) => {
-      const blockElement = this._blockElmentGetter(block)?.parentElement;
+      let blockElement = this._blockElmentGetter(block)?.parentElement;
+      const blockPortalSelector = block.flavour.replace(
+        'affine:',
+        '.edgeless-block-portal-'
+      );
+      blockElement = blockElement?.closest(blockPortalSelector);
+      if (!blockElement) {
+        throw new Error('Could not find edgeless block portal.');
+      }
+
       const blockBound = Bound.deserialize(block.xywh);
       const canvasData = await html2canvas(
         blockElement as HTMLElement,


### PR DESCRIPTION
To close #5520 

https://github.com/toeverything/blocksuite/assets/99816898/d5c652d9-b830-45ab-815e-97339483ca93

