### PR TITLE
fix(playground): missing root model after refresh page

### DIFF
--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -33,6 +33,7 @@ export async function mountDefaultPageEditor(workspace: Workspace) {
     if (!target) {
       throw new Error(`Failed to jump to page ${pageId}`);
     }
+    target.load();
     editor.page = target;
   });
 

--- a/packages/playground/apps/starter/data/multiple-editor.ts
+++ b/packages/playground/apps/starter/data/multiple-editor.ts
@@ -30,6 +30,7 @@ export const multiEditor: InitFn = (workspace: Workspace, id: string) => {
       if (!target) {
         throw new Error(`Failed to jump to page ${pageId}`);
       }
+      target.load();
       editor.page = target;
     });
 
@@ -77,6 +78,7 @@ export const multiEditorVertical: InitFn = (
       if (!target) {
         throw new Error(`Failed to jump to page ${pageId}`);
       }
+      target.load();
       editor.page = target;
     });
     app.append(editor);

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -31,6 +31,7 @@ export async function mountDefaultPageEditor(workspace: Workspace) {
     if (!target) {
       throw new Error(`Failed to jump to page ${pageId}`);
     }
+    target.load();
     editor.page = target;
   });
 


### PR DESCRIPTION
Step to reproduce bug:

1. new a link page
2. refresh page
3. click page

What is actually happening:

page have not redirect but console log root model miss. 