### PR TITLE
fix(edgeless): active eventDispatcher when edgeless tool updated

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-service.ts
@@ -168,6 +168,7 @@ export class EdgelessPageService extends PageService {
     disposables.add(
       slots.edgelessToolUpdated.on(edgelessTool => {
         slots.cursorUpdated.emit(getCursorMode(edgelessTool));
+        if (!this.std.event.isActive) this.std.event.activate();
       })
     );
 


### PR DESCRIPTION
Active event dispatcher when edgeless tool updated if current event dispatcher is inactive, otherwise some tool controller event like pointerMove would not be dispatched and the tool overlay would not be displayed when first time switch to edgeless mode.

before:

https://github.com/toeverything/blocksuite/assets/99816898/90c1d639-9e1b-4de8-95a6-4cf246b6ce74

after:

https://github.com/toeverything/blocksuite/assets/99816898/a3e8d772-1010-4845-8c6f-3ca5c17e3821

