### PR TITLE
fix(page): allow block cards to expand horizontally on note resize

### DIFF
--- a/packages/blocks/src/attachment-block/styles.ts
+++ b/packages/blocks/src/attachment-block/styles.ts
@@ -10,7 +10,6 @@ export const styles = css`
     gap: 12px;
 
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.horizontalThin}px;
     height: ${EMBED_CARD_HEIGHT.horizontalThin}px;
 
     padding: 12px;

--- a/packages/blocks/src/bookmark-block/styles.ts
+++ b/packages/blocks/src/bookmark-block/styles.ts
@@ -8,7 +8,6 @@ export const styles = css`
     box-sizing: border-box;
     display: flex;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.horizontal}px;
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
 
     border-radius: 8px;
@@ -21,7 +20,7 @@ export const styles = css`
   }
 
   .affine-bookmark-content {
-    width: 536px;
+    width: calc(100% - 204px);
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -194,7 +193,7 @@ export const styles = css`
     }
 
     .affine-bookmark-content-title {
-      width: 536px;
+      width: calc(100% - 204px);
     }
 
     .affine-bookmark-content-url {

--- a/packages/blocks/src/embed-figma-block/styles.ts
+++ b/packages/blocks/src/embed-figma-block/styles.ts
@@ -1,13 +1,12 @@
 import { css, html } from 'lit';
 
-import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
+import { EMBED_CARD_HEIGHT } from '../_common/consts.js';
 
 export const styles = css`
   .affine-embed-figma-block {
     margin: 0 auto;
     box-sizing: border-box;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.figma}px;
     height: ${EMBED_CARD_HEIGHT.figma}px;
     display: flex;
     flex-direction: column;

--- a/packages/blocks/src/embed-github-block/styles.ts
+++ b/packages/blocks/src/embed-github-block/styles.ts
@@ -8,7 +8,6 @@ export const styles = css`
     box-sizing: border-box;
     display: flex;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.horizontal}px;
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
 
     border-radius: 8px;
@@ -21,7 +20,7 @@ export const styles = css`
   }
 
   .affine-embed-github-content {
-    width: 536px;
+    width: calc(100% - 204px);
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/packages/blocks/src/embed-linked-doc-block/styles.ts
+++ b/packages/blocks/src/embed-linked-doc-block/styles.ts
@@ -8,7 +8,6 @@ export const styles = css`
     box-sizing: border-box;
     display: flex;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.horizontal}px;
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
     border-radius: 8px;
     border: 1px solid var(--affine-background-tertiary-color);
@@ -19,7 +18,7 @@ export const styles = css`
   }
 
   .affine-embed-linked-doc-content {
-    width: 536px;
+    width: calc(100% - 204px);
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -210,7 +209,7 @@ export const styles = css`
     }
 
     .affine-embed-linked-doc-content-title {
-      width: 536px;
+      width: calc(100% - 204px);
     }
 
     .affine-embed-linked-doc-content-description {

--- a/packages/blocks/src/embed-loom-block/styles.ts
+++ b/packages/blocks/src/embed-loom-block/styles.ts
@@ -1,13 +1,12 @@
 import { css, html } from 'lit';
 
-import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
+import { EMBED_CARD_HEIGHT } from '../_common/consts.js';
 
 export const styles = css`
   .affine-embed-loom-block {
     margin: 0 auto;
     box-sizing: border-box;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.video}px;
     height: ${EMBED_CARD_HEIGHT.video}px;
     display: flex;
     flex-direction: column;

--- a/packages/blocks/src/embed-synced-doc-block/styles.ts
+++ b/packages/blocks/src/embed-synced-doc-block/styles.ts
@@ -143,7 +143,6 @@ export const cardStyles = css`
     box-sizing: border-box;
     display: flex;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.horizontal}px;
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
     border-radius: 8px;
     border: 1px solid var(--affine-background-tertiary-color);
@@ -154,7 +153,7 @@ export const cardStyles = css`
   }
 
   .affine-embed-synced-doc-card-content {
-    width: 536px;
+    width: calc(100% - 204px);
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/packages/blocks/src/embed-youtube-block/styles.ts
+++ b/packages/blocks/src/embed-youtube-block/styles.ts
@@ -1,13 +1,12 @@
 import { css, html } from 'lit';
 
-import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
+import { EMBED_CARD_HEIGHT } from '../_common/consts.js';
 
 export const styles = css`
   .affine-embed-youtube-block {
     margin: 0 auto;
     box-sizing: border-box;
     width: 100%;
-    max-width: ${EMBED_CARD_WIDTH.video}px;
     height: ${EMBED_CARD_HEIGHT.video}px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
[AFF-615](https://linear.app/affine-design/issue/AFF-615/once-the-card-exceeds-752px-it-will-not-adapt-to-the-width)
Changes:
- allow all block card to expand horizontally on note resize, affected blocks :
![image](https://github.com/toeverything/blocksuite/assets/54364088/8f355cda-09c1-4c9d-af28-21ce6ed205c5)
