### PR TITLE
feat: use spacebar to switch to pan in brush and eraser mode

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-keyboard.ts
@@ -248,19 +248,30 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
 
   private _space(event: KeyboardEvent) {
     const edgeless = this.pageElement;
-    const type = edgeless.edgelessTool.type;
     const selection = edgeless.service.selection;
+    const currentTool = edgeless.edgelessTool;
+    const type = currentTool.type;
+    const allowedTools = ['default', 'pan', 'brush', 'eraser'];
 
-    if (type !== 'default' && type !== 'pan') {
+    if (!allowedTools.includes(type)) {
       return;
     }
+    const revertToPrevTool = (ev: KeyboardEvent) => {
+      if (ev.key === ' ') this._setEdgelessTool(edgeless, currentTool);
+    };
+
     if (event.type === 'keydown') {
       if (type === 'pan' || (type === 'default' && selection.editing)) {
         return;
       }
       this._setEdgelessTool(edgeless, { type: 'pan', panning: false });
+      this.pageElement.dispatcher.disposables.addFromEvent(
+        document,
+        'keyup',
+        revertToPrevTool
+      );
     } else if (event.type === 'keyup') {
-      this._setEdgelessTool(edgeless, { type: 'default' });
+      document.removeEventListener('keyup', revertToPrevTool, false);
     }
   }
 


### PR DESCRIPTION

Subject: Feature Enhancement: Spacebar Toggle for Pan Mode in EdgelessMode

### Reason
I've observed that using the middle mouse button is quite handy for switching to hand mode during drawing in EdgelessMode, as a dedicated Photoshop user, I believe it is more ergonomic to use the spacebar with the LMB to switch to the pan mode while drawing. To enhance the user experience, I've refactored to enable the use of the spacebar to toggle between pan mode and brush/eraser mode seamlessly.

Pull Request Changes:
- Use the spacebar to switch to pan mode while in brush | eraser mode