### PR TITLE
fix(page): onCut should delete blocks between fromElement and toElement

### DIFF
--- a/packages/blocks/src/page-block/commands/text-crud/delete-text.ts
+++ b/packages/blocks/src/page-block/commands/text-crud/delete-text.ts
@@ -75,7 +75,11 @@ export const deleteTextCommand: Command<
   toText.delete(0, to.length);
 
   selectedElements
-    .filter(el => el.id !== fromElement.id && el.id !== toElement.id)
+    .filter(
+      el =>
+        el.model.id !== fromElement.model.id &&
+        el.model.id !== toElement.model.id
+    )
     .forEach(el => {
       ctx.std.page.deleteBlock(el.model);
     });


### PR DESCRIPTION
Fix text cut: didn't filter out and delete the blocks between fromElement and toElement.
before:

https://github.com/toeverything/blocksuite/assets/99816898/2c9c2ba0-e2f9-4048-87cd-aeacef6aaf4f

after:

https://github.com/toeverything/blocksuite/assets/99816898/f8adcfe8-b1ab-47eb-aa00-d98ebefae200

