### PR TITLE
fix(edgeless): insert frame/group into page

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-frame-button.ts
@@ -9,6 +9,8 @@ import { html } from 'lit/static-html.js';
 import { toast } from '../../../../_common/components/toast.js';
 import { NoteIcon, RenameIcon } from '../../../../_common/icons/index.js';
 import type { CssVariableName } from '../../../../_common/theme/css-variables.js';
+import { NoteDisplayMode } from '../../../../_common/types.js';
+import { matchFlavours } from '../../../../_common/utils/model.js';
 import type { FrameBlockModel } from '../../../../frame-block/index.js';
 import {
   deserializeXYWH,
@@ -107,13 +109,17 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
     if (!this.surface.page.root) return;
 
     const root = this.surface.page.root;
-    const pageChildren = root.children;
-    const last = pageChildren[pageChildren.length - 1];
+    const notes = root.children.filter(
+      model =>
+        matchFlavours(model, ['affine:note']) &&
+        model.displayMode !== NoteDisplayMode.EdgelessOnly
+    );
+    const lastNote = notes[notes.length - 1];
     const referenceFrame = this.frames[0];
 
-    let targetParent = last?.id;
+    let targetParent = lastNote?.id;
 
-    if (last?.flavour !== 'affine:note') {
+    if (!lastNote) {
       const targetXYWH = deserializeXYWH(referenceFrame.xywh);
 
       targetXYWH[1] = targetXYWH[1] + targetXYWH[3];

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-group-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-group-button.ts
@@ -11,8 +11,8 @@ import {
   RenameIcon,
   UngroupButtonIcon,
 } from '../../../../_common/icons/index.js';
+import { NoteDisplayMode } from '../../../../_common/types.js';
 import { matchFlavours } from '../../../../_common/utils/model.js';
-import { NoteDisplayMode } from '../../../../index.js';
 import type { GroupElementModel } from '../../../../surface-block/index.js';
 import {
   deserializeXYWH,

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-group-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/change-group-button.ts
@@ -11,6 +11,8 @@ import {
   RenameIcon,
   UngroupButtonIcon,
 } from '../../../../_common/icons/index.js';
+import { matchFlavours } from '../../../../_common/utils/model.js';
+import { NoteDisplayMode } from '../../../../index.js';
 import type { GroupElementModel } from '../../../../surface-block/index.js';
 import {
   deserializeXYWH,
@@ -38,13 +40,17 @@ export class EdgelessChangeGroupButton extends WithDisposable(LitElement) {
     if (!this.surface.page.root) return;
 
     const root = this.surface.page.root;
-    const pageChildren = root.children;
-    const last = pageChildren[pageChildren.length - 1];
+    const notes = root.children.filter(
+      model =>
+        matchFlavours(model, ['affine:note']) &&
+        model.displayMode !== NoteDisplayMode.EdgelessOnly
+    );
+    const lastNote = notes[notes.length - 1];
     const referenceGroup = this.groups[0];
 
-    let targetParent = last?.id;
+    let targetParent = lastNote?.id;
 
-    if (last?.flavour !== 'affine:note') {
+    if (!lastNote) {
       const targetXYWH = deserializeXYWH(referenceGroup.xywh);
 
       targetXYWH[1] = targetXYWH[1] + targetXYWH[3];


### PR DESCRIPTION
When insert frame or group into page, should insert into the last doc visible note. If there is no doc visible note, should create a new one then insert the frame or group into it.

To fix [TOV-527](https://linear.app/affine-design/issue/TOV-527/unable-to-insert-frame-into-page)