### PR TITLE
fix(edgeless): enable double click on cards in surface

### DIFF
--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -71,10 +71,8 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
   }
 
   private _handleDoubleClick(event: MouseEvent) {
-    if (!this.bookmark.isInSurface) {
-      event.stopPropagation();
-      this._openLink();
-    }
+    event.stopPropagation();
+    this._openLink();
   }
 
   override render() {

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -69,6 +69,11 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
     }
   }
 
+  private _handleDoubleClick(event: MouseEvent) {
+    event.stopPropagation();
+    this.open();
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -169,6 +174,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
               selected: this._isSelected,
             })}
             @click=${this._handleClick}
+            @dblclick=${this._handleDoubleClick}
           >
             <div class="affine-embed-figma">
               <div class="affine-embed-figma-iframe-container">

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -78,10 +78,8 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
   }
 
   private _handleDoubleClick(event: MouseEvent) {
-    if (!this.isInSurface) {
-      event.stopPropagation();
-      this.open();
-    }
+    event.stopPropagation();
+    this.open();
   }
 
   private _handleAssigneeClick(assignee: string) {

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -342,7 +342,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
   }
 
   private _handleDoubleClick(event: MouseEvent) {
-    if (this.isInSurface) return;
     event.stopPropagation();
     this.open();
   }

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -79,6 +79,11 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
     }
   }
 
+  private _handleDoubleClick(event: MouseEvent) {
+    event.stopPropagation();
+    this.open();
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -214,6 +219,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
               selected: this._isSelected,
             })}
             @click=${this._handleClick}
+            @dblclick=${this._handleDoubleClick}
           >
             <div class="affine-embed-youtube-video">
               ${videoId


### PR DESCRIPTION
[AFF-540](https://linear.app/affine-design/issue/AFF-540/double-clicking-on-the-linked-doc-does-not-open-the-corresponding-doc)