### PR TITLE
fix: format bar popup disappears on edgeless

### DIFF
--- a/packages/blocks/src/_common/components/hover/when-hover.ts
+++ b/packages/blocks/src/_common/components/hover/when-hover.ts
@@ -102,9 +102,11 @@ export const whenHover = (
       onHoverChange(new MouseEvent('mouseover'));
     }
     element.addEventListener('mouseover', onHoverChange, {
+      capture: true,
       signal: abortController.signal,
     });
     element.addEventListener('mouseleave', onHoverChange, {
+      capture: true,
       signal: abortController.signal,
     });
   };


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/6202

This pull request adds the `capture` option to the `mouseover` and `mouseleave` event listeners, ensuring that the listeners can correctly capture the events.
