### PR TITLE
feat(page): code clipboard

### DIFF
--- a/packages/block-std/src/index.ts
+++ b/packages/block-std/src/index.ts
@@ -1,3 +1,4 @@
+export * from './clipboard/index.js';
 export * from './command/index.js';
 export * from './event/index.js';
 export * from './scope/index.js';

--- a/packages/blocks/src/_common/adapters/index.ts
+++ b/packages/blocks/src/_common/adapters/index.ts
@@ -1,5 +1,6 @@
 export * from './html.js';
 export * from './image.js';
 export * from './markdown.js';
+export * from './mix-text.js';
 export * from './notion-html.js';
 export * from './plain-text.js';

--- a/packages/blocks/src/code-block/clipboard/index.ts
+++ b/packages/blocks/src/code-block/clipboard/index.ts
@@ -1,0 +1,93 @@
+import { Clipboard, type UIEventHandler } from '@blocksuite/block-std';
+import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
+import type { BlockElement } from '@blocksuite/lit';
+
+import { HtmlAdapter, PlainTextAdapter } from '../../_common/adapters/index.js';
+import { pasteMiddleware } from '../../page-block/clipboard/middlewares/index.js';
+
+export class CodeClipboardController {
+  protected _disposables = new DisposableGroup();
+  host: BlockElement;
+
+  private get _std() {
+    return this.host.std;
+  }
+
+  private _clipboard!: Clipboard;
+  private _plaintextAdapter = new PlainTextAdapter();
+  private _htmlAdapter = new HtmlAdapter();
+
+  constructor(host: BlockElement) {
+    this.host = host;
+  }
+
+  hostConnected() {
+    if (this._disposables.disposed) {
+      this._disposables = new DisposableGroup();
+    }
+    this._clipboard = new Clipboard(this._std);
+    this.host.handleEvent('paste', this.onPagePaste);
+    this._init();
+  }
+
+  hostDisconnected() {
+    this._disposables.dispose();
+  }
+
+  protected _init = () => {
+    this._clipboard.registerAdapter('text/plain', this._plaintextAdapter, 90);
+    this._clipboard.registerAdapter('text/html', this._htmlAdapter, 80);
+    const paste = pasteMiddleware(this._std);
+    this._clipboard.use(paste);
+
+    this._disposables.add({
+      dispose: () => {
+        this._clipboard.unregisterAdapter('text/plain');
+        this._clipboard.unregisterAdapter('text/html');
+        this._clipboard.unuse(paste);
+      },
+    });
+  };
+
+  public onPagePaste: UIEventHandler = ctx => {
+    const e = ctx.get('clipboardState').raw;
+    e.preventDefault();
+
+    this._std.page.captureSync();
+    this._std.command
+      .pipe()
+      .try(cmd => [
+        cmd.getTextSelection().inline<'currentSelectionPath'>((ctx, next) => {
+          const textSelection = ctx.currentTextSelection;
+          assertExists(textSelection);
+          const end = textSelection.to ?? textSelection.from;
+          next({ currentSelectionPath: end.path });
+        }),
+        cmd.getBlockSelections().inline<'currentSelectionPath'>((ctx, next) => {
+          const currentBlockSelections = ctx.currentBlockSelections;
+          assertExists(currentBlockSelections);
+          const blockSelection = currentBlockSelections.at(-1);
+          if (!blockSelection) {
+            return;
+          }
+          next({ currentSelectionPath: blockSelection.path });
+        }),
+      ])
+      .getBlockIndex()
+      .inline((ctx, next) => {
+        assertExists(ctx.parentBlock);
+        this._clipboard
+          .paste(
+            e,
+            this._std.page,
+            ctx.parentBlock.model.id,
+            ctx.blockIndex ? ctx.blockIndex + 1 : undefined
+          )
+          .catch(console.error);
+
+        return next();
+      })
+      .run();
+    return true;
+  };
+}

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -33,6 +33,7 @@ import { PAGE_HEADER_HEIGHT } from '../_common/consts.js';
 import { ArrowDownIcon } from '../_common/icons/index.js';
 import { listenToThemeChange } from '../_common/theme/utils.js';
 import { getThemeMode } from '../_common/utils/index.js';
+import { CodeClipboardController } from './clipboard/index.js';
 import type { CodeBlockModel, HighlightOptionsGetter } from './code-model.js';
 import { CodeOptionTemplate } from './components/code-option.js';
 import { LangList } from './components/lang-list.js';
@@ -142,6 +143,8 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
   @state()
   private _langListAbortController?: AbortController;
+
+  clipboardController = new CodeClipboardController(this);
 
   private get _showLangList() {
     return !!this._langListAbortController;
@@ -265,6 +268,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
   override connectedCallback() {
     super.connectedCallback();
     // set highlight options getter used by "exportToHtml"
+    this.clipboardController.hostConnected();
     this.setHighlightOptionsGetter(() => {
       return {
         lang: this._perviousLanguage.id as Lang,
@@ -438,6 +442,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
   override disconnectedCallback() {
     super.disconnectedCallback();
+    this.clipboardController.hostDisconnected();
     this._richTextResizeObserver.disconnect();
   }
 

--- a/packages/blocks/src/page-block/clipboard/index.ts
+++ b/packages/blocks/src/page-block/clipboard/index.ts
@@ -6,7 +6,7 @@ import type { BlockSnapshot, Page } from '@blocksuite/store';
 import {
   HtmlAdapter,
   ImageAdapter,
-  PlainTextAdapter,
+  MixTextAdapter,
 } from '../../_common/adapters/index.js';
 import {
   defaultImageProxyMiddleware,
@@ -24,7 +24,7 @@ export class PageClipboard {
   }
 
   private _clipboardAdapter = new ClipboardAdapter();
-  private _plaintextAdapter = new PlainTextAdapter();
+  private _mixtextAdapter = new MixTextAdapter();
   private _htmlAdapter = new HtmlAdapter();
   private _imageAdapter = new ImageAdapter();
 
@@ -64,11 +64,7 @@ export class PageClipboard {
     ].map(type =>
       this._std.clipboard.registerAdapter(type, this._imageAdapter, 80)
     );
-    this._std.clipboard.registerAdapter(
-      'text/plain',
-      this._plaintextAdapter,
-      70
-    );
+    this._std.clipboard.registerAdapter('text/plain', this._mixtextAdapter, 70);
     const copy = copyMiddleware(this._std);
     const paste = pasteMiddleware(this._std);
     this._std.clipboard.use(copy);


### PR DESCRIPTION
Codes like yaml, which starts with -, still cannot properly handled by MixTextAdapter.
In this PR, we adopt a temporary measure which adds new clipboards instance to code blocks.
This closes #6004.
