### PR TITLE
feat(edgeless): embed-html style update

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-caption.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-caption.ts
@@ -7,6 +7,7 @@ import type { AttachmentBlockComponent } from '../../../attachment-block/attachm
 import type { BookmarkBlockComponent } from '../../../bookmark-block/bookmark-block.js';
 import type { EmbedFigmaBlockComponent } from '../../../embed-figma-block/embed-figma-block.js';
 import type { EmbedGithubBlockComponent } from '../../../embed-github-block/embed-github-block.js';
+import type { EmbedHtmlBlockComponent } from '../../../embed-html-block/embed-html-block.js';
 import type { EmbedLinkedDocBlockComponent } from '../../../embed-linked-doc-block/embed-linked-doc-block.js';
 import type { EmbedYoutubeBlockComponent } from '../../../embed-youtube-block/embed-youtube-block.js';
 import type { ImageBlockComponent } from '../../../image-block/image-block.js';
@@ -42,6 +43,7 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
     | EmbedYoutubeBlockComponent
     | EmbedFigmaBlockComponent
     | EmbedLinkedDocBlockComponent
+    | EmbedHtmlBlockComponent
     | SurfaceRefBlockComponent;
 
   @state()

--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -1,3 +1,5 @@
+import './../button.js';
+
 import type { BlockStdScope } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/lit';
 import { Slice } from '@blocksuite/store';

--- a/packages/blocks/src/_common/components/embed-card/embed-card-style-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-style-popper.ts
@@ -1,4 +1,5 @@
 import './../button.js';
+import '../tooltip/tooltip.js';
 
 import type { BlockStdScope } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/lit';

--- a/packages/blocks/src/_common/consts.ts
+++ b/packages/blocks/src/_common/consts.ts
@@ -20,6 +20,7 @@ export const EMBED_CARD_WIDTH: Record<EmbedCardStyle, number> = {
   cubeThick: 170,
   video: 752,
   figma: 752,
+  html: 752,
 };
 
 export const EMBED_CARD_HEIGHT: Record<EmbedCardStyle, number> = {
@@ -31,6 +32,7 @@ export const EMBED_CARD_HEIGHT: Record<EmbedCardStyle, number> = {
   cubeThick: 132,
   video: 544,
   figma: 544,
+  html: 544,
 };
 
 export const DEFAULT_IMAGE_PROXY_ENDPOINT =

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -42,7 +42,9 @@ export class EmbedBlockElement<
   }
 
   get edgeless() {
-    if (this._isInSurface) return null;
+    if (!this._isInSurface) {
+      return null;
+    }
     return this.host.querySelector('affine-edgeless-page');
   }
 
@@ -180,6 +182,7 @@ export class EmbedBlockElement<
         <div
           class="embed-block-container"
           style=${styleMap({
+            position: 'relative',
             width: '100%',
             margin: '18px 0px',
           })}

--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -7,6 +7,7 @@ import type { EmbedLinkedDocModel } from '../embed-linked-doc-block/embed-linked
 import type { EmbedYoutubeModel } from '../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../frame-block/index.js';
 import type { ImageBlockModel } from '../image-block/index.js';
+import type { EmbedHtmlModel } from '../index.js';
 import type { BookmarkBlockModel } from '../models.js';
 import type { NoteBlockModel } from '../note-block/index.js';
 import type { EdgelessModel } from '../page-block/edgeless/type.js';
@@ -128,7 +129,8 @@ export type TopLevelBlockModel =
   | EmbedGithubModel
   | EmbedYoutubeModel
   | EmbedFigmaModel
-  | EmbedLinkedDocModel;
+  | EmbedLinkedDocModel
+  | EmbedHtmlModel;
 
 export type { EdgelessModel as EdgelessModel };
 
@@ -258,4 +260,5 @@ export type EmbedCardStyle =
   | 'cube'
   | 'cubeThick'
   | 'video'
-  | 'figma';
+  | 'figma'
+  | 'html';

