### PR TITLE
fix: input overflow menu (#6001)

### DIFF
--- a/packages/blocks/src/_common/components/menu/menu.ts
+++ b/packages/blocks/src/_common/components/menu/menu.ts
@@ -132,6 +132,10 @@ export class MenuComponent<_T> extends WithDisposable(ShadowlessElement) {
       z-index: 999;
     }
 
+    affine-menu * {
+      box-sizing: border-box;
+    }
+
     .affine-menu-body {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
#6001 Drag handle wrong position due to webkit2gtk bug.