### PR TITLE
feat(edgeless): support note scaling on shift + corner resize

### DIFF
--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -80,6 +80,9 @@ type NoteEdgelessProps = {
   };
   collapse?: boolean;
   collapsedHeight?: number;
+  width?: number;
+  height?: number;
+  scale?: number;
 };
 
 export class NoteBlockModel extends selectable<NoteProps>(BlockModel) {

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -80,8 +80,6 @@ type NoteEdgelessProps = {
   };
   collapse?: boolean;
   collapsedHeight?: number;
-  width?: number;
-  height?: number;
   scale?: number;
 };
 

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -209,16 +209,16 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
     const { xywh, edgeless } = this.model;
 
     const bound = Bound.deserialize(xywh);
-    const width = edgeless.width ?? bound.w;
-    const height = edgeless.height ?? bound.h;
     const scale = edgeless.scale ?? 1;
+    const width = bound.w / scale;
+    const height = bound.h / scale;
 
     const rect = this._affineNote.getBoundingClientRect();
     const zoom = this.surface.viewport.zoom;
     this._noteFullHeight =
-      (rect.height + 2 * EDGELESS_BLOCK_CHILD_PADDING * scale) / zoom;
+      rect.height / scale / zoom + 2 * EDGELESS_BLOCK_CHILD_PADDING;
 
