### PR TITLE
chore: reduce delay of user input behavior in test

### DIFF
--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -105,8 +105,10 @@ test('can click and copy image', async ({ page }) => {
   await activeEmbed(page);
   await copyByKeyboard(page);
   await pressEnter(page);
+  await waitNextFrame(page);
 
   await pasteByKeyboard(page);
+  await waitNextFrame(page);
   await assertRichImage(page, 2);
 });
 

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -726,6 +726,7 @@ test.describe('toggle list', () => {
 
     await expect(prefixes).toHaveCount(3);
     await parentPrefix.hover();
+    await waitNextFrame(page);
     await assertToggleIconVisible(toggleIcon);
 
     await toggleIcon.click();

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -602,8 +602,9 @@ test.describe('indent correctly when deleting list item', () => {
     await pressBackspace(page);
     await pressBackspace(page);
     await pressBackspace(page);
-    await pressEnter(page);
+    await assertRichTexts(page, ['a', 'b', 'c', '']);
 
+    await pressEnter(page);
     await type(page, '- d');
     await pressEnter(page);
     await pressTab(page);
@@ -617,6 +618,7 @@ test.describe('indent correctly when deleting list item', () => {
     await pressBackspace(page);
     await pressBackspace(page);
 
+    await assertRichTexts(page, ['a', 'b', '', 'd', 'e', 'f']);
     await assertBlockChildrenIds(page, '1', ['3', '9']);
     await assertBlockChildrenIds(page, '3', ['4']);
     await assertBlockChildrenIds(page, '4', ['5']);

--- a/tests/markdown.spec.ts
+++ b/tests/markdown.spec.ts
@@ -33,8 +33,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '[] ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'todo');
   await undoByClick(page);
   await assertText(page, '[] ');
@@ -45,8 +45,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '[ ] ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'todo');
   await undoByClick(page);
   await assertText(page, '[ ] ');
@@ -57,8 +57,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '[x] ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'todo');
   await undoByClick(page);
   await assertText(page, '[x] ');
@@ -67,8 +67,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '* ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'bulleted');
   await undoByClick(page);
   await assertText(page, '* ');
@@ -77,8 +77,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '- ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'bulleted');
   await undoByClick(page);
   await assertText(page, '- ');
@@ -87,8 +87,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '1. ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'numbered');
   await undoByClick(page);
   await assertText(page, '1. ');
@@ -97,8 +97,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '20. ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'numbered');
   await undoByClick(page);
   await assertText(page, '20. ');
@@ -107,8 +107,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '# ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h1');
   await undoByClick(page);
   await assertText(page, '# ');
@@ -117,8 +117,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '## ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h2');
   await undoByClick(page);
   await assertText(page, '## ');
@@ -127,8 +127,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '### ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h3');
   await undoByClick(page);
   await assertText(page, '### ');
@@ -137,8 +137,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '#### ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h4');
   await undoByClick(page);
   await assertText(page, '#### ');
@@ -147,8 +147,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '##### ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h5');
   await undoByClick(page);
   await assertText(page, '##### ');
@@ -157,8 +157,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '###### ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'h6');
   await undoByClick(page);
   await assertText(page, '###### ');
@@ -167,8 +167,8 @@ test('markdown shortcut', async ({ page }) => {
 
   await waitNextFrame(page);
   await type(page, '> ');
-  [id] = await getCursorBlockIdAndHeight(page);
   await waitNextFrame(page);
+  [id] = await getCursorBlockIdAndHeight(page);
   await assertBlockType(page, id, 'quote');
   await undoByClick(page);
   await assertText(page, '> ');

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -307,7 +307,7 @@ test('should slash menu works with fast type', async ({ page }) => {
   await initEmptyParagraphState(page);
   await focusRichText(page);
 
-  await type(page, 'a/text', 10);
+  await type(page, 'a/text', 0);
   const slashMenu = page.locator(`.slash-menu`);
   await expect(slashMenu).toBeVisible();
 });

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -23,7 +23,7 @@ export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
 export const SHIFT_KEY = 'Shift';
 
-export async function type(page: Page, content: string, delay = 5) {
+export async function type(page: Page, content: string, delay = 10) {
   await page.keyboard.type(content, { delay });
 }
 
@@ -77,7 +77,7 @@ export async function pressArrowUp(page: Page, count = 1) {
 export async function pressEnter(page: Page, count = 1) {
   // avoid flaky test by simulate real user input
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Enter', { delay: 10 });
+    await page.keyboard.press('Enter', { delay: 20 });
   }
 }
 
@@ -136,7 +136,7 @@ export async function strikethrough(page: Page) {
 }
 
 export async function copyByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+c`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+c`, { delay: 20 });
 }
 
 export async function cutByKeyboard(page: Page) {
@@ -156,7 +156,7 @@ export async function pasteByKeyboard(page: Page, forceFocus = true) {
     }
   }
 
-  await page.keyboard.press(`${SHORT_KEY}+v`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+v`, { delay: 20 });
 }
 
 export async function createCodeBlock(page: Page) {

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -77,7 +77,7 @@ export async function pressArrowUp(page: Page, count = 1) {
 export async function pressEnter(page: Page, count = 1) {
   // avoid flaky test by simulate real user input
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Enter', { delay: 20 });
+    await page.keyboard.press('Enter', { delay: 30 });
   }
 }
 

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -23,7 +23,7 @@ export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
 export const SHIFT_KEY = 'Shift';
 
-export async function type(page: Page, content: string, delay = 50) {
+export async function type(page: Page, content: string, delay = 10) {
   await page.keyboard.type(content, { delay });
 }
 

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -23,7 +23,7 @@ export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
 export const SHIFT_KEY = 'Shift';
 
-export async function type(page: Page, content: string, delay = 10) {
+export async function type(page: Page, content: string, delay = 5) {
   await page.keyboard.type(content, { delay });
 }
 
@@ -38,51 +38,51 @@ export async function withPressKey(
 }
 
 export async function defaultTool(page: Page) {
-  await page.keyboard.press('v', { delay: 50 });
+  await page.keyboard.press('v', { delay: 10 });
 }
 
 export async function pressBackspace(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Backspace', { delay: 50 });
+    await page.keyboard.press('Backspace', { delay: 10 });
   }
 }
 
 export async function pressSpace(page: Page) {
-  await page.keyboard.press('Space', { delay: 50 });
+  await page.keyboard.press('Space', { delay: 10 });
 }
 
 export async function pressArrowLeft(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowLeft', { delay: 50 });
+    await page.keyboard.press('ArrowLeft', { delay: 10 });
   }
 }
 export async function pressArrowRight(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowRight', { delay: 50 });
+    await page.keyboard.press('ArrowRight', { delay: 10 });
   }
 }
 
 export async function pressArrowDown(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowDown', { delay: 50 });
+    await page.keyboard.press('ArrowDown', { delay: 10 });
   }
 }
 
 export async function pressArrowUp(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowUp', { delay: 50 });
+    await page.keyboard.press('ArrowUp', { delay: 10 });
   }
 }
 
 export async function pressEnter(page: Page, count = 1) {
   // avoid flaky test by simulate real user input
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Enter', { delay: 50 });
+    await page.keyboard.press('Enter', { delay: 10 });
   }
 }
 
 export async function pressEnterWithShortkey(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Enter`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+Enter`, { delay: 10 });
 }
 
 export async function pressEscape(page: Page) {
@@ -95,52 +95,52 @@ export async function undoByKeyboard(page: Page) {
 
 export async function formatType(page: Page) {
   await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+1`, {
-    delay: 50,
+    delay: 10,
   });
 }
 
 export async function redoByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Shift+Z`, { delay: 20 });
+  await page.keyboard.press(`${SHORT_KEY}+Shift+Z`, { delay: 10 });
 }
 
 export async function selectAllByKeyboard(page: Page) {
   await page.keyboard.press(`${SHORT_KEY}+a`, {
-    delay: 50,
+    delay: 10,
   });
 }
 
 export async function pressTab(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Tab', { delay: 50 });
+    await page.keyboard.press('Tab', { delay: 10 });
   }
 }
 
 export async function pressShiftTab(page: Page) {
-  await page.keyboard.press('Shift+Tab', { delay: 50 });
+  await page.keyboard.press('Shift+Tab', { delay: 10 });
 }
 
 export async function pressBackspaceWithShortKey(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 10 });
 }
 
 export async function pressShiftEnter(page: Page) {
-  await page.keyboard.press('Shift+Enter', { delay: 50 });
+  await page.keyboard.press('Shift+Enter', { delay: 10 });
 }
 
 export async function inlineCode(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+e`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+e`, { delay: 10 });
 }
 
 export async function strikethrough(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Shift+s`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+Shift+s`, { delay: 10 });
 }
 
 export async function copyByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+c`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+c`, { delay: 10 });
 }
 
 export async function cutByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+x`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+x`, { delay: 10 });
 }
 
 /**
@@ -156,7 +156,7 @@ export async function pasteByKeyboard(page: Page, forceFocus = true) {
     }
   }
 
-  await page.keyboard.press(`${SHORT_KEY}+v`, { delay: 50 });
+  await page.keyboard.press(`${SHORT_KEY}+v`, { delay: 10 });
 }
 
 export async function createCodeBlock(page: Page) {
@@ -193,7 +193,7 @@ export async function fillLine(page: Page, toNext = false) {
     let nextHeight;
     // type until current block height is changed, means has new line
     do {
-      await page.keyboard.type('a', { delay: 50 });
+      await page.keyboard.type('a', { delay: 10 });
       [, nextHeight] = await getCursorBlockIdAndHeight(page);
     } while (nextHeight === height);
     if (!toNext) {
@@ -204,16 +204,16 @@ export async function fillLine(page: Page, toNext = false) {
 
 export async function pressForwardDelete(page: Page) {
   if (IS_MAC) {
-    await page.keyboard.press('Control+d', { delay: 50 });
+    await page.keyboard.press('Control+d', { delay: 10 });
   } else {
-    await page.keyboard.press('Delete', { delay: 50 });
+    await page.keyboard.press('Delete', { delay: 10 });
   }
 }
 
 export async function pressForwardDeleteWord(page: Page) {
   if (IS_MAC) {
-    await page.keyboard.press('Alt+Delete', { delay: 50 });
+    await page.keyboard.press('Alt+Delete', { delay: 10 });
   } else {
-    await page.keyboard.press('Control+Delete', { delay: 50 });
+    await page.keyboard.press('Control+Delete', { delay: 10 });
   }
 }

--- a/tests/utils/actions/keyboard.ts
+++ b/tests/utils/actions/keyboard.ts
@@ -23,7 +23,7 @@ export const MODIFIER_KEY = IS_MAC ? 'Alt' : 'Shift';
 
 export const SHIFT_KEY = 'Shift';
 
-export async function type(page: Page, content: string, delay = 10) {
+export async function type(page: Page, content: string, delay = 20) {
   await page.keyboard.type(content, { delay });
 }
 
@@ -38,39 +38,39 @@ export async function withPressKey(
 }
 
 export async function defaultTool(page: Page) {
-  await page.keyboard.press('v', { delay: 10 });
+  await page.keyboard.press('v', { delay: 20 });
 }
 
 export async function pressBackspace(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Backspace', { delay: 10 });
+    await page.keyboard.press('Backspace', { delay: 20 });
   }
 }
 
 export async function pressSpace(page: Page) {
-  await page.keyboard.press('Space', { delay: 10 });
+  await page.keyboard.press('Space', { delay: 20 });
 }
 
 export async function pressArrowLeft(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowLeft', { delay: 10 });
+    await page.keyboard.press('ArrowLeft', { delay: 20 });
   }
 }
 export async function pressArrowRight(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowRight', { delay: 10 });
+    await page.keyboard.press('ArrowRight', { delay: 20 });
   }
 }
 
 export async function pressArrowDown(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowDown', { delay: 10 });
+    await page.keyboard.press('ArrowDown', { delay: 20 });
   }
 }
 
 export async function pressArrowUp(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('ArrowUp', { delay: 10 });
+    await page.keyboard.press('ArrowUp', { delay: 20 });
   }
 }
 
@@ -82,7 +82,7 @@ export async function pressEnter(page: Page, count = 1) {
 }
 
 export async function pressEnterWithShortkey(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Enter`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+Enter`, { delay: 20 });
 }
 
 export async function pressEscape(page: Page) {
@@ -95,44 +95,44 @@ export async function undoByKeyboard(page: Page) {
 
 export async function formatType(page: Page) {
   await page.keyboard.press(`${SHORT_KEY}+${MODIFIER_KEY}+1`, {
-    delay: 10,
+    delay: 20,
   });
 }
 
 export async function redoByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Shift+Z`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+Shift+Z`, { delay: 20 });
 }
 
 export async function selectAllByKeyboard(page: Page) {
   await page.keyboard.press(`${SHORT_KEY}+a`, {
-    delay: 10,
+    delay: 20,
   });
 }
 
 export async function pressTab(page: Page, count = 1) {
   for (let i = 0; i < count; i++) {
-    await page.keyboard.press('Tab', { delay: 10 });
+    await page.keyboard.press('Tab', { delay: 20 });
   }
 }
 
 export async function pressShiftTab(page: Page) {
-  await page.keyboard.press('Shift+Tab', { delay: 10 });
+  await page.keyboard.press('Shift+Tab', { delay: 20 });
 }
 
 export async function pressBackspaceWithShortKey(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+Backspace`, { delay: 20 });
 }
 
 export async function pressShiftEnter(page: Page) {
-  await page.keyboard.press('Shift+Enter', { delay: 10 });
+  await page.keyboard.press('Shift+Enter', { delay: 20 });
 }
 
 export async function inlineCode(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+e`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+e`, { delay: 20 });
 }
 
 export async function strikethrough(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+Shift+s`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+Shift+s`, { delay: 20 });
 }
 
 export async function copyByKeyboard(page: Page) {
@@ -140,7 +140,7 @@ export async function copyByKeyboard(page: Page) {
 }
 
 export async function cutByKeyboard(page: Page) {
-  await page.keyboard.press(`${SHORT_KEY}+x`, { delay: 10 });
+  await page.keyboard.press(`${SHORT_KEY}+x`, { delay: 20 });
 }
 
 /**
@@ -193,7 +193,7 @@ export async function fillLine(page: Page, toNext = false) {
     let nextHeight;
     // type until current block height is changed, means has new line
     do {
-      await page.keyboard.type('a', { delay: 10 });
+      await page.keyboard.type('a', { delay: 20 });
       [, nextHeight] = await getCursorBlockIdAndHeight(page);
     } while (nextHeight === height);
     if (!toNext) {
@@ -204,16 +204,16 @@ export async function fillLine(page: Page, toNext = false) {
 
 export async function pressForwardDelete(page: Page) {
   if (IS_MAC) {
-    await page.keyboard.press('Control+d', { delay: 10 });
+    await page.keyboard.press('Control+d', { delay: 20 });
   } else {
-    await page.keyboard.press('Delete', { delay: 10 });
+    await page.keyboard.press('Delete', { delay: 20 });
   }
 }
 
 export async function pressForwardDeleteWord(page: Page) {
   if (IS_MAC) {
-    await page.keyboard.press('Alt+Delete', { delay: 10 });
+    await page.keyboard.press('Alt+Delete', { delay: 20 });
   } else {
-    await page.keyboard.press('Control+Delete', { delay: 10 });
+    await page.keyboard.press('Control+Delete', { delay: 20 });
   }
 }

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -34,7 +34,7 @@ declare global {
 
 export const defaultPlaygroundURL = new URL(`http://localhost:5173/starter/`);
 
-const NEXT_FRAME_TIMEOUT = 100;
+const NEXT_FRAME_TIMEOUT = 50;
 const DEFAULT_PLAYGROUND = defaultPlaygroundURL.toString();
 const RICH_TEXT_SELECTOR = '.inline-editor';
 


### PR DESCRIPTION
It is a reliability test for the `InlineEditor`

This pull request reduces the typing delay in the test from `50` milliseconds to `20` milliseconds.

If set to `10ms`, it may cause random test failures. Most failures occur due to insufficient delay after `pressEnter`.

