### PR TITLE
fix:  console error when pressing delete key in the paragraph before a database

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -868,11 +868,13 @@ function handleParagraphBlockForwardDelete(
       'affine:code',
       'affine:attachment',
     ];
+
     if (
       nextSibling &&
-      ignoreForwardDeleteFlavourList.includes(nextSibling.flavour as Flavour)
-    )
+      matchFlavours(nextSibling, ignoreForwardDeleteFlavourList)
+    ) {
       return true;
+    }
 
     return (
       handleParagraphOrList(page, model, nextSibling, firstChild) ||

--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -23,6 +23,7 @@ import {
   focusTitle,
 } from '../../../_common/utils/selection.js';
 import type { ListBlockModel } from '../../../list-block/index.js';
+import type { Flavour } from '../../../models.js';
 import type { PageBlockModel } from '../../../page-block/index.js';
 import type { ExtendedModel } from '../../types.js';
 
@@ -861,6 +862,18 @@ function handleParagraphBlockForwardDelete(
     // TODO
     return false;
   } else {
+    const ignoreForwardDeleteFlavourList: Flavour[] = [
+      'affine:database',
+      'affine:image',
+      'affine:code',
+      'affine:attachment',
+    ];
+    if (
+      nextSibling &&
+      ignoreForwardDeleteFlavourList.includes(nextSibling.flavour as Flavour)
+    )
+      return true;
+
     return (
       handleParagraphOrList(page, model, nextSibling, firstChild) ||
       handleEmbedDividerCode(nextSibling, firstChild)


### PR DESCRIPTION
![iShot_2024-02-23_11 26 45](https://github.com/toeverything/blocksuite/assets/4506072/e50fecfa-0b47-4846-8108-348733477033)

我看notion的行为就是在表格和image等block前的paragraph block按下delete键，会被直接忽略