### PR TITLE
fix: line number container in code-block should not contenteditable

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -10,6 +10,7 @@ import {
   matchFlavours,
 } from '../../../_common/utils/model.js';
 import {
+  getBlockComponentByModel,
   getDocTitleByEditorHost,
   getInlineEditorByModel,
   getNextBlock,
@@ -639,6 +640,28 @@ function handleParagraphDeleteActions(
       index: lengthBeforeJoin,
       length: 0,
     }).catch(console.error);
+    return true;
+  } else if (
+    matchFlavours(previousSibling, [
+      'affine:attachment',
+      'affine:bookmark',
+      'affine:code',
+      'affine:image',
+    ])
+  ) {
+    page.deleteBlock(model, {
+      bringChildrenTo: parent,
+    });
+    const previousSiblingElement = getBlockComponentByModel(
+      editorHost,
+      previousSibling
+    );
+    assertExists(previousSiblingElement);
+    const selection = editorHost.selection.create('block', {
+      path: previousSiblingElement.path,
+    });
+    editorHost.selection.setGroup('note', [selection]);
+
     return true;
   }
 

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -588,6 +588,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
       getStandardLanguage(this.model.language) ?? PLAIN_TEXT_REGISTRATION;
     const curLanguageDisplayName = curLanguage.displayName ?? curLanguage.id;
     return html`<div
+      contenteditable="false"
       class="lang-list-wrapper caret-ignore"
       style="${this._showLangList ? 'visibility: visible;' : ''}"
     >
@@ -628,7 +629,7 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
     >
       ${this._curLanguageButtonTemplate()}
       <div class="rich-text-container">
-        <div id="line-numbers"></div>
+        <div contenteditable="false" id="line-numbers"></div>
         <rich-text
           .yText=${this.model.text.yText}
           .inlineEventSource=${this.topContenteditableElement ?? nothing}

--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Page } from '@playwright/test';
 
 import { moveToImage } from './utils/actions/drag.js';
 import {
+  pressArrowUp,
   pressBackspace,
   pressEnter,
   pressEscape,
@@ -18,9 +19,12 @@ import {
   waitNextFrame,
 } from './utils/actions/misc.js';
 import {
+  assertBlockCount,
+  assertBlockSelections,
   assertImageOption,
   assertKeyboardWorkInInput,
   assertRichImage,
+  assertRichTextInlineRange,
   assertStoreMatchJSX,
 } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
@@ -580,4 +584,26 @@ test(`support dragging attachment block directly`, async ({ page }) => {
   </affine:note>
 </affine:page>`
   );
+});
+
+test('press backspace after bookmark block can select bookmark block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  const { insertAttachment, waitLoading } = getAttachment(page);
+
+  await focusRichText(page);
+  await pressEnter(page);
+  await pressArrowUp(page);
+  await insertAttachment();
+  // Wait for the attachment to be uploaded
+  await waitLoading();
+
+  await focusRichText(page);
+  await assertBlockCount(page, 'paragraph', 1);
+  await assertRichTextInlineRange(page, 0, 0);
+  await pressBackspace(page);
+  await assertBlockSelections(page, [['0', '1', '4']]);
+  await assertBlockCount(page, 'paragraph', 0);
 });

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -11,6 +11,8 @@ import {
   initEmptyEdgelessState,
   initEmptyParagraphState,
   pressArrowRight,
+  pressArrowUp,
+  pressBackspace,
   pressEnter,
   selectAllByKeyboard,
   setInlineRangeInSelectedRichText,
@@ -20,7 +22,12 @@ import {
   waitForInlineEditorStateUpdated,
   waitNextFrame,
 } from './utils/actions/index.js';
-import { assertStoreMatchJSX } from './utils/asserts.js';
+import {
+  assertBlockCount,
+  assertBlockSelections,
+  assertRichTextInlineRange,
+  assertStoreMatchJSX,
+} from './utils/asserts.js';
 import { scoped, test } from './utils/playwright.js';
 
 const inputUrl = 'http://localhost';
@@ -457,4 +464,26 @@ test(scoped`support dragging bookmark block directly`, async ({ page }) => {
   </affine:note>
 </affine:page>`
   );
+});
+
+test('press backspace after bookmark block can select bookmark block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  await pressEnter(page);
+  await pressArrowUp(page);
+  await type(page, '/links');
+  await pressEnter(page);
+  await type(page, inputUrl);
+  await pressEnter(page);
+
+  await focusRichText(page);
+  await assertBlockCount(page, 'paragraph', 1);
+  await assertRichTextInlineRange(page, 0, 0);
+  await pressBackspace(page);
+  await assertBlockSelections(page, [['0', '1', '4']]);
+  await assertBlockCount(page, 'paragraph', 0);
 });

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -19,6 +19,7 @@ import {
   moveToImage,
   pasteByKeyboard,
   pressArrowLeft,
+  pressBackspace,
   pressEnter,
   redoByKeyboard,
   scrollToTop,
@@ -27,6 +28,8 @@ import {
   waitNextFrame,
 } from './utils/actions/index.js';
 import {
+  assertBlockCount,
+  assertBlockSelections,
   assertImageOption,
   assertImageSize,
   assertRichDragButton,
@@ -376,4 +379,20 @@ test('image loaded successfully', async ({ page }) => {
   await expect(img).toBeVisible();
   const src = await img.getAttribute('src');
   expect(src).toBeDefined();
+});
+
+test('press backspace after image block can select image block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initImageState(page);
+  await assertRichImage(page, 1);
+
+  await activeEmbed(page);
+  await pressEnter(page);
+  await assertRichTextInlineRange(page, 0, 0);
+  await assertBlockCount(page, 'paragraph', 1);
+  await pressBackspace(page);
+  await assertBlockSelections(page, [['0', '1', '2']]);
+  await assertBlockCount(page, 'paragraph', 0);
 });

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -13,7 +13,7 @@ import type {
 } from '@blocks/index.js';
 import { assertExists } from '@global/utils/index.js';
 import type { InlineRootElement } from '@inline/inline-editor.js';
-import type { BlockElement } from '@lit/element/index.js';
+import type { BlockElement, EditorHost } from '@lit/element/index.js';
 import type { Locator } from '@playwright/test';
 import { expect, type Page } from '@playwright/test';
 import { PAGE_VERSION, WORKSPACE_VERSION } from '@store/consts.js';
@@ -1053,4 +1053,16 @@ export async function assertNotHasClass(locator: Locator, className: string) {
 export async function assertNoteSequence(page: Page, expected: string) {
   const actual = await page.locator('.edgeless-index-label').innerText();
   expect(expected).toBe(actual);
+}
+
+export async function assertBlockSelections(page: Page, paths: string[][]) {
+  const selections = await page.evaluate(() => {
+    const host = document.querySelector<EditorHost>('editor-host');
+    if (!host) {
+      throw new Error('editor-host host not found');
+    }
+    return host.selection.filter('block');
+  });
+  const actualPaths = selections.map(selection => selection.path);
+  expect(actualPaths).toEqual(paths);
 }


### PR DESCRIPTION
In order to fix a certain test, incidentally improved the experience when pressing the backspace key after certain blocks.

https://github.com/toeverything/blocksuite/assets/50035259/c44ff633-e0cc-4f64-a306-6ffcf1c9ec91

