### PR TITLE
fix: view in edgeless mode

### DIFF
--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -720,8 +720,12 @@ export class EdgelessPageBlockComponent extends BlockElement<
         this._getSavedViewport() ?? this.service.getFitToScreenData();
       if ('xywh' in viewport) {
         const { xywh, padding } = viewport;
-        const bound = Bound.deserialize(xywh);
-        this.service.viewport.setViewportByBound(bound, padding);
+        try {
+          const bound = Bound.deserialize(xywh);
+          this.service.viewport.setViewportByBound(bound, padding);
+        } catch {
+          /* empty */
+        }
       } else {
         const { zoom, centerX, centerY } = viewport;
         this.service.viewport.setViewport(zoom, [centerX, centerY]);

--- a/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
+++ b/packages/blocks/src/page-block/edgeless/edgeless-page-block.ts
@@ -54,7 +54,6 @@ import {
   serializeXYWH,
   Vec,
 } from '../../surface-block/index.js';
-import type { SerializedViewport } from '../../surface-block/managers/edit-session.js';
 import type {
   IndexedCanvasUpdateEvent,
   SurfaceBlockComponent,
@@ -685,30 +684,6 @@ export class EdgelessPageBlockComponent extends BlockElement<
     }, this);
   }
 
-  private _getSavedViewport(): SerializedViewport | null {
-    let result: SerializedViewport | null = null;
-    const storedViewport = this.service.editSession.getItem('viewport');
-    if (!storedViewport) return null;
-
-    if ('referenceId' in storedViewport) {
-      const block = this.service.getElementById(storedViewport.referenceId);
-
-      if (block) {
-        this.service.viewport.setViewportByBound(
-          Bound.deserialize(block.xywh),
-          storedViewport.padding
-        );
-        result = storedViewport;
-      } else {
-        result = null;
-      }
-    } else {
-      result = storedViewport;
-    }
-
-    return result;
-  }
-
   private _initViewport() {
     this.service.viewport.setContainer(this);
     this.service.viewport.setCumulativeParentScale(
@@ -717,15 +692,12 @@ export class EdgelessPageBlockComponent extends BlockElement<
 
     const run = () => {
       const viewport =
-        this._getSavedViewport() ?? this.service.getFitToScreenData();
+        this.service.editSession.getItem('viewport') ??
+        this.service.getFitToScreenData();
+
       if ('xywh' in viewport) {
-        const { xywh, padding } = viewport;
-        try {
-          const bound = Bound.deserialize(xywh);
-          this.service.viewport.setViewportByBound(bound, padding);
-        } catch {
-          /* empty */
-        }
+        const bound = Bound.deserialize(viewport.xywh);
+        this.service.viewport.setViewportByBound(bound, viewport.padding);
       } else {
         const { zoom, centerX, centerY } = viewport;
         this.service.viewport.setViewport(zoom, [centerX, centerY]);

--- a/packages/blocks/src/surface-block/managers/edit-session.ts
+++ b/packages/blocks/src/surface-block/managers/edit-session.ts
@@ -118,7 +118,6 @@ const SessionPropsSchema = z.object({
       zoom: z.number(),
     }),
     z.object({
-      referenceId: z.string(),
       xywh: z.string(),
       padding: z
         .tuple([z.number(), z.number(), z.number(), z.number()])

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -15,7 +15,7 @@ import {
   MoreDeleteIcon,
 } from '../_common/icons/index.js';
 import { requestConnectedFrame } from '../_common/utils/event.js';
-import { buildPath, getEditorContainer } from '../_common/utils/query.js';
+import { buildPath } from '../_common/utils/query.js';
 import type { PageService } from '../index.js';
 import type { FrameBlockModel, SurfaceBlockModel } from '../models.js';
 import { getBackgroundGrid } from '../page-block/edgeless/utils/query.js';
@@ -26,7 +26,7 @@ import { deserializeXYWH } from '../surface-block/utils/xywh.js';
 import type { SurfaceRefBlockModel } from './surface-ref-model.js';
 import { SurfaceRefPortal } from './surface-ref-portal.js';
 import type { SurfaceRefRenderer } from './surface-ref-renderer.js';
-import type { SurfaceRefBlockService } from './surface-ref-service.js';
+import { SurfaceRefBlockService } from './surface-ref-service.js';
 import { noContentPlaceholder } from './utils.js';
 
 noop(SurfaceRefPortal);
@@ -489,24 +489,17 @@ export class SurfaceRefBlockComponent extends BlockElement<
   viewInEdgeless() {
     if (!this._referencedModel) return;
 
-    const editorContainer = getEditorContainer(this.host);
+    const viewport = {
+      xywh: '', // FIXME
+      referenceId: this.model.reference,
+      padding: [60, 20, 20, 20] as [number, number, number, number],
+    };
+    (<PageService>this.std.spec.getService('affine:page')).editSession.setItem(
+      'viewport',
+      viewport
+    );
 
-    if (editorContainer.mode !== 'edgeless') {
-      editorContainer.mode = 'edgeless';
-
-      const viewport = {
-        xywh: '', // FIXME
-        referenceId: this.model.reference,
-        padding: [60, 20, 20, 20] as [number, number, number, number],
-      };
-      (<PageService>(
-        this.std.spec.getService('affine:page')
-      )).editSession.setItem('viewport', viewport);
-    }
-
-    this.selection.update(selections => {
-      return selections.filter(sel => !PathFinder.equals(sel.path, this.path));
-    });
+    SurfaceRefBlockService.editorModeSwitch.emit('edgeless');
   }
 
   private _renderMask(referencedModel: RefElement, flavourOrType: string) {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -490,8 +490,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     if (!this._referencedModel) return;
 
     const viewport = {
-      xywh: '', // FIXME
-      referenceId: this.model.reference,
+      xywh: this._referencedModel.xywh,
       padding: [60, 20, 20, 20] as [number, number, number, number],
     };
     (<PageService>this.std.spec.getService('affine:page')).editSession.setItem(

--- a/packages/blocks/src/surface-ref-block/surface-ref-service.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-service.ts
@@ -1,9 +1,11 @@
 import { BlockService } from '@blocksuite/block-std';
-import type { Page } from '@blocksuite/store';
+import { type Page, Slot } from '@blocksuite/store';
 
 import { SurfaceRefRenderer } from './surface-ref-renderer.js';
 
 export class SurfaceRefBlockService extends BlockService {
+  static editorModeSwitch = new Slot<'edgeless' | 'page'>();
+
   private _rendererMap = new Map<string, SurfaceRefRenderer>();
 
   getRenderer(id: string, page: Page = this.page, stackingCanvas = false) {

--- a/packages/playground/apps/components/debug-menu.ts
+++ b/packages/playground/apps/components/debug-menu.ts
@@ -238,9 +238,6 @@ export class DebugMenu extends ShadowlessElement {
   private _canRedo = false;
 
   @property({ attribute: false })
-  mode: 'page' | 'edgeless' = 'page';
-
-  @property({ attribute: false })
   readonly = false;
 
   @state()
@@ -251,6 +248,14 @@ export class DebugMenu extends ShadowlessElement {
 
   private _styleMenu!: Pane;
   private _showStyleDebugMenu = false;
+
+  get mode() {
+    return this.editor.mode;
+  }
+
+  set mode(value: 'page' | 'edgeless') {
+    this.editor.mode = value;
+  }
 
   @state()
   private _dark = getDarkModeConfig();
@@ -305,8 +310,7 @@ export class DebugMenu extends ShadowlessElement {
   }
 
   private _switchEditorMode() {
-    const mode = this.editor.mode === 'page' ? 'edgeless' : 'page';
-    this.mode = mode;
+    this.mode = this.mode === 'page' ? 'edgeless' : 'page';
   }
 
   private _toggleOutlinePanel() {
@@ -546,13 +550,13 @@ export class DebugMenu extends ShadowlessElement {
       this._canUndo = this.page.canUndo;
       this._canRedo = this.page.canRedo;
     });
+
+    this.editor.slots.pageModeSwitched.on(() => {
+      this.requestUpdate();
+    });
   }
 
   override update(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('mode')) {
-      const mode = this.mode;
-      this.editor.mode = mode;
-    }
     if (changedProperties.has('_hasOffset')) {
       const appRoot = document.getElementById('app');
       if (!appRoot) return;

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -25,6 +25,7 @@ export async function mountDefaultPageEditor(workspace: Workspace) {
   if (!app) return;
 
   const editor = new AffineEditorContainer();
+  editor.mode = defaultMode;
   editor.page = page;
   editor.slots.pageLinkClicked.on(({ pageId }) => {
     const target = workspace.getPage(pageId);
@@ -57,7 +58,6 @@ export async function mountDefaultPageEditor(workspace: Workspace) {
   const debugMenu = new DebugMenu();
   debugMenu.workspace = workspace;
   debugMenu.editor = editor;
-  debugMenu.mode = defaultMode;
   debugMenu.outlinePanel = outlinePanel;
   debugMenu.framePanel = framePanel;
   debugMenu.copilotPanel = copilotPanelPanel;

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -11,6 +11,7 @@ import type {
 import {
   DocEditorBlockSpecs,
   EdgelessEditorBlockSpecs,
+  SurfaceRefBlockService,
   ThemeObserver,
 } from '@blocksuite/blocks';
 import { assertExists, Slot } from '@blocksuite/global/utils';
@@ -166,6 +167,11 @@ export class AffineEditorContainer
 
     this.themeObserver.observe(document.documentElement);
     this._disposables.add(this.themeObserver);
+    this._disposables.add(
+      SurfaceRefBlockService.editorModeSwitch.on(mode => {
+        this.mode = mode;
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
Related to [TOV-536](https://linear.app/affine-design/issue/TOV-536/view-in-edgeless-%E6%8C%89%E9%92%AE%E4%B8%8D%E7%94%9F%E6%95%88%E4%BA%86)

The previous implementation always assumed the `AffineEditorContainer` existed while the latest version of AFFiNE replaced the `AffineEditorContainer` with its own implementation.
The solution is to add a new slot to tell the app to switch the mode. The blocksuite user needs to listen to that slot and switch the mode on their own.