### PR TITLE
fix(page): popup menu should not close, when on top of hoverable block

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -19,36 +19,41 @@ import type { EmbedToolbarBlock } from './embed-card-toolbar.js';
 export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
   static override styles = css`
     .embed-card-more-menu {
+      box-sizing: border-box;
+      padding-bottom: 4px;
+    }
+
+    .embed-card-more-menu-container {
       border-radius: 8px;
       padding: 8px;
       background: var(--affine-background-overlay-panel-color);
       box-shadow: var(--affine-shadow-2);
     }
 
-    .embed-card-more-menu .menu-item {
+    .embed-card-more-menu-container > .menu-item {
       display: flex;
       justify-content: flex-start;
       align-items: center;
       width: 100%;
     }
 
-    .embed-card-more-menu .menu-item:hover {
+    .embed-card-more-menu-container > .menu-item:hover {
       background: var(--affine-hover-color);
     }
 
-    .embed-card-more-menu .menu-item:hover.delete {
+    .embed-card-more-menu-container > .menu-item:hover.delete {
       background: var(--affine-background-error-color);
       color: var(--affine-error-color);
     }
-    .embed-card-more-menu .menu-item:hover.delete > svg {
+    .embed-card-more-menu-container > .menu-item:hover.delete > svg {
       color: var(--affine-error-color);
     }
 
-    .embed-card-more-menu .menu-item svg {
+    .embed-card-more-menu-container > .menu-item svg {
       margin: 0 8px;
     }
 
-    .embed-card-more-menu .divider {
+    .embed-card-more-menu-container > .divider {
       width: 148px;
       height: 1px;
       margin: 8px;
@@ -109,62 +114,66 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
   }
 
   override render() {
-    return html`<div class="embed-card-more-menu">
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item open"
-        text="Open"
-        @click=${() => this._open()}
-      >
-        ${OpenIcon}
-      </icon-button>
+    return html`
+      <div class="embed-card-more-menu">
+        <div class="embed-card-more-menu-container">
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item open"
+            text="Open"
+            @click=${() => this._open()}
+          >
+            ${OpenIcon}
+          </icon-button>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item copy"
-        text="Copy"
-        @click=${() => this._copyBlock()}
-      >
-        ${CopyIcon}
-      </icon-button>
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item copy"
+            text="Copy"
+            @click=${() => this._copyBlock()}
+          >
+            ${CopyIcon}
+          </icon-button>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item duplicate"
-        text="Duplicate"
-        ?disabled=${this._page.readonly}
-        @click=${() => this._duplicateBlock()}
-      >
-        ${DuplicateIcon}
-      </icon-button>
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item duplicate"
+            text="Duplicate"
+            ?disabled=${this._page.readonly}
+            @click=${() => this._duplicateBlock()}
+          >
+            ${DuplicateIcon}
+          </icon-button>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item reload"
-        text="Reload"
-        ?disabled=${this._page.readonly}
-        @click=${() => this._refreshData()}
-      >
-        ${RefreshIcon}
-      </icon-button>
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item reload"
+            text="Reload"
+            ?disabled=${this._page.readonly}
+            @click=${() => this._refreshData()}
+          >
+            ${RefreshIcon}
+          </icon-button>
 
-      <div class="divider"></div>
+          <div class="divider"></div>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item delete"
-        text="Delete"
-        ?disabled=${this._page.readonly}
-        @click=${() => this._page.deleteBlock(this._model)}
-      >
-        ${DeleteIcon}
-      </icon-button>
-    </div> `;
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item delete"
+            text="Delete"
+            ?disabled=${this._page.readonly}
+            @click=${() => this._page.deleteBlock(this._model)}
+          >
+            ${DeleteIcon}
+          </icon-button>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/blocks/src/_common/components/embed-card/embed-card-style-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-style-popper.ts
@@ -15,7 +15,12 @@ import { getEmbedCardIcons } from '../../utils/url.js';
 @customElement('embed-card-style-menu')
 export class EmbedCardStyleMenu extends WithDisposable(LitElement) {
   static override styles = css`
-    :host {
+    .embed-card-style-menu {
+      box-sizing: border-box;
+      padding-bottom: 8px;
+    }
+
+    .embed-card-style-menu-container {
       border-radius: 8px;
       padding: 8px;
       gap: 8px;
@@ -26,11 +31,11 @@ export class EmbedCardStyleMenu extends WithDisposable(LitElement) {
       box-shadow: var(--affine-shadow-2);
     }
 
-    icon-button {
+    .embed-card-style-menu-container > icon-button {
       padding: var(--1, 0px);
     }
 
-    icon-button.selected {
+    .embed-card-style-menu-container > icon-button.selected {
       border: 1px solid var(--affine-brand-color);
     }
   `;
@@ -50,33 +55,37 @@ export class EmbedCardStyleMenu extends WithDisposable(LitElement) {
   override render() {
     const { EmbedCardHorizontalIcon, EmbedCardListIcon } = getEmbedCardIcons();
     return html`
-      <icon-button
-        width="76px"
-        height="76px"
-        class=${classMap({
-          selected: this.model.style === 'horizontal',
-        })}
-        @click=${() => this._setEmbedCardStyle('horizontal')}
-      >
-        ${EmbedCardHorizontalIcon}
-        <affine-tooltip .offset=${4}
-          >${'Large horizontal style'}</affine-tooltip
-        >
-      </icon-button>
+      <div class="embed-card-style-menu">
+        <div class="embed-card-style-menu-container">
+          <icon-button
+            width="76px"
+            height="76px"
+            class=${classMap({
+              selected: this.model.style === 'horizontal',
+            })}
+            @click=${() => this._setEmbedCardStyle('horizontal')}
+          >
+            ${EmbedCardHorizontalIcon}
+            <affine-tooltip .offset=${4}
+              >${'Large horizontal style'}</affine-tooltip
+            >
+          </icon-button>
 
-      <icon-button
-        width="76px"
-        height="76px"
-        class=${classMap({
-          selected: this.model.style === 'list',
-        })}
-        @click=${() => this._setEmbedCardStyle('list')}
-      >
-        ${EmbedCardListIcon}
-        <affine-tooltip .offset=${4}
-          >${'Small horizontal style'}</affine-tooltip
-        >
-      </icon-button>
+          <icon-button
+            width="76px"
+            height="76px"
+            class=${classMap({
+              selected: this.model.style === 'list',
+            })}
+            @click=${() => this._setEmbedCardStyle('list')}
+          >
+            ${EmbedCardListIcon}
+            <affine-tooltip .offset=${4}
+              >${'Small horizontal style'}</affine-tooltip
+            >
+          </icon-button>
+        </div>
+      </div>
     `;
   }
 }

--- a/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
@@ -5,7 +5,7 @@ import type { EditorHost } from '@blocksuite/lit';
 import { WithDisposable } from '@blocksuite/lit';
 import type { BlockModel } from '@blocksuite/store';
 import { Workspace } from '@blocksuite/store';
-import { flip, offset } from '@floating-ui/dom';
+import { flip } from '@floating-ui/dom';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -447,7 +447,7 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
       computePosition: {
         referenceElement,
         placement: 'top',
-        middleware: [flip(), offset(8)],
+        middleware: [flip()],
         autoUpdate: true,
       },
       abortController: this._cardStyleMenuAbortController,
@@ -475,7 +475,7 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
       computePosition: {
         referenceElement: this.embedCardToolbarElement,
         placement: 'top-end',
-        middleware: [flip(), offset(4)],
+        middleware: [flip()],
         autoUpdate: true,
       },
       abortController: this._moreMenuAbortController,

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup-more-menu-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup-more-menu-popup.ts
@@ -18,36 +18,41 @@ import type { AffineInlineEditor } from '../../../affine-inline-specs.js';
 export class LinkPopupMoreMenu extends WithDisposable(LitElement) {
   static override styles = css`
     .link-popup-more-menu {
+      box-sizing: border-box;
+      padding-bottom: 4px;
+    }
+
+    .link-popup-more-menu-container {
       border-radius: 8px;
       padding: 8px;
       background: var(--affine-background-overlay-panel-color);
       box-shadow: var(--affine-shadow-2);
     }
 
-    .menu-item {
+    .link-popup-more-menu-container > .menu-item {
       display: flex;
       justify-content: flex-start;
       align-items: center;
       width: 100%;
     }
 
-    .menu-item:hover {
+    .link-popup-more-menu-container > .menu-item:hover {
       background: var(--affine-hover-color);
     }
 
-    .menu-item:hover.delete {
+    .link-popup-more-menu-container > .menu-item:hover.delete {
       background: var(--affine-background-error-color);
       color: var(--affine-error-color);
     }
-    .menu-item:hover.delete > svg {
+    .link-popup-more-menu > .menu-item:hover.delete > svg {
       color: var(--affine-error-color);
     }
 
-    .menu-item svg {
+    .link-popup-more-menu-container > .menu-item svg {
       margin: 0 8px;
     }
 
-    .divider {
+    .link-popup-more-menu-container > .divider {
       width: 148px;
       height: 1px;
       margin: 8px;
@@ -105,49 +110,53 @@ export class LinkPopupMoreMenu extends WithDisposable(LitElement) {
   }
 
   override render() {
-    return html`<div class="link-popup-more-menu">
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item open"
-        text="Open"
-        @click=${() => this._openLink()}
-      >
-        ${OpenIcon}
-      </icon-button>
+    return html`
+      <div class="link-popup-more-menu">
+        <div class="link-popup-more-menu-container">
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item open"
+            text="Open"
+            @click=${() => this._openLink()}
+          >
+            ${OpenIcon}
+          </icon-button>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item copy"
-        text="Copy"
-        @click=${() => this._copyUrl()}
-      >
-        ${CopyIcon}
-      </icon-button>
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item copy"
+            text="Copy"
+            @click=${() => this._copyUrl()}
+          >
+            ${CopyIcon}
+          </icon-button>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item unlink"
-        text="Remove link"
-        @click=${() => this._removeLink()}
-      >
-        ${UnlinkIcon}
-      </icon-button>
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item unlink"
+            text="Remove link"
+            @click=${() => this._removeLink()}
+          >
+            ${UnlinkIcon}
+          </icon-button>
 
-      <div class="divider"></div>
+          <div class="divider"></div>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item delete"
-        text="Delete"
-        @click=${() => this._delete()}
-      >
-        ${DeleteIcon}
-      </icon-button>
-    </div> `;
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item delete"
+            text="Delete"
+            @click=${() => this._delete()}
+          >
+            ${DeleteIcon}
+          </icon-button>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -392,7 +392,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
       computePosition: {
         referenceElement: this.popupContainer,
         placement: 'top-end',
-        middleware: [flip(), offset(4)],
+        middleware: [flip()],
         autoUpdate: true,
       },
       abortController: this._moreMenuAbortController,

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup-more-menu-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup-more-menu-popup.ts
@@ -14,36 +14,41 @@ import type { AffineInlineEditor } from '../../affine-inline-specs.js';
 export class ReferencePopupMoreMenu extends WithDisposable(LitElement) {
   static override styles = css`
     .reference-popup-more-menu {
+      box-sizing: border-box;
+      padding-bottom: 4px;
+    }
+
+    .reference-popup-more-menu-container {
       border-radius: 8px;
       padding: 8px;
       background: var(--affine-background-overlay-panel-color);
       box-shadow: var(--affine-shadow-2);
     }
 
-    .menu-item {
+    .reference-popup-more-menu-container > .menu-item {
       display: flex;
       justify-content: flex-start;
       align-items: center;
       width: 100%;
     }
 
-    .menu-item:hover {
+    .reference-popup-more-menu-container > .menu-item:hover {
       background: var(--affine-hover-color);
     }
 
-    .menu-item:hover.delete {
+    .reference-popup-more-menu-container > .menu-item:hover.delete {
       background: var(--affine-background-error-color);
       color: var(--affine-error-color);
     }
-    .menu-item:hover.delete > svg {
+    .reference-popup-more-menu-container > .menu-item:hover.delete > svg {
       color: var(--affine-error-color);
     }
 
-    .menu-item svg {
+    .reference-popup-more-menu-container > .menu-item svg {
       margin: 0 8px;
     }
 
-    .divider {
+    .reference-popup-more-menu-container > .divider {
       width: 148px;
       height: 1px;
       margin: 8px;
@@ -102,29 +107,33 @@ export class ReferencePopupMoreMenu extends WithDisposable(LitElement) {
   }
 
   override render() {
-    return html`<div class="reference-popup-more-menu">
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item open"
-        text="Open"
-        @click=${() => this._openPage()}
-      >
-        ${OpenIcon}
-      </icon-button>
+    return html`
+      <div class="reference-popup-more-menu">
+        <div class="reference-popup-more-menu-container">
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item open"
+            text="Open"
+            @click=${() => this._openPage()}
+          >
+            ${OpenIcon}
+          </icon-button>
 
-      <div class="divider"></div>
+          <div class="divider"></div>
 
-      <icon-button
-        width="126px"
-        height="32px"
-        class="menu-item delete"
-        text="Delete"
-        @click=${() => this._delete()}
-      >
-        ${DeleteIcon}
-      </icon-button>
-    </div> `;
+          <icon-button
+            width="126px"
+            height="32px"
+            class="menu-item delete"
+            text="Delete"
+            @click=${() => this._delete()}
+          >
+            ${DeleteIcon}
+          </icon-button>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -187,7 +187,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
       computePosition: {
         referenceElement: this.popupContainer,
         placement: 'top-end',
-        middleware: [flip(), offset(4)],
+        middleware: [flip()],
         autoUpdate: true,
       },
       abortController: this._moreMenuAbortController,

--- a/packages/blocks/src/attachment-block/components/more-menu.ts
+++ b/packages/blocks/src/attachment-block/components/more-menu.ts
@@ -22,45 +22,52 @@ export const MoreMenu = ({
   abortController: AbortController;
 }) => {
   const readonly = model.page.readonly;
-  return html`<style>
+  return html`
+    <style>
       ${moreMenuStyles}
     </style>
+
     <div ${ref(moreMenuRef)} class="affine-attachment-options-more">
-      <icon-button
-        width="126px"
-        height="32px"
-        text="Download"
-        @click="${() => downloadAttachment(model)}"
-      >
-        ${DownloadIcon}
-      </icon-button>
-      <icon-button
-        width="126px"
-        height="32px"
-        text="Duplicate"
-        ?hidden=${readonly}
-        @click="${() => {
-          const prop: { flavour: 'affine:attachment' } = {
-            flavour: 'affine:attachment',
-            ...cloneAttachmentProperties(model),
-          };
-          model.page.addSiblingBlocks(model, [prop]);
-        }}"
-      >
-        ${DuplicateIcon}
-      </icon-button>
-      <icon-button
-        width="126px"
-        height="32px"
-        text="Delete"
-        class="danger"
-        ?hidden=${readonly}
-        @click="${() => {
-          model.page.deleteBlock(model);
-          abortController.abort();
-        }}"
-      >
-        ${DeleteIcon}
-      </icon-button>
-    </div>`;
+      <div class="affine-attachment-options-more-container">
+        <icon-button
+          width="126px"
+          height="32px"
+          text="Download"
+          @click="${() => downloadAttachment(model)}"
+        >
+          ${DownloadIcon}
+        </icon-button>
+
+        <icon-button
+          width="126px"
+          height="32px"
+          text="Duplicate"
+          ?hidden=${readonly}
+          @click="${() => {
+            const prop: { flavour: 'affine:attachment' } = {
+              flavour: 'affine:attachment',
+              ...cloneAttachmentProperties(model),
+            };
+            model.page.addSiblingBlocks(model, [prop]);
+          }}"
+        >
+          ${DuplicateIcon}
+        </icon-button>
+
+        <icon-button
+          width="126px"
+          height="32px"
+          text="Delete"
+          class="danger"
+          ?hidden=${readonly}
+          @click="${() => {
+            model.page.deleteBlock(model);
+            abortController.abort();
+          }}"
+        >
+          ${DeleteIcon}
+        </icon-button>
+      </div>
+    </div>
+  `;
 };

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -158,7 +158,7 @@ export function AttachmentOptionsTemplate({
             computePosition: {
               referenceElement: containerEl,
               placement: 'top-end',
-              middleware: [flip(), offset(4)],
+              middleware: [flip()],
             },
           });
         }}

--- a/packages/blocks/src/attachment-block/components/styles.ts
+++ b/packages/blocks/src/attachment-block/components/styles.ts
@@ -54,6 +54,11 @@ export const renameStyles = css`
 
 export const moreMenuStyles = css`
   .affine-attachment-options-more {
+    box-sizing: border-box;
+    padding-bottom: 4px;
+  }
+
+  .affine-attachment-options-more-container {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -65,21 +70,21 @@ export const moreMenuStyles = css`
     box-shadow: var(--affine-shadow-2);
   }
 
-  .affine-attachment-options-more icon-button {
+  .affine-attachment-options-more-container > icon-button {
     display: flex;
     align-items: center;
     padding: 8px;
     gap: 8px;
   }
-  .affine-attachment-options-more icon-button[hidden] {
+  .affine-attachment-options-more-container > icon-button[hidden] {
     display: none;
   }
 
-  .affine-attachment-options-more icon-button:hover.danger {
+  .affine-attachment-options-more-container > icon-button:hover.danger {
     background: var(--affine-background-error-color);
     color: var(--affine-error-color);
   }
-  .affine-attachment-options-more icon-button:hover.danger > svg {
+  .affine-attachment-options-more-container > icon-button:hover.danger > svg {
     color: var(--affine-error-color);
   }
 `;


### PR DESCRIPTION
Bug: due to 4px offset b/w toolbar and popup menu, if the gap is over another block which shows toolbar on hover, then current toolbar will close on moving mouse from toolbar through the gap to the popup.

https://github.com/toeverything/blocksuite/assets/54364088/ecbba892-902b-446c-abb9-edf1abe4cb0f

