### PR TITLE
fix: treat embed-* blocks without iframe as card view

### DIFF
--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -94,6 +94,12 @@ export class LinkPopup extends WithDisposable(LitElement) {
         this.abortController.abort();
       })
     );
+
+    if (this.type === 'view') {
+      this._embedOptions = this._pageService.getEmbedBlockOptions(
+        this.currentLink
+      );
+    }
   }
 
   protected override firstUpdated() {

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -94,10 +94,6 @@ export class LinkPopup extends WithDisposable(LitElement) {
         this.abortController.abort();
       })
     );
-
-    this._embedOptions = this._pageService.getEmbedBlockOptions(
-      this.currentLink
-    );
   }
 
   protected override firstUpdated() {
@@ -155,6 +151,12 @@ export class LinkPopup extends WithDisposable(LitElement) {
         popupContainer.style.top = `${y}px`;
       })
       .catch(console.error);
+
+    if (this.type === 'view') {
+      this._embedOptions = this._pageService.getEmbedBlockOptions(
+        this.currentLink
+      );
+    }
   }
 
   private get _pageService() {

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -6,7 +6,10 @@ import { computePosition, flip, inline, offset, shift } from '@floating-ui/dom';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
-import type { PageService } from '../../../../../../page-block/page-service.js';
+import type {
+  EmbedOptions,
+  PageService,
+} from '../../../../../../page-block/page-service.js';
 import type { IconButton } from '../../../../../components/button.js';
 import { createLitPortal } from '../../../../../components/portal.js';
 import { toast } from '../../../../../components/toast.js';
@@ -60,6 +63,8 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
   private _moreMenuAbortController: AbortController | null = null;
 
+  private _embedOptions: EmbedOptions | null = null;
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -88,6 +93,10 @@ export class LinkPopup extends WithDisposable(LitElement) {
         if (children.includes(this.blockElement.model)) return;
         this.abortController.abort();
       })
+    );
+
+    this._embedOptions = this._pageService.getEmbedBlockOptions(
+      this.currentLink
     );
   }
 
@@ -181,7 +190,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
     return link;
   }
 
-  private _isBookmarkAllowed() {
+  private get _isBookmarkAllowed() {
     const blockElement = this.blockElement;
     const schema = blockElement.host.page.schema;
     const parent = blockElement.host.page.getParent(blockElement.model);
@@ -198,6 +207,10 @@ export class LinkPopup extends WithDisposable(LitElement) {
     }
 
     return true;
+  }
+
+  private get _canConvertToEmbedView() {
+    return this._embedOptions?.viewType === 'embed';
   }
 
   private _onConfirm() {
@@ -241,7 +254,15 @@ export class LinkPopup extends WithDisposable(LitElement) {
   }
 
   private _convertToCardView() {
-    if (!this.inlineEditor.isValidInlineRange(this.targetInlineRange)) return;
+    if (!this.inlineEditor.isValidInlineRange(this.targetInlineRange)) {
+      return;
+    }
+
+    let targetFlavour = 'affine:bookmark';
+
+    if (this._embedOptions && this._embedOptions.viewType === 'card') {
+      targetFlavour = this._embedOptions.flavour;
+    }
 
     const blockElement = this.blockElement;
     const url = this.currentLink;
@@ -254,7 +275,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
     const parent = page.getParent(blockElement.model);
     assertExists(parent);
     const index = parent.children.indexOf(blockElement.model);
-    page.addBlock('affine:bookmark', props, parent, index + 1);
+    page.addBlock(targetFlavour, props, parent, index + 1);
 
     const totalTextLength = this.inlineEditor.yTextLength;
     const inlineTextLength = this.targetInlineRange.length;
@@ -267,17 +288,13 @@ export class LinkPopup extends WithDisposable(LitElement) {
     this.abortController.abort();
   }
 
-  private _canConvertToEmbedView() {
-    const url = this.currentLink;
-    return !!this._pageService.getEmbedBlockOptions(url);
-  }
-
   private _convertToEmbedView() {
-    const url = this.currentLink;
-    const embedOptions = this._pageService.getEmbedBlockOptions(url);
-    if (!embedOptions) return;
+    if (!this._embedOptions || this._embedOptions.viewType !== 'embed') {
+      return;
+    }
 
-    const { flavour } = embedOptions;
+    const { flavour } = this._embedOptions;
+    const url = this.currentLink;
 
     const blockElement = this.blockElement;
     const page = blockElement.host.page;
@@ -292,7 +309,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
     if (totalTextLength === inlineTextLength) {
       page.deleteBlock(blockElement.model);
     } else {
-      this.inlineEditor.deleteText(this.targetInlineRange);
+      this.inlineEditor.formatText(this.targetInlineRange, { link: null });
     }
 
     this.abortController.abort();
@@ -406,7 +423,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
         <span class="affine-link-popover-dividing-line"></span>
 
-        ${this._isBookmarkAllowed()
+        ${this._isBookmarkAllowed
           ? html`
               <div class="affine-link-popover-view-selector">
                 <icon-button
@@ -429,7 +446,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
                   <affine-tooltip .offset=${12}>${'Card view'}</affine-tooltip>
                 </icon-button>
 
-                ${this._canConvertToEmbedView()
+                ${this._canConvertToEmbedView
                   ? html` <icon-button
                       size="24px"
                       class="affine-link-popover-view-selector-button embed"

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -9,8 +9,8 @@ import { customElement, property, query } from 'lit/decorators.js';
 import type { PageBlockComponent } from '../../../../../page-block/types.js';
 import { createLitPortal } from '../../../../components/portal.js';
 import { BLOCK_ID_ATTR } from '../../../../consts.js';
-import { MoreVerticalIcon } from '../../../../icons/index.js';
-import { EmbedWebIcon, LinkIcon, OpenIcon } from '../../../../icons/text.js';
+import { BookmarkIcon, MoreVerticalIcon } from '../../../../icons/index.js';
+import { LinkIcon, OpenIcon } from '../../../../icons/text.js';
 import type { AffineInlineEditor } from '../../affine-inline-specs.js';
 import { ReferencePopupMoreMenu } from './reference-popup-more-menu-popup.js';
 import { styles } from './styles.js';
@@ -118,7 +118,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     pageElement.slots.pageLinkClicked.emit({ pageId: refPageId });
   }
 
-  private _convertToEmbedView() {
+  private _convertToCardView() {
     const blockElement = this.blockElement;
     const page = blockElement.host.page;
     const parent = page.getParent(blockElement.model);
@@ -192,9 +192,9 @@ export class ReferencePopup extends WithDisposable(LitElement) {
                 size="24px"
                 class="affine-reference-popover-view-selector-button embed"
                 hover="false"
-                @click=${() => this._convertToEmbedView()}
+                @click=${() => this._convertToCardView()}
               >
-                ${EmbedWebIcon}
+                ${BookmarkIcon}
                 <affine-tooltip .offset=${12}>${'Embed view'}</affine-tooltip>
               </icon-button>
             </div>

--- a/packages/blocks/src/embed-github-block/embed-github-service.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-service.ts
@@ -29,6 +29,7 @@ export class EmbedGithubService extends BlockService<EmbedGithubModel> {
       flavour: this.flavour,
       urlRegex: githubUrlRegex,
       styles: EmbedGithubStyles,
+      viewType: 'card',
     });
   }
 }

--- a/packages/blocks/src/embed-github-block/styles.ts
+++ b/packages/blocks/src/embed-github-block/styles.ts
@@ -310,6 +310,7 @@ export const styles = css`
 
     .affine-embed-github-content-assignees-text-users.user {
       color: var(--affine-link-color);
+      cursor: pointer;
     }
 
     .affine-embed-github-content-assignees-text-users.placeholder {

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -294,7 +294,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
     pageElement.slots.pageLinkClicked.emit({ pageId: linkedDocId });
   };
 
-  covertToinline = () => {
+  covertToInline = () => {
     const { page, pageId } = this.model;
     const parent = page.getParent(this.model);
     const index = parent?.children.indexOf(this.model);

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
@@ -25,6 +25,7 @@ export class EmbedYoutubeService extends BlockService<EmbedYoutubeModel> {
       flavour: this.flavour,
       urlRegex: youtubeUrlRegex,
       styles: EmbedYoutubeStyles,
+      viewType: 'embed',
     });
   }
 }

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -33,10 +33,11 @@ import { FontLoader } from './font-loader/font-loader.js';
 import type { PageBlockModel } from './page-model.js';
 import type { PageBlockComponent } from './types.js';
 
-type EmbedOptions = {
+export type EmbedOptions = {
   flavour: string;
   urlRegex: RegExp;
   styles: EmbedCardStyle[];
+  viewType: 'card' | 'embed';
 };
 
 export class PageService extends BlockService<PageBlockModel> {


### PR DESCRIPTION
[TOV-380](https://linear.app/affine-design/issue/TOV-380/github-links-should-not-have-an-embed-view)