### PR TITLE
fix(page): synced block placeholder should not appear after adding content

### DIFF
--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -154,9 +154,8 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
       return;
     }
 
-    if (contentBlocks.length === 1 && contentBlocks[0].text?.length === 0) {
-      this._empty = true;
-    }
+    this._empty =
+      contentBlocks.length === 1 && contentBlocks[0].text?.length === 0;
   }
 
   private async _load() {


### PR DESCRIPTION
bug: 

https://github.com/toeverything/blocksuite/assets/54364088/a2b2091b-4126-4f0d-9dcf-0ee5138812cf

