### PR TITLE
fix: disable two fingers back/forward swipe in chrome

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/toolbar/common/slide-menu.ts
+++ b/packages/blocks/src/page-block/edgeless/components/toolbar/common/slide-menu.ts
@@ -24,6 +24,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
       align-items: center;
       width: var(--menu-width);
       overflow-x: auto;
+      overscroll-behavior-x: none;
       position: relative;
       height: calc(var(--menu-height) + 1px);
       box-sizing: border-box;


### PR DESCRIPTION
https://caniuse.com/css-overscroll-behavior


https://github.com/toeverything/blocksuite/assets/27926/b23608a9-5c0f-4da7-9162-6818fd59955e

