### PR TITLE
fix(page): correct image fetch via proxy with response.ok check

### DIFF
--- a/packages/blocks/src/_common/adapters/utils.ts
+++ b/packages/blocks/src/_common/adapters/utils.ts
@@ -10,9 +10,14 @@ export const fetchImage = async (
     if (!proxy) {
       return await fetch(url, init);
     }
-    return await fetch(proxy + '?url=' + encodeURIComponent(url), init).catch(
-      () => fetch(url, init)
-    );
+    return await fetch(proxy + '?url=' + encodeURIComponent(url), init)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return res;
+      })
+      .catch(() => fetch(url, init));
   } catch (error) {
     console.warn('Error fetching image:', error);
     throw error;


### PR DESCRIPTION
Changes:
- Added response.ok check for image fetch via proxy, as fetch does not throw error for non-200 statuses.

Linked with https://github.com/toeverything/AFFiNE/pull/5849