### PR TITLE
refactor: move edgeless page slots to edgeless page service

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -81,7 +81,7 @@ export class EdgelessBrushToolButton extends EdgelessToolButton<
     if (this._states.some(key => changedProperties.has(key))) {
       if (this._menu) {
         this.updateMenu();
-        this.edgeless.slots.edgelessToolUpdated.emit({
+        this.edgeless.tools.setEdgelessTool({
           type: this._type,
         });
       }

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -76,7 +76,7 @@ export class EdgelessConnectorToolButton extends EdgelessToolButton<
     if (this._states.some(key => changedProperties.has(key))) {
       if (this._menu) {
         this.updateMenu();
-        this.edgeless.slots.edgelessToolUpdated.emit({
+        this.edgeless.tools.setEdgelessTool({
           type: this._type,
           mode: this.mode,
         });

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-menu.ts
@@ -62,7 +62,7 @@ export class EdgelessNoteMenu extends WithDisposable(LitElement) {
   childFlavour!: NoteChildrenFlavour;
 
   @property({ attribute: false })
-  childType!: string;
+  childType!: string | null;
 
   @property({ attribute: false })
   tip!: string;
@@ -75,6 +75,22 @@ export class EdgelessNoteMenu extends WithDisposable(LitElement) {
       tip: string;
     }>
   ) => void;
+
+  override firstUpdated() {
+    this.disposables.add(
+      this.edgeless.slots.edgelessToolUpdated.on(tool => {
+        if (tool.type !== 'affine:note') return;
+        this.childFlavour = tool.childFlavour;
+        this.childType = tool.childType;
+        this.tip = tool.tip;
+      })
+    );
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disposables.dispose();
+  }
 
   override render() {
     if (this.edgeless.edgelessTool.type !== 'affine:note') return nothing;

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/note/note-tool-button.ts
@@ -78,7 +78,7 @@ export class EdgelessNoteToolButton extends WithDisposable(LitElement) {
             Object.assign(this, { [key]: props[key] });
           }
         });
-        this.edgeless.slots.edgelessToolUpdated.emit({
+        this.edgeless.tools.setEdgelessTool({
           type: 'affine:note',
           childFlavour: this.childFlavour,
           childType: this.childType,

--- a/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -189,7 +189,7 @@ export class EdgelessShapeToolButton extends EdgelessToolButton<
     if (this._states.some(key => changedProperties.has(key))) {
       if (this._menu) {
         this.updateMenu();
-        this.edgeless.slots.edgelessToolUpdated.emit({
+        this.edgeless.tools.setEdgelessTool({
           type: this._type,
           shapeType: this.shapeType,
         });

--- a/packages/blocks/src/page-block/edgeless/components/zoom/zoom-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/zoom/zoom-toolbar.ts
@@ -12,12 +12,7 @@ import {
   type EdgelessTool,
   stopPropagation,
 } from '../../../../_common/utils/index.js';
-import { clamp } from '../../../../_common/utils/math.js';
-import {
-  ZOOM_MAX,
-  ZOOM_MIN,
-  ZOOM_STEP,
-} from '../../../../surface-block/index.js';
+import { ZOOM_STEP } from '../../../../surface-block/index.js';
 import type { EdgelessPageBlockComponent } from '../../edgeless-page-block.js';
 
 export type ZoomAction = 'fit' | 'out' | 'reset' | 'in';
@@ -110,40 +105,21 @@ export class EdgelessZoomToolbar extends WithDisposable(LitElement) {
     return this.edgeless.edgelessTool;
   }
 
+  get edgelessService() {
+    return this.edgeless.service;
+  }
+
   get zoom() {
     return this.viewport.zoom;
   }
 
   get viewport() {
-    return this.edgeless.service.viewport;
-  }
-
-  private _setZoomByStep(step: number) {
-    this.viewport.smoothZoom(clamp(this.zoom + step, ZOOM_MIN, ZOOM_MAX));
-  }
-
-  private _zoomToFit() {
-    const { centerX, centerY, zoom } = this.edgeless.getFitToScreenData();
-    this.viewport.setViewport(zoom, [centerX, centerY], true);
+    return this.edgelessService.viewport;
   }
 
   setEdgelessTool = (edgelessTool: EdgelessTool) => {
     this.edgeless.tools.setEdgelessTool(edgelessTool);
   };
-
-  setZoomByAction(action: ZoomAction) {
-    switch (action) {
-      case 'fit':
-        this._zoomToFit();
-        break;
-      case 'reset':
-        this.viewport.smoothZoom(1.0);
-        break;
-      case 'in':
-      case 'out':
-        this._setZoomByStep(ZOOM_STEP * (action === 'in' ? 1 : -1));
-    }
-  }
 
   override firstUpdated() {
     const {
@@ -189,7 +165,7 @@ export class EdgelessZoomToolbar extends WithDisposable(LitElement) {
           .tooltip=${'Fit to screen'}
           .tipPosition=${this._isVerticalBar() ? 'right' : 'top-end'}
           .arrow=${!this._isVerticalBar()}
-          @click=${() => this._zoomToFit()}
+          @click=${() => this.edgelessService.zoomToFit()}
         >
           ${ViewBarIcon}
         </edgeless-tool-icon-button>
@@ -197,7 +173,7 @@ export class EdgelessZoomToolbar extends WithDisposable(LitElement) {
           .tooltip=${'Zoom out'}
           .tipPosition=${this._isVerticalBar() ? 'right' : 'top'}
           .arrow=${!this._isVerticalBar()}
-          @click=${() => this._setZoomByStep(-ZOOM_STEP)}
+          @click=${() => this.edgelessService.setZoomByStep(-ZOOM_STEP)}
         >
           ${MinusIcon}
         </edgeless-tool-icon-button>
@@ -208,7 +184,7 @@ export class EdgelessZoomToolbar extends WithDisposable(LitElement) {
           .tooltip=${'Zoom in'}
           .tipPosition=${this._isVerticalBar() ? 'right' : 'top'}
           .arrow=${!this._isVerticalBar()}
-          @click=${() => this._setZoomByStep(ZOOM_STEP)}
+          @click=${() => this.edgelessService.setZoomByStep(ZOOM_STEP)}
         >
           ${PlusIcon}
         </edgeless-tool-icon-button>

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/default-tool.ts
@@ -245,7 +245,8 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
       const viewport = this._service.viewport;
       if (viewport.zoom === 1) {
         // Fit to Screen
-        const { centerX, centerY, zoom } = this._edgeless.getFitToScreenData();
+        const { centerX, centerY, zoom } =
+          this._edgeless.service.getFitToScreenData();
         viewport.setViewport(zoom, [centerX, centerY], true);
       } else {
         // Zoom to 100% and Center

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/note-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/note-tool.ts
@@ -131,7 +131,7 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
 
     if (width < NOTE_MIN_WIDTH || height < NOTE_MIN_HEIGHT) {
       //TODO: add toast to notify user
-      this._edgeless.slots.edgelessToolUpdated.emit({ type: 'default' });
+      this._edgeless.tools.setEdgelessTool({ type: 'default' });
       return;
     }
 

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/pan-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/pan-tool.ts
@@ -33,7 +33,7 @@ export class PanToolController extends EdgelessToolController<PanTool> {
 
   onContainerDragStart(e: PointerEventState) {
     this._lastPoint = [e.x, e.y];
-    this._edgeless.slots.edgelessToolUpdated.emit({
+    this._edgeless.tools.setEdgelessTool({
       type: 'pan',
       panning: true,
     });
@@ -56,7 +56,7 @@ export class PanToolController extends EdgelessToolController<PanTool> {
 
   onContainerDragEnd() {
     this._lastPoint = null;
-    this._edgeless.slots.edgelessToolUpdated.emit({
+    this._edgeless.tools.setEdgelessTool({
       type: 'pan',
       panning: false,
     });

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/shape-tool.ts
@@ -57,6 +57,7 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
   }
 
   onContainerClick(e: PointerEventState): void {
+    console.log('onContainerClick: ', this.tool);
     this.clearOverlay();
 
     this._page.captureSync();

--- a/packages/blocks/src/page-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/page-block/edgeless/controllers/tools/shape-tool.ts
@@ -57,7 +57,6 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
   }
 
   onContainerClick(e: PointerEventState): void {
-    console.log('onContainerClick: ', this.tool);
     this.clearOverlay();
 
     this._page.captureSync();

--- a/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
@@ -152,19 +152,19 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
         'Mod-1': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.pageElement.slots.zoomUpdated.emit('fit');
+          this.pageElement.service.setZoomByAction('fit');
         },
         'Mod--': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.pageElement.slots.zoomUpdated.emit('out');
+          this.pageElement.service.setZoomByAction('out');
         },
         'Mod-0': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.pageElement.slots.zoomUpdated.emit('reset');
+          this.pageElement.service.setZoomByAction('reset');
         },
         'Mod-=': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.pageElement.slots.zoomUpdated.emit('in');
+          this.pageElement.service.setZoomByAction('in');
         },
         Backspace: () => {
           this._delete();

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -11,7 +11,7 @@ import {
 import { BlockElement } from '@blocksuite/lit';
 import { type BlockModel } from '@blocksuite/store';
 import { css, html } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
+import { customElement, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import { toast } from '../../_common/components/toast.js';
@@ -22,6 +22,7 @@ import {
 } from '../../_common/consts.js';
 import { listenToThemeChange } from '../../_common/theme/utils.js';
 import {
+  type EdgelessTool,
   NoteDisplayMode,
   Point,
   requestConnectedFrame,
@@ -155,6 +156,11 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
   mouseRoot!: HTMLElement;
 
+  @state()
+  edgelessTool: EdgelessTool = {
+    type: localStorage.defaultTool ?? 'default',
+  };
+
   @query('edgeless-block-portal-container')
   pageBlockContainer!: EdgelessBlockPortalContainer;
 
@@ -170,10 +176,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
   get tools() {
     return this.service.tool;
-  }
-
-  get edgelessTool() {
-    return this.service.tool.edgelessTool;
   }
 
   get dispatcher() {
@@ -257,6 +259,9 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
     disposables.add(this.tools);
     disposables.add(this.service.selection);
+    disposables.add(
+      slots.edgelessToolUpdated.on(tool => (this.edgelessTool = tool))
+    );
     disposables.add(
       slots.cursorUpdated.on(
         throttle((cursor: string) => {

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
@@ -53,7 +53,6 @@ export class EdgelessPageService extends PageService {
 
   slots = {
     edgelessToolUpdated: new Slot<EdgelessTool>(),
-    zoomUpdated: new Slot<ZoomAction>(),
     pressShiftKeyUpdated: new Slot<boolean>(),
     cursorUpdated: new Slot<string>(),
     copyAsPng: new Slot<{
@@ -173,9 +172,6 @@ export class EdgelessPageService extends PageService {
       })
     );
 
-    disposables.add(
-      slots.zoomUpdated.on((action: ZoomAction) => this.setZoomByAction(action))
-    );
     disposables.add(
       slots.pressShiftKeyUpdated.on(pressed => {
         this.tool.shiftKey = pressed;

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
@@ -60,7 +60,6 @@ export class EdgelessPageService extends PageService {
       shapes: CanvasElement[];
     }>(),
     pageLinkClicked: new Slot<{ pageId: string; blockId?: string }>(),
-    tagClicked: new Slot<{ tagId: string }>(),
     readonlyUpdated: new Slot<boolean>(),
     draggingAreaUpdated: new Slot(),
     navigatorSettingUpdated: new Slot<{

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -5,7 +5,7 @@ import {
   type UIEventHandler,
   type UIEventState,
 } from '@blocksuite/block-std';
-import { DisposableGroup, Slot } from '@blocksuite/global/utils';
+import { DisposableGroup } from '@blocksuite/global/utils';
 
 import {
   type EdgelessTool,
@@ -81,8 +81,6 @@ export class EdgelessToolsManager {
   private _shiftKey = false;
 
   private _dragging = false;
-
-  edgelessToolUpdated = new Slot<EdgelessTool>();
 
   get dragging() {
     return this._dragging;
@@ -409,7 +407,7 @@ export class EdgelessToolsManager {
     if (this.edgelessTool === edgelessTool) return;
     const lastType = this.edgelessTool.type;
     this._controllers[lastType].beforeModeSwitch(edgelessTool);
-    this._controllers[edgelessTool.type].beforeModeSwitch(edgelessTool);
+    this._controllers[type].beforeModeSwitch(edgelessTool);
 
     if (
       type === 'default' &&
@@ -422,6 +420,7 @@ export class EdgelessToolsManager {
     }
 
     this.selection.set(state);
+    this.edgelessTool = edgelessTool;
     this.container.slots.edgelessToolUpdated.emit(edgelessTool);
     this._controllers[lastType].afterModeSwitch(edgelessTool);
     this._controllers[edgelessTool.type].afterModeSwitch(edgelessTool);

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -369,7 +369,7 @@ export class EdgelessToolsManager {
         edgelessTool: edgelessTool,
       } = this._rightClickTimer;
       if (e.raw.timeStamp - timeStamp > 233) {
-        this.container.slots.edgelessToolUpdated.emit(edgelessTool);
+        this.setEdgelessTool(edgelessTool);
       } else {
         clearTimeout(timer);
       }

--- a/packages/blocks/src/page-block/edgeless/utils/note.ts
+++ b/packages/blocks/src/page-block/edgeless/utils/note.ts
@@ -46,7 +46,7 @@ export function addNote(
       note.edgeless.collapsedHeight = height;
     });
   }
-  edgeless.slots.edgelessToolUpdated.emit({ type: 'default' });
+  edgeless.tools.setEdgelessTool({ type: 'default' });
 
   // Wait for edgelessTool updated
   requestAnimationFrame(() => {

--- a/packages/blocks/src/page-block/widgets/block-hub/config.ts
+++ b/packages/blocks/src/page-block/widgets/block-hub/config.ts
@@ -89,7 +89,7 @@ export const BLOCKHUB_TEXT_ITEMS: BlockHubItem[] = [
   },
   {
     flavour: 'affine:code',
-    type: null,
+    type: 'code',
     name: 'Code Block',
     description: 'Capture a code snippet.',
     icon: CodeBlockIcon,

--- a/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
+++ b/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
@@ -128,7 +128,7 @@ export class OutlinePanelHeader extends WithDisposable(LitElement) {
               ? 'active'
               : ''}"
             .tooltip=${this._settingPopperShow ? '' : 'Preview Settings'}
-            .tipPosition=${'left'}
+            .tipPosition=${'bottom'}
             .iconContainerPadding=${2}
             .active=${this._settingPopperShow}
             .activeMode=${'background'}


### PR DESCRIPTION
- Move edgeless page slots to edgeless page service and remove some slots.
- Move zoom related actions to service.
- Uniformly use toolManager.setEdgelessTool when changing tool types.