### PR TITLE
fix(page): delete block when deleting the last database view

### DIFF
--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -465,6 +465,10 @@ class DatabaseBlockViewSource implements ViewSource {
         },
         delete: () => {
           this.model.page.captureSync();
+          if (this.model.getViewList().length === 1) {
+            this.model.page.deleteBlock(this.model);
+            return;
+          }
           this.model.deleteView(id);
           this.currentId = undefined;
           this.model.applyViewsUpdate();


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/6071

This pull request fixes an issue where the last database view was not being deleted properly. 

Before

https://github.com/toeverything/blocksuite/assets/18554747/891a4c92-095b-4be6-aad8-9feeb1e7eaae

