### PR TITLE
fix: title & description on generic link card when fetch failed

### DIFF
--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -36,6 +36,9 @@ export class BookmarkBlockComponent extends BlockElement<
   @property({ attribute: false })
   loading = false;
 
+  @property({ attribute: false })
+  loadingFailed = false;
+
   @state()
   showCaption = false;
 

--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -66,23 +66,28 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
   }
 
   override render() {
-    const {
-      icon,
-      title = 'Bookmark',
-      url,
-      description,
-      image,
-      style,
-    } = this.bookmark.model;
+    const { icon, title, url, description, image, style } = this.bookmark.model;
 
     const loading = this.bookmark.loading;
+    const loadingFailed = this.bookmark.loadingFailed;
 
     const cardClassMap = classMap({
       loading,
+      'loading-failed': loadingFailed,
       [style]: true,
     });
 
-    const titleText = loading ? 'Loading...' : title;
+    const domainName = url.match(
+      /^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:/\n]+)/im
+    )?.[1];
+
+    const titleText = loading
+      ? 'Loading...'
+      : !title
+        ? loadingFailed
+          ? domainName ?? 'Link card'
+          : ''
+        : title;
 
     const { LoadingIcon, EmbedCardBannerIcon } = getEmbedCardIcons();
 
@@ -99,7 +104,13 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
           </object>`
         : WebIcon16;
 
-    const descriptionText = loading ? '' : description;
+    const descriptionText = loading
+      ? ''
+      : !description
+        ? loadingFailed
+          ? 'Failed to retrieve link information.'
+          : url
+        : description ?? '';
 
     const bannerImage =
       !loading && image

--- a/packages/blocks/src/bookmark-block/doc-bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/doc-bookmark-block.ts
@@ -48,7 +48,7 @@ export class DocBookmarkBlockComponent extends WithDisposable(
         <embed-card-toolbar
           .model=${this.model}
           .block=${this.block}
-          .host=${this}
+          .host=${this.host}
           .abortController=${abortController}
           .std=${this.block.std}
         ></embed-card-toolbar>

--- a/packages/blocks/src/bookmark-block/styles.ts
+++ b/packages/blocks/src/bookmark-block/styles.ts
@@ -156,6 +156,12 @@ export const styles = css`
     }
   }
 
+  .affine-bookmark-card.loading-failed {
+    .affine-bookmark-content-description {
+      color: var(--affine-placeholder-color);
+    }
+  }
+
   .affine-bookmark-card.list {
     height: ${EMBED_CARD_HEIGHT.list}px;
 


### PR DESCRIPTION
[TOV-383](https://linear.app/affine-design/issue/TOV-383/the-display-of-links-for-which-no-information-was-fetched-does-not)

![image](https://github.com/toeverything/blocksuite/assets/54364088/b0250f05-ad42-45cd-a1be-e52a62d9d742)