-    if (bound.h >= this._noteFullHeight) {
+    if (height >= this._noteFullHeight) {
       return nothing;
     }
 
@@ -226,7 +226,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
       <div
         style=${styleMap({
           width: `${width}px`,
-          height: `${this._noteFullHeight / scale - height}px`,
+          height: `${this._noteFullHeight - height}px`,
           position: 'absolute',
           left: '0px',
           top: `${height}px`,
@@ -281,7 +281,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
       const zoom = this.surface.viewport.zoom;
       const scale = this.model.edgeless.scale ?? 1;
       this._noteFullHeight =
-        (rect.height + 2 * EDGELESS_BLOCK_CHILD_PADDING * scale) / zoom;
+        rect.height / scale / zoom + 2 * EDGELESS_BLOCK_CHILD_PADDING;
     });
     observer.observe(this, { childList: true, subtree: true });
     _disposables.add(() => observer.disconnect());
@@ -296,14 +296,11 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
     const { xywh, background, edgeless } = model;
     const { borderRadius, borderSize, borderStyle, shadowType } =
       edgeless.style;
+    const { collapse, collapsedHeight, scale = 1 } = edgeless;
+
     const bound = Bound.deserialize(xywh);
-    const {
-      collapse,
-      collapsedHeight,
-      width = bound.w,
-      height = bound.h,
-      scale = 1,
-    } = edgeless;
+    const width = bound.w / scale;
+    const height = bound.h / scale;
 
     const style = {
       position: 'absolute',
@@ -349,8 +346,8 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
       collapsedHeight !== this._noteFullHeight;
 
     const isCollapseArrowUp = collapse
-      ? this._noteFullHeight < bound.h
-      : !!collapsedHeight && collapsedHeight * scale < bound.h;
+      ? this._noteFullHeight < height
+      : !!collapsedHeight && collapsedHeight < height;
 
     return html`
       <div

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -215,10 +215,10 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
 
     const rect = this._affineNote.getBoundingClientRect();
     const zoom = this.surface.viewport.zoom;
-    const noteFullHeight =
+    this._noteFullHeight =
       (rect.height + 2 * EDGELESS_BLOCK_CHILD_PADDING * scale) / zoom;
 
-    if (bound.h >= noteFullHeight) {
+    if (bound.h >= this._noteFullHeight) {
       return nothing;
     }
 
@@ -226,9 +226,7 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
       <div
         style=${styleMap({
           width: `${width}px`,
-          height: `${
-            noteFullHeight / scale - EDGELESS_BLOCK_CHILD_PADDING - height
-          }px`,
+          height: `${this._noteFullHeight / scale - height}px`,
           position: 'absolute',
           left: '0px',
           top: `${height}px`,

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-note-button.ts
@@ -298,16 +298,14 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     this.notes.forEach(note => {
       const { collapse, collapsedHeight } = note.edgeless;
 
-      const bound = Bound.deserialize(note.xywh);
       if (collapse) {
         this.page.updateBlock(note, () => {
-          note.edgeless.collapsedHeight = bound.h;
           note.edgeless.collapse = false;
         });
-      } else {
-        if (collapsedHeight) {
-          bound.h = collapsedHeight;
-        }
+      } else if (collapsedHeight) {
+        const { xywh, edgeless } = note;
+        const bound = Bound.deserialize(xywh);
+        bound.h = collapsedHeight * (edgeless.scale ?? 1);
         this.page.updateBlock(note, () => {
           note.edgeless.collapse = true;
           note.xywh = bound.serialize();

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -484,7 +484,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         } else if (curBound.h !== bound.h) {
           edgeless.page.updateBlock(element, () => {
             element.edgeless.collapse = true;
-            element.edgeless.collapsedHeight = height;
+            element.edgeless.collapsedHeight = bound.h / scale;
           });
         }
 

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -774,6 +774,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       slots.pressShiftKeyUpdated.on(pressed => {
         this._shiftKey = pressed;
         this._resizeManager.onPressShiftKey(pressed);
+        this._updateCursor(false);
       })
     );
 

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -774,7 +774,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       slots.pressShiftKeyUpdated.on(pressed => {
         this._shiftKey = pressed;
         this._resizeManager.onPressShiftKey(pressed);
-        this._updateCursor(false);
+        this._updateSelectedRect();
       })
     );
 

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -323,6 +323,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   @state()
   private _isNoteHeightLimit = false;
 
+  @state()
+  private _shiftKey = false;
+
   @property({ attribute: false })
   toolbarVisible = false;
 
@@ -379,6 +382,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     for (const element of elements) {
       if (isNoteBlock(element)) {
         areAllConnectors = false;
+        if (this._shiftKey) {
+          areAllShapes = false;
+          areAllTexts = false;
+        }
       } else if (isFrameBlock(element)) {
         areAllConnectors = false;
       } else if (
@@ -420,6 +427,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     this.edgeless.slots.elementResizeStart.emit();
     this.selection.elements.forEach(el => {
       el.stash('xywh');
+      el.stash('edgeless' as 'xywh');
 
       if (rotation) {
         el.stash('rotate' as 'xywh');
@@ -432,6 +440,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
       this._dragEndCallback.push(() => {
         el.pop('xywh');
+        el.pop('edgeless' as 'xywh');
 
         if (rotation) {
           el.pop('rotate' as 'xywh');
@@ -465,18 +474,32 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       if (isNoteBlock(element)) {
         const curBound = Bound.deserialize(element.xywh);
         const props: Partial<NoteBlockModel> = {};
-        if (curBound.h !== bound.h && !element.edgeless.collapse) {
+
+        let width = element.edgeless.width ?? curBound.w;
+        let height = element.edgeless.height ?? curBound.h;
+        let scale = element.edgeless.scale ?? 1;
+
+        if (this._shiftKey) {
+          scale = bound.w / width;
+        } else if (curBound.h !== bound.h) {
           edgeless.page.updateBlock(element, () => {
             element.edgeless.collapse = true;
+            element.edgeless.collapsedHeight = height;
           });
         }
 
-        bound.w = clamp(bound.w, NOTE_MIN_WIDTH, Infinity);
-        bound.h = clamp(bound.h, NOTE_MIN_HEIGHT, Infinity);
+        width = bound.w / scale;
+        width = clamp(width, NOTE_MIN_WIDTH, Infinity);
+        bound.w = width * scale;
 
-        this._isNoteWidthLimit = bound.w === NOTE_MIN_WIDTH ? true : false;
-        this._isNoteHeightLimit = bound.h === NOTE_MIN_HEIGHT ? true : false;
+        height = bound.h / scale;
+        height = clamp(height, NOTE_MIN_HEIGHT, Infinity);
+        bound.h = height * scale;
 
+        this._isNoteWidthLimit = width === NOTE_MIN_WIDTH ? true : false;
+        this._isNoteHeightLimit = height === NOTE_MIN_HEIGHT ? true : false;
+
+        props.edgeless = { ...element.edgeless, width, height, scale };
         props.xywh = bound.serialize();
         edgeless.surface.updateElement(element.id, props);
       } else if (
@@ -748,9 +771,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     });
 
     _disposables.add(
-      slots.pressShiftKeyUpdated.on(pressed =>
-        this._resizeManager.onPressShiftKey(pressed)
-      )
+      slots.pressShiftKeyUpdated.on(pressed => {
+        this._shiftKey = pressed;
+        this._resizeManager.onPressShiftKey(pressed);
+      })
     );
 
     _disposables.add(selection.slots.updated.on(this._updateOnSelectionChange));

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -475,9 +475,9 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         const curBound = Bound.deserialize(element.xywh);
         const props: Partial<NoteBlockModel> = {};
 
-        let width = element.edgeless.width ?? curBound.w;
-        let height = element.edgeless.height ?? curBound.h;
         let scale = element.edgeless.scale ?? 1;
+        let width = curBound.w / scale;
+        let height = curBound.h / scale;
 
         if (this._shiftKey) {
           scale = bound.w / width;
@@ -499,7 +499,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         this._isNoteWidthLimit = width === NOTE_MIN_WIDTH ? true : false;
         this._isNoteHeightLimit = height === NOTE_MIN_HEIGHT ? true : false;
 
-        props.edgeless = { ...element.edgeless, width, height, scale };
+        props.edgeless = { ...element.edgeless, scale };
         props.xywh = bound.serialize();
         edgeless.surface.updateElement(element.id, props);
       } else if (

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -415,6 +415,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
       noteIndex?: number;
       offsetX?: number;
       offsetY?: number;
+      scale?: number;
     } = {}
   ) {
     const {
@@ -424,12 +425,18 @@ export class EdgelessPageBlockComponent extends BlockElement<
       offsetY = DEFAULT_NOTE_OFFSET_Y,
       parentId = this.page.root?.id,
       noteIndex: noteIndex,
+      scale = 1,
     } = options;
     const [x, y] = this.surface.toModelCoord(point.x, point.y);
     return this.surface.addElement(
       'affine:note',
       {
-        xywh: serializeXYWH(x - offsetX, y - offsetY, width, height),
+        xywh: serializeXYWH(
+          x - offsetX * scale,
+          y - offsetY * scale,
+          width,
+          height
+        ),
         displayMode: NoteDisplayMode.EdgelessOnly,
       },
       parentId,

--- a/packages/blocks/src/page-block/widgets/drag-handle/config.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/config.ts
@@ -51,6 +51,7 @@ export type OnDragEndProps = {
   dropBlockId: string;
   dropType: DropType | null;
   dragPreview: DragPreview;
+  noteScale: number;
 };
 
 export type DragHandleOption = {

--- a/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
@@ -1277,6 +1277,7 @@ export class AffineDragHandleWidget extends WidgetElement<
           dropBlockId: this.dropBlockId,
           dropType: this.dropType,
           dragPreview: this.dragPreview,
+          noteScale: this.noteScale,
         })
       ) {
         this._hide(true);

--- a/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/drag-handle.ts
@@ -37,7 +37,7 @@ import {
   isTopLevelBlock,
 } from '../../../page-block/edgeless/utils/query.js';
 import { autoScroll } from '../../../page-block/text-selection/utils.js';
-import type { IVec } from '../../../surface-block/index.js';
+import { Bound, type IVec } from '../../../surface-block/index.js';
 import { DragPreview } from './components/drag-preview.js';
 import { DropIndicator } from './components/drop-indicator.js';
 import type { DragHandleOption, DropResult, DropType } from './config.js';
@@ -1124,7 +1124,11 @@ export class AffineDragHandleWidget extends WidgetElement<
       const newNoteBlock = this.page.getBlockById(newNoteId) as NoteBlockModel;
       assertExists(newNoteBlock);
 
+      const bound = Bound.deserialize(newNoteBlock.xywh);
+      bound.h *= this.noteScale;
+      bound.w *= this.noteScale;
       this.page.updateBlock(newNoteBlock, {
+        xywh: bound.serialize(),
         edgeless: {
           ...newNoteBlock.edgeless,
           scale: this.noteScale,

--- a/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/page-block/widgets/drag-handle/utils.ts
@@ -358,6 +358,7 @@ export function convertDragPreviewDocToEdgeless({
   cssSelector,
   width,
   height,
+  noteScale,
 }: OnDragEndProps & {
   blockComponent: BlockElement;
   cssSelector: string;
@@ -380,8 +381,8 @@ export function convertDragPreviewDocToEdgeless({
   const bound = new Bound(
     point[0],
     point[1],
-    width ?? previewEl.clientWidth,
-    height ?? previewEl.clientHeight
+    (width ?? previewEl.clientWidth) * noteScale,
+    (height ?? previewEl.clientHeight) * noteScale
   );
 
   const blockModel = blockComponent.model;


### PR DESCRIPTION
[TOV-372](https://linear.app/affine-design/issue/TOV-372/note-%E7%9A%84%E7%BC%A9%E6%94%BE)

Changes:
- Added scaling support for note by adding new prop `scale` to `NoteBlockModel`.
- Shift + corner resize will update scale & xywh in model.
- Normal resize will update just xywh in model.
- Updated calculations for collapsed content and collapse arrow.
- Disabled edge resize on note when shift key is pressed.

Should be non-breaking