### PR TITLE
fix(edgeless): cannot click more button in AFFiNE

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -113,6 +113,7 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
       border-radius: 8px;
       padding: 0 8px;
       font-family: ${unsafeCSS(baseTheme.fontSansFamily)};
+      user-select: none;
     }
 
     component-toolbar-menu-divider {


### PR DESCRIPTION
To fix:
 [TOV-453](https://linear.app/affine-design/issue/TOV-453/新-note-通过选区创建的-note，点击后-more-后，直接关闭了-toolbar)
[TOV-471](https://linear.app/affine-design/issue/TOV-471/group-toolbar-点more无法激活)

Should not select edgeless component toolbar text and should not trigger selectionchange event when click toolbar button.

https://github.com/toeverything/blocksuite/assets/99816898/1e4701d6-e71b-491f-ade8-7a1bc6b112ce

