### PR TITLE
fix: arrow buttons are disabled when kanban exists in page

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -118,3 +118,4 @@ Example:
 - Umar Faiz, @umar23faiz, 2023/12/29
 - Adithyan, @golok727, 2024/02/10
 - zkwolf, @zkwolf, 2024/2/19
+- Yuntian Sun, @ununian, 2024/02/20

--- a/packages/blocks/src/database-block/kanban/controller/hotkeys.ts
+++ b/packages/blocks/src/database-block/kanban/controller/hotkeys.ts
@@ -7,6 +7,10 @@ export class KanbanHotkeysController implements ReactiveController {
     this.host.addController(this);
   }
 
+  private get hasSelection() {
+    return !!this.host.selectionController.selection;
+  }
+
   public hostConnected() {
     this.host.disposables.add(
       this.host.bindHotkey({
@@ -18,21 +22,29 @@ export class KanbanHotkeysController implements ReactiveController {
           this.host.selectionController.focusIn();
         },
         ArrowUp: context => {
+          if (!this.hasSelection) return false;
+
           this.host.selectionController.focusNext('up');
           context.get('keyboardState').raw.preventDefault();
           return true;
         },
         ArrowDown: context => {
+          if (!this.hasSelection) return false;
+
           this.host.selectionController.focusNext('down');
           context.get('keyboardState').raw.preventDefault();
           return true;
         },
         ArrowLeft: context => {
+          if (!this.hasSelection) return false;
+
           this.host.selectionController.focusNext('left');
           context.get('keyboardState').raw.preventDefault();
           return true;
         },
         ArrowRight: context => {
+          if (!this.hasSelection) return false;
+
           this.host.selectionController.focusNext('right');
           context.get('keyboardState').raw.preventDefault();
           return true;


### PR DESCRIPTION
![iShot_2024-02-20_16 56 02](https://github.com/toeverything/blocksuite/assets/4506072/a754edaf-b985-4f8f-8230-2008f7ace654)