### PR TITLE
refactor(edgeless): move edgeless tool to service

### DIFF
--- a/packages/blocks/src/page-block/edgeless/controllers/tools/index.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/index.ts
@@ -9,7 +9,7 @@ import type { EdgelessBlockModel } from '../../type.js';
 export abstract class EdgelessToolController<
   Tool extends EdgelessTool = EdgelessTool,
 > {
-  protected readonly _edgeless: EdgelessPageBlockComponent;
+  protected _edgeless!: EdgelessPageBlockComponent;
 
   protected _draggingArea: SelectionArea | null = null;
 
@@ -17,12 +17,12 @@ export abstract class EdgelessToolController<
 
   enableHover = false;
 
-  constructor(
-    edgeless: EdgelessPageBlockComponent,
-    service: EdgelessPageService
-  ) {
-    this._edgeless = edgeless;
+  constructor(service: EdgelessPageService) {
     this._service = service;
+  }
+
+  mount(edgeless: EdgelessPageBlockComponent) {
+    this._edgeless = edgeless;
   }
 
   get draggingArea() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -79,9 +79,19 @@ import {
   type ZoomAction,
 } from './components/zoom/zoom-toolbar.js';
 import { EdgelessClipboardController } from './controllers/clipboard.js';
+import { BrushToolController } from './controllers/tools/brush-tool.js';
+import { ConnectorToolController } from './controllers/tools/connector-tool.js';
+import { DefaultToolController } from './controllers/tools/default-tool.js';
+import { EraserToolController } from './controllers/tools/eraser-tool.js';
+import { PresentToolController } from './controllers/tools/frame-navigator-tool.js';
+import { FrameToolController } from './controllers/tools/frame-tool.js';
+import { NoteToolController } from './controllers/tools/note-tool.js';
+import { PanToolController } from './controllers/tools/pan-tool.js';
+import { ShapeToolController } from './controllers/tools/shape-tool.js';
+import { TextToolController } from './controllers/tools/text-tool.js';
 import { EdgelessPageKeyboardManager } from './edgeless-keyboard.js';
 import type { EdgelessPageService } from './edgeless-page-service.js';
-import { EdgelessToolsManager } from './services/tools-manager.js';
+import type { EdgelessToolConstructor } from './services/tools-manager.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import {
   DEFAULT_NOTE_HEIGHT,
@@ -201,7 +211,9 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
   fontLoader!: FontLoader;
 
-  tools!: EdgelessToolsManager;
+  get tools() {
+    return this.service.tool;
+  }
 
   get dispatcher() {
     return this.service?.uiEventDispatcher;
@@ -839,6 +851,26 @@ export class EdgelessPageBlockComponent extends BlockElement<
     }
   }
 
+  private _initTools() {
+    const tools = [
+      DefaultToolController,
+      BrushToolController,
+      EraserToolController,
+      TextToolController,
+      ShapeToolController,
+      ConnectorToolController,
+      NoteToolController,
+      FrameToolController,
+      PanToolController,
+      PresentToolController,
+    ] as EdgelessToolConstructor[];
+
+    tools.forEach(tool => {
+      this.service.registerTool(tool);
+    });
+    this.service.tool.mount(this);
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     this.clipboardController.hostConnected();
@@ -862,7 +894,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.mouseRoot = this.parentElement!;
-    this.tools = new EdgelessToolsManager(this, this.host.event);
+    this._initTools();
   }
 
   override disconnectedCallback() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -906,9 +906,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
     }
 
     this.keyboardManager = null;
-
-    this.tools.clear();
-    this.tools.dispose();
   }
 
   override renderBlock() {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
@@ -25,6 +25,8 @@ import type { SurfaceService } from '../../surface-block/surface-service.js';
 import { Bound } from '../../surface-block/utils/bound.js';
 import { PageService } from '../page-service.js';
 import { EdgelessSelectionManager } from './services/selection-manager.js';
+import type { EdgelessToolConstructor } from './services/tools-manager.js';
+import { EdgelessToolsManager } from './services/tools-manager.js';
 import type {
   EdgelessBlockModel,
   EdgelessModel,
@@ -37,6 +39,7 @@ export class EdgelessPageService extends PageService {
   private _layer!: LayerManager;
   private _selection!: EdgelessSelectionManager;
   private _viewport!: Viewport;
+  private _tool!: EdgelessToolsManager;
 
   override mounted() {
     super.mounted();
@@ -52,6 +55,7 @@ export class EdgelessPageService extends PageService {
     this._layer = LayerManager.create(this.page, this._surface);
     this._viewport = new Viewport();
     this._selection = new EdgelessSelectionManager(this);
+    this._tool = EdgelessToolsManager.create(this, []);
   }
 
   override unmounted() {
@@ -60,6 +64,11 @@ export class EdgelessPageService extends PageService {
     this._selection.dispose();
     this.selectionManager.set([]);
     this.viewport.dispose();
+    this.tool.dispose();
+  }
+
+  get tool() {
+    return this._tool;
   }
 
   get surface() {
@@ -401,6 +410,10 @@ export class EdgelessPageService extends PageService {
       editing: false,
       elements: elements.map(ele => ele.id),
     });
+  }
+
+  registerTool(Tool: EdgelessToolConstructor) {
+    return this.tool.register(Tool);
   }
 
   getConnectors(element: EdgelessModel | string) {


### PR DESCRIPTION
- Move the tools manager to the service
- Tool can be registered dynamically through `tool.register` method