### PR TITLE
feat(page): create linked doc from block selection

### DIFF
--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -146,12 +146,25 @@ export const quickActionConfig: QuickActionConfig[] = [
             'before'
           )[0];
 
+          let title = '';
+
           selectedModels.forEach(model => {
             const keys = model.keys as (keyof typeof model)[];
             const values = keys.map(key => model[key]);
             const blockProps = Object.fromEntries(
               keys.map((key, i) => [key, values[i]])
             );
+
+            if (!title && matchFlavours(model, ['affine:paragraph'])) {
+              const type = model.type;
+              if (type.match(/^h[1-6]$/)) {
+                title = model.text.toString();
+                newPage.workspace.setPageMeta(newPage.id, {
+                  title,
+                });
+              }
+            }
+
             newPage.addBlock(model.flavour, blockProps, noteId);
             page.deleteBlock(model);
           });

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -120,12 +120,13 @@ export const quickActionConfig: QuickActionConfig[] = [
       ).selectedModels;
       assertExists(selectedModels);
 
+      host.selection.clear();
+
       const firstBlock = selectedModels[0];
       assertExists(firstBlock);
 
       const page = host.page;
       const newPage = page.workspace.createPage({});
-
       newPage
         .load(() => {
           const pageBlockId = newPage.addBlock('affine:page', {
@@ -134,6 +135,17 @@ export const quickActionConfig: QuickActionConfig[] = [
           newPage.addBlock('affine:surface', {}, pageBlockId);
           const noteId = newPage.addBlock('affine:note', {}, pageBlockId);
 
+          page.addSiblingBlocks(
+            firstBlock,
+            [
+              {
+                flavour: 'affine:embed-linked-doc',
+                pageId: newPage.id,
+              },
+            ],
+            'before'
+          )[0];
+
           selectedModels.forEach(model => {
             const keys = model.keys as (keyof typeof model)[];
             const values = keys.map(key => model[key]);
@@ -141,26 +153,10 @@ export const quickActionConfig: QuickActionConfig[] = [
               keys.map((key, i) => [key, values[i]])
             );
             newPage.addBlock(model.flavour, blockProps, noteId);
+            page.deleteBlock(model);
           });
         })
         .catch(console.error);
-
-      page.addSiblingBlocks(
-        firstBlock,
-        [
-          {
-            flavour: 'affine:embed-linked-doc',
-            pageId: newPage.id,
-          },
-        ],
-        'before'
-      )[0];
-
-      selectedModels.forEach(model => {
-        page.deleteBlock(model);
-      });
-
-      host.selection.clear();
     },
   },
 ];

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -95,7 +95,7 @@ export const quickActionConfig: QuickActionConfig[] = [
     id: 'convert-to-linked-doc',
     name: 'Create Linked Doc',
     icon: FontLinkedPageIcon,
-    hotkey: `Mod-g`,
+    hotkey: `Mod-Shift-l`,
     showWhen: host => {
       const selectedModels = host.command.getChainCtx(
         getChainWithHost(host.std).getSelectedModels({

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -100,12 +100,13 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
     const onLoad = () => {
       if (linkedDoc.root) {
         displayLinkedPageInfo();
+        this._loading = false;
       } else {
         linkedDoc.slots.rootAdded.once(() => {
           displayLinkedPageInfo();
+          this._loading = false;
         });
       }
-      this._loading = false;
     };
 
     this._loading = true;

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-service.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-service.ts
@@ -1,6 +1,11 @@
 import { BlockService } from '@blocksuite/block-std';
+import { Slot } from '@blocksuite/store';
 
 export class EmbedLinkedDocService extends BlockService {
+  slots = {
+    linkedDocCreated: new Slot<{ pageId: string }>(),
+  };
+
   private _getPageMode: (pageId: string) => 'page' | 'edgeless' = pageId =>
     pageId.endsWith('edgeless') ? 'edgeless' : 'page';
 

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -90,7 +90,7 @@ test('should format quick bar show when clicking drag handle', async ({
   if (!box) {
     throw new Error("formatBar doesn't exist");
   }
-  assertAlmostEqual(box.x, 264.5, 5);
+  assertAlmostEqual(box.x, 248.5, 5);
   assertAlmostEqual(box.y - dragHandleRect.y, -55.5, 5);
 });
 
@@ -979,7 +979,7 @@ test('should format quick bar work in single block selection', async ({
   const selectionRect = await blockSelections.boundingBox();
   assertExists(formatRect);
   assertExists(selectionRect);
-  assertAlmostEqual(formatRect.x - selectionRect.x, 160.5, 10);
+  assertAlmostEqual(formatRect.x - selectionRect.x, 144.5, 10);
   assertAlmostEqual(formatRect.y - selectionRect.y, 33, 10);
 
   const boldBtn = formatBar.getByTestId('bold');
@@ -1069,7 +1069,7 @@ test('should format quick bar work in multiple block selection', async ({
   }
   const rect = await blockSelections.first().boundingBox();
   assertExists(rect);
-  assertAlmostEqual(box.x - rect.x, 160.5, 10);
+  assertAlmostEqual(box.x - rect.x, 144.5, 10);
   assertAlmostEqual(box.y - rect.y, 99, 10);
 
   await formatBarController.boldBtn.click();
@@ -1267,7 +1267,7 @@ test('should format quick bar show after convert to code block', async ({
     { x: 0, y: 0 }
   );
   await expect(formatBarController.formatBar).toBeVisible();
-  await formatBarController.assertBoundingBox(264.5, 343);
+  await formatBarController.assertBoundingBox(248.5, 343);
 
   await formatBarController.openParagraphMenu();
   await formatBarController.codeBlockBtn.click();

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -26,6 +26,7 @@ import {
   redoByKeyboard,
   resetHistory,
   setInlineRangeInSelectedRichText,
+  SHIFT_KEY,
   SHORT_KEY,
   strikethrough,
   type,
@@ -1313,7 +1314,9 @@ test('enter in title should move cursor in new paragraph block', async ({
   await assertRichTexts(page, ['world', '']);
 });
 
-test('should support ctrl/cmd+g convert to database', async ({ page }) => {
+test('should support ctrl/cmd+shift+g convert to linked doc', async ({
+  page,
+}) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await initThreeParagraphs(page);
@@ -1327,13 +1330,18 @@ test('should support ctrl/cmd+g convert to database', async ({ page }) => {
   );
 
   await waitNextFrame(page);
-  await page.keyboard.press(`${SHORT_KEY}+g`);
-  const tableView = page.locator('.modal-view-item.table');
-  await tableView.click();
-  const database = page.locator('affine-database');
-  await expect(database).toBeVisible();
-  const rows = page.locator('.affine-database-block-row');
-  expect(await rows.count()).toBe(3);
+  await page.keyboard.press(`${SHORT_KEY}+${SHIFT_KEY}+l`);
+
+  const linkedDocCard = page.locator('affine-embed-linked-doc-block');
+  await expect(linkedDocCard).toBeVisible();
+
+  const title = page.locator('.affine-embed-linked-doc-content-title-text');
+  expect(await title.innerText()).toBe('Untitled');
+
+  const description = page.locator(
+    '.affine-embed-linked-doc-content-description'
+  );
+  expect(await description.innerText()).toBe('123');
 });
 
 test('should forwardDelete works when delete single character', async ({


### PR DESCRIPTION
Changes:
- Implemented logic for creating new linked page with block selections in doc editor
- Format-bar widget will show an icon to create linked page, when only blocks are selected.
- Linked page can be created using toolbar or shortcut (mod+shift+L).
- If the first selection is a heading(h1-h6), it will be used as the linked-page title.
- `embedLinkedDocService.slots.linkedDocCreated` will emit pageId on linked page creation, toast to be implemented in affine.