### PR TITLE
feat(page): support for parsing bookmarks as links in Markdown

### DIFF
--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -580,6 +580,39 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
           context.skipAllChildren();
           break;
         }
+        case 'affine:bookmark': {
+          // Parse bookmark as link
+          if (
+            typeof o.node.props.title !== 'string' ||
+            typeof o.node.props.url !== 'string'
+          ) {
+            break;
+          }
+          context
+            .openNode(
+              {
+                type: 'paragraph',
+                children: [],
+              },
+              'children'
+            )
+            .openNode(
+              {
+                type: 'link',
+                url: o.node.props.url,
+                children: [
+                  {
+                    type: 'text',
+                    value: o.node.props.title,
+                  },
+                ],
+              },
+              'children'
+            )
+            .closeNode()
+            .closeNode();
+          break;
+        }
       }
     });
     walker.setLeave(async (o, context) => {

--- a/packages/store/src/adapter/context.ts
+++ b/packages/store/src/adapter/context.ts
@@ -9,13 +9,13 @@ export class ASTWalkerContext<TNode extends object> {
 
   private _globalContext: Record<string, unknown> = Object.create(null);
 
-  private _defautltProp: Keyof<TNode> = 'children' as unknown as Keyof<TNode>;
+  private _defaultProp: Keyof<TNode> = 'children' as unknown as Keyof<TNode>;
 
   _skip = false;
   _skipChildrenNum = 0;
 
   setDefaultProp = (parentProp: Keyof<TNode>) => {
-    this._defautltProp = parentProp;
+    this._defaultProp = parentProp;
   };
 
   get stack() {
@@ -33,7 +33,7 @@ export class ASTWalkerContext<TNode extends object> {
   openNode(node: TNode, parentProp?: Keyof<TNode>) {
     this._stack.push({
       node,
-      prop: parentProp ?? this._defautltProp,
+      prop: parentProp ?? this._defaultProp,
       context: Object.create(null),
     });
     return this;


### PR DESCRIPTION
This pull request adds support for parsing bookmark blocks as links in Markdown.
