### PR TITLE
refactor: move doc page block slots to service

### DIFF
--- a/packages/blocks/src/page-block/doc/doc-page-block.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-block.ts
@@ -1,12 +1,12 @@
 import { PathFinder, type PointerEventState } from '@blocksuite/block-std';
-import { assertExists, Slot } from '@blocksuite/global/utils';
+import { assertExists } from '@blocksuite/global/utils';
 import { BlockElement } from '@blocksuite/lit';
 import type { Text } from '@blocksuite/store';
 import { css, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { EditingState, Viewport } from '../../_common/utils/index.js';
+import type { Viewport } from '../../_common/utils/index.js';
 import {
   asyncFocusRichText,
   getDocTitleInlineEditor,
@@ -98,22 +98,11 @@ export class DocPageBlockComponent extends BlockElement<
   @query('.affine-doc-page-block-container')
   pageBlockContainer!: HTMLDivElement;
 
-  slots = {
-    draggingAreaUpdated: new Slot<DOMRect | null>(),
-    selectedRectsUpdated: new Slot<DOMRect[]>(),
-    embedRectsUpdated: new Slot<DOMRect[]>(),
-    embedEditingStateUpdated: new Slot<EditingState | null>(),
-    pageLinkClicked: new Slot<{
-      pageId: string;
-      blockId?: string;
-    }>(),
-    tagClicked: new Slot<{
-      tagId: string;
-    }>(),
-    viewportUpdated: new Slot<Viewport>(),
-  };
-
   private _viewportElement: HTMLDivElement | null = null;
+
+  get slots() {
+    return this.service.slots;
+  }
 
   get viewportElement(): HTMLDivElement {
     if (this._viewportElement) return this._viewportElement;

--- a/packages/blocks/src/page-block/doc/doc-page-service.ts
+++ b/packages/blocks/src/page-block/doc/doc-page-service.ts
@@ -1,3 +1,17 @@
+import { Slot } from '@blocksuite/store';
+
+import type { Viewport } from '../../_common/utils/index.js';
 import { PageService } from '../page-service.js';
 
-export class DocPageService extends PageService {}
+export class DocPageService extends PageService {
+  slots = {
+    pageLinkClicked: new Slot<{
+      pageId: string;
+      blockId?: string;
+    }>(),
+    tagClicked: new Slot<{
+      tagId: string;
+    }>(),
+    viewportUpdated: new Slot<Viewport>(),
+  };
+}


### PR DESCRIPTION
- [x] Move doc page block slots to doc page service.
- [x] Remove slots that are no longer used