### PR TITLE
fix(edgeless): frame title disappear after reordering frames

### DIFF
--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -24,26 +24,26 @@ export class FrameBlockComponent extends BlockElement<FrameBlockModel> {
 
   get isInner() {
     const title = this.titleElement;
-    if (!title) return false;
-    return title.isInner;
+    return !!title?.isInner;
   }
 
-  get surface() {
+  private get _surface() {
     return this.closest('affine-edgeless-page')!.surface;
   }
 
-  get edgeless() {
+  private get _edgeless() {
     return this.closest('affine-edgeless-page');
   }
 
   override connectedCallback() {
     super.connectedCallback();
+
     let lastZoom = 0;
     this._disposables.add(
-      this.edgeless!.service.viewport.viewportUpdated.on(({ zoom }) => {
+      this._edgeless!.service.viewport.viewportUpdated.on(({ zoom }) => {
         if (zoom !== lastZoom) {
-          this.requestUpdate();
           lastZoom = zoom;
+          this.requestUpdate();
         }
       })
     );
@@ -62,7 +62,7 @@ export class FrameBlockComponent extends BlockElement<FrameBlockModel> {
   }
 
   override firstUpdated() {
-    this.surface.edgeless.slots.edgelessToolUpdated.on(tool => {
+    this._surface.edgeless.slots.edgelessToolUpdated.on(tool => {
       this._isNavigator = tool.type === 'frameNavigator' ? true : false;
     });
   }

--- a/packages/blocks/src/page-block/edgeless/components/block-portal/frame/edgeless-frame.ts
+++ b/packages/blocks/src/page-block/edgeless/components/block-portal/frame/edgeless-frame.ts
@@ -14,7 +14,11 @@ const FRAME_OFFSET = 8;
 
 @customElement('edgeless-frame-title')
 export class EdgelessFrameTitle extends WithDisposable(ShadowlessElement) {
-  isInner = false;
+  @property({ attribute: false })
+  frame!: FrameBlockModel;
+
+  @property({ attribute: false })
+  edgeless!: EdgelessPageBlockComponent;
 
   @state()
   private _editing = false;
@@ -22,17 +26,19 @@ export class EdgelessFrameTitle extends WithDisposable(ShadowlessElement) {
   @state()
   private _isNavigator = false;
 
-  @property({ attribute: false })
-  frame!: FrameBlockModel;
+  private _isInner = false;
 
-  @property({ attribute: false })
-  edgeless!: EdgelessPageBlockComponent;
+  get isInner() {
+    return this._isInner;
+  }
 
   private _updateElement = () => {
     this.requestUpdate();
   };
 
-  override firstUpdated() {
+  override connectedCallback() {
+    super.connectedCallback();
+
     const { _disposables, edgeless } = this;
     const { service, surface } = edgeless;
 
@@ -62,19 +68,14 @@ export class EdgelessFrameTitle extends WithDisposable(ShadowlessElement) {
 
     _disposables.add(
       edgeless.service.selection.slots.updated.on(() => {
-        if (
+        this._editing =
           edgeless.service.selection.selectedIds[0] === this.frame.id &&
-          edgeless.service.selection.editing
-        ) {
-          this._editing = true;
-        } else {
-          this._editing = false;
-        }
+          edgeless.service.selection.editing;
       })
     );
 
     surface.edgeless.slots.edgelessToolUpdated.on(tool => {
-      this._isNavigator = tool.type === 'frameNavigator' ? true : false;
+      this._isNavigator = tool.type === 'frameNavigator';
     });
 
     this.setAttribute('data-frame-title-id', this.frame.id);
@@ -86,59 +87,64 @@ export class EdgelessFrameTitle extends WithDisposable(ShadowlessElement) {
   }
 
   override render() {
-    const { edgeless, frame: model, _isNavigator } = this;
-    const { service } = edgeless;
-    const { zoom } = service.viewport;
+    const model = this.frame;
     const bound = Bound.deserialize(model.xywh);
-    this.isInner = service.frames.some(frame => {
-      if (frame.id === model.id) return false;
-      if (Bound.deserialize(frame.xywh).contains(bound)) {
-        return true;
-      }
-      return false;
-    });
 
-    const [x, y] = service.viewport.toViewCoord(bound.x, bound.y);
-    const { isInner } = this;
-    const text = model.title.toString();
+    const { frames, viewport } = this.edgeless.service;
+    const { zoom } = viewport;
 
-    const top = (isInner ? FRAME_OFFSET : -(29 + FRAME_OFFSET)) + y;
-    const left = (isInner ? FRAME_OFFSET : 0) + x;
-    const maxWidth = isInner
+    this._isInner = frames.some(
+      frame =>
+        frame.id !== model.id && Bound.deserialize(frame.xywh).contains(bound)
+    );
+
+    const { _isNavigator, _editing, _isInner } = this;
+
+    const [x, y] = viewport.toViewCoord(bound.x, bound.y);
+    const left = (_isInner ? FRAME_OFFSET : 0) + x;
+    const top = (_isInner ? FRAME_OFFSET : -(29 + FRAME_OFFSET)) + y;
+    const maxWidth = _isInner
       ? bound.w * zoom - FRAME_OFFSET / zoom
       : bound.w * zoom;
-    const hidden = 32 / zoom > bound.h && isInner;
+    const hidden = 32 / zoom > bound.h && _isInner;
+
+    const text = model.title.toString();
+
     return html`
-      ${text && !_isNavigator && !this._editing
-        ? html` <div
-            style=${styleMap({
-              display: hidden ? 'none' : 'initial',
-              position: 'absolute',
-              zIndex: 1,
-              left: '0px',
-              top: '0px',
-              transform: `translate(${left}px, ${top}px)`,
-              borderRadius: '4px',
-              width: 'fit-content',
-              maxWidth: maxWidth + 'px',
-              padding: '8px 10px',
-              fontSize: '14px',
-              background: isInner
-                ? 'var(--affine-white)'
-                : 'var(--affine-text-primary-color)',
-              color: isInner
-                ? 'var(--affine-text-secondary-color)'
-                : 'var(--affine-white)',
-              cursor: 'default',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              border: isInner ? '1px solid var(--affine-border-color)' : 'none',
-            })}
-            class="affine-frame-title"
-          >
-            ${text}
-          </div>`
+      ${text && !_isNavigator && !_editing
+        ? html`
+            <div
+              style=${styleMap({
+                display: hidden ? 'none' : 'initial',
+                position: 'absolute',
+                zIndex: 1,
+                left: '0px',
+                top: '0px',
+                transform: `translate(${left}px, ${top}px)`,
+                borderRadius: '4px',
+                width: 'fit-content',
+                maxWidth: maxWidth + 'px',
+                padding: '8px 10px',
+                fontSize: '14px',
+                background: _isInner
+                  ? 'var(--affine-white)'
+                  : 'var(--affine-text-primary-color)',
+                color: _isInner
+                  ? 'var(--affine-text-secondary-color)'
+                  : 'var(--affine-white)',
+                cursor: 'default',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                border: _isInner
+                  ? '1px solid var(--affine-border-color)'
+                  : 'none',
+              })}
+              class="affine-frame-title"
+            >
+              ${text}
+            </div>
+          `
         : nothing}
     `;
   }
@@ -198,11 +204,13 @@ export class EdgelessFramesContainer extends WithDisposable(ShadowlessElement) {
         frame => frame.id,
         (frame, index) =>
           this.onlyTitle
-            ? html`<edgeless-frame-title
-                .frame=${frame}
-                .edgeless=${this.edgeless}
-              >
-              </edgeless-frame-title>`
+            ? html`
+                <edgeless-frame-title
+                  .frame=${frame}
+                  .edgeless=${this.edgeless}
+                >
+                </edgeless-frame-title>
+              `
             : html`
                 <edgeless-block-portal-frame
                   .index=${index}

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-frame-button.ts
@@ -1,3 +1,4 @@
+import '../buttons/tool-icon-button.js';
 import './component-toolbar-menu-divider.js';
 
 import { WithDisposable } from '@blocksuite/lit';
@@ -164,9 +165,12 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
               @click=${this._insertIntoPage}
             >
               ${NoteIcon}
+
               <span style="margin-left: 2px;">Insert into Page</span>
             </edgeless-tool-icon-button>
+
             <component-toolbar-menu-divider></component-toolbar-menu-divider>
+
             <edgeless-tool-icon-button
               .tooltip=${'Rename'}
               .tipPosition=${'bottom'}
@@ -176,6 +180,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
             >
               ${RenameIcon}
             </edgeless-tool-icon-button>
+
             <component-toolbar-menu-divider></component-toolbar-menu-divider>
           `
         : nothing}
@@ -190,6 +195,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
       >
         <div class="fill-color-container">${ColorUnit(background)}</div>
       </edgeless-tool-icon-button>
+
       <div class="color-panel-container fill-color">
         <edgeless-color-panel
           .value=${background}

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -1,5 +1,6 @@
 import '../buttons/tool-icon-button.js';
 import '../toolbar/shape/shape-menu.js';
+import '../../../../_common/components/menu-divider.js';
 
 import { WithDisposable } from '@blocksuite/lit';
 import { baseTheme } from '@toeverything/theme';

--- a/packages/blocks/src/page-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
+++ b/packages/blocks/src/page-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
@@ -73,7 +73,7 @@ export class EdgelessNavigatorBlackBackground extends WithDisposable(
     );
 
     _disposables.add(
-      edgeless.slots.fullScrennToggled.on(
+      edgeless.slots.fullScreenToggled.on(
         () =>
           setTimeout(() => {
             this.requestUpdate();

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -173,7 +173,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     },
   })
   private _currentFrameIndex = 0;
-  private _timer: ReturnType<typeof setTimeout> | null = null;
+  private _timer?: ReturnType<typeof setTimeout>;
   private _cachedIndex = -1;
 
   private get _frames(): FrameBlockModel[] {
@@ -368,7 +368,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
 
   private _toggleFullScreen() {
     if (document.fullscreenElement) {
-      this._timer && clearTimeout(this._timer);
+      clearTimeout(this._timer);
       document.exitFullscreen().catch(console.error);
     } else {
       launchIntoFullscreen(this.edgeless.viewportElement);
@@ -378,7 +378,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     }
 
     setTimeout(() => this._moveToCurrentFrame(), 400);
-    this.edgeless.slots.fullScrennToggled.emit();
+    this.edgeless.slots.fullScreenToggled.emit();
   }
 
   private get _FrameNavigator() {
@@ -394,6 +394,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       >
         ${FrameNavigatorPrevIcon}
       </edgeless-tool-icon-button>
+
       <div class="edgeless-frame-navigator">
         <span
           class="edgeless-frame-navigator-title"
@@ -401,34 +402,38 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
             (this._currentFrameIndex = this._currentFrameIndex + 0)}
           >${frame?.title ?? 'no frame'}</span
         >
+
         <span class="edgeless-frame-navigator-count"
           >${frames.length === 0 ? 0 : current + 1}/${frames.length}</span
         >
       </div>
+
       <edgeless-tool-icon-button
         .tooltip=${'Next'}
         @click=${() => this._nextFrame()}
       >
         ${FrameNavigatorNextIcon}
       </edgeless-tool-icon-button>
+
       <div class="short-divider"></div>
+
       <edgeless-frame-order-button
         .frames=${this._frames}
         .edgeless=${this.edgeless}
       >
       </edgeless-frame-order-button>
+
       <edgeless-tool-icon-button
         .tooltip=${document.fullscreenElement
           ? 'Exit Full Screen'
           : 'Enter Full Screen'}
-        @click=${() => {
-          this._toggleFullScreen();
-        }}
+        @click=${() => this._toggleFullScreen()}
       >
         ${document.fullscreenElement
           ? NavigatorExitFullScreenIcon
           : NavigatorFullScreenIcon}
       </edgeless-tool-icon-button>
+
       <edgeless-navigator-setting-button
         .edgeless=${this.edgeless}
         .hideToolbar=${this._hideToolbar}
@@ -441,7 +446,9 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
         }}
       >
       </edgeless-navigator-setting-button>
+
       <div class="short-divider"></div>
+
       <div
         class="edgeless-frame-navigator-stop"
         @click=${() => {
@@ -452,7 +459,6 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
           );
 
           document.fullscreenElement && this._toggleFullScreen();
-          setTimeout(() => this._moveToCurrentFrame(), 400);
         }}
       >
         Stop
@@ -465,28 +471,33 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     const { type } = edgelessTool;
     return html`
       <div class="full-divider"></div>
+
       <div class="brush-and-eraser">
         <edgeless-brush-tool-button
           .edgeless=${this.edgeless}
           .active=${type === 'brush'}
         ></edgeless-brush-tool-button>
+
         <edgeless-eraser-tool-button
           .edgelessTool=${this.edgelessTool}
           .edgeless=${this.edgeless}
           .setEdgelessTool=${this.setEdgelessTool}
         ></edgeless-eraser-tool-button>
       </div>
+
       <div class="edgeless-toolbar-right-part">
         <edgeless-shape-tool-button
           .edgeless=${this.edgeless}
           .active=${type === 'shape'}
         ></edgeless-shape-tool-button>
+
         <edgeless-text-tool-button
           .edgeless=${this.edgeless}
           .active=${type === 'text'}
         >
           ${EdgelessTextIcon}
         </edgeless-text-tool-button>
+
         <edgeless-toolbar-button
           class="transform-button"
           .disabled=${this._imageLoading}
@@ -497,6 +508,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
         >
           ${EdgelessImageIcon}
         </edgeless-toolbar-button>
+
         <edgeless-template-button .edgeless=${this.edgeless}>
         </edgeless-template-button>
       </div>

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-order-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/frame-order-menu.ts
@@ -11,7 +11,7 @@ import type { EdgelessPageBlockComponent } from '../../../edgeless-page-block.js
 @customElement('edgeless-frame-order-menu')
 export class EdgelessFrameOrderMenu extends WithDisposable(LitElement) {
   static override styles = css`
-    .edgeelss-frame-order-items-container {
+    .edgeless-frame-order-items-container {
       max-height: 281px;
       border-radius: 8px;
       padding: 8px 0px 8px 8px;
@@ -113,7 +113,7 @@ export class EdgelessFrameOrderMenu extends WithDisposable(LitElement) {
   @property({ attribute: false })
   frames!: FrameBlockModel[];
 
-  @query('.edgeelss-frame-order-items-container')
+  @query('.edgeless-frame-order-items-container')
   private _container!: HTMLDivElement;
 
   @query('.indicator-line')
@@ -218,7 +218,7 @@ export class EdgelessFrameOrderMenu extends WithDisposable(LitElement) {
 
     return html`
       <div
-        class="edgeelss-frame-order-items-container"
+        class="edgeless-frame-order-items-container"
         @click=${(e: MouseEvent) => e.stopPropagation()}
       >
         ${repeat(

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
@@ -110,6 +110,7 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
       >
         ${NavigatorSettingsIcon}
       </edgeless-tool-icon-button>
+
       <div
         class="navigator-setting-menu"
         @click=${(e: MouseEvent) => {
@@ -119,16 +120,20 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
         <div class="item-container">
           <div class="text title">Playback Settings</div>
         </div>
+
         <div class="item-container">
           <div class="text">Dark background</div>
+
           <toggle-switch
             .on=${this.blackBackground}
             .onChange=${this._onBlackBackgroundChange}
           >
           </toggle-switch>
         </div>
+
         <div class="item-container">
           <div class="text">Hide toolbar</div>
+
           <toggle-switch
             .on=${this.hideToolbar}
             .onChange=${(checked: boolean) => {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -199,7 +199,7 @@ export class EdgelessPageBlockComponent extends BlockElement<
       fillScreen?: boolean;
     }>(),
     navigatorFrameChanged: new Slot<FrameBlockModel>(),
-    fullScrennToggled: new Slot(),
+    fullScreenToggled: new Slot(),
 
     elementResizeStart: new Slot(),
     elementResizeEnd: new Slot(),


### PR DESCRIPTION
[TOV-499](https://linear.app/affine-design/issue/TOV-499/frame-title-disappear-after-reordering-frames)

closes #6125 