### PR TITLE
fix(playground): editor host undefined

### DIFF
--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -47,7 +47,7 @@ function subscribePage(workspace: Workspace) {
 
     document.body.appendChild(quickEdgelessMenu);
 
-    page.slots.ready.on(() => {
+    requestAnimationFrame(() => {
       const contentParser = new ContentParser(editor.host, page);
       quickEdgelessMenu.contentParser = contentParser;
     });
@@ -69,6 +69,7 @@ async function syncProviders(
   const providers = workspace.providers;
 
   for (const provider of providers) {
+    console.log('provider: ', provider);
     if ('active' in provider) {
       provider.sync();
       await provider.whenReady;
@@ -144,6 +145,7 @@ async function initWorkspace(workspace: Workspace) {
     });
     page.resetHistory();
   } else {
+    console.log('init workspace');
     await syncProviders(workspace, getProviderCreators());
   }
 }

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -69,7 +69,6 @@ async function syncProviders(
   const providers = workspace.providers;
 
   for (const provider of providers) {
-    console.log('provider: ', provider);
     if ('active' in provider) {
       provider.sync();
       await provider.whenReady;
@@ -145,7 +144,6 @@ async function initWorkspace(workspace: Workspace) {
     });
     page.resetHistory();
   } else {
-    console.log('init workspace');
     await syncProviders(workspace, getProviderCreators());
   }
 }

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -40,13 +40,17 @@ function subscribePage(workspace: Workspace) {
     const page = workspace.getPage(pageId) as Page;
 
     const editor = createEditor(page, app);
-    const contentParser = new ContentParser(editor.host, page);
     const quickEdgelessMenu = new QuickEdgelessMenu();
     quickEdgelessMenu.workspace = workspace;
     quickEdgelessMenu.editor = editor;
     quickEdgelessMenu.mode = defaultMode;
-    quickEdgelessMenu.contentParser = contentParser;
+
     document.body.appendChild(quickEdgelessMenu);
+
+    page.slots.ready.on(() => {
+      const contentParser = new ContentParser(editor.host, page);
+      quickEdgelessMenu.contentParser = contentParser;
+    });
 
     window.editor = editor;
     window.page = page;

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -47,10 +47,10 @@ function subscribePage(workspace: Workspace) {
 
     document.body.appendChild(quickEdgelessMenu);
 
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       const contentParser = new ContentParser(editor.host, page);
       quickEdgelessMenu.contentParser = contentParser;
-    });
+    }, 100);
 
     window.editor = editor;
     window.page = page;

--- a/packages/playground/apps/default/main.ts
+++ b/packages/playground/apps/default/main.ts
@@ -47,6 +47,7 @@ function subscribePage(workspace: Workspace) {
 
     document.body.appendChild(quickEdgelessMenu);
 
+    // FIXME: should remove contentParser after move export functions to page service
     setTimeout(() => {
       const contentParser = new ContentParser(editor.host, page);
       quickEdgelessMenu.contentParser = contentParser;

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -63,6 +63,7 @@ function subscribePage(workspace: Workspace) {
     debugMenu.leftSidePanel = leftSidePanel;
     debugMenu.pagesPanel = pagesPanel;
 
+    // FIXME: should remove contentParser after move export functions to page service
     page.slots.ready.once(() => {
       const contentParser = new ContentParser(editor.host, page);
       debugMenu.contentParser = contentParser;

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -45,7 +45,6 @@ function subscribePage(workspace: Workspace) {
     const page = workspace.getPage(pageId) as Page;
 
     const editor = createEditor(page, app);
-    const contentParser = new ContentParser(editor.host, page);
     const debugMenu = new DebugMenu();
     const outlinePanel = new CustomOutlinePanel();
     const framePanel = new CustomFramePanel();
@@ -57,13 +56,18 @@ function subscribePage(workspace: Workspace) {
     debugMenu.workspace = workspace;
     debugMenu.editor = editor;
     debugMenu.mode = defaultMode;
-    debugMenu.contentParser = contentParser;
     debugMenu.outlinePanel = outlinePanel;
     debugMenu.framePanel = framePanel;
     debugMenu.copilotPanel = copilotPanelPanel;
     debugMenu.sidePanel = sidePanel;
     debugMenu.leftSidePanel = leftSidePanel;
     debugMenu.pagesPanel = pagesPanel;
+
+    page.slots.ready.once(() => {
+      console.log('page ready');
+      const contentParser = new ContentParser(editor.host, page);
+      debugMenu.contentParser = contentParser;
+    });
 
     outlinePanel.editor = editor;
     copilotPanelPanel.editor = editor;

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -64,7 +64,6 @@ function subscribePage(workspace: Workspace) {
     debugMenu.pagesPanel = pagesPanel;
 
     page.slots.ready.once(() => {
-      console.log('page ready');
       const contentParser = new ContentParser(editor.host, page);
       debugMenu.contentParser = contentParser;
     });


### PR DESCRIPTION
Before converting contentParser to page service, make sure that the playground can work normally for the time being.

Note: ContentParser and its related usage will be removed later.