### PR TITLE
fix(edgeless): add default text color of shape-element

### DIFF
--- a/packages/blocks/src/surface-block/elements/shape/consts.ts
+++ b/packages/blocks/src/surface-block/elements/shape/consts.ts
@@ -77,6 +77,8 @@ export const STROKE_COLORS = [
 
 export const DEFAULT_SHAPE_STROKE_COLOR = STROKE_COLORS[0];
 
+export const DEFAULT_SHAPE_TEXT_COLOR = STROKE_COLORS[9];
+
 export const StrokeColorsSchema = z.union([
   z.literal('--affine-palette-line-yellow'),
   z.literal('--affine-palette-line-orange'),

--- a/packages/blocks/src/surface-block/managers/edit-session.ts
+++ b/packages/blocks/src/surface-block/managers/edit-session.ts
@@ -32,6 +32,7 @@ import { TextAlign, TextVerticalAlign } from '../elements/consts.js';
 import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
+  DEFAULT_SHAPE_TEXT_COLOR,
   FillColorsSchema,
   SHAPE_TEXT_FONT_SIZE,
   ShapeType,
@@ -155,6 +156,7 @@ export class EditSessionStorage {
       lineWidth: LineWidth.Thin,
     },
     shape: {
+      color: DEFAULT_SHAPE_TEXT_COLOR,
       shapeType: ShapeType.Rect,
       fillColor: DEFAULT_SHAPE_FILL_COLOR,
       strokeColor: DEFAULT_SHAPE_STROKE_COLOR,


### PR DESCRIPTION
### Before
<img width="561" alt="Screenshot 2024-02-26 at 16 29 24" src="https://github.com/toeverything/blocksuite/assets/27926/25dae5df-2ac7-4df4-806b-868a38d2477e">


### After
<img width="591" alt="Screenshot 2024-02-26 at 16 28 36" src="https://github.com/toeverything/blocksuite/assets/27926/b01ab71f-2004-4601-87f5-10b534f63ade">
