### PR TITLE
fix(edgeless): no need to adjust position of component-toolbar when more-actions-container is opened

### DIFF
--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -175,9 +175,6 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
   @state()
   top = 0;
 
-  @state()
-  private _showPopper = false;
-
   get page() {
     return this.edgeless.page;
   }
@@ -327,10 +324,6 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
     `;
   }
 
-  protected togglePopper = (showPopper: boolean) => {
-    this._showPopper = showPopper;
-  };
-
   private _updateOnSelectedChange = (element: string | { id: string }) => {
     const id = typeof element === 'string' ? element : element.id;
 
@@ -427,9 +420,6 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
     top < 0 && (top = y + bound.h * viewport.zoom + offset);
 
     left = clamp(x, 10, width - rect.width - 10);
-    if (this._showPopper) {
-      left = clamp(x, 10, width - rect.width - 80);
-    }
     top = clamp(top, 10, height - rect.height - 100);
     return [left, top];
   }
@@ -533,7 +523,6 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
         <edgeless-more-button
           .edgeless=${edgeless}
           .vertical=${true}
-          .setPopperShow=${this.togglePopper}
         ></edgeless-more-button>
       </div>`;
   }

--- a/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/page-block/edgeless/components/component-toolbar/more-button.ts
@@ -170,9 +170,6 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
   @state()
   private _showPopper = false;
 
-  @property({ attribute: false })
-  setPopperShow!: (popperShow: boolean) => void;
-
   @query('.more-actions-container')
   private _actionsMenu!: HTMLDivElement;
 
@@ -260,7 +257,6 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       this._actionsMenu,
       ({ display }) => {
         this._showPopper = display === 'show';
-        this.setPopperShow(this._showPopper);
       }
     );
     _disposables.add(this._actionsMenuPopper);


### PR DESCRIPTION
Related to #6288 

### Before
<img width="488" alt="Screenshot 2024-02-24 at 16 18 34" src="https://github.com/toeverything/blocksuite/assets/27926/413d3045-5d09-4d00-ad83-9eecf7f63435">

### After
<img width="410" alt="Screenshot 2024-02-24 at 16 18 04" src="https://github.com/toeverything/blocksuite/assets/27926/0e54fd04-a463-4995-8f9a-7474ae395157">
