### PR TITLE
fix(page): export png position shift

### DIFF
--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -320,8 +320,9 @@ export class ExportManager {
       '.affine-doc-page-block-container'
     );
     const rect = pageContainer?.getBoundingClientRect();
+    const { viewport } = pageElement;
     const pageWidth = rect?.width;
-    const pageLeft = rect?.left;
+    const pageLeft = rect?.left ?? 0;
     const viewportHeight = viewportElement?.scrollHeight;
 
     const replaceRichTextWithSvgElementFunc =
@@ -352,7 +353,7 @@ export class ExportManager {
         await replaceRichTextWithSvgElementFunc(element);
       },
       backgroundColor: window.getComputedStyle(viewportElement).backgroundColor,
-      x: pageLeft,
+      x: pageLeft - viewport.left,
       width: pageWidth,
       height: viewportHeight,
       useCORS: this._exportOptions.imageProxyEndpoint ? false : true,


### PR DESCRIPTION
To fix [TOV-401](https://linear.app/affine-design/issue/TOV-401/png导出大小有问题（右边多出很多空格，且长内容会被截断）)

https://github.com/toeverything/blocksuite/assets/99816898/af136d50-9e22-445f-af27-befbcd854860

https://github.com/toeverything/blocksuite/assets/99816898/db1e2b74-a478-4cb5-b677-d3c1e0f8d04a

