### PR TITLE
feat: support config `reference-node` externally

### DIFF
--- a/packages/blocks/src/_common/inline/presets/affine-inline-specs.ts
+++ b/packages/blocks/src/_common/inline/presets/affine-inline-specs.ts
@@ -5,6 +5,7 @@ import { html } from 'lit';
 import { z } from 'zod';
 
 import type { InlineSpecs } from '../inline-manager.js';
+import type { ReferenceNodeConfig } from './nodes/reference-node/reference-config.js';
 
 export type AffineInlineEditor = InlineEditor<AffineTextAttributes>;
 export type AffineInlineRootElement = InlineRootElement<AffineTextAttributes>;
@@ -24,110 +25,120 @@ export interface AffineTextAttributes {
   color?: string | null;
 }
 
-export const affineInlineSpecs: InlineSpecs<AffineTextAttributes>[] = [
-  {
-    name: 'bold',
-    schema: z.literal(true).optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.bold;
+export const affineInlineSpecsWithoutReference: InlineSpecs<AffineTextAttributes>[] =
+  [
+    {
+      name: 'bold',
+      schema: z.literal(true).optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.bold;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
+    {
+      name: 'italic',
+      schema: z.literal(true).optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.italic;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-  },
-  {
-    name: 'italic',
-    schema: z.literal(true).optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.italic;
+    {
+      name: 'underline',
+      schema: z.literal(true).optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.underline;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
+    {
+      name: 'strike',
+      schema: z.literal(true).optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.strike;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-  },
-  {
-    name: 'underline',
-    schema: z.literal(true).optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.underline;
+    {
+      name: 'code',
+      schema: z.literal(true).optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.code;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
+    {
+      name: 'link',
+      schema: z.string().optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.link;
+      },
+      renderer: delta => {
+        return html`<affine-link .delta=${delta}></affine-link>`;
+      },
     },
-  },
-  {
-    name: 'strike',
-    schema: z.literal(true).optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.strike;
+    {
+      name: 'background',
+      schema: z.string().optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.background;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
+    {
+      name: 'color',
+      schema: z.string().optional().nullable().catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.color;
+      },
+      renderer: delta => {
+        return html`<affine-text .delta=${delta}></affine-text>`;
+      },
     },
-  },
-  {
-    name: 'code',
-    schema: z.literal(true).optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.code;
+  ];
+
+export function getAffineInlineSpecsWithReference(
+  referenceNodeConfig: ReferenceNodeConfig
+): InlineSpecs<AffineTextAttributes>[] {
+  return [
+    ...affineInlineSpecsWithoutReference,
+    {
+      name: 'reference',
+      schema: z
+        .object({
+          type: z.enum([
+            // @deprecated Subpage is deprecated, use LinkedPage instead
+            'Subpage',
+            'LinkedPage',
+          ]),
+          pageId: z.string(),
+        })
+        .optional()
+        .nullable()
+        .catch(undefined),
+      match: delta => {
+        return !!delta.attributes?.reference;
+      },
+      renderer: (delta, selected) => {
+        return html`<affine-reference
+          .delta=${delta}
+          .selected=${selected}
+          .config=${referenceNodeConfig}
+        ></affine-reference>`;
+      },
+      embed: true,
     },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
-    },
-  },
-  {
-    name: 'link',
-    schema: z.string().optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.link;
-    },
-    renderer: delta => {
-      return html`<affine-link .delta=${delta}></affine-link>`;
-    },
-  },
-  {
-    name: 'reference',
-    schema: z
-      .object({
-        type: z.enum([
-          // @deprecated Subpage is deprecated, use LinkedPage instead
-          'Subpage',
-          'LinkedPage',
-        ]),
-        pageId: z.string(),
-      })
-      .optional()
-      .nullable()
-      .catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.reference;
-    },
-    renderer: (delta, selected) => {
-      return html`<affine-reference
-        .delta=${delta}
-        .selected=${selected}
-      ></affine-reference>`;
-    },
-    embed: true,
-  },
-  {
-    name: 'background',
-    schema: z.string().optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.background;
-    },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
-    },
-  },
-  {
-    name: 'color',
-    schema: z.string().optional().nullable().catch(undefined),
-    match: delta => {
-      return !!delta.attributes?.color;
-    },
-    renderer: delta => {
-      return html`<affine-text .delta=${delta}></affine-text>`;
-    },
-  },
-];
+  ];
+}

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
@@ -1,10 +1,15 @@
 import type { Page } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
+import type { AffineReference } from './reference-node.js';
+
 export class ReferenceNodeConfig {
-  private _customIcon: TemplateResult | null = null;
-  private _customTitle: string | null = null;
-  private _customContent: TemplateResult | null = null;
+  private _customIcon: ((reference: AffineReference) => TemplateResult) | null =
+    null;
+  private _customTitle: ((reference: AffineReference) => string) | null = null;
+  private _customContent:
+    | ((reference: AffineReference) => TemplateResult)
+    | null = null;
   private _page: Page | null = null;
 
   get customIcon() {
@@ -23,15 +28,15 @@ export class ReferenceNodeConfig {
     return this._customContent;
   }
 
-  setCustomContent(content: TemplateResult | null) {
+  setCustomContent(content: ReferenceNodeConfig['_customContent']) {
     this._customContent = content;
   }
 
-  setCustomIcon(icon: TemplateResult | null) {
+  setCustomIcon(icon: ReferenceNodeConfig['_customIcon']) {
     this._customIcon = icon;
   }
 
-  setCustomTitle(title: string | null) {
+  setCustomTitle(title: ReferenceNodeConfig['_customTitle']) {
     this._customTitle = title;
   }
 

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
@@ -4,6 +4,7 @@ import type { TemplateResult } from 'lit';
 export class ReferenceNodeConfig {
   private _customIcon: TemplateResult | null = null;
   private _customTitle: string | null = null;
+  private _customContent: TemplateResult | null = null;
   private _page: Page | null = null;
 
   get customIcon() {
@@ -16,6 +17,14 @@ export class ReferenceNodeConfig {
 
   get page() {
     return this._page;
+  }
+
+  get customContent() {
+    return this._customContent;
+  }
+
+  setCustomContent(content: TemplateResult | null) {
+    this._customContent = content;
   }
 
   setCustomIcon(icon: TemplateResult | null) {

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-config.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@blocksuite/store';
+import type { TemplateResult } from 'lit';
+
+export class ReferenceNodeConfig {
+  private _customIcon: TemplateResult | null = null;
+  private _customTitle: string | null = null;
+  private _page: Page | null = null;
+
+  get customIcon() {
+    return this._customIcon;
+  }
+
+  get customTitle() {
+    return this._customTitle;
+  }
+
+  get page() {
+    return this._page;
+  }
+
+  setCustomIcon(icon: TemplateResult | null) {
+    this._customIcon = icon;
+  }
+
+  setCustomTitle(title: string | null) {
+    this._customTitle = title;
+  }
+
+  setPage(page: Page | null) {
+    this._page = page;
+  }
+}

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -115,6 +115,10 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     return this.config.customTitle;
   }
 
+  get customContent() {
+    return this.config.customContent;
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -215,6 +219,12 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
         : {}
     );
 
+    const content =
+      this.customContent ??
+      html`${icon}<span data-title=${title} class="affine-reference-title"
+          >${title}</span
+        >`;
+
     // we need to add `<v-text .str=${ZERO_WIDTH_NON_JOINER}></v-text>` in an
     // embed element to make sure inline range calculation is correct
     return html`<span
@@ -223,9 +233,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
       class="affine-reference"
       style=${style}
       @click=${this._onClick}
-      >${icon}<span data-title=${title} class="affine-reference-title"
-        >${title}</span
-      ><v-text .str=${ZERO_WIDTH_NON_JOINER}></v-text
+      >${content}<v-text .str=${ZERO_WIDTH_NON_JOINER}></v-text
     ></span>`;
   }
 }

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -197,16 +197,18 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     const type = attributes.reference?.type;
     assertExists(type, 'Unable to get reference type!');
 
-    const title =
-      this.customTitle ??
-      (isDeleted
+    const title = this.customTitle
+      ? this.customTitle(this)
+      : isDeleted
         ? 'Deleted page'
         : refMeta.title.length > 0
           ? refMeta.title
-          : DEFAULT_PAGE_NAME);
-    const icon =
-      this.customIcon ??
-      (type === 'LinkedPage' ? FontLinkedPageIcon : FontPageIcon);
+          : DEFAULT_PAGE_NAME;
+    const icon = this.customIcon
+      ? this.customIcon(this)
+      : type === 'LinkedPage'
+        ? FontLinkedPageIcon
+        : FontPageIcon;
 
     const style = affineTextStyles(
       attributes,
@@ -219,11 +221,11 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
         : {}
     );
 
-    const content =
-      this.customContent ??
-      html`${icon}<span data-title=${title} class="affine-reference-title"
-          >${title}</span
-        >`;
+    const content = this.customContent
+      ? this.customContent(this)
+      : html`${icon}<span data-title=${title} class="affine-reference-title"
+            >${title}</span
+          >`;
 
     // we need to add `<v-text .str=${ZERO_WIDTH_NON_JOINER}></v-text>` in an
     // embed element to make sure inline range calculation is correct

--- a/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
@@ -1,19 +1,17 @@
 import { assertExists } from '@blocksuite/global/utils';
 import type { Y } from '@blocksuite/store';
 import { Text, Workspace } from '@blocksuite/store';
-import { css } from 'lit';
+import { css, nothing } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import { createIcon } from '../../../../_common/components/icon/uni-icon.js';
 import type { RichText } from '../../../../_common/components/rich-text/rich-text.js';
-import { InlineManager } from '../../../../_common/inline/inline-manager.js';
 import {
   type AffineInlineEditor,
-  affineInlineSpecs,
   type AffineTextAttributes,
 } from '../../../../_common/inline/presets/affine-inline-specs.js';
-import { affineInlineMarkdownMatches } from '../../../../_common/inline/presets/markdown.js';
+import type { DatabaseBlockComponent } from '../../../database-block.js';
 import { BaseCellRenderer } from '../base-cell.js';
 import { columnRenderer, createFromBaseCellRenderer } from '../renderer.js';
 import { richTextColumnTypeName, richTextPureColumnConfig } from './define.js';
@@ -103,7 +101,15 @@ export class RichTextCell extends BaseCellRenderer<Y.Text> {
     }
   `;
 
-  readonly inlineManager = new InlineManager();
+  get service() {
+    const database = this.closest<DatabaseBlockComponent>('affine-database');
+    return database?.service;
+  }
+
+  get inlineManager() {
+    assertExists(this.service);
+    return this.service.inlineManager;
+  }
   get attributesSchema() {
     return this.inlineManager.getSchema();
   }
@@ -124,9 +130,6 @@ export class RichTextCell extends BaseCellRenderer<Y.Text> {
   override connectedCallback() {
     super.connectedCallback();
 
-    this.inlineManager.registerSpecs(affineInlineSpecs);
-    this.inlineManager.registerMarkdownMatches(affineInlineMarkdownMatches);
-
     if (!this.value || typeof this.value === 'string') {
       this._initYText(this.value);
     }
@@ -138,6 +141,8 @@ export class RichTextCell extends BaseCellRenderer<Y.Text> {
   };
 
   override render() {
+    if (!this.service) return nothing;
+
     return html`<rich-text
       .yText=${this.value}
       .attributesSchema=${this.attributesSchema}
@@ -181,7 +186,15 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
     }
   `;
 
-  readonly inlineManager = new InlineManager();
+  get service() {
+    const database = this.closest<DatabaseBlockComponent>('affine-database');
+    return database?.service;
+  }
+
+  get inlineManager() {
+    assertExists(this.service);
+    return this.service.inlineManager;
+  }
   get attributesSchema() {
     return this.inlineManager.getSchema();
   }
@@ -201,9 +214,6 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
 
   override connectedCallback() {
     super.connectedCallback();
-
-    this.inlineManager.registerSpecs(affineInlineSpecs);
-    this.inlineManager.registerMarkdownMatches(affineInlineMarkdownMatches);
 
     if (!this.value || typeof this.value === 'string') {
       this._initYText(this.value);
@@ -313,6 +323,8 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
   };
 
   override render() {
+    if (!this.service) return nothing;
+
     return html`<rich-text
       .yText=${this.value}
       .attributesSchema=${this.attributesSchema}

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -44,10 +44,14 @@ import type { SingleViewSource, ViewSource } from './common/view-source.js';
 import type { DataViewNative, DataViewNativeConfig } from './data-view.js';
 import type { DatabaseBlockModel } from './database-model.js';
 import { DatabaseBlockSchema } from './database-model.js';
+import type { DatabaseService } from './database-service.js';
 import type { InsertToPosition } from './types.js';
 
 @customElement('affine-database')
-export class DatabaseBlockComponent extends BlockElement<DatabaseBlockModel> {
+export class DatabaseBlockComponent extends BlockElement<
+  DatabaseBlockModel,
+  DatabaseService
+> {
   static override styles = css`
     ${unsafeCSS(dataViewCommonStyle('affine-database'))}
     affine-database {

--- a/packages/blocks/src/database-block/database-service.ts
+++ b/packages/blocks/src/database-block/database-service.ts
@@ -2,16 +2,36 @@ import { BlockService } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import type { BlockModel, Page } from '@blocksuite/store';
 
+import { InlineManager } from '../_common/inline/inline-manager.js';
+import {
+  type AffineTextAttributes,
+  getAffineInlineSpecsWithReference,
+} from '../_common/inline/presets/affine-inline-specs.js';
+import { affineInlineMarkdownMatches } from '../_common/inline/presets/markdown.js';
+import { ReferenceNodeConfig } from '../_common/inline/presets/nodes/reference-node/reference-config.js';
 import type { DataViewTypes } from './common/data-view.js';
 import { DatabaseSelection } from './common/selection.js';
 import type { DatabaseBlockModel } from './database-model.js';
 
-export class DatabaseService extends BlockService<DatabaseBlockModel> {
+export class DatabaseService<
+  TextAttributes extends AffineTextAttributes = AffineTextAttributes,
+> extends BlockService<DatabaseBlockModel> {
+  readonly inlineManager = new InlineManager<TextAttributes>();
+  readonly referenceNodeConfig = new ReferenceNodeConfig();
+
   override mounted(): void {
     super.mounted();
     this.selectionManager.register(DatabaseSelection);
 
     this.handleEvent('selectionChange', () => true);
+
+    this.referenceNodeConfig.setPage(this.page);
+
+    const inlineSpecs = getAffineInlineSpecsWithReference(
+      this.referenceNodeConfig
+    );
+    this.inlineManager.registerSpecs(inlineSpecs);
+    this.inlineManager.registerMarkdownMatches(affineInlineMarkdownMatches);
   }
 
   initDatabaseBlock(

--- a/packages/blocks/src/list-block/list-service.ts
+++ b/packages/blocks/src/list-block/list-service.ts
@@ -2,24 +2,28 @@ import { BlockService } from '@blocksuite/block-std';
 
 import { InlineManager } from '../_common/inline/inline-manager.js';
 import {
-  affineInlineSpecs,
   type AffineTextAttributes,
+  getAffineInlineSpecsWithReference,
 } from '../_common/inline/presets/affine-inline-specs.js';
 import { affineInlineMarkdownMatches } from '../_common/inline/presets/markdown.js';
+import { ReferenceNodeConfig } from '../_common/inline/presets/nodes/reference-node/reference-config.js';
 import type { ListBlockModel } from './list-model.js';
 
 export class ListService<
   TextAttributes extends AffineTextAttributes = AffineTextAttributes,
 > extends BlockService<ListBlockModel> {
   readonly inlineManager = new InlineManager<TextAttributes>();
+  readonly referenceNodeConfig = new ReferenceNodeConfig();
 
   override mounted(): void {
     super.mounted();
-    (
-      this.inlineManager as unknown as InlineManager<AffineTextAttributes>
-    ).registerSpecs(affineInlineSpecs);
-    (
-      this.inlineManager as unknown as InlineManager<AffineTextAttributes>
-    ).registerMarkdownMatches(affineInlineMarkdownMatches);
+
+    this.referenceNodeConfig.setPage(this.page);
+
+    const inlineSpecs = getAffineInlineSpecsWithReference(
+      this.referenceNodeConfig
+    );
+    this.inlineManager.registerSpecs(inlineSpecs);
+    this.inlineManager.registerMarkdownMatches(affineInlineMarkdownMatches);
   }
 }

--- a/packages/blocks/src/paragraph-block/paragraph-service.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-service.ts
@@ -2,20 +2,28 @@ import { BlockService } from '@blocksuite/block-std';
 
 import { InlineManager } from '../_common/inline/inline-manager.js';
 import {
-  affineInlineSpecs,
   type AffineTextAttributes,
+  getAffineInlineSpecsWithReference,
 } from '../_common/inline/presets/affine-inline-specs.js';
 import { affineInlineMarkdownMatches } from '../_common/inline/presets/markdown.js';
+import { ReferenceNodeConfig } from '../_common/inline/presets/nodes/reference-node/reference-config.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 
 export class ParagraphService<
   TextAttributes extends AffineTextAttributes = AffineTextAttributes,
 > extends BlockService<ParagraphBlockModel> {
   readonly inlineManager = new InlineManager<TextAttributes>();
+  readonly referenceNodeConfig = new ReferenceNodeConfig();
 
   override mounted(): void {
     super.mounted();
-    this.inlineManager.registerSpecs(affineInlineSpecs);
+
+    this.referenceNodeConfig.setPage(this.page);
+
+    const inlineSpecs = getAffineInlineSpecsWithReference(
+      this.referenceNodeConfig
+    );
+    this.inlineManager.registerSpecs(inlineSpecs);
     this.inlineManager.registerMarkdownMatches(affineInlineMarkdownMatches);
   }
 }


### PR DESCRIPTION
In some situations, we need to pass certain configurations from the outside to the `reference-node`. This PR enables us to convey these configurations through the service.

```ts
// support affine:paragraph, affine:list and affine:database now
const service = block.service;
const referenceNodeConfig = service.referenceNodeConfig;
// setup `Page`
this.referenceNodeConfig.setPage(page);
// config custom icon and title
this.referenceNodeConfig.setCustomIcon(customIcon);
this.referenceNodeConfig.setCustomTitle(customTitle);
// fully customized content (interactions of click and hover will still be retained)
this.referenceNodeConfig.setCustomContent(customContent);
```