### PR TITLE
fix(edgeless): don't record last props in session

### DIFF
--- a/packages/blocks/src/surface-block/managers/edit-session.ts
+++ b/packages/blocks/src/surface-block/managers/edit-session.ts
@@ -223,7 +223,6 @@ export class EditSessionStorage {
 
     recursive(props, overrideProps);
     this.slots.lastPropsUpdated.emit({ type, props: overrideProps });
-    sessionStorage.setItem(SESSION_PROP_KEY, JSON.stringify(this._lastProps));
   }
 
   apply(type: EdgelessElementType, props: Record<string, unknown>) {


### PR DESCRIPTION
Fix [AFF-237](https://linear.app/affine-design/issue/AFF-237/confirm-the-modified-scope-of-shapenotesconnector-toolbar)