### PR TITLE
fix(edgeless): github icon size on note-menu

### DIFF
--- a/packages/blocks/src/embed-github-block/styles.ts
+++ b/packages/blocks/src/embed-github-block/styles.ts
@@ -387,8 +387,8 @@ export const styles = css`
 `;
 
 export const GithubIcon = html`<svg
-  width="16"
-  height="16"
+  width="20"
+  height="20"
   viewBox="0 0 16 16"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<img width="256" alt="Screenshot 2024-02-27 at 22 41 58" src="https://github.com/toeverything/blocksuite/assets/27926/c4f29269-effe-4914-8f31-061ccf0671f2">
