### PR TITLE
fix: improve code block performance

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -367,8 +367,8 @@ export class RichText extends WithDisposable(ShadowlessElement) {
       .catch(console.error);
   }
 
-  override updated() {
-    if (this._inlineEditor) {
+  override updated(changedProperties: Map<string | number | symbol, unknown>) {
+    if (this._inlineEditor && changedProperties.has('readonly')) {
       this._inlineEditor.setReadonly(this.readonly);
     }
   }

--- a/packages/blocks/src/note-block/note-block.ts
+++ b/packages/blocks/src/note-block/note-block.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { BlockElement, RangeManager } from '@blocksuite/lit';
+import { BlockElement } from '@blocksuite/lit';
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -25,8 +25,6 @@ export class NoteBlockComponent extends BlockElement<
 
   override connectedCallback() {
     super.connectedCallback();
-
-    this.setAttribute(RangeManager.rangeSyncExcludeAttr, 'true');
 
     this.keymapController.bind();
   }

--- a/packages/framework/inline/src/inline-editor.ts
+++ b/packages/framework/inline/src/inline-editor.ts
@@ -302,43 +302,38 @@ export class InlineEditor<
 
     this.slots.textChange.emit();
 
-    Promise.resolve()
-      .then(() => {
-        this.deltaService.render().catch(console.error);
+    this.deltaService.render().catch(console.error);
 
-        const inlineRange = this.rangeService.getInlineRange();
-        if (!inlineRange || transaction.local) return;
+    const inlineRange = this.rangeService.getInlineRange();
+    if (!inlineRange || transaction.local) return;
 
-        const lastStartRelativePosition =
-          this.rangeService.lastStartRelativePosition;
-        const lastEndRelativePosition =
-          this.rangeService.lastEndRelativePosition;
-        if (!lastStartRelativePosition || !lastEndRelativePosition) return;
+    const lastStartRelativePosition =
+      this.rangeService.lastStartRelativePosition;
+    const lastEndRelativePosition = this.rangeService.lastEndRelativePosition;
+    if (!lastStartRelativePosition || !lastEndRelativePosition) return;
 
-        const doc = this.yText.doc;
-        assertExists(doc);
-        const absoluteStart = Y.createAbsolutePositionFromRelativePosition(
-          lastStartRelativePosition,
-          doc
-        );
-        const absoluteEnd = Y.createAbsolutePositionFromRelativePosition(
-          lastEndRelativePosition,
-          doc
-        );
+    const doc = this.yText.doc;
+    assertExists(doc);
+    const absoluteStart = Y.createAbsolutePositionFromRelativePosition(
+      lastStartRelativePosition,
+      doc
+    );
+    const absoluteEnd = Y.createAbsolutePositionFromRelativePosition(
+      lastEndRelativePosition,
+      doc
+    );
 
-        const startIndex = absoluteStart?.index;
-        const endIndex = absoluteEnd?.index;
-        if (!startIndex || !endIndex) return;
+    const startIndex = absoluteStart?.index;
+    const endIndex = absoluteEnd?.index;
+    if (!startIndex || !endIndex) return;
 
-        const newInlineRange: InlineRange = {
-          index: startIndex,
-          length: endIndex - startIndex,
-        };
-        if (!this.isValidInlineRange(newInlineRange)) return;
+    const newInlineRange: InlineRange = {
+      index: startIndex,
+      length: endIndex - startIndex,
+    };
+    if (!this.isValidInlineRange(newInlineRange)) return;
 
-        this.setInlineRange(newInlineRange);
-      })
-      .catch(console.error);
+    this.setInlineRange(newInlineRange);
   };
 
   private _bindYTextObserver() {

--- a/packages/framework/inline/src/inline-editor.ts
+++ b/packages/framework/inline/src/inline-editor.ts
@@ -302,38 +302,43 @@ export class InlineEditor<
 
     this.slots.textChange.emit();
 
-    this.deltaService.render().catch(console.error);
+    Promise.resolve()
+      .then(() => {
+        this.deltaService.render().catch(console.error);
 
-    const inlineRange = this.rangeService.getInlineRange();
-    if (!inlineRange || transaction.local) return;
+        const inlineRange = this.rangeService.getInlineRange();
+        if (!inlineRange || transaction.local) return;
 
-    const lastStartRelativePosition =
-      this.rangeService.lastStartRelativePosition;
-    const lastEndRelativePosition = this.rangeService.lastEndRelativePosition;
-    if (!lastStartRelativePosition || !lastEndRelativePosition) return;
+        const lastStartRelativePosition =
+          this.rangeService.lastStartRelativePosition;
+        const lastEndRelativePosition =
+          this.rangeService.lastEndRelativePosition;
+        if (!lastStartRelativePosition || !lastEndRelativePosition) return;
 
-    const doc = this.yText.doc;
-    assertExists(doc);
-    const absoluteStart = Y.createAbsolutePositionFromRelativePosition(
-      lastStartRelativePosition,
-      doc
-    );
-    const absoluteEnd = Y.createAbsolutePositionFromRelativePosition(
-      lastEndRelativePosition,
-      doc
-    );
+        const doc = this.yText.doc;
+        assertExists(doc);
+        const absoluteStart = Y.createAbsolutePositionFromRelativePosition(
+          lastStartRelativePosition,
+          doc
+        );
+        const absoluteEnd = Y.createAbsolutePositionFromRelativePosition(
+          lastEndRelativePosition,
+          doc
+        );
 
-    const startIndex = absoluteStart?.index;
-    const endIndex = absoluteEnd?.index;
-    if (!startIndex || !endIndex) return;
+        const startIndex = absoluteStart?.index;
+        const endIndex = absoluteEnd?.index;
+        if (!startIndex || !endIndex) return;
 
-    const newInlineRange: InlineRange = {
-      index: startIndex,
-      length: endIndex - startIndex,
-    };
-    if (!this.isValidInlineRange(newInlineRange)) return;
+        const newInlineRange: InlineRange = {
+          index: startIndex,
+          length: endIndex - startIndex,
+        };
+        if (!this.isValidInlineRange(newInlineRange)) return;
 
-    this.setInlineRange(newInlineRange);
+        this.setInlineRange(newInlineRange);
+      })
+      .catch(console.error);
   };
 
   private _bindYTextObserver() {

--- a/packages/framework/inline/src/services/range.ts
+++ b/packages/framework/inline/src/services/range.ts
@@ -73,7 +73,7 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
       // range change may happen before the editor is prepared
       await this.editor.waitForUpdate();
       // improve performance
-      setTimeout(() => {
+      requestIdleCallback(() => {
         this.editor.requestUpdate(false);
       });
     }

--- a/packages/framework/inline/src/services/range.ts
+++ b/packages/framework/inline/src/services/range.ts
@@ -72,7 +72,10 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
     if (this.editor.mounted) {
       // range change may happen before the editor is prepared
       await this.editor.waitForUpdate();
-      this.editor.requestUpdate(false);
+      // improve performance
+      setTimeout(() => {
+        this.editor.requestUpdate(false);
+      });
     }
 
     if (!sync) {

--- a/packages/framework/lit/src/utils/range-binding.ts
+++ b/packages/framework/lit/src/utils/range-binding.ts
@@ -1,6 +1,6 @@
 import type { BaseSelection, TextSelection } from '@blocksuite/block-std';
 import { PathFinder } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
+import { assertExists, throttle } from '@blocksuite/global/utils';
 
 import { BlockElement } from '../element/block-element.js';
 import type { RangeManager } from './range-manager.js';
@@ -28,9 +28,12 @@ export class RangeBinding {
     );
 
     this.host.disposables.add(
-      this.host.event.add('selectionChange', () => {
-        this._onNativeSelectionChanged().catch(console.error);
-      })
+      this.host.event.add(
+        'selectionChange',
+        throttle(() => {
+          this._onNativeSelectionChanged().catch(console.error);
+        }, 30)
+      )
     );
 
     this.host.disposables.add(

--- a/packages/framework/lit/src/utils/range-binding.ts
+++ b/packages/framework/lit/src/utils/range-binding.ts
@@ -64,7 +64,7 @@ export class RangeBinding {
           selections.find((selection): selection is TextSelection =>
             selection.is('text')
           ) ?? null;
-        console.log(text);
+
         const eq =
           text && this._prevSelection
             ? text.equals(this._prevSelection)

--- a/packages/framework/lit/src/utils/range-binding.ts
+++ b/packages/framework/lit/src/utils/range-binding.ts
@@ -55,7 +55,7 @@ export class RangeBinding {
   }
 
   isComposing = false;
-  private _prevSelection: BaseSelection | null = null;
+  private _prevTextSelection: TextSelection | null = null;
   private _onStdSelectionChanged = (selections: BaseSelection[]) => {
     // wait for lit updated
     this.host.updateComplete
@@ -66,14 +66,14 @@ export class RangeBinding {
           ) ?? null;
 
         const eq =
-          text && this._prevSelection
-            ? text.equals(this._prevSelection)
-            : text === this._prevSelection;
+          text && this._prevTextSelection
+            ? text.equals(this._prevTextSelection)
+            : text === this._prevTextSelection;
         if (eq) {
           return;
         }
 
-        this._prevSelection = text;
+        this._prevTextSelection = text;
         if (text) {
           this.rangeManager.syncTextSelectionToRange(text);
         } else {
@@ -117,13 +117,13 @@ export class RangeBinding {
       );
       if (inlineEditor?.isComposing) return;
 
-      this._prevSelection = this.rangeManager.rangeToTextSelection(
+      this._prevTextSelection = this.rangeManager.rangeToTextSelection(
         range,
         isRangeReversed
       );
       this.rangeManager.syncRangeToTextSelection(range, isRangeReversed);
     } else {
-      this._prevSelection = null;
+      this._prevTextSelection = null;
       this.selectionManager.clear(['text']);
     }
   };

--- a/packages/framework/lit/src/utils/range-binding.ts
+++ b/packages/framework/lit/src/utils/range-binding.ts
@@ -106,7 +106,10 @@ export class RangeBinding {
       const inlineEditor = this.rangeManager.getClosestInlineEditor(
         range.commonAncestorContainer
       );
-      if (inlineEditor && inlineEditor.isComposing) return;
+      if (!inlineEditor || inlineEditor.isComposing) {
+        this._prevSelection = null;
+        return;
+      }
 
       this._prevSelection = this.rangeManager.rangeToTextSelection(
         range,

--- a/packages/framework/lit/src/utils/range-manager.ts
+++ b/packages/framework/lit/src/utils/range-manager.ts
@@ -35,6 +35,9 @@ export class RangeManager {
     if (topContenteditableElement instanceof HTMLElement) {
       topContenteditableElement.blur();
     }
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
   }
 
   set(range: Range) {


### PR DESCRIPTION
Test 600+ lines code:

before:
<img width="1282" alt="image" src="https://github.com/toeverything/blocksuite/assets/50035259/fa374884-a1f1-42ca-a76d-30cfed57f02e">

after:
<img width="1199" alt="image" src="https://github.com/toeverything/blocksuite/assets/50035259/8b47eebd-83c8-480f-b9e8-302374c013bd">

For further optimization, we may need to refactor the rendering mechanism of the inline editor.