### PR TITLE
refactor: expose transformers on page service

### DIFF
--- a/packages/blocks/src/_common/transformers/html.ts
+++ b/packages/blocks/src/_common/transformers/html.ts
@@ -4,7 +4,7 @@ import { Job } from '@blocksuite/store';
 import { HtmlAdapter } from '../adapters/index.js';
 import { createAssetsArchive, download } from './utils.js';
 
-export async function exportPage(page: Page) {
+async function exportPage(page: Page) {
   const job = new Job({ workspace: page.workspace });
   const snapshot = await job.pageToSnapshot(page);
   const adapter = new HtmlAdapter();
@@ -30,3 +30,7 @@ export async function exportPage(page: Page) {
   }
   download(downloadBlob, name);
 }
+
+export const HtmlTransformer = {
+  exportPage,
+};

--- a/packages/blocks/src/_common/transformers/index.ts
+++ b/packages/blocks/src/_common/transformers/index.ts
@@ -1,9 +1,9 @@
-export * as HtmlTransformer from './html.js';
-export * as MarkdownTransformer from './markdown.js';
+export { HtmlTransformer } from './html.js';
+export { MarkdownTransformer } from './markdown.js';
 export {
   customImageProxyMiddleware,
   defaultImageProxyMiddleware,
   replaceIdMiddleware,
   setImageProxyMiddlewareURL,
 } from './middlewares.js';
-export * as ZipTransformer from './zip.js';
+export { ZipTransformer } from './zip.js';

--- a/packages/blocks/src/_common/transformers/markdown.ts
+++ b/packages/blocks/src/_common/transformers/markdown.ts
@@ -6,7 +6,7 @@ import { MarkdownAdapter } from '../adapters/index.js';
 import { defaultImageProxyMiddleware } from './middlewares.js';
 import { createAssetsArchive, download } from './utils.js';
 
-export async function exportPage(page: Page) {
+async function exportPage(page: Page) {
   const job = new Job({ workspace: page.workspace });
   const snapshot = await job.pageToSnapshot(page);
 
@@ -41,7 +41,7 @@ type ImportMarkdownOptions = {
   noteId: string;
 };
 
-export async function importMarkdown({
+async function importMarkdown({
   page,
   markdown,
   noteId,
@@ -71,3 +71,8 @@ export async function importMarkdown({
 
   return;
 }
+
+export const MarkdownTransformer = {
+  exportPage,
+  importMarkdown,
+};

--- a/packages/blocks/src/_common/transformers/zip.ts
+++ b/packages/blocks/src/_common/transformers/zip.ts
@@ -11,7 +11,7 @@ import JSZip from 'jszip';
 
 import { replaceIdMiddleware } from './middlewares.js';
 
-export async function exportPages(workspace: Workspace, pages: Page[]) {
+async function exportPages(workspace: Workspace, pages: Page[]) {
   const zip = new JSZip();
 
   const job = new Job({ workspace });
@@ -38,7 +38,7 @@ export async function exportPages(workspace: Workspace, pages: Page[]) {
   return zip.generateAsync({ type: 'blob' });
 }
 
-export async function importPages(workspace: Workspace, imported: Blob) {
+async function importPages(workspace: Workspace, imported: Blob) {
   const zip = new JSZip();
   const { files } = await zip.loadAsync(imported);
 
@@ -112,3 +112,8 @@ export async function importPages(workspace: Workspace, imported: Blob) {
     })
   );
 }
+
+export const ZipTransformer = {
+  exportPages,
+  importPages,
+};

--- a/packages/blocks/src/page-block/page-service.ts
+++ b/packages/blocks/src/page-block/page-service.ts
@@ -8,6 +8,11 @@ import {
 } from '../_common/components/file-drop-manager.js';
 import { DEFAULT_IMAGE_PROXY_ENDPOINT } from '../_common/consts.js';
 import { ExportManager } from '../_common/export-manager/export-manager.js';
+import {
+  HtmlTransformer,
+  MarkdownTransformer,
+  ZipTransformer,
+} from '../_common/transformers/index.js';
 import type { EmbedCardStyle } from '../_common/types.js';
 import { DEFAULT_CANVAS_TEXT_FONT_CONFIG } from '../surface-block/consts.js';
 import { EditSessionStorage } from '../surface-block/managers/edit-session.js';
@@ -45,6 +50,12 @@ export class PageService extends BlockService<PageBlockModel> {
 
   fileDropManager!: FileDropManager;
   exportManager!: ExportManager;
+
+  transformers = {
+    markdown: MarkdownTransformer,
+    html: HtmlTransformer,
+    zip: ZipTransformer,
+  };
 
   private _fileDropOptions: FileDropOptions = {
     flavour: this.flavour,

--- a/packages/playground/apps/default/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/default/components/quick-edgeless-menu.ts
@@ -479,7 +479,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
                 >
                   <sl-menu-item>
                     <sl-icon slot="prefix" name="github"></sl-icon>
-                    Github
+                    GitHub
                   </sl-menu-item>
                 </a>
               </sl-menu>

--- a/packages/playground/apps/default/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/default/components/quick-edgeless-menu.ts
@@ -20,10 +20,7 @@ import type { AffineTextAttributes } from '@blocksuite/blocks';
 import {
   ColorVariables,
   extractCssVariables,
-  HtmlTransformer,
-  MarkdownTransformer,
   type PageService,
-  ZipTransformer,
 } from '@blocksuite/blocks';
 import type { DeltaInsert } from '@blocksuite/inline';
 import { ShadowlessElement } from '@blocksuite/lit';
@@ -189,11 +186,13 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   }
 
   private _exportHtml() {
-    HtmlTransformer.exportPage(this.page).catch(console.error);
+    const htmlTransformer = this.pageService.transformers.html;
+    htmlTransformer.exportPage(this.page).catch(console.error);
   }
 
   private _exportMarkDown() {
-    MarkdownTransformer.exportPage(this.page).catch(console.error);
+    const markdownTransformer = this.pageService.transformers.markdown;
+    markdownTransformer.exportPage(this.page).catch(console.error);
   }
 
   private _exportPng() {
@@ -201,7 +200,8 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   }
 
   private async _exportSnapshot() {
-    const file = await ZipTransformer.exportPages(this.workspace, [this.page]);
+    const zipTransformer = this.pageService.transformers.zip;
+    const file = await zipTransformer.exportPages(this.workspace, [this.page]);
     const url = URL.createObjectURL(file);
     const a = document.createElement('a');
     a.setAttribute('href', url);
@@ -222,7 +222,8 @@ export class QuickEdgelessMenu extends ShadowlessElement {
         return;
       }
       try {
-        const pages = await ZipTransformer.importPages(this.workspace, file);
+        const zipTransformer = this.pageService.transformers.zip;
+        const pages = await zipTransformer.importPages(this.workspace, file);
         for (const page of pages) {
           const noteBlock = window.page.getBlockByFlavour('affine:note');
           window.page.addBlock(


### PR DESCRIPTION
This allows importing and exporting page(s) easily in AFFiNE.

``` ts
const pageService = host.spec.getService('affine:page') as PageService;

const htmlTransformer = pageService.transformers.html;
htmlTransformer.exportPage(page);

const markdownTransformer = pageService.transformers.markdown;
markdownTransformer.exportPage(page);

const zipTransformer = pageService.transformers.zip;
zipTransformer.exportPages(workspace, [page]);
```