--- a/packages/blocks/src/_common/utils/model.ts
+++ b/packages/blocks/src/_common/utils/model.ts
@@ -15,6 +15,7 @@ import type {
   DividerBlockSchema,
   EmbedFigmaModel,
   EmbedGithubModel,
+  EmbedHtmlModel,
   EmbedLinkedDocModel,
   EmbedYoutubeModel,
   FrameBlockModel,
@@ -53,6 +54,7 @@ export type BlockModels = {
   'affine:embed-youtube': EmbedYoutubeModel;
   'affine:embed-figma': EmbedFigmaModel;
   'affine:embed-linked-doc': EmbedLinkedDocModel;
+  'affine:embed-html': EmbedHtmlModel;
 };
 
 export type BlockSchemas = {

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -57,7 +57,9 @@ export class BookmarkBlockComponent extends BlockElement<
   }
 
   get edgeless() {
-    if (this._isInSurface) return null;
+    if (!this._isInSurface) {
+      return null;
+    }
     return this.host.querySelector('affine-edgeless-page');
   }
 

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -1,57 +1,190 @@
-import { css, html, type PropertyValues } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import '../_common/components/block-selection.js';
+import '../_common/components/embed-card/embed-card-caption.js';
+import '../_common/components/embed-card/embed-card-toolbar.js';
 
+import { PathFinder } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
+import { html, nothing } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
-import type { EmbedHtmlModel } from './embed-html-model.js';
+import { Bound } from '../surface-block/utils/bound.js';
+import type { EmbedHtmlModel, EmbedHtmlStyles } from './embed-html-model.js';
+import type { EmbedHtmlService } from './embed-html-service.js';
+import { HtmlIcon, styles } from './styles.js';
 
 @customElement('affine-embed-html-block')
-export class EmbedHtmlBlock extends EmbedBlockElement<EmbedHtmlModel> {
-  static override styles = css`
-    //affine-html {
-    //  display: block;
-    //}
-    //
-    .embed-html-block-iframe {
-      border: none;
-      width: 100%;
-    }
-  `;
-  @query('.embed-html-block-iframe')
-  iframe!: HTMLIFrameElement;
+export class EmbedHtmlBlockComponent extends EmbedBlockElement<
+  EmbedHtmlModel,
+  EmbedHtmlService
+> {
+  static override styles = styles;
 
-  updateWH = () => {
-    const [, , w, h] = JSON.parse(this.model.xywh);
-    this.iframe.style.width = `${w}px`;
-    this.iframe.style.height = `${h}px`;
+  override _cardStyle: (typeof EmbedHtmlStyles)[number] = 'html';
+
+  @state()
+  private _isSelected = false;
+
+  @state()
+  private _showOverlay = true;
+
+  @query('iframe')
+  private _iframe!: HTMLIFrameElement;
+
+  @query('embed-card-caption')
+  captionElement!: EmbedCardCaption;
+
+  private _isDragging = false;
+
+  private _isResizing = false;
+
+  open = () => {
+    this._iframe.requestFullscreen().catch(console.error);
   };
 
-  public override connectedCallback() {
-    super.connectedCallback();
-    this.disposables.add(this.model.propsUpdated.on(this.updateWH));
+  refreshData = () => {};
+
+  private _selectBlock() {
+    const selectionManager = this.host.selection;
+    const blockSelection = selectionManager.create('block', {
+      path: this.path,
+    });
+    selectionManager.setGroup('note', [blockSelection]);
   }
 
-  protected override firstUpdated(_changedProperties: PropertyValues) {
-    super.firstUpdated(_changedProperties);
-    this.updateWH();
+  private _handleClick(event: MouseEvent) {
+    event.stopPropagation();
+    if (!this.isInSurface) {
+      this._selectBlock();
+    }
+  }
+
+  private _handleDoubleClick(event: MouseEvent) {
+    event.stopPropagation();
+    this.open();
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    // this is required to prevent iframe from capturing pointer events
+    this.disposables.add(
+      this.std.selection.slots.changed.on(sels => {
+        this._isSelected = sels.some(sel =>
+          PathFinder.equals(sel.path, this.path)
+        );
+        this._showOverlay =
+          this._isResizing || this._isDragging || !this._isSelected;
+      })
+    );
+    // this is required to prevent iframe from capturing pointer events
+    this.handleEvent('pointerMove', ctx => {
+      this._isDragging = ctx.get('pointerState').dragging;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    if (this.isInSurface) {
+      const surface = this.surface;
+      assertExists(surface);
+      this.disposables.add(
+        this.model.propsUpdated.on(() => {
+          this.requestUpdate();
+        })
+      );
+
+      this.edgeless?.slots.elementResizeStart.on(() => {
+        this._isResizing = true;
+        this._showOverlay = true;
+      });
+
+      this.edgeless?.slots.elementResizeEnd.on(() => {
+        this._isResizing = false;
+        this._showOverlay =
+          this._isResizing || this._isDragging || !this._isSelected;
+      });
+    }
   }
 
   override renderBlock(): unknown {
+    const { style, xywh } = this.model;
+
+    this._cardStyle = style;
+
+    const bound = Bound.deserialize(xywh);
+    this._width = this.isInSurface ? bound.w : EMBED_CARD_WIDTH[style];
+    this._height = this.isInSurface ? bound.h : EMBED_CARD_HEIGHT[style];
+
+    const titleText = 'Basic HTML Page Structure';
+
+    const htmlSrc = `
+      <style>
+        body { 
+          margin: 0;
+        } 
+      </style>
+      ${this.model.html}
+    `;
+
     return this.renderEmbed(() => {
       if (!this.model.html) {
         return html` <div class="affine-html-empty">Empty</div>`;
       }
-      return html`<iframe
-        class="embed-html-block-iframe"
-        sandbox="allow-scripts"
-        scrolling="false"
-        .srcdoc="${this.model.html}"
-      ></iframe>`;
+      return html`
+        <div
+          class=${classMap({
+            'affine-embed-html-block': true,
+            selected: this._isSelected,
+          })}
+          style=${styleMap({
+            width: this.isInSurface ? `${this._width}px` : '100%',
+            height: `${this._height}px`,
+          })}
+          @click=${this._handleClick}
+          @dblclick=${this._handleDoubleClick}
+        >
+          <div class="affine-embed-html">
+            <div class="affine-embed-html-iframe-container">
+              <iframe
+                class="embed-html-block-iframe"
+                sandbox="allow-scripts"
+                scrolling="no"
+                allowfullscreen
+                .srcdoc=${htmlSrc}
+              ></iframe>
+
+              <div
+                class=${classMap({
+                  'affine-embed-html-iframe-overlay': true,
+                  hide: !this._showOverlay,
+                })}
+              ></div>
+            </div>
+          </div>
+
+          <div class="affine-embed-html-title">
+            <div class="affine-embed-html-title-icon">${HtmlIcon}</div>
+
+            <div class="affine-embed-html-title-text">${titleText}</div>
+          </div>
+        </div>
+
+        <embed-card-caption .block=${this}></embed-card-caption>
+
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : nothing}
+      `;
     });
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'affine-embed-html-block': EmbedHtmlBlock;
+    'affine-embed-html-block': EmbedHtmlBlockComponent;
   }
 }

--- a/packages/blocks/src/embed-html-block/embed-html-model.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-model.ts
@@ -1,8 +1,13 @@
 import { BlockModel } from '@blocksuite/store';
 
 import { defineEmbedModel } from '../_common/embed-block-helper/index.js';
+import type { EmbedCardStyle } from '../_common/types.js';
+
+export const EmbedHtmlStyles: EmbedCardStyle[] = ['html'] as const;
 
 export type EmbedHtmlBlockProps = {
+  style: (typeof EmbedHtmlStyles)[number];
+  caption: string | null;
   html?: string;
   design?: string;
 };

--- a/packages/blocks/src/embed-html-block/embed-html-spec.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-spec.ts
@@ -1,16 +1,29 @@
 import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/index.js';
-import { EmbedHtmlModel } from './embed-html-model.js';
+import {
+  type EmbedHtmlBlockProps,
+  EmbedHtmlModel,
+  EmbedHtmlStyles,
+} from './embed-html-model.js';
+import { EmbedHtmlService } from './embed-html-service.js';
+
+const defaultEmbedHtmlProps: EmbedHtmlBlockProps = {
+  style: EmbedHtmlStyles[0],
+  caption: null,
+  html: undefined,
+  design: undefined,
+};
 
 export const EmbedHtmlBlockSpec = createEmbedBlock({
   schema: {
     name: 'html',
     version: 1,
     toModel: () => new EmbedHtmlModel(),
-    props: () => ({}),
+    props: (): EmbedHtmlBlockProps => defaultEmbedHtmlProps,
   },
   view: {
     component: literal`affine-embed-html-block`,
   },
+  service: EmbedHtmlService,
 });

--- a/packages/blocks/src/embed-html-block/index.ts
+++ b/packages/blocks/src/embed-html-block/index.ts
@@ -1,7 +1,7 @@
 import { noop } from '@blocksuite/global/utils';
 
-import { EmbedHtmlBlock } from './embed-html-block.js';
-noop(EmbedHtmlBlock);
+import { EmbedHtmlBlockComponent } from './embed-html-block.js';
+noop(EmbedHtmlBlockComponent);
 
 export * from './embed-html-block.js';
 export * from './embed-html-model.js';

--- a/packages/blocks/src/embed-html-block/styles.ts
+++ b/packages/blocks/src/embed-html-block/styles.ts
@@ -1,0 +1,126 @@
+import { css, html } from 'lit';
+
+export const EMBED_HTML_MIN_WIDTH = 370;
+export const EMBED_HTML_MIN_HEIGHT = 80;
+
+export const styles = css`
+  .affine-embed-html-block {
+    margin: 0 auto;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    padding: 12px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+
+    border-radius: 12px;
+    border: 1px solid var(--affine-background-tertiary-color);
+
+    opacity: var(--add, 1);
+    background: var(--affine-background-primary-color);
+    box-shadow: var(--affine-shadow-1);
+    user-select: none;
+  }
+
+  .affine-embed-html {
+    width: 100%;
+    height: calc(100% - 20px - 22px);
+    opacity: var(--add, 1);
+  }
+
+  .affine-embed-html img,
+  .affine-embed-html object,
+  .affine-embed-html svg {
+    width: 100%;
+    height: 100%;
+    object-fit: fill;
+    border-radius: 4px 4px var(--1, 0px) var(--1, 0px);
+  }
+
+  .affine-embed-html-iframe-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border-radius: 4px 4px 0px 0px;
+    box-shadow: var(--affine-shadow-1);
+    overflow: hidden;
+  }
+
+  .affine-embed-html-iframe-container > iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
+
+  .affine-embed-html-iframe-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .affine-embed-html-iframe-overlay.hide {
+    display: none;
+  }
+
+  .affine-embed-html-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    padding: var(--1, 0px);
+    border-radius: var(--1, 0px);
+    opacity: var(--add, 1);
+  }
+
+  .affine-embed-html-title-icon {
+    display: flex;
+    width: 20px;
+    height: 20px;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .affine-embed-html-title-icon img,
+  .affine-embed-html-title-icon object,
+  .affine-embed-html-title-icon svg {
+    width: 20px;
+    height: 20px;
+    fill: var(--affine-background-primary-color);
+  }
+
+  .affine-embed-html-title-text {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+
+    word-break: break-word;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--affine-text-primary-color);
+
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-sm);
+    font-style: normal;
+    font-weight: 600;
+    line-height: 22px;
+  }
+`;
+
+export const HtmlIcon = html`<svg
+  width="20"
+  height="20"
+  viewBox="0 0 20 20"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M6.66667 1.875C5.40101 1.875 4.375 2.90101 4.375 4.16667V6.66667C4.375 7.01184 4.65482 7.29167 5 7.29167C5.34518 7.29167 5.625 7.01184 5.625 6.66667V4.16667C5.625 3.59137 6.09137 3.125 6.66667 3.125H12.9349C13.2563 3.125 13.5598 3.27341 13.7571 3.52714L15.8222 6.18232C15.9645 6.36517 16.0417 6.5902 16.0417 6.82185V15C16.0417 15.5753 15.5753 16.0417 15 16.0417H6.66667C6.09137 16.0417 5.625 15.5753 5.625 15V13.75C5.625 13.4048 5.34518 13.125 5 13.125C4.65482 13.125 4.375 13.4048 4.375 13.75V15C4.375 16.2657 5.40101 17.2917 6.66667 17.2917H15C16.2657 17.2917 17.2917 16.2657 17.2917 15V6.82185C17.2917 6.31223 17.1218 5.81716 16.8089 5.4149L14.7438 2.75972C14.3096 2.2015 13.642 1.875 12.9349 1.875H6.66667ZM2.30713 11.4758C2.30713 11.7936 2.47945 11.9727 2.78158 11.9727C3.0837 11.9727 3.25602 11.7936 3.25602 11.4758V10.6679H4.3929V11.4758C4.3929 11.7936 4.56523 11.9727 4.86735 11.9727C5.16947 11.9727 5.3418 11.7936 5.3418 11.4758V9.12821C5.3418 8.81043 5.16947 8.63139 4.86735 8.63139C4.56523 8.63139 4.3929 8.81043 4.3929 9.12821V9.91374H3.25602V9.12821C3.25602 8.81043 3.0837 8.63139 2.78158 8.63139C2.47945 8.63139 2.30713 8.81043 2.30713 9.12821V11.4758ZM6.51672 11.4758C6.51672 11.7936 6.68905 11.9727 6.99117 11.9727C7.29329 11.9727 7.46562 11.7936 7.46562 11.4758V9.44377H7.9423C8.19295 9.44377 8.3608 9.30725 8.3608 9.06555C8.3608 8.82385 8.19743 8.68734 7.9423 8.68734H6.04004C5.78491 8.68734 5.62154 8.82385 5.62154 9.06555C5.62154 9.30725 5.78939 9.44377 6.04004 9.44377H6.51672V11.4758ZM9.05457 11.9727C8.79049 11.9727 8.64054 11.8138 8.64054 11.534V9.25354C8.64054 8.85518 8.85986 8.63139 9.25598 8.63139C9.58944 8.63139 9.76624 8.76343 9.90051 9.11479L10.46 10.5717H10.4779L11.0352 9.11479C11.1694 8.76343 11.3462 8.63139 11.6797 8.63139C12.0758 8.63139 12.2951 8.85518 12.2951 9.25354V11.534C12.2951 11.8138 12.1452 11.9727 11.8811 11.9727C11.617 11.9727 11.4671 11.8138 11.4671 11.534V10.0458H11.4492L10.8069 11.6638C10.742 11.8272 10.639 11.901 10.4712 11.901C10.3011 11.901 10.1914 11.825 10.1288 11.6638L9.48649 10.0458H9.46859V11.534C9.46859 11.8138 9.31864 11.9727 9.05457 11.9727ZM12.745 11.4199C12.745 11.7377 12.9173 11.9167 13.2194 11.9167H14.5868C14.8419 11.9167 15.0053 11.7802 15.0053 11.5385C15.0053 11.2968 14.8374 11.1603 14.5868 11.1603H13.6938V9.12821C13.6938 8.81043 13.5215 8.63139 13.2194 8.63139C12.9173 8.63139 12.745 8.81043 12.745 9.12821V11.4199Z"
+    fill="#77757D"
+  />
+</svg> `;

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -10,7 +10,6 @@ import { html, nothing, render, type TemplateResult } from 'lit';
 import { customElement, query, queryAsync, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ref } from 'lit/directives/ref.js';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
 import { HoverController } from '../_common/components/hover/controller.js';
@@ -507,53 +506,47 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
     return this.renderEmbed(
       () => html`
         <div
-          style=${styleMap({
-            position: 'relative',
-          })}
+          ${this.isInSurface ? null : ref(this._whenHover.setReference)}
+          class="affine-embed-linked-doc-block${cardClassMap}"
+          @click=${this._handleClick}
+          @dblclick=${this._handleDoubleClick}
         >
-          <div
-            ${this.isInSurface ? null : ref(this._whenHover.setReference)}
-            class="affine-embed-linked-doc-block${cardClassMap}"
-            @click=${this._handleClick}
-            @dblclick=${this._handleDoubleClick}
-          >
-            <div class="affine-embed-linked-doc-content">
-              <div class="affine-embed-linked-doc-content-title">
-                <div class="affine-embed-linked-doc-content-title-icon">
-                  ${titleIcon}
-                </div>
-
-                <div class="affine-embed-linked-doc-content-title-text">
-                  ${titleText}
-                </div>
+          <div class="affine-embed-linked-doc-content">
+            <div class="affine-embed-linked-doc-content-title">
+              <div class="affine-embed-linked-doc-content-title-icon">
+                ${titleIcon}
               </div>
 
-              <div class="affine-embed-linked-doc-content-description">
-                ${descriptionText}
-              </div>
-
-              <div class="affine-embed-linked-doc-content-date">
-                <span>Updated</span>
-
-                <span>${dateText}</span>
+              <div class="affine-embed-linked-doc-content-title-text">
+                ${titleText}
               </div>
             </div>
 
-            <div class="affine-embed-linked-doc-banner render"></div>
+            <div class="affine-embed-linked-doc-content-description">
+              ${descriptionText}
+            </div>
 
-            ${showDefaultBanner
-              ? html`<div class="affine-embed-linked-doc-banner default">
-                  ${defaultBanner}
-                </div>`
-              : nothing}
+            <div class="affine-embed-linked-doc-content-date">
+              <span>Updated</span>
+
+              <span>${dateText}</span>
+            </div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <div class="affine-embed-linked-doc-banner render"></div>
 
-          ${this.selected?.is('block')
-            ? html`<affine-block-selection></affine-block-selection>`
+          ${showDefaultBanner
+            ? html`<div class="affine-embed-linked-doc-banner default">
+                ${defaultBanner}
+              </div>`
             : nothing}
         </div>
+
+        <embed-card-caption .block=${this}></embed-card-caption>
+
+        ${this.selected?.is('block')
+          ? html`<affine-block-selection></affine-block-selection>`
+          : nothing}
       `
     );
   }

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -77,7 +77,9 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
   }
 
   get edgeless() {
-    if (this._isInSurface) return null;
+    if (!this._isInSurface) {
+      return null;
+    }
     return this.host.querySelector('affine-edgeless-page');
   }
 

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-embed-card-button.ts
@@ -22,6 +22,7 @@ import {
   CopyIcon,
   EditIcon,
   EmbedWebIcon,
+  ExpandFullIcon,
   OpenIcon,
   PaletteIcon,
   RefreshIcon,
@@ -40,7 +41,10 @@ import type { EmbedLinkedDocBlockComponent } from '../../../../embed-linked-doc-
 import type { EmbedLinkedDocModel } from '../../../../embed-linked-doc-block/embed-linked-doc-model.js';
 import type { EmbedYoutubeBlockComponent } from '../../../../embed-youtube-block/embed-youtube-block.js';
 import type { EmbedYoutubeModel } from '../../../../embed-youtube-block/embed-youtube-model.js';
-import type { BookmarkBlockComponent } from '../../../../index.js';
+import type {
+  BookmarkBlockComponent,
+  EmbedHtmlModel,
+} from '../../../../index.js';
 import {
   Bound,
   type EdgelessBlockType,
@@ -50,6 +54,7 @@ import type { EmbedOptions, PageService } from '../../../page-service.js';
 import {
   isBookmarkBlock,
   isEmbedGithubBlock,
+  isEmbedHtmlBlock,
   isEmbedLinkedDocBlock,
 } from '../../utils/query.js';
 import { createButtonPopper } from '../utils.js';
@@ -70,6 +75,11 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       display: flex;
       justify-content: center;
       align-items: center;
+    }
+
+    .change-embed-card-button svg {
+      width: 20px;
+      height: 20px;
     }
 
     .change-embed-card-button.url {
@@ -148,7 +158,8 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     | EmbedGithubModel
     | EmbedYoutubeModel
     | EmbedFigmaModel
-    | EmbedLinkedDocModel;
+    | EmbedLinkedDocModel
+    | EmbedHtmlModel;
 
   @property({ attribute: false })
   std!: BlockStdScope;
@@ -220,6 +231,10 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
   private get _canShowOpenButton() {
     return isEmbedLinkedDocBlock(this.model);
+  }
+
+  private get _canShowFullScreenButton() {
+    return isEmbedHtmlBlock(this.model);
   }
 
   private get _isCardView() {
@@ -451,10 +466,18 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
                 .vertical=${true}
               ></component-toolbar-menu-divider>`
           : nothing}
-
-        <div class="change-embed-card-view-style">
-          ${this._canConvertToEmbedView
-            ? html`
+        ${this._canShowFullScreenButton
+          ? html`<edgeless-tool-icon-button
+              .tooltip=${'Full screen'}
+              class="change-embed-card-button expand"
+              @click=${this._open}
+            >
+              ${ExpandFullIcon}
+            </edgeless-tool-icon-button> `
+          : nothing}
+        ${this._canConvertToEmbedView
+          ? html`
+              <div class="change-embed-card-view-style">
                 <div class="change-embed-card-button-view-selector">
                   <edgeless-tool-icon-button
                     class=${classMap({
@@ -486,29 +509,29 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
                     ${EmbedWebIcon}
                   </edgeless-tool-icon-button>
                 </div>
-              `
-            : nothing}
-          ${this._canShowCardStylePanel
-            ? html`
-                <div class="change-embed-card-button card-style">
-                  <edgeless-tool-icon-button
-                    .tooltip=${this._showPopper ? '' : 'Card style'}
-                    ?disabled=${this._page.readonly}
-                    @click=${() => this._cardStylePopper?.toggle()}
-                  >
-                    ${PaletteIcon}
-                  </edgeless-tool-icon-button>
+              </div>
+            `
+          : nothing}
+        ${this._canShowCardStylePanel
+          ? html`
+              <div class="change-embed-card-button card-style">
+                <edgeless-tool-icon-button
+                  .tooltip=${this._showPopper ? '' : 'Card style'}
+                  ?disabled=${this._page.readonly}
+                  @click=${() => this._cardStylePopper?.toggle()}
+                >
+                  ${PaletteIcon}
+                </edgeless-tool-icon-button>
 
-                  <card-style-panel
-                    .value=${model.style}
-                    .options=${this._getCardStyleOptions}
-                    .onSelect=${this._setCardStyle}
-                  >
-                  </card-style-panel>
-                </div>
-              `
-            : nothing}
-        </div>
+                <card-style-panel
+                  .value=${model.style}
+                  .options=${this._getCardStyleOptions}
+                  .onSelect=${this._setCardStyle}
+                >
+                </card-style-panel>
+              </div>
+            `
+          : nothing}
 
         <component-toolbar-menu-divider
           .vertical=${true}

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -42,6 +42,7 @@ import type { EmbedLinkedDocModel } from '../../../../embed-linked-doc-block/emb
 import type { EmbedYoutubeModel } from '../../../../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../../image-block/index.js';
+import type { EmbedHtmlModel } from '../../../../index.js';
 import type { AttachmentBlockModel } from '../../../../models.js';
 import type { NoteBlockModel } from '../../../../note-block/index.js';
 import type {
@@ -80,7 +81,8 @@ type CategorizedElements = {
     EmbedGithubModel[] &
     EmbedYoutubeModel[] &
     EmbedFigmaModel[] &
-    EmbedLinkedDocModel[];
+    EmbedLinkedDocModel[] &
+    EmbedHtmlModel[];
 };
 
 type ToolBarCustomAction = {

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -636,8 +636,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         height = clamp(height, NOTE_MIN_HEIGHT, Infinity);
         bound.h = height * scale;
 
-        this._isWidthLimit = width === NOTE_MIN_WIDTH ? true : false;
-        this._isHeightLimit = height === NOTE_MIN_HEIGHT ? true : false;
+        this._isWidthLimit = width === NOTE_MIN_WIDTH;
+        this._isHeightLimit = height === NOTE_MIN_HEIGHT;
 
         props.edgeless = { ...element.edgeless, scale };
         props.xywh = bound.serialize();
@@ -646,8 +646,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         bound.w = clamp(bound.w, EMBED_HTML_MIN_WIDTH, Infinity);
         bound.h = clamp(bound.h, EMBED_HTML_MIN_HEIGHT, Infinity);
 
-        this._isWidthLimit = bound.w === EMBED_HTML_MIN_WIDTH ? true : false;
-        this._isHeightLimit = bound.h === EMBED_HTML_MIN_HEIGHT ? true : false;
+        this._isWidthLimit = bound.w === EMBED_HTML_MIN_WIDTH;
+        this._isHeightLimit = bound.h === EMBED_HTML_MIN_HEIGHT;
 
         const props: Partial<EmbedHtmlModel> = {};
         props.xywh = bound.serialize();

--- a/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/page-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -20,6 +20,11 @@ import {
 } from '../../../../_common/utils/event.js';
 import { pickValues } from '../../../../_common/utils/iterable.js';
 import { clamp } from '../../../../_common/utils/math.js';
+import {
+  EMBED_HTML_MIN_HEIGHT,
+  EMBED_HTML_MIN_WIDTH,
+} from '../../../../embed-html-block/styles.js';
+import type { EmbedHtmlModel } from '../../../../index.js';
 import type { BookmarkBlockModel } from '../../../../models.js';
 import { NoteBlockModel } from '../../../../note-block/note-model.js';
 import { normalizeTextBound } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
@@ -53,6 +58,11 @@ import {
   isBookmarkBlock,
   isCanvasElement,
   isEmbeddedBlock,
+  isEmbedFigmaBlock,
+  isEmbedGithubBlock,
+  isEmbedHtmlBlock,
+  isEmbedLinkedDocBlock,
+  isEmbedYoutubeBlock,
   isFrameBlock,
   isImageBlock,
   isNoteBlock,
@@ -426,10 +436,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   private _scaleDirection?: HandleDirection;
 
   @state()
-  private _isNoteWidthLimit = false;
+  private _isWidthLimit = false;
 
   @state()
-  private _isNoteHeightLimit = false;
+  private _isHeightLimit = false;
 
   @state()
   private _shiftKey = false;
@@ -497,6 +507,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
           areAllShapes = false;
           areAllTexts = false;
         }
+      } else if (isEmbedHtmlBlock(element)) {
+        areAllConnectors = false;
       } else if (isFrameBlock(element)) {
         areAllConnectors = false;
       } else if (this._isProportionalElement(element)) {
@@ -525,10 +537,13 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
   private _isProportionalElement(element: EdgelessModel) {
     return (
+      isAttachmentBlock(element) ||
       isImageBlock(element) ||
       isBookmarkBlock(element) ||
-      isAttachmentBlock(element) ||
-      isEmbeddedBlock(element)
+      isEmbedFigmaBlock(element) ||
+      isEmbedGithubBlock(element) ||
+      isEmbedYoutubeBlock(element) ||
+      isEmbedLinkedDocBlock(element)
     );
   }
 
@@ -621,10 +636,20 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         height = clamp(height, NOTE_MIN_HEIGHT, Infinity);
         bound.h = height * scale;
 
-        this._isNoteWidthLimit = width === NOTE_MIN_WIDTH ? true : false;
-        this._isNoteHeightLimit = height === NOTE_MIN_HEIGHT ? true : false;
+        this._isWidthLimit = width === NOTE_MIN_WIDTH ? true : false;
+        this._isHeightLimit = height === NOTE_MIN_HEIGHT ? true : false;
 
         props.edgeless = { ...element.edgeless, scale };
+        props.xywh = bound.serialize();
+        edgeless.service.updateElement(element.id, props);
+      } else if (isEmbedHtmlBlock(element)) {
+        bound.w = clamp(bound.w, EMBED_HTML_MIN_WIDTH, Infinity);
+        bound.h = clamp(bound.h, EMBED_HTML_MIN_HEIGHT, Infinity);
+
+        this._isWidthLimit = bound.w === EMBED_HTML_MIN_WIDTH ? true : false;
+        this._isHeightLimit = bound.h === EMBED_HTML_MIN_HEIGHT ? true : false;
+
+        const props: Partial<EmbedHtmlModel> = {};
         props.xywh = bound.serialize();
         edgeless.service.updateElement(element.id, props);
       } else if (this._isProportionalElement(element)) {
@@ -729,8 +754,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     });
 
     this._dragEndCallback = [];
-    this._isNoteWidthLimit = false;
-    this._isNoteHeightLimit = false;
+    this._isWidthLimit = false;
+    this._isHeightLimit = false;
 
     this._updateCursor(false);
 
@@ -1085,7 +1110,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       <style>
         .affine-edgeless-selected-rect .handle[aria-label='right']::after {
           content: '';
-          display: ${this._isNoteWidthLimit ? 'initial' : 'none'};
+          display: ${this._isWidthLimit ? 'initial' : 'none'};
           position: absolute;
           top: 0;
           left: 1.5px;
@@ -1097,7 +1122,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
         .affine-edgeless-selected-rect .handle[aria-label='bottom']::after {
           content: '';
-          display: ${this._isNoteHeightLimit ? 'initial' : 'none'};
+          display: ${this._isHeightLimit ? 'initial' : 'none'};
           position: absolute;
           top: 1.5px;
           left: 0px;

--- a/packages/blocks/src/page-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/query.ts
@@ -13,6 +13,7 @@ import type { EmbedLinkedDocModel } from '../../../embed-linked-doc-block/embed-
 import type { EmbedYoutubeModel } from '../../../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
+import type { EmbedHtmlModel } from '../../../index.js';
 import type { AttachmentBlockModel } from '../../../models.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
 import {
@@ -120,6 +121,14 @@ export function isEmbedLinkedDocBlock(
     !!element &&
     'flavour' in element &&
     element.flavour === 'affine:embed-linked-doc'
+  );
+}
+
+export function isEmbedHtmlBlock(
+  element: BlockModel | EdgelessModel | null
+): element is EmbedHtmlModel {
+  return (
+    !!element && 'flavour' in element && element.flavour === 'affine:embed-html'
   );
 }
 

--- a/packages/blocks/src/surface-block/edgeless-types.ts
+++ b/packages/blocks/src/surface-block/edgeless-types.ts
@@ -2,6 +2,7 @@ import type { AttachmentBlockModel } from '../attachment-block/attachment-model.
 import type { BookmarkBlockModel } from '../bookmark-block/bookmark-model.js';
 import type { EmbedFigmaModel } from '../embed-figma-block/embed-figma-model.js';
 import type { EmbedGithubModel } from '../embed-github-block/embed-github-model.js';
+import type { EmbedHtmlModel } from '../embed-html-block/embed-html-model.js';
 import type { EmbedLinkedDocModel } from '../embed-linked-doc-block/embed-linked-doc-model.js';
 import type { EmbedYoutubeModel } from '../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../frame-block/index.js';
@@ -18,6 +19,7 @@ export type EdgelessBlockModelMap = {
   'affine:embed-youtube': EmbedYoutubeModel;
   'affine:embed-figma': EmbedFigmaModel;
   'affine:embed-linked-doc': EmbedLinkedDocModel;
+  'affine:embed-html': EmbedHtmlModel;
 };
 
 export type EdgelessBlockType =
@@ -29,7 +31,8 @@ export type EdgelessBlockType =
   | 'affine:embed-github'
   | 'affine:embed-youtube'
   | 'affine:embed-figma'
-  | 'affine:embed-linked-doc';
+  | 'affine:embed-linked-doc'
+  | 'affine:embed-html';
 
 export type EdgelessElementType =
   | EdgelessBlockType


### PR DESCRIPTION
[Figma](https://www.figma.com/file/JbC1cSHY4tDerKhpSjOXa6/%F0%9F%8F%A1-2024-S1?type=design&node-id=961%3A19305&mode=dev)

Changes:
- Updated embed-html card style (doc & edgeless)
- Added support for caption (doc & edgeless)
- Added support for resize - horizontal, vertical & diagonal (edgeless only)
- Added support for full screen view
- Added toolbar button in edgeless
- Added clipboard support
- Added drag & drop support - surface to note & vice-versa

Pending:
- Toolbar in doc mode (design needed)