### PR TITLE
fix(page): linked page/web toolbar should not be displayed when the page is in read-only mode

### DIFF
--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
@@ -81,6 +81,10 @@ export class AffineLink extends ShadowlessElement {
   `;
 
   private _whenHover = new HoverController(this, ({ abortController }) => {
+    if (this.blockElement.page.readonly) {
+      return null;
+    }
+
     const selection = this.std.selection;
     const textSelection = selection.find('text');
     if (

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -199,6 +199,10 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
   }
 
   private _whenHover = new HoverController(this, ({ abortController }) => {
+    if (this.page.readonly) {
+      return null;
+    }
+
     const selection = this.std.selection;
     const textSelection = selection.find('text');
     if (


### PR DESCRIPTION
[TOV-509](https://linear.app/affine-design/issue/TOV-509/linked-pageweb-toolbar-should-not-be-displayed-when-the-page-is-in)
closes #6137 