### PR TITLE
fix(edgeless): bugs of connector and block

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../../_common/utils/event.js';
 import { pickValues } from '../../../../_common/utils/iterable.js';
 import { clamp } from '../../../../_common/utils/math.js';
-import { type BookmarkBlockModel } from '../../../../models.js';
+import type { BookmarkBlockModel } from '../../../../models.js';
 import { NoteBlockModel } from '../../../../note-block/note-model.js';
 import { normalizeTextBound } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { TextElementModel } from '../../../../surface-block/element-model/text.js';

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -19,7 +19,8 @@ import {
 } from '../../../../_common/utils/event.js';
 import { pickValues } from '../../../../_common/utils/iterable.js';
 import { clamp } from '../../../../_common/utils/math.js';
-import type { BookmarkBlockModel, NoteBlockModel } from '../../../../models.js';
+import { type BookmarkBlockModel } from '../../../../models.js';
+import { NoteBlockModel } from '../../../../note-block/note-model.js';
 import { normalizeTextBound } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { TextElementModel } from '../../../../surface-block/element-model/text.js';
 import type { ElementModel } from '../../../../surface-block/index.js';
@@ -514,7 +515,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     this.edgeless.slots.elementResizeStart.emit();
     this.selection.elements.forEach(el => {
       el.stash('xywh');
-      el.stash('edgeless' as 'xywh');
+
+      if (el instanceof NoteBlockModel) {
+        el.stash('edgeless');
+      }
 
       if (rotation) {
         el.stash('rotate' as 'xywh');
@@ -527,7 +531,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
       this._dragEndCallback.push(() => {
         el.pop('xywh');
-        el.pop('edgeless' as 'xywh');
+
+        if (el instanceof NoteBlockModel) {
+          el.pop('edgeless');
+        }
 
         if (rotation) {
           el.pop('rotate' as 'xywh');

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
@@ -30,7 +30,6 @@ export function connector(
   // points might not be build yet in some senarios
   // eg. undo/redo, copy/paste
   if (!points.length || points.length < 2) {
-    console.warn('connector points not ready yet, there is something wrong.');
     return;
   }
 

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -209,7 +209,17 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
     delete this[prop];
 
     // @ts-ignore
-    this[prop] = value;
+    if (this['_yProps']?.has(prop)) {
+      this.surface.page.transact(() => {
+        this.yMap.set(prop as string, value);
+      });
+    }
+    // @ts-ignore
+    else if (this['_localProps']?.has(prop)) {
+      this._local.set(prop as string, value);
+    } else {
+      console.warn('pop a prop that is not yfield or local:', prop);
+    }
   }
 
   containedByBounds(bounds: Bound): boolean {

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -208,9 +208,8 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
     // @ts-ignore
     delete this[prop];
 
-    this.surface.page.transact(() => {
-      this.yMap.set(prop as string, value);
-    });
+    // @ts-ignore
+    this[prop] = value;
   }
 
   containedByBounds(bounds: Bound): boolean {

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -50,8 +50,11 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
   }
 
   /**
-   * When the ymap is not connected to the doc, the value cannot be accessed.
-   * But sometimes we need to access the value when creating the element model, those temporary values are stored here.
+   * When the ymap is not connected to the doc, its value cannot be read.
+   * But we need to use those value during the creation, so the yfied decorated field's value will
+   * be stored in this map too during the creation.
+   *
+   * After the ymap is connected to the doc, this map will be cleared.
    */
   protected _preserved: Map<string, unknown> = new Map();
   protected _stashed: Map<keyof Props | string, unknown>;

--- a/packages/blocks/src/surface-block/element-model/connector.ts
+++ b/packages/blocks/src/surface-block/element-model/connector.ts
@@ -42,6 +42,8 @@ type ConnectorElementProps = BaseProps & {
 };
 
 export class ConnectorElementModel extends ElementModel<ConnectorElementProps> {
+  updatingPath = false;
+
   get type() {
     return 'connector';
   }
@@ -153,5 +155,11 @@ export class ConnectorElementModel extends ElementModel<ConnectorElementProps> {
     return new PointLocation(
       Bound.deserialize(this.xywh).getRelativePoint(point)
     );
+  }
+
+  override serialize() {
+    const result = super.serialize();
+    result.xywh = this.xywh;
+    return result;
   }
 }

--- a/packages/blocks/src/surface-block/element-model/decorators.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators.ts
@@ -17,6 +17,13 @@ export function setCreateState(
 
 export function yfield(fallback?: unknown): PropertyDecorator {
   return function yDecorator(prototype: unknown, prop: string | symbol) {
+    // @ts-ignore
+    const yProps = prototype['_yProps'] ?? new Set();
+    // @ts-ignore
+    prototype['_yProps'] = yProps;
+
+    yProps.add(prop);
+
     Object.defineProperty(prototype, prop, {
       get(this: ElementModel) {
         return (
@@ -62,8 +69,15 @@ export function yfield(fallback?: unknown): PropertyDecorator {
 }
 
 export function local(): PropertyDecorator {
-  return function localDecorator(target: unknown, prop: string | symbol) {
-    Object.defineProperty(target, prop, {
+  return function localDecorator(prototype: unknown, prop: string | symbol) {
+    // @ts-ignore
+    const localProps = prototype['_localProps'] ?? new Set();
+    // @ts-ignore
+    prototype['_localProps'] = localProps;
+
+    localProps.add(prop);
+
+    Object.defineProperty(prototype, prop, {
       get(this: ElementModel) {
         return this._local.get(prop);
       },
@@ -71,10 +85,10 @@ export function local(): PropertyDecorator {
         const oldValue = this._local.get(prop);
         const newVal = state.creating
           ? originalValue
-          : convertProps(target, prop, originalValue, this);
+          : convertProps(prototype, prop, originalValue, this);
 
         const derivedProps = getDeriveProperties(
-          target,
+          prototype,
           prop,
           originalValue,
           this

--- a/packages/blocks/src/surface-block/element-model/index.ts
+++ b/packages/blocks/src/surface-block/element-model/index.ts
@@ -74,6 +74,7 @@ export function createElementModel(
           ...payload,
         });
     });
+    elementModel['_preserved'].clear();
     mounted = true;
   };
 
@@ -168,9 +169,6 @@ export function createModelFromProps(
     // @ts-ignore
     elementModel.model[key] = props[key];
   });
-
-  // @ts-ignore
-  elementModel.model._preserved.clear();
 
   return elementModel;
 }

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -1119,9 +1119,11 @@ export class ConnectorPathGenerator {
       return p.setVec(Vec.sub(p, [bound.x, bound.y]));
     });
 
+    connector.updatingPath = true;
     // the property assignment order matters
     connector.xywh = bound.serialize();
     connector.path = relativePoints;
+    connector.updatingPath = false;
   }
 
   generateOrthogonalConnectorPath(input: OrthogonalConnectorInput) {

--- a/packages/blocks/src/surface-block/middlewares/connector.ts
+++ b/packages/blocks/src/surface-block/middlewares/connector.ts
@@ -55,6 +55,12 @@ export function connectorMiddleware(surface: SurfaceBlockModel) {
     }),
   ];
 
+  surface
+    .getElementsByType('connector')
+    .forEach(connector =>
+      updateConnectorPath(connector as ConnectorElementModel)
+    );
+
   return () => {
     disposables.forEach(d => d.dispose());
   };

--- a/packages/blocks/src/surface-block/middlewares/connector.ts
+++ b/packages/blocks/src/surface-block/middlewares/connector.ts
@@ -12,10 +12,10 @@ export function connectorMiddleware(surface: SurfaceBlockModel) {
   });
   const updateConnectorPath = (connector: ConnectorElementModel) => {
     if (
-      ((connector?.source.id && getElementById(connector.source.id)) ||
-        connector?.source.position) &&
-      ((connector?.target.id && getElementById(connector.target.id)) ||
-        connector?.target.position)
+      ((connector.source?.id && getElementById(connector.source.id)) ||
+        connector.source?.position) &&
+      ((connector.target?.id && getElementById(connector.target.id)) ||
+        connector.target?.position)
     ) {
       pathGenerator.updatePath(connector);
     }

--- a/packages/blocks/src/surface-block/surface-model.ts
+++ b/packages/blocks/src/surface-block/surface-model.ts
@@ -246,19 +246,19 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
     };
 
     elementsYMap.forEach((val, key) => {
-      this._elementModels.set(
-        key,
-        createElementModel(
-          val.get('type') as string,
-          val.get('id') as string,
-          val,
-          this,
-          {
-            onChange: payload => this.elementUpdated.emit(payload),
-            skipFieldInit: true,
-          }
-        )
+      const model = createElementModel(
+        val.get('type') as string,
+        val.get('id') as string,
+        val,
+        this,
+        {
+          onChange: payload => this.elementUpdated.emit(payload),
+          skipFieldInit: true,
+        }
       );
+
+      this._elementModels.set(key, model);
+      model.mount();
     });
     elementsYMap.observe(onElementsMapChange);
 

--- a/packages/playground/apps/starter/components/pages-panel.ts
+++ b/packages/playground/apps/starter/components/pages-panel.ts
@@ -89,6 +89,7 @@ export class PagesPanel extends WithDisposable(ShadowlessElement) {
           });
           const click = () => {
             this.editor.page = page;
+            this.editor.page.resetHistory();
             this.requestUpdate();
           };
           const deletePage = () => {

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -68,7 +68,12 @@ export class Block {
       });
     });
 
-    this.yBlock.observeDeep(() => {
+    this.yBlock.observeDeep(evtArr => {
+      const evt = evtArr[0];
+      // filter out events from itself
+      // as this event is triggered in observe function
+      if (!evt || evt.currentTarget === evt.target) return;
+
       this.options.onChange?.(this, '', undefined);
     });
   }

--- a/packages/store/src/workspace/block/block.ts
+++ b/packages/store/src/workspace/block/block.ts
@@ -67,6 +67,10 @@ export class Block {
         }
       });
     });
+
+    this.yBlock.observeDeep(() => {
+      this.options.onChange?.(this, '', undefined);
+    });
   }
 
   stash = (prop: string) => {

--- a/packages/store/src/workspace/page.ts
+++ b/packages/store/src/workspace/page.ts
@@ -706,7 +706,10 @@ export class Page extends Space<FlatBlockMap> {
 
     this._blockTree.onBlockAdded(id, this, {
       onChange: (block, key) => {
-        block.model.propsUpdated.emit({ key });
+        if (key) {
+          block.model.propsUpdated.emit({ key });
+        }
+
         this.slots.blockUpdated.emit({
           type: 'update',
           id,

--- a/tests/edgeless/clipboard.spec.ts
+++ b/tests/edgeless/clipboard.spec.ts
@@ -9,6 +9,7 @@ import {
   edgelessCommonSetup as commonSetup,
   pasteByKeyboard,
   selectAllByKeyboard,
+  waitNextFrame,
 } from '../utils/actions/index.js';
 import { assertConnectorPath } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
@@ -19,10 +20,12 @@ test.describe('connector clipboard', () => {
   }) => {
     await commonSetup(page);
     await createConnectorElement(page, [0, 0], [200, 100]);
+    await waitNextFrame(page);
     await copyByKeyboard(page);
     const move = await toViewCoord(page, [100, -50]);
     await page.mouse.click(move[0], move[1]);
     await pasteByKeyboard(page, false);
+    await waitNextFrame(page);
     await assertConnectorPath(
       page,
       [
@@ -48,6 +51,7 @@ test.describe('connector clipboard', () => {
     const move = await toViewCoord(page, [150, -50]);
     await page.mouse.click(move[0], move[1]);
     await pasteByKeyboard(page, false);
+    await waitNextFrame(page);
     await assertConnectorPath(
       page,
       [
@@ -70,6 +74,7 @@ test.describe('connector clipboard', () => {
     const move = await toViewCoord(page, [150, -49.5]);
     await page.mouse.move(move[0], move[1]);
     await pasteByKeyboard(page, false);
+    await waitNextFrame(page);
     await assertConnectorPath(
       page,
       [


### PR DESCRIPTION
- Defer the connectors' path updating to avoid double calculation
- Call mount after creating models
- Connectors' path should be updated when the xywh prop gets updated.
- Prevent `pop` from writing value to the ymap when the property is a local one
- Emit event in block observeDeep