### PR TITLE
fix: show github status on update

### DIFF
--- a/packages/blocks/src/embed-github-block/utils.ts
+++ b/packages/blocks/src/embed-github-block/utils.ts
@@ -112,6 +112,9 @@ export async function refreshEmbedGithubStatus(
 
   embedGithubElement.page.updateBlock(embedGithubElement.model, {
     status: githubApiData.status,
+    statusReason: githubApiData.statusReason,
+    createdAt: githubApiData.createdAt,
+    assignees: githubApiData.assignees,
   });
 }
 


### PR DESCRIPTION
bug:
<img width="311" alt="image" src="https://github.com/toeverything/blocksuite/assets/54364088/f7fefa64-9715-43d5-a786-43885433086e">
