### PR TITLE
chore: replace ambiguous "page" with "doc"

### DIFF
--- a/packages/blocks/src/page-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/page-block/widgets/linked-doc/config.ts
@@ -88,7 +88,7 @@ export const getMenus: (ctx: {
 
   return [
     {
-      name: 'Link to Page',
+      name: 'Link to Doc',
       styles: 'overflow-y: scroll; max-height: 224px;',
       items: filteredPageList.map(page => ({
         key: page.id,
@@ -103,11 +103,11 @@ export const getMenus: (ctx: {
       })),
     },
     {
-      name: 'New page',
+      name: 'New Doc',
       items: [
         {
           key: 'create',
-          name: `Create "${displayPageName}" page`,
+          name: `Create "${displayPageName}" doc`,
           icon: NewPageIcon,
           action: async () => {
             const pageName = query;

--- a/packages/blocks/src/page-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/page-block/widgets/slash-menu/config.ts
@@ -188,10 +188,10 @@ export const menuGroups: SlashMenuOptions['menus'] = [
   },
 
   {
-    name: 'Pages',
+    name: 'Docs',
     items: [
       {
-        name: 'New Page',
+        name: 'New Doc',
         icon: NewPageIcon,
         action: async ({ pageElement, model }) => {
           const newPage = await createDefaultPage(pageElement.page.workspace);
@@ -204,7 +204,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
         },
       },
       {
-        name: 'Link Page',
+        name: 'Link Doc',
         alias: ['dual link'],
         icon: DualLinkIcon,
         showWhen: (_, pageElement) => {

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -698,14 +698,14 @@ test.describe('linked page popover', () => {
     await expect(pageBtn).toHaveText([
       'page1',
       'page2',
-      'Create "Untitled" page',
+      'Create "Untitled" doc',
       'Import',
     ]);
     // page2
     //  ^  ^
     await type(page, 'a2');
     await expect(pageBtn).toHaveCount(3);
-    await expect(pageBtn).toHaveText(['page2', 'Create "a2" page', 'Import']);
+    await expect(pageBtn).toHaveText(['page2', 'Create "a2" doc', 'Import']);
     await pressEnter(page);
     await expect(linkedPagePopover).toBeHidden();
     await assertExistRefText('page2');

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -416,6 +416,8 @@ test.describe('slash search', () => {
     await expect(slashItems).toHaveText([
       'Code Block',
       'Italic',
+      'New Doc',
+      'Link Doc',
       'File',
       'Copy',
       'Duplicate',


### PR DESCRIPTION
In order to distinguish between `doc` and `page mode` [TOV-532](https://linear.app/affine-design/issue/TOV-532/affine-侧-page-名称更改为-doc)