### PR TITLE
fix(edgeless): drag to add note should support collapse

### DIFF
--- a/packages/blocks/src/page-block/edgeless/utils/note.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/note.ts
@@ -9,7 +9,11 @@ import {
 } from '../../../_common/utils/index.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { EdgelessPageBlockComponent } from '../edgeless-page-block.js';
-import { DEFAULT_NOTE_HEIGHT, DEFAULT_NOTE_WIDTH } from './consts.js';
+import {
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+  NOTE_MIN_HEIGHT,
+} from './consts.js';
 
 export type NoteOptions = {
   childFlavour: NoteChildrenFlavour;
@@ -35,9 +39,12 @@ export function addNote(
     { type: options.childType },
     noteId
   );
-  if (options.collapse) {
+  if (options.collapse && height > NOTE_MIN_HEIGHT) {
     const note = page.getBlockById(noteId) as NoteBlockModel;
-    page.updateBlock(note, () => (note.edgeless.collapse = true));
+    page.updateBlock(note, () => {
+      note.edgeless.collapse = true;
+      note.edgeless.collapsedHeight = height;
+    });
   }
   edgeless.slots.edgelessToolUpdated.emit({ type: 'default' });
 

--- a/tests/edgeless/selection.spec.ts
+++ b/tests/edgeless/selection.spec.ts
@@ -211,7 +211,8 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   );
   await setEdgelessTool(page, 'default');
   await page.mouse.click(210, 110);
-  let selectedRect = await page.locator(selectedRectClass);
+  let selectedRect = page.locator(selectedRectClass);
+  await page.waitForTimeout(300);
   await expect(selectedRect).toBeHidden();
   // Click to start selection and hold the mouse to trigger auto panning to the left
   await page.mouse.move(210, 110);
@@ -221,7 +222,7 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   await page.mouse.up();
 
   // Expect to select the shape element
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
   await page.waitForTimeout(300);
   await expect(selectedRect).toBeVisible();
 
@@ -241,7 +242,8 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   );
   await setEdgelessTool(page, 'default');
   await page.mouse.click(600, 100);
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
+  await page.waitForTimeout(300);
   await expect(selectedRect).toBeHidden();
   // Click to start selection and hold the mouse to trigger auto panning to the top
   await page.mouse.move(600, 100);
@@ -251,7 +253,7 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   await page.mouse.up();
 
   // Expect to select the empty note
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
   await page.waitForTimeout(300);
   await expect(selectedRect).toBeVisible();
 
@@ -271,7 +273,8 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   );
   await setEdgelessTool(page, 'default');
   await page.mouse.click(800, 600);
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
+  await page.waitForTimeout(100);
   await expect(selectedRect).toBeHidden();
   // Click to start selection and hold the mouse to trigger auto panning to the right
   await page.mouse.move(800, 600);
@@ -281,7 +284,7 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   await page.mouse.up();
 
   // Expect to select the empty note
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
   await page.waitForTimeout(300);
   await expect(selectedRect).toBeVisible();
 
@@ -304,7 +307,8 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   );
   await setEdgelessTool(page, 'default');
   await page.mouse.click(700, 800);
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
+  await page.waitForTimeout(100);
   await expect(selectedRect).toBeHidden();
 
   // Click to start selection and hold the mouse to trigger auto panning to the right
@@ -315,7 +319,8 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
   await page.mouse.up();
 
   // Expect to select the empty note
-  selectedRect = await page.locator(selectedRectClass);
+  selectedRect = page.locator(selectedRectClass);
+  await page.waitForTimeout(300);
   await expect(selectedRect).toBeVisible();
 });
 


### PR DESCRIPTION
To fix [TOV-454](https://linear.app/affine-design/issue/TOV-454/新-note-通过选区创建后-无法使用-auto-size-custom-size-的切换)

https://github.com/toeverything/blocksuite/assets/99816898/12cb198c-368b-4f39-8d2c-e8e032745fa8

