### PR TITLE
chore: remove `blockVversions` in snapshot

### DIFF
--- a/packages/blocks/src/_common/adapters/html.ts
+++ b/packages/blocks/src/_common/adapters/html.ts
@@ -226,7 +226,6 @@ export class HtmlAdapter extends BaseAdapter<Html> {
     return {
       type: 'slice',
       content: [contentSlice],
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/adapters/image.ts
+++ b/packages/blocks/src/_common/adapters/image.ts
@@ -89,7 +89,6 @@ export class ImageAdapter extends BaseAdapter<Image> {
     return {
       type: 'slice',
       content,
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -45,7 +45,6 @@ type MarkdownAST =
 type MarkdownToSliceSnapshotPayload = {
   file: Markdown;
   assets?: AssetsManager;
-  blockVersions: Record<string, number>;
   pageVersion: number;
   workspaceVersion: number;
   workspaceId: string;
@@ -235,7 +234,6 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
     return {
       type: 'slice',
       content: [contentSlice],
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/adapters/mix-text.ts
+++ b/packages/blocks/src/_common/adapters/mix-text.ts
@@ -202,7 +202,6 @@ export class MixTextAdapter extends BaseAdapter<MixText> {
     const sliceSnapshot = await this._markdownAdapter.toSliceSnapshot({
       file: payload.file,
       assets: payload.assets,
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/adapters/notion-html.ts
+++ b/packages/blocks/src/_common/adapters/notion-html.ts
@@ -206,7 +206,6 @@ export class NotionHtmlAdapter extends BaseAdapter<NotionHtml> {
     return {
       type: 'slice',
       content: [contentSlice],
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/adapters/plain-text.ts
+++ b/packages/blocks/src/_common/adapters/plain-text.ts
@@ -232,7 +232,6 @@ export class PlainTextAdapter extends BaseAdapter<PlainText> {
     return {
       type: 'slice',
       content: [contentSlice],
-      blockVersions: payload.blockVersions,
       pageVersion: payload.pageVersion,
       workspaceVersion: payload.workspaceVersion,
       workspaceId: payload.workspaceId,

--- a/packages/blocks/src/_common/transformers/markdown.ts
+++ b/packages/blocks/src/_common/transformers/markdown.ts
@@ -55,7 +55,6 @@ export async function importMarkdown({
   const snapshot = await adapter.toSliceSnapshot({
     file: markdown,
     assets: job.assetsManager,
-    blockVersions: page.workspace.meta.blockVersions!,
     pageVersion: page.workspace.meta.pageVersion!,
     workspaceVersion: page.workspace.meta.workspaceVersion!,
     workspaceId: page.workspace.id,

--- a/packages/blocks/src/_common/transformers/zip.ts
+++ b/packages/blocks/src/_common/transformers/zip.ts
@@ -77,7 +77,7 @@ export async function importPages(workspace: Workspace, imported: Blob) {
       if (payload.type === 'page') {
         workspace.schema.upgradePage(
           info?.pageVersion ?? 0,
-          info?.blockVersions ?? {},
+          {},
           payload.page.spaceDoc
         );
       }

--- a/packages/blocks/src/surface-block/service/template.ts
+++ b/packages/blocks/src/surface-block/service/template.ts
@@ -150,7 +150,7 @@ export class TemplateJob {
     }
   }
 
-  private _getMergeBlockId(modelData: SnapshotReturn<object>) {
+  private _getMergeBlockId(modelData: BlockSnapshot) {
     switch (modelData.flavour as MergeBlockFlavour) {
       case 'affine:page':
         return this.model.page.root!.id;

--- a/packages/store/src/__tests__/__snapshots__/transformer.unit.spec.ts.snap
+++ b/packages/store/src/__tests__/__snapshots__/transformer.unit.spec.ts.snap
@@ -53,5 +53,6 @@ exports[`model to snapshot 1`] = `
       ],
     },
   },
+  "version": 1,
 }
 `;

--- a/packages/store/src/transformer/base.ts
+++ b/packages/store/src/transformer/base.ts
@@ -4,7 +4,10 @@ import type { AssetsManager } from './assets.js';
 import { fromJSON, toJSON } from './json.js';
 import type { BlockSnapshot } from './type.js';
 
-type BlockSnapshotLeaf = Pick<BlockSnapshot, 'id' | 'flavour' | 'props'>;
+type BlockSnapshotLeaf = Pick<
+  BlockSnapshot,
+  'id' | 'flavour' | 'props' | 'version'
+>;
 
 export type FromSnapshotPayload = {
   json: BlockSnapshotLeaf;
@@ -20,6 +23,7 @@ export type ToSnapshotPayload<Props extends object> = {
 export type SnapshotReturn<Props extends object> = {
   id: string;
   flavour: string;
+  version: number;
   props: Props;
 };
 
@@ -46,13 +50,14 @@ export class BaseBlockTransformer<Props extends object = object> {
   async fromSnapshot({
     json,
   }: FromSnapshotPayload): Promise<SnapshotReturn<Props>> {
-    const { flavour, id, props: _props } = json;
+    const { flavour, id, version, props: _props } = json;
 
     const props = this._propsFromSnapshot(_props);
 
     return {
       id,
       flavour,
+      version: version ?? -1,
       props,
     };
   }
@@ -60,13 +65,14 @@ export class BaseBlockTransformer<Props extends object = object> {
   async toSnapshot({
     model,
   }: ToSnapshotPayload<Props>): Promise<BlockSnapshotLeaf> {
-    const { id, flavour } = model;
+    const { id, flavour, version } = model;
 
     const props = this._propsToSnapshot(model);
 
     return {
       id,
       flavour,
+      version,
       props,
     };
   }

--- a/packages/store/src/transformer/job.ts
+++ b/packages/store/src/transformer/job.ts
@@ -87,15 +87,12 @@ export class Job {
 
   private _getWorkspaceMeta() {
     const { meta } = this._workspace;
-    const { blockVersions, pageVersion, workspaceVersion, properties, pages } =
-      meta;
-    assertExists(blockVersions);
+    const { pageVersion, workspaceVersion, properties, pages } = meta;
     assertExists(pageVersion);
     assertExists(workspaceVersion);
     assertExists(properties);
     assertExists(pages);
     return {
-      blockVersions: { ...blockVersions },
       pageVersion,
       workspaceVersion,
       properties: JSON.parse(JSON.stringify(properties)) as PagesPropertiesMeta,
@@ -338,14 +335,8 @@ export class Job {
       type: 'slice',
       slice,
     });
-    const {
-      content,
-      blockVersions,
-      pageVersion,
-      workspaceVersion,
-      pageId,
-      workspaceId,
-    } = slice.data;
+    const { content, pageVersion, workspaceVersion, pageId, workspaceId } =
+      slice.data;
     const contentSnapshot = [];
     for (const block of content) {
       contentSnapshot.push(await this.blockToSnapshot(block));
@@ -354,7 +345,6 @@ export class Job {
       type: 'slice',
       workspaceId,
       pageId,
-      blockVersions,
       pageVersion,
       workspaceVersion,
       content: contentSnapshot,
@@ -380,14 +370,8 @@ export class Job {
       snapshot,
     });
     SliceSnapshotSchema.parse(snapshot);
-    const {
-      content,
-      blockVersions,
-      pageVersion,
-      workspaceVersion,
-      workspaceId,
-      pageId,
-    } = snapshot;
+    const { content, pageVersion, workspaceVersion, workspaceId, pageId } =
+      snapshot;
     const contentBlocks = [];
     for (const [i, block] of content.entries()) {
       contentBlocks.push(
@@ -396,7 +380,6 @@ export class Job {
     }
     const slice = new Slice({
       content: contentBlocks,
-      blockVersions,
       pageVersion,
       workspaceVersion,
       workspaceId,

--- a/packages/store/src/transformer/slice.ts
+++ b/packages/store/src/transformer/slice.ts
@@ -7,7 +7,6 @@ type SliceData = {
   content: BlockModel[];
   workspaceId: string;
   pageId: string;
-  blockVersions: Record<string, number>;
   pageVersion: number;
   workspaceVersion: number;
 };
@@ -22,7 +21,6 @@ export class Slice {
       content: models,
       workspaceId: page.workspace.id,
       pageId: page.id,
-      blockVersions: { ...meta.blockVersions },
       pageVersion,
       workspaceVersion,
     });
@@ -32,10 +30,6 @@ export class Slice {
 
   get content() {
     return this.data.content;
-  }
-
-  get blockVersions() {
-    return this.data.blockVersions;
   }
 
   get pageVersion() {

--- a/packages/store/src/transformer/type.ts
+++ b/packages/store/src/transformer/type.ts
@@ -6,6 +6,7 @@ export type BlockSnapshot = {
   type: 'block';
   id: string;
   flavour: string;
+  version?: number;
   props: Record<string, unknown>;
   children: BlockSnapshot[];
 };
@@ -14,6 +15,7 @@ export const BlockSnapshotSchema: z.ZodType<BlockSnapshot> = z.object({
   type: z.literal('block'),
   id: z.string(),
   flavour: z.string(),
+  version: z.number().optional(),
   props: z.record(z.unknown()),
   children: z.lazy(() => BlockSnapshotSchema.array()),
 });
@@ -21,7 +23,6 @@ export const BlockSnapshotSchema: z.ZodType<BlockSnapshot> = z.object({
 export type SliceSnapshot = {
   type: 'slice';
   content: BlockSnapshot[];
-  blockVersions: Record<string, number>;
   pageVersion: number;
   workspaceVersion: number;
   workspaceId: string;
@@ -31,7 +32,6 @@ export type SliceSnapshot = {
 export const SliceSnapshotSchema: z.ZodType<SliceSnapshot> = z.object({
   type: z.literal('slice'),
   content: BlockSnapshotSchema.array(),
-  blockVersions: z.record(z.number()),
   pageVersion: z.number(),
   workspaceVersion: z.number(),
   workspaceId: z.string(),
@@ -41,7 +41,6 @@ export const SliceSnapshotSchema: z.ZodType<SliceSnapshot> = z.object({
 export type WorkspaceInfoSnapshot = {
   id: string;
   type: 'info';
-  blockVersions: Record<string, number>;
   pageVersion: number;
   workspaceVersion: number;
   properties: PagesPropertiesMeta;
@@ -51,7 +50,6 @@ export const WorkspaceInfoSnapshotSchema: z.ZodType<WorkspaceInfoSnapshot> =
   z.object({
     id: z.string(),
     type: z.literal('info'),
-    blockVersions: z.record(z.number()),
     pageVersion: z.number(),
     workspaceVersion: z.number(),
     properties: z.record(z.any()),

--- a/tests/snapshots/clipboard.spec.ts-snapshots/clipboard.json
+++ b/tests/snapshots/clipboard.spec.ts-snapshots/clipboard.json
@@ -3,6 +3,7 @@
     "type": "block",
     "id": "3",
     "flavour": "affine:list",
+    "version": 1,
     "props": {
       "type": "bulleted",
       "text": {
@@ -21,6 +22,7 @@
         "type": "block",
         "id": "4",
         "flavour": "affine:list",
+        "version": 1,
         "props": {
           "type": "bulleted",
           "text": {
@@ -39,6 +41,7 @@
             "type": "block",
             "id": "5",
             "flavour": "affine:list",
+            "version": 1,
             "props": {
               "type": "bulleted",
               "text": {


### PR DESCRIPTION
In favor of https://github.com/toeverything/blocksuite/pull/6065