### PR TITLE
fix(edgeless): switching to hand tool while right clicking affine#5664

### DIFF
--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -57,9 +57,7 @@ export class EdgelessToolsManager {
     return manager;
   }
 
-  private _edgelessTool: EdgelessTool = {
-    type: 'default',
-  };
+  private _edgelessTool: EdgelessTool = this._getToolFromLocalStorage();
 
   private _container!: EdgelessPageBlockComponent;
   private _service!: EdgelessPageService;
@@ -181,6 +179,12 @@ export class EdgelessToolsManager {
       x: e.x,
       y: e.y,
     };
+  }
+
+  private _getToolFromLocalStorage(): EdgelessTool {
+    const type = localStorage.defaultTool;
+    if (type === 'pan') return { type: 'pan', panning: false };
+    return { type: 'default' };
   }
 
   private _initMouseAndWheelEvents() {

--- a/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/page-block/edgeless/services/tools-manager.ts
@@ -1,9 +1,9 @@
 import type { SurfaceSelection } from '@blocksuite/block-std';
-import {
-  type EventName,
+import type {
+  EventName,
   PointerEventState,
-  type UIEventHandler,
-  type UIEventState,
+  UIEventHandler,
+  UIEventState,
 } from '@blocksuite/block-std';
 import { DisposableGroup } from '@blocksuite/global/utils';
 
@@ -72,12 +72,6 @@ export class EdgelessToolsManager {
 
   /** Latest mouse position in view coords */
   private _lastMousePos: { x: number; y: number } = { x: 0, y: 0 };
-
-  private _rightClickTimer: {
-    edgelessTool: EdgelessTool;
-    timer: number;
-    timeStamp: number;
-  } | null = null;
 
   // pressed shift key
   private _shiftKey = false;
@@ -322,25 +316,6 @@ export class EdgelessToolsManager {
 
   private _onContainerContextMenu = (e: UIEventState) => {
     e.event.preventDefault();
-    const pointerEventState = new PointerEventState({
-      event: e.event as PointerEvent,
-      rect: this.dispatcher.host.getBoundingClientRect(),
-      startX: 0,
-      startY: 0,
-      last: null,
-      cumulativeParentScale: 1,
-    });
-
-    const edgelessTool = this.edgelessTool;
-    if (edgelessTool.type !== 'pan' && !this._rightClickTimer) {
-      this._rightClickTimer = {
-        edgelessTool: edgelessTool,
-        timeStamp: e.event.timeStamp,
-        timer: window.setTimeout(() => {
-          this._controllers['pan'].onContainerDragStart(pointerEventState);
-        }, 233),
-      };
-    }
   };
 
   private _onContainerPointerDown = (e: PointerEventState) => {
@@ -373,21 +348,7 @@ export class EdgelessToolsManager {
     this.setEdgelessTool({ type: 'pan', panning: true });
   };
 
-  private _onContainerPointerUp = (e: PointerEventState) => {
-    if (e.button === 2 && this._rightClickTimer) {
-      const {
-        timer,
-        timeStamp,
-        edgelessTool: edgelessTool,
-      } = this._rightClickTimer;
-      if (e.raw.timeStamp - timeStamp > 233) {
-        this.setEdgelessTool(edgelessTool);
-      } else {
-        clearTimeout(timer);
-      }
-      this._rightClickTimer = null;
-    }
-  };
+  private _onContainerPointerUp = (_ev: PointerEventState) => {};
 
   private _isDocOnlyNote(selectedId: string) {
     const selected = this.service.page.getBlockById(selectedId);


### PR DESCRIPTION

# Fix  [Affine#5664](https://github.com/toeverything/AFFiNE/issues/5664)
# Changes
- The viewport no longer pans when right-clicking with tools other than the pan tool.
- Eliminated the creation of a custom PointerDownEvent in the ContextMenuEvent. Now, the actual PointerEvent is utilized, 

# Extras

Addressed an issue where the default tool loaded from local storage was set in the toolbar but not activated for use. For instance, if the pan tool was set and the browser was reloaded, the toolbar displayed the pan tool, but the active tool was defaulted to default. 

https://github.com/toeverything/blocksuite/assets/123532141/e5dcf9e4-ad9b-4a6b-9f79-4f9f82bed97f


