### PR TITLE
fix(edgeless): shift panel-wrapper to keep it in view

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/utils.ts
+++ b/packages/blocks/src/page-block/edgeless/components/utils.ts
@@ -1,5 +1,5 @@
 import { assertExists, type Disposable } from '@blocksuite/global/utils';
-import { computePosition, flip, offset } from '@floating-ui/dom';
+import { computePosition, flip, offset, shift } from '@floating-ui/dom';
 import { css, html } from 'lit';
 
 import {
@@ -80,6 +80,9 @@ export function createButtonPopper(
         }),
         flip({
           fallbackPlacements: ['bottom'],
+        }),
+        shift({
+          padding: 10,
         }),
       ],
     })


### PR DESCRIPTION
### Before

<img width="386" alt="Screenshot 2024-02-23 at 15 57 33" src="https://github.com/toeverything/blocksuite/assets/27926/df23f572-1819-4b24-b9f2-723d9e4530e6">


### After

<img width="419" alt="Screenshot 2024-02-23 at 15 56 36" src="https://github.com/toeverything/blocksuite/assets/27926/2a5e9aea-c91f-43b8-aa6e-efa6d2174c53">
