### PR TITLE
refactor: simplify the usage of `affine-block-selection`

### DIFF
--- a/packages/blocks/src/_common/components/block-selection.ts
+++ b/packages/blocks/src/_common/components/block-selection.ts
@@ -1,4 +1,5 @@
-import { css, LitElement } from 'lit';
+import type { BlockElement } from '@blocksuite/lit';
+import { css, LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 /**
@@ -37,19 +38,30 @@ export class BlockSelection extends LitElement {
   `;
 
   @property({ attribute: false })
+  block!: BlockElement;
+
+  @property({ attribute: false })
   borderRadius?: number = 5;
 
   @property({ attribute: false })
   borderWidth?: number = 0;
 
+  protected override updated(_changedProperties: PropertyValues): void {
+    super.updated(_changedProperties);
+    this.style.display = this.block.selected?.is('block') ? 'block' : 'none';
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
+
     this.style.borderRadius = `${this.borderRadius}px`;
     if (this.borderWidth !== 0) {
       this.style.boxSizing = 'content-box';
       this.style.transform = `translate(-${this.borderWidth}px, -${this.borderWidth}px)`;
     }
     this.style.borderWidth = `${this.borderWidth}px`;
+
+    this.block.host.selection.slots.changed.on(() => this.requestUpdate());
   }
 }
 

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -1,10 +1,9 @@
 import '../_common/components/embed-card/embed-card-caption.js';
 
-import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import { flip, offset } from '@floating-ui/dom';
-import { html, nothing, render } from 'lit';
+import { html, render } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ref } from 'lit/directives/ref.js';
@@ -246,10 +245,10 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(
-      this.std.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.path)
-        );
+      this.std.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.selected?.is('block') || !!this.selected?.is('surface');
+
         this._showOverlay =
           this._isResizing || this._isDragging || !this._isSelected;
       })
@@ -393,60 +392,60 @@ export class AttachmentBlockComponent extends BlockElement<AttachmentBlockModel>
 
     const embedView = this._embedView;
 
-    return html`<div
-      ${this.isInSurface ? null : ref(this._whenHover.setReference)}
-      class="affine-attachment-container"
-      style=${containerStyleMap}
-    >
-      ${embedView
-        ? html`<div
-            class="affine-attachment-embed-container"
-            @click=${this._handleClick}
-            @dblclick=${this._handleDoubleClick}
-          >
-            ${embedView}
+    return html`
+      <div
+        ${this.isInSurface ? null : ref(this._whenHover.setReference)}
+        class="affine-attachment-container"
+        style=${containerStyleMap}
+      >
+        ${embedView
+          ? html`<div
+              class="affine-attachment-embed-container"
+              @click=${this._handleClick}
+              @dblclick=${this._handleDoubleClick}
+            >
+              ${embedView}
 
-            <div
+              <div
+                class=${classMap({
+                  'affine-attachment-iframe-overlay': true,
+                  hide: !this._showOverlay,
+                })}
+              ></div>
+            </div>`
+          : html`<div
               class=${classMap({
-                'affine-attachment-iframe-overlay': true,
-                hide: !this._showOverlay,
+                'affine-attachment-card': true,
+                [cardStyle]: true,
+                loading: this.loading,
+                error: this.error,
+                unsynced: false,
               })}
-            ></div>
-          </div>`
-        : html`<div
-            class=${classMap({
-              'affine-attachment-card': true,
-              [cardStyle]: true,
-              loading: this.loading,
-              error: this.error,
-              unsynced: false,
-            })}
-            @click=${this._handleClick}
-            @dblclick=${this._handleDoubleClick}
-          >
-            <div class="affine-attachment-content">
-              <div class="affine-attachment-content-title">
-                <div class="affine-attachment-content-title-icon">
-                  ${titleIcon}
+              @click=${this._handleClick}
+              @dblclick=${this._handleDoubleClick}
+            >
+              <div class="affine-attachment-content">
+                <div class="affine-attachment-content-title">
+                  <div class="affine-attachment-content-title-icon">
+                    ${titleIcon}
+                  </div>
+
+                  <div class="affine-attachment-content-title-text">
+                    ${titleText}
+                  </div>
                 </div>
 
-                <div class="affine-attachment-content-title-text">
-                  ${titleText}
-                </div>
+                <div class="affine-attachment-content-info">${infoText}</div>
               </div>
 
-              <div class="affine-attachment-content-info">${infoText}</div>
-            </div>
+              <div class="affine-attachment-banner">${FileTypeIcon}</div>
+            </div>`}
 
-            <div class="affine-attachment-banner">${FileTypeIcon}</div>
-          </div>`}
+        <embed-card-caption .block=${this}></embed-card-caption>
 
-      <embed-card-caption .block=${this}></embed-card-caption>
-
-      ${this.selected?.is('block')
-        ? html`<affine-block-selection></affine-block-selection>`
-        : nothing}
-    </div> `;
+        <affine-block-selection .block=${this}></affine-block-selection>
+      </div>
+    `;
   }
 }
 

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -6,7 +6,7 @@ import '../_common/components/embed-card/embed-card-toolbar.js';
 import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import { flip, offset } from '@floating-ui/dom';
-import { html, nothing, render } from 'lit';
+import { html, render } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -272,23 +272,23 @@ export class BookmarkBlockComponent extends BlockElement<
       });
     }
 
-    return html`<div
-      ${this.isInSurface ? null : ref(this._whenHover.setReference)}
-      class="affine-bookmark-container"
-      style=${containerStyleMap}
-    >
-      <bookmark-card
-        .bookmark=${this}
-        .loading=${this.loading}
-        .error=${this.error}
-      ></bookmark-card>
+    return html`
+      <div
+        ${this.isInSurface ? null : ref(this._whenHover.setReference)}
+        class="affine-bookmark-container"
+        style=${containerStyleMap}
+      >
+        <bookmark-card
+          .bookmark=${this}
+          .loading=${this.loading}
+          .error=${this.error}
+        ></bookmark-card>
 
-      <embed-card-caption .block=${this}></embed-card-caption>
+        <embed-card-caption .block=${this}></embed-card-caption>
 
-      ${this.selected?.is('block')
-        ? html`<affine-block-selection></affine-block-selection>`
-        : nothing}
-    </div> `;
+        <affine-block-selection .block=${this}></affine-block-selection>
+      </div>
+    `;
   }
 }
 

--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -1,4 +1,3 @@
-import { PathFinder } from '@blocksuite/block-std';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -42,10 +41,10 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
     this.disposables.add(() => this._themeObserver.dispose());
 
     this.disposables.add(
-      this.bookmark.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.bookmark.path)
-        );
+      this.bookmark.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.bookmark.selected?.is('block') ||
+          !!this.bookmark.selected?.is('surface');
       })
     );
   }

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -620,35 +620,37 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
   }
 
   override renderBlock(): TemplateResult<1> {
-    return html`<div
-      ${ref(this._whenHover.setReference)}
-      class=${classMap({
-        'affine-code-block-container': true,
-        wrap: this._wrap,
-      })}
-    >
-      ${this._curLanguageButtonTemplate()}
-      <div class="rich-text-container">
-        <div contenteditable="false" id="line-numbers"></div>
-        <rich-text
-          .yText=${this.model.text.yText}
-          .inlineEventSource=${this.topContenteditableElement ?? nothing}
-          .undoManager=${this.model.page.history}
-          .attributesSchema=${this.attributesSchema}
-          .attributeRenderer=${this.getAttributeRenderer()}
-          .readonly=${this.model.page.readonly}
-          .inlineRangeProvider=${this._inlineRangeProvider}
-          .enableClipboard=${false}
-          .enableUndoRedo=${false}
-          .wrapText=${this._wrap}
-        >
-        </rich-text>
+    return html`
+      <div
+        ${ref(this._whenHover.setReference)}
+        class=${classMap({
+          'affine-code-block-container': true,
+          wrap: this._wrap,
+        })}
+      >
+        ${this._curLanguageButtonTemplate()}
+        <div class="rich-text-container">
+          <div contenteditable="false" id="line-numbers"></div>
+          <rich-text
+            .yText=${this.model.text.yText}
+            .inlineEventSource=${this.topContenteditableElement ?? nothing}
+            .undoManager=${this.model.page.history}
+            .attributesSchema=${this.attributesSchema}
+            .attributeRenderer=${this.getAttributeRenderer()}
+            .readonly=${this.model.page.readonly}
+            .inlineRangeProvider=${this._inlineRangeProvider}
+            .enableClipboard=${false}
+            .enableUndoRedo=${false}
+            .wrapText=${this._wrap}
+          >
+          </rich-text>
+        </div>
+
+        ${this.renderModelChildren(this.model)}
+
+        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
-      ${this.renderModelChildren(this.model)}
-      ${this.selected?.is('block')
-        ? html`<affine-block-selection></affine-block-selection>`
-        : null}
-    </div>`;
+    `;
   }
 }
 

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -13,7 +13,6 @@ import { Slice } from '@blocksuite/store';
 import { css, nothing, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { when } from 'lit/directives/when.js';
 import { html } from 'lit/static-html.js';
 
 import { DragIndicator } from '../_common/components/index.js';
@@ -379,13 +378,11 @@ export class DatabaseBlockComponent extends BlockElement<
           ${ref(this._view)}
           .config="${config}"
         ></affine-data-view-native>
-        ${when(
-          this.selected?.is('block'),
-          () =>
-            html` <affine-block-selection
-              style="z-index: 1"
-            ></affine-block-selection>`
-        )}
+
+        <affine-block-selection
+          .block=${this}
+          style="z-index: 1"
+        ></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -1,4 +1,6 @@
 /// <reference types="vite/client" />
+import '../_common/components/block-selection.js';
+
 import { BlockElement } from '@blocksuite/lit';
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -51,10 +53,10 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
     return html`
       <div class="affine-divider-block-container">
         <hr />
+
         ${children}
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : null}
+
+        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -2,10 +2,9 @@ import '../_common/components/block-selection.js';
 import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/embed-card/embed-card-toolbar.js';
 
-import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { flip, offset } from '@floating-ui/dom';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ref } from 'lit/directives/ref.js';
@@ -97,10 +96,10 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(
-      this.std.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.path)
-        );
+      this.std.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.selected?.is('block') || !!this.selected?.is('surface');
+
         this._showOverlay =
           this._isResizing || this._isDragging || !this._isSelected;
       })
@@ -237,9 +236,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
 
         <embed-card-caption .block=${this}></embed-card-caption>
 
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : nothing}
+        <affine-block-selection .block=${this}></affine-block-selection>
       `
     );
   }

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -2,7 +2,6 @@ import '../_common/components/block-selection.js';
 import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/embed-card/embed-card-toolbar.js';
 
-import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { flip, offset } from '@floating-ui/dom';
 import { html, nothing } from 'lit';
@@ -123,10 +122,9 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
     );
 
     this.disposables.add(
-      this.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.path)
-        );
+      this.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.selected?.is('block') || !!this.selected?.is('surface');
       })
     );
 
@@ -339,9 +337,7 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
 
           <embed-card-caption .block=${this}></embed-card-caption>
 
-          ${this.selected?.is('block')
-            ? html`<affine-block-selection></affine-block-selection>`
-            : nothing}
+          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
       `
     );

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -2,9 +2,8 @@ import '../_common/components/block-selection.js';
 import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/embed-card/embed-card-toolbar.js';
 
-import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -73,10 +72,10 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(
-      this.std.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.path)
-        );
+      this.std.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.selected?.is('block') || !!this.selected?.is('surface');
+
         this._showOverlay =
           this._isResizing || this._isDragging || !this._isSelected;
       })
@@ -175,9 +174,7 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
 
         <embed-card-caption .block=${this}></embed-card-caption>
 
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : nothing}
+        <affine-block-selection .block=${this}></affine-block-selection>
       `;
     });
   }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -544,9 +544,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
 
         <embed-card-caption .block=${this}></embed-card-caption>
 
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : nothing}
+        <affine-block-selection .block=${this}></affine-block-selection>
       `
     );
   }

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -2,7 +2,6 @@ import '../_common/components/block-selection.js';
 import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/embed-card/embed-card-toolbar.js';
 
-import { PathFinder } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { flip, offset } from '@floating-ui/dom';
 import { html, nothing } from 'lit';
@@ -118,10 +117,10 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(
-      this.std.selection.slots.changed.on(sels => {
-        this._isSelected = sels.some(sel =>
-          PathFinder.equals(sel.path, this.path)
-        );
+      this.std.selection.slots.changed.on(() => {
+        this._isSelected =
+          !!this.selected?.is('block') || !!this.selected?.is('surface');
+
         this._showOverlay =
           this._isResizing || this._isDragging || !this._isSelected;
       })
@@ -302,9 +301,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
 
         <embed-card-caption .block=${this}></embed-card-caption>
 
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : nothing}
+        <affine-block-selection .block=${this}></affine-block-selection>
       `
     );
   }

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -5,7 +5,7 @@ import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/block-selection.js';
 
 import { BlockElement } from '@blocksuite/lit';
-import { html, nothing, render } from 'lit';
+import { html, render } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -302,9 +302,7 @@ export class ImageBlockComponent extends BlockElement<ImageBlockModel> {
 
         <embed-card-caption .block=${this}></embed-card-caption>
 
-        ${this.selected?.is('block')
-          ? html`<affine-block-selection></affine-block-selection>`
-          : nothing}
+        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
 
       ${this.isInSurface ? null : Object.values(this.widgets)}

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -1,12 +1,12 @@
 /// <reference types="vite/client" />
 import '../_common/components/rich-text/rich-text.js';
+import '../_common/components/block-selection.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import type { InlineRangeProvider } from '@blocksuite/inline';
 import { BlockElement, getInlineRangeProvider } from '@blocksuite/lit';
 import { html, nothing, type TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
-import { when } from 'lit/directives/when.js';
 
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
@@ -202,11 +202,10 @@ export class ListBlockComponent extends BlockElement<
             .enableUndoRedo=${false}
           ></rich-text>
         </div>
+
         ${collapsed ? nothing : children}
-        ${when(
-          this.selected?.is('block'),
-          () => html`<affine-block-selection></affine-block-selection>`
-        )}
+
+        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -1,11 +1,11 @@
 import '../_common/components/rich-text/rich-text.js';
+import '../_common/components/block-selection.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { type InlineRangeProvider } from '@blocksuite/inline';
 import { BlockElement, getInlineRangeProvider } from '@blocksuite/lit';
 import { css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import { when } from 'lit/directives/when.js';
 
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
@@ -280,11 +280,10 @@ export class ParagraphBlockComponent extends BlockElement<
             .enableUndoRedo=${false}
           ></rich-text>
         </div>
+
         ${children}
-        ${when(
-          this.selected?.is('block'),
-          () => html`<affine-block-selection></affine-block-selection>`
-        )}
+
+        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -554,7 +554,7 @@ test(`support dragging attachment block directly`, async ({ page }) => {
   await page.mouse.move(rect.x + 40, rect.y + rect.height + 80, { steps: 20 });
   await page.mouse.up();
 
-  const rects = page.locator('affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(1);
 
   await assertStoreMatchJSX(

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -416,7 +416,7 @@ test(scoped`support dragging bookmark block directly`, async ({ page }) => {
   await page.mouse.up();
   await page.waitForTimeout(200);
 
-  const rects = page.locator('affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(1);
 
   await assertStoreMatchJSX(

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -606,7 +606,9 @@ test('press backspace inside should select code block', async ({ page }) => {
   await initEmptyCodeBlockState(page);
   await focusRichText(page);
   const codeBlock = page.locator('affine-code');
-  const selectedRects = page.locator('affine-block-selection');
+  const selectedRects = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await page.keyboard.press('Backspace');
   await expect(selectedRects).toHaveCount(1);
   await expect(codeBlock).toBeVisible();

--- a/tests/drag.spec.ts
+++ b/tests/drag.spec.ts
@@ -525,7 +525,9 @@ test('should be able to drag & drop multiple blocks', async ({ page }) => {
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
 
   await dragHandleFromBlockToBlockBottomById(page, '2', '4', true);
@@ -641,7 +643,9 @@ test('should be able to drag & drop multiple blocks to nested block', async ({
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
 
   await dragHandleFromBlockToBlockBottomById(page, '3', '8');
@@ -774,7 +778,9 @@ test('should create preview when dragging', async ({ page }) => {
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
 
   await dragHandleFromBlockToBlockBottomById(
@@ -809,7 +815,9 @@ test('should drag and drop blocks under block-level selection', async ({
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
 
   const editorHost = getEditorHostLocator(page);
@@ -858,7 +866,9 @@ test('should trigger click event on editor container when clicking on blocks und
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
   await expect(page.locator('*:focus')).toHaveCount(0);
 
@@ -903,7 +913,9 @@ test('should get to selected block when dragging unselected block', async ({
   await page.mouse.down();
   await page.mouse.up();
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(1);
 
   await page.mouse.move(editorRect1.x - 5, editorRect0.y);
@@ -954,7 +966,9 @@ test('should clear the currently selected block when clicked again', async ({
   await page.mouse.down();
   await page.mouse.up();
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(1);
 
   let selectedBlockRect = await blockSelections.nth(0).boundingBox();
@@ -1018,7 +1032,9 @@ test('should support moving blocks from multiple notes', async ({ page }) => {
     }
   );
 
-  const blockSelections = page.locator('affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(2);
 
   const editorHost = getEditorHostLocator(page);

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -982,7 +982,9 @@ test('should format quick bar work in single block selection', async ({
     { x: -26 - 24, y: -10 },
     { x: 0, y: 0 }
   );
-  const blockSelections = page.locator('.selected,affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(1);
 
   const { formatBar } = getFormatBar(page);
@@ -1071,7 +1073,9 @@ test('should format quick bar work in multiple block selection', async ({
     { x: 20, y: 20 },
     { x: 0, y: 0 }
   );
-  const blockSelections = page.locator('.selected,affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(3);
 
   const formatBarController = getFormatBar(page);
@@ -1173,7 +1177,9 @@ test('should format quick bar with block selection works when update block type'
     { x: 20, y: 20 },
     { x: 0, y: 0 }
   );
-  const blockSelections = page.locator('.selected,affine-block-selection');
+  const blockSelections = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(blockSelections).toHaveCount(3);
 
   const formatBarController = getFormatBar(page);

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -236,7 +236,7 @@ test('select image should not show format bar', async ({ page }) => {
     { x: rect.x - 20, y: rect.y + 20 },
     { x: rect.x + 20, y: rect.y + 40 }
   );
-  const rects = page.locator('affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(1);
   const formatQuickBar = page.locator(`.format-quick-bar`);
   await expect(formatQuickBar).not.toBeVisible();

--- a/tests/selection/block.spec.ts
+++ b/tests/selection/block.spec.ts
@@ -939,7 +939,12 @@ test('should not clear selected rects when scrolling the wheel', async ({
     if (!viewport) {
       throw new Error();
     }
-    return viewport.querySelectorAll('.selected,affine-block-selection').length;
+    const rects = viewport.querySelectorAll('affine-block-selection');
+    const visibleRects = Array.from(rects).filter(rect => {
+      const display = window.getComputedStyle(rect).display;
+      return display !== 'none';
+    });
+    return visibleRects.length;
   });
 
   expect(count0).toBe(count2);

--- a/tests/selection/block.spec.ts
+++ b/tests/selection/block.spec.ts
@@ -235,7 +235,7 @@ test('selection on heavy page', async ({ page }) => {
       },
     }
   );
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(5);
 });
 
@@ -471,7 +471,7 @@ test('should keep selection state when scrolling backward', async ({
     return viewport.scrollTop;
   });
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(3 + 5 + 3);
   expect(scrollTop).toBe(0);
 });
@@ -545,7 +545,7 @@ test('should keep selection state when scrolling forward', async ({ page }) => {
     }
     return viewport.scrollTop;
   });
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(3 + 5 + 3);
   // See https://jestjs.io/docs/expect#tobeclosetonumber-numdigits
   // Math.abs(scrollTop - distance) < Math.pow(10, -1 * -0.01)/2 = 0.511646496140377
@@ -619,7 +619,7 @@ test('should keep selection state when scrolling backward with the scroll wheel'
   );
 
   // get count with scroll wheel
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
   const scrollTop0 = await page.evaluate(() => {
     const viewport = document.querySelector('.affine-doc-viewport');
@@ -733,7 +733,7 @@ test('should keep selection state when scrolling forward with the scroll wheel',
   );
 
   // get count with scroll wheel
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
   const scrollTop0 = await page.evaluate(() => {
     const viewport = document.querySelector('.affine-doc-viewport');
@@ -837,7 +837,7 @@ test('should not clear selected rects when clicking on scrollbar', async ({
     }
   );
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
   const scrollTop0 = await page.evaluate(() => {
     const viewport = document.querySelector('.affine-doc-viewport');
@@ -920,7 +920,7 @@ test('should not clear selected rects when scrolling the wheel', async ({
     }
   );
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
 
   await page.mouse.wheel(viewport.right, -distance / 4);
@@ -1001,7 +1001,7 @@ test('should refresh selected rects when resizing the window/viewport', async ({
     }
   );
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
   const scrollTop0 = await page.evaluate(() => {
     const viewport = document.querySelector('.affine-doc-viewport');
@@ -1067,7 +1067,7 @@ test('should clear block selection before native selection', async ({
     }
   );
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   const count0 = await rects.count();
 
   await dragBetweenIndices(
@@ -1135,7 +1135,7 @@ test('should not be misaligned when the editor container has padding or margin',
     }
   );
 
-  const rects = page.locator('.selected,affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(3);
 });
 
@@ -1157,7 +1157,9 @@ test('undo should clear block selection', async ({ page }) => {
   );
 
   await redoByKeyboard(page);
-  const selectedBlocks = page.locator('.selected,affine-block-selection');
+  const selectedBlocks = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(selectedBlocks).toHaveCount(1);
 
   await undoByKeyboard(page);
@@ -1278,7 +1280,9 @@ test('should not show option menu of image on block selection', async ({
   await expect(
     page.locator('.affine-embed-editing-state-container')
   ).toHaveCount(0);
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(1);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(1);
 });
 
 test.skip('should be cleared when dragging block card from BlockHub', async ({
@@ -1293,7 +1297,9 @@ test.skip('should be cleared when dragging block card from BlockHub', async ({
   await selectAllByKeyboard(page);
   await selectAllByKeyboard(page);
 
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(3);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(3);
 
   await page.click('.block-hub-menu-container [role="menuitem"]');
   await page.waitForTimeout(200);
@@ -1308,7 +1314,9 @@ test.skip('should be cleared when dragging block card from BlockHub', async ({
     { steps: 50 }
   );
 
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(0);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(0);
 });
 
 test('click bottom of page and if the last is embed block, editor should insert a new editable block', async ({
@@ -1374,7 +1382,9 @@ test('should select blocks when pressing escape', async ({ page }) => {
 
   await focusRichText(page, 2);
   await page.keyboard.press('Escape');
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(1);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(1);
   await page.keyboard.press('Escape');
 
   const cords = await getIndexCoordinate(page, [1, 2]);
@@ -1384,7 +1394,9 @@ test('should select blocks when pressing escape', async ({ page }) => {
   await page.mouse.up();
 
   await page.keyboard.press('Escape');
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(1);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(1);
 });
 
 test('should un-select blocks when pressing escape', async ({ page }) => {
@@ -1395,20 +1407,28 @@ test('should un-select blocks when pressing escape', async ({ page }) => {
 
   await focusRichText(page, 2);
   await pressEscape(page);
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(1);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(1);
 
   await pressEscape(page);
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(0);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(0);
 
   await focusRichText(page, 2);
   await pressEnter(page);
   await type(page, '-');
   await pressSpace(page);
   await clickListIcon(page, 0);
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(1);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(1);
 
   await pressEscape(page);
-  await expect(page.locator('.selected,affine-block-selection')).toHaveCount(0);
+  await expect(
+    page.locator('affine-block-selection').locator('visible=true')
+  ).toHaveCount(0);
 });
 
 test('verify cursor position after changing block type', async ({ page }) => {
@@ -1513,7 +1533,7 @@ test('should not select parent block when dragging area only intersects with chi
   await page.mouse.move(coord.x + 20, coord.y + 50, { steps: 20 });
   await page.mouse.up();
 
-  let rects = page.locator('.selected,affine-block-selection');
+  let rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(2);
 
   // indent children blocks
@@ -1529,7 +1549,7 @@ test('should not select parent block when dragging area only intersects with chi
   await page.mouse.move(secondCoord.x + 100, secondCoord.y + 10, { steps: 20 });
   await page.mouse.up();
 
-  rects = page.locator('.selected,affine-block-selection');
+  rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(1);
 });
 
@@ -1564,7 +1584,7 @@ test('scroll should update dragging area and select blocks when dragging', async
   await page.mouse.move(coord.x + 100, coord.y + 10, { steps: 40 });
   await waitNextFrame(page, 300);
 
-  let rects = page.locator('.selected,affine-block-selection');
+  let rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(2);
 
   // scroll to end by wheel
@@ -1578,6 +1598,6 @@ test('scroll should update dragging area and select blocks when dragging', async
 
   await page.mouse.up();
 
-  rects = page.locator('.selected,affine-block-selection');
+  rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(3);
 });

--- a/tests/selection/native.spec.ts
+++ b/tests/selection/native.spec.ts
@@ -1471,7 +1471,7 @@ test('should clear native selection before block selection', async ({
 
   expect(text0).toBe('456');
   expect(textCount).toBe(0);
-  const rects = page.locator('affine-block-selection');
+  const rects = page.locator('affine-block-selection').locator('visible=true');
   await expect(rects).toHaveCount(1);
 });
 

--- a/tests/selection/native.spec.ts
+++ b/tests/selection/native.spec.ts
@@ -2008,7 +2008,9 @@ test('click to select divided', async ({ page }) => {
   await assertDivider(page, 1);
 
   await page.click('affine-divider');
-  const selectedBlocks = page.locator('.selected,affine-block-selection');
+  const selectedBlocks = page
+    .locator('affine-block-selection')
+    .locator('visible=true');
   await expect(selectedBlocks).toHaveCount(1);
 
   await pressForwardDelete(page);


### PR DESCRIPTION
Changes:
- simplify the usage of `affine-block-selection`

i.e. replace
```ts 
${this.selected?.is('block')
    ? html`<affine-block-selection></affine-block-selection>`
    : nothing}
```
with 
```ts 
<affine-block-selection .block=${this}></affine-block-selection>
```