### PR TITLE
fix: export png incorrectly when svg without width and height

### DIFF
--- a/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/clipboard.ts
@@ -115,6 +115,10 @@ export class EdgelessClipboardController extends PageClipboard {
     return pageService;
   }
 
+  private get _exportManager() {
+    return this._pageService.exportManager;
+  }
+
   override hostConnected() {
     if (this._disposables.disposed) {
       this._disposables = new DisposableGroup();
@@ -949,6 +953,7 @@ export class EdgelessClipboardController extends PageClipboard {
     ctx.fillStyle = window.getComputedStyle(container).backgroundColor;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+    const replaceImgSrcWithSvg = this._exportManager.replaceImgSrcWithSvg;
     const replaceRichTextWithSvgElementFunc =
       this._replaceRichTextWithSvgElement.bind(this);
 
@@ -990,7 +995,7 @@ export class EdgelessClipboardController extends PageClipboard {
             element.style.setProperty('box-shadow', 'none');
           }
         });
-
+        await replaceImgSrcWithSvg(element);
         await replaceRichTextWithSvgElementFunc(element);
       },
       backgroundColor: window.getComputedStyle(viewportElement).backgroundColor,


### PR DESCRIPTION
To fix #5552 

This issue is due to the fact that when the svg does not set the width and height, but only sets the viewBox, it will adaptively change the size, causing only a small part of the rendering result to be displayed. If the width and height of an svg are set correctly, the exported svg will be complete. 

In order to solve this problem, special processing needs to be done when the img src is svg, and the width and height of svg need to be set.

Since there is no way to directly determine whether the img is of svg type from the url suffix of the img src, we need to fetch the blob first and then determine the blob type, which may cause the export time to become longer.

https://github.com/toeverything/blocksuite/assets/99816898/8f6137fa-8079-4966-b008-46cf45f6dc87



