### PR TITLE
fix(edgeless): prevent file drop indicator on block elements in surface

### DIFF
--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -103,7 +103,10 @@ export class FileDropManager {
     let result: DropResult | null = null;
     if (element) {
       const model = getModelByBlockComponent(element);
-      result = calcDropTarget(point, model, element);
+      const parent = this.editorHost.page.getParent(model);
+      if (!matchFlavours(parent, ['affine:surface'])) {
+        result = calcDropTarget(point, model, element);
+      }
     }
     if (result) {
       FileDropManager._dropResult = result;

--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -65,6 +65,10 @@ export class FileDropManager {
     return this._blockService.std.host as EditorHost;
   }
 
+  get page() {
+    return this._blockService.page;
+  }
+
   get type(): 'before' | 'after' {
     return !FileDropManager._dropResult ||
       FileDropManager._dropResult.type !== 'before'
@@ -73,19 +77,35 @@ export class FileDropManager {
   }
 
   get targetModel(): BlockModel | null {
-    const pageBlock = this._blockService.page.root;
-    assertExists(pageBlock);
-
     let targetModel = FileDropManager._dropResult?.modelState.model || null;
 
     if (!targetModel && isInsideDocEditor(this.editorHost)) {
-      const lastNote = pageBlock.children[pageBlock.children.length - 1];
-      if (!matchFlavours(lastNote, ['affine:note'])) {
-        throw new Error('The last block is not a note block.');
-      }
-      targetModel = lastNote.lastItem();
-    }
+      const pageModel = this.page.root;
+      assertExists(pageModel);
 
+      let lastNote = pageModel.children[pageModel.children.length - 1];
+      if (!lastNote || !matchFlavours(lastNote, ['affine:note'])) {
+        const newNoteId = this.page.addBlock('affine:note', {}, pageModel.id);
+        const newNote = this.page.getBlockById(newNoteId);
+        assertExists(newNote);
+        lastNote = newNote;
+      }
+
+      const lastItem = lastNote.lastItem();
+      if (lastItem && !matchFlavours(lastItem, ['affine:note'])) {
+        targetModel = lastItem;
+      } else {
+        const newParagraphId = this.page.addBlock(
+          'affine:paragraph',
+          {},
+          lastNote,
+          0
+        );
+        const newParagraph = this.page.getBlockById(newParagraphId);
+        assertExists(newParagraph);
+        targetModel = newParagraph;
+      }
+    }
     return targetModel;
   }
 
@@ -94,7 +114,9 @@ export class FileDropManager {
 
     // allow only external drag-and-drop files
     const effectAllowed = event.dataTransfer?.effectAllowed ?? 'none';
-    if (effectAllowed !== 'all') return;
+    if (effectAllowed !== 'all') {
+      return;
+    }
 
     const { clientX, clientY } = event;
     const point = new Point(clientX, clientY);
@@ -103,7 +125,7 @@ export class FileDropManager {
     let result: DropResult | null = null;
     if (element) {
       const model = getModelByBlockComponent(element);
-      const parent = this.editorHost.page.getParent(model);
+      const parent = this.page.getParent(model);
       if (!matchFlavours(parent, ['affine:surface'])) {
         result = calcDropTarget(point, model, element);
       }
@@ -117,18 +139,31 @@ export class FileDropManager {
     }
   };
 
+  onDragLeave = () => {
+    FileDropManager._dropResult = null;
+    this._indicator.rect = null;
+  };
+
   private _onDrop = (event: DragEvent) => {
+    this._indicator.rect = null;
+
     const { onDrop } = this._fileDropOptions;
-    if (!onDrop) return;
+    if (!onDrop) {
+      return;
+    }
 
     event.preventDefault();
 
     // allow only external drag-and-drop files
     const effectAllowed = event.dataTransfer?.effectAllowed ?? 'none';
-    if (effectAllowed !== 'all') return;
+    if (effectAllowed !== 'all') {
+      return;
+    }
 
     const droppedFiles = event.dataTransfer?.files;
-    if (!droppedFiles || !droppedFiles.length) return;
+    if (!droppedFiles || !droppedFiles.length) {
+      return;
+    }
 
     const targetModel = this.targetModel;
     const place = this.type;
@@ -139,7 +174,5 @@ export class FileDropManager {
     onDrop({ files: [...droppedFiles], targetModel, place, point })?.catch(
       console.error
     );
-
-    this._indicator.rect = null;
   };
 }

--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -225,10 +225,12 @@ export class EdgelessClipboardController extends PageClipboard {
         }
       });
 
-      await Promise.all([
-        this.host.addImages(imageFiles, point),
-        this.host.addAttachments(attachmentFiles, point),
-      ]);
+      // when only images in clipboard, add image-blocks else add all files as attachments
+      if (attachmentFiles.length === 0) {
+        await this.host.addImages(imageFiles, point);
+      } else {
+        await this.host.addAttachments([...files], point);
+      }
 
       return;
     }

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -152,12 +152,18 @@ export class PageService extends BlockService<PageBlockModel> {
 
     this.loadFonts();
 
-    this.fileDropManager = new FileDropManager(this, this._fileDropOptions);
     this.exportManager = new ExportManager(this, this._exportOptions);
+
+    this.fileDropManager = new FileDropManager(this, this._fileDropOptions);
     this.disposables.addFromEvent(
       this.std.host,
       'dragover',
       this.fileDropManager.onDragOver
+    );
+    this.disposables.addFromEvent(
+      this.std.host,
+      'dragleave',
+      this.fileDropManager.onDragLeave
     );
   }
 


### PR DESCRIPTION
[TOV-426](https://linear.app/affine-design/issue/TOV-426/图片拖入后，卡住-insert-的-ui，并且添加图片不生效。)