### PR TITLE
fix(page): the style of editor-host does not take effect

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -119,3 +119,4 @@ Example:
 - Adithyan, @golok727, 2024/02/10
 - zkwolf, @zkwolf, 2024/2/19
 - Yuntian Sun, @ununian, 2024/02/20
+- wumo, @wumo1016, 2024/2/27

--- a/packages/blocks/src/root-block/page/page-root-block.ts
+++ b/packages/blocks/src/root-block/page/page-root-block.ts
@@ -49,7 +49,7 @@ export class PageRootBlockComponent extends BlockElement<
   PageRootBlockWidgetName
 > {
   static override styles = css`
-    editor-host:has(* > affine-page-root) {
+    editor-host:has(> affine-page-root, * > affine-page-root) {
       display: block;
       height: 100%;
     }


### PR DESCRIPTION
When affine-page-root is used as a direct child element of editor-host, the style of editor-host does not take effect.

https://github.com/toeverything/blocksuite/assets/47590453/e71a18dd-300e-4fdd-a19c-c8853cf014e2

