### PR TITLE
refactor: models -> schemas

### DIFF
--- a/packages/blocks/models.js
+++ b/packages/blocks/models.js
@@ -1,3 +1,0 @@
-/* eslint-disable */
-/// <reference types="./dist/models.d.ts" />
-export * from './dist/models.js';

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -58,7 +58,7 @@
   "exports": {
     "./dist/*": "./dist/*",
     ".": "./src/index.ts",
-    "./models": "./src/models.ts"
+    "./schemas": "./src/schemas.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -71,9 +71,9 @@
         "module": "./dist/index.js",
         "import": "./dist/index.js"
       },
-      "./models": {
-        "types": "./dist/models.d.ts",
-        "default": "./dist/models.js"
+      "./schemas": {
+        "types": "./dist/schemas.d.ts",
+        "default": "./dist/schemas.js"
       }
     }
   },
@@ -82,7 +82,7 @@
     "dist",
     "!src/__tests__",
     "!dist/__tests__",
-    "models.d.ts",
-    "models.js"
+    "schemas.d.ts",
+    "schemas.js"
   ]
 }

--- a/packages/blocks/schemas.d.ts
+++ b/packages/blocks/schemas.d.ts
@@ -1,3 +1,3 @@
 /* eslint-disable */
 // @ts-ignore
-export * from './dist/models';
+export * from './dist/schemas';

--- a/packages/blocks/schemas.js
+++ b/packages/blocks/schemas.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+/// <reference types="./dist/schemas.d.ts" />
+export * from './dist/schemas.js';

--- a/packages/blocks/src/__tests__/database/database.unit.spec.ts
+++ b/packages/blocks/src/__tests__/database/database.unit.spec.ts
@@ -66,7 +66,7 @@ describe('DatabaseManager', () => {
     noteBlockId = doc.addBlock('affine:note', {}, rootId);
 
     databaseBlockId = doc.addBlock(
-      'affine:database' as BlockSuite.ModelKeys,
+      'affine:database' as BlockSuite.Flavour,
       {
         columns: [],
         titleColumn: 'Title',

--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -105,7 +105,7 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
     const parent = doc.getParent(model);
     const index = parent?.children.indexOf(model);
     doc.addBlock(
-      model.flavour as BlockSuite.ModelKeys,
+      model.flavour as BlockSuite.Flavour,
       duplicateProps,
       parent,
       index

--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -22,7 +22,6 @@ import {
   focusTitle,
 } from '../../../_common/utils/selection.js';
 import type { ListBlockModel } from '../../../list-block/index.js';
-import type { Flavour } from '../../../models.js';
 import type { RootBlockModel } from '../../../root-block/index.js';
 import type { ExtendedModel } from '../../types.js';
 
@@ -862,7 +861,7 @@ function handleParagraphBlockForwardDelete(
     // TODO
     return false;
   } else {
-    const ignoreForwardDeleteFlavourList: Flavour[] = [
+    const ignoreForwardDeleteFlavourList: BlockSuite.Flavour[] = [
       'affine:database',
       'affine:image',
       'affine:code',

--- a/packages/blocks/src/_common/configs/text-conversion.ts
+++ b/packages/blocks/src/_common/configs/text-conversion.ts
@@ -1,6 +1,5 @@
 import type { TemplateResult } from 'lit';
 
-import type { BlockSchemas } from '../../models.js';
 import {
   BulletedListIcon,
   CheckBoxIcon,
@@ -22,7 +21,7 @@ import {
  * which are also used for registering hotkeys for converting block flavours.
  */
 interface TextConversionConfig {
-  flavour: keyof BlockSchemas;
+  flavour: BlockSuite.Flavour;
   type?: string;
   name: string;
   hotkey: string[] | null;

--- a/packages/blocks/src/_common/configs/text-format/consts.ts
+++ b/packages/blocks/src/_common/configs/text-format/consts.ts
@@ -1,14 +1,14 @@
-import type { Flavour } from '../../../models.js';
-
 // corresponding to `formatText` command
-export const FORMAT_TEXT_SUPPORT_FLAVOURS: Flavour[] = [
+export const FORMAT_TEXT_SUPPORT_FLAVOURS: BlockSuite.Flavour[] = [
   'affine:paragraph',
   'affine:list',
 ];
 // corresponding to `formatBlock` command
-export const FORMAT_BLOCK_SUPPORT_FLAVOURS: Flavour[] = [
+export const FORMAT_BLOCK_SUPPORT_FLAVOURS: BlockSuite.Flavour[] = [
   'affine:paragraph',
   'affine:list',
 ];
 // corresponding to `formatNative` command
-export const FORMAT_NATIVE_SUPPORT_FLAVOURS: Flavour[] = ['affine:database'];
+export const FORMAT_NATIVE_SUPPORT_FLAVOURS: BlockSuite.Flavour[] = [
+  'affine:database',
+];

--- a/packages/blocks/src/_common/configs/text-format/utils.ts
+++ b/packages/blocks/src/_common/configs/text-format/utils.ts
@@ -6,7 +6,6 @@ import {
 } from '@blocksuite/inline';
 import type { BlockElement, EditorHost } from '@blocksuite/lit';
 
-import type { Flavour } from '../../../models.js';
 import { BLOCK_ID_ATTR } from '../../consts.js';
 import type {
   AffineInlineEditor,
@@ -59,7 +58,9 @@ function getCombinedFormat(host: EditorHost): AffineTextAttributes {
         .getSelectedBlocks({
           types: ['text'],
           filter: el =>
-            FORMAT_TEXT_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+            FORMAT_TEXT_SUPPORT_FLAVOURS.includes(
+              el.model.flavour as BlockSuite.Flavour
+            ),
         })
         .inline((ctx, next) => {
           const { selectedBlocks } = ctx;
@@ -89,7 +90,9 @@ function getCombinedFormat(host: EditorHost): AffineTextAttributes {
         .getSelectedBlocks({
           types: ['block'],
           filter: el =>
-            FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+            FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(
+              el.model.flavour as BlockSuite.Flavour
+            ),
         })
         .inline((ctx, next) => {
           const { selectedBlocks } = ctx;
@@ -133,7 +136,7 @@ function getCombinedFormat(host: EditorHost): AffineTextAttributes {
             const blockElement = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
             if (blockElement) {
               return FORMAT_NATIVE_SUPPORT_FLAVOURS.includes(
-                blockElement.model.flavour as Flavour
+                blockElement.model.flavour as BlockSuite.Flavour
               );
             }
             return false;
@@ -195,7 +198,9 @@ export function isFormatSupported(host: EditorHost) {
         .getSelectedBlocks({
           types: ['text'],
           filter: el =>
-            FORMAT_TEXT_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+            FORMAT_TEXT_SUPPORT_FLAVOURS.includes(
+              el.model.flavour as BlockSuite.Flavour
+            ),
         })
         .inline((ctx, next) => {
           const { currentTextSelection, selectedBlocks } = ctx;
@@ -223,7 +228,9 @@ export function isFormatSupported(host: EditorHost) {
         .getSelectedBlocks({
           types: ['block'],
           filter: el =>
-            FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+            FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(
+              el.model.flavour as BlockSuite.Flavour
+            ),
         })
         .inline((ctx, next) => {
           const { selectedBlocks } = ctx;
@@ -258,7 +265,7 @@ export function isFormatSupported(host: EditorHost) {
             const blockElement = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
             if (blockElement) {
               return FORMAT_NATIVE_SUPPORT_FLAVOURS.includes(
-                blockElement.model.flavour as Flavour
+                blockElement.model.flavour as BlockSuite.Flavour
               );
             }
             return false;

--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -10,12 +10,12 @@ import {
   isInsidePageEditor,
   matchFlavours,
 } from '../../_common/utils/index.js';
-import type { RootBlockModel } from '../../models.js';
 import type { EdgelessRootBlockComponent } from '../../root-block/edgeless/edgeless-root-block.js';
 import { getBlocksInFrame } from '../../root-block/edgeless/frame-manager.js';
 import type { EdgelessBlockModel } from '../../root-block/edgeless/type.js';
 import { xywhArrayToObject } from '../../root-block/edgeless/utils/convert.js';
 import { getBackgroundGrid } from '../../root-block/edgeless/utils/query.js';
+import type { RootBlockModel } from '../../root-block/index.js';
 import type { IBound } from '../../surface-block/consts.js';
 import type { ElementModel } from '../../surface-block/element-model/index.js';
 import type { Renderer } from '../../surface-block/index.js';

--- a/packages/blocks/src/_common/transformers/middlewares.ts
+++ b/packages/blocks/src/_common/transformers/middlewares.ts
@@ -2,7 +2,8 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { DeltaOperation, JobMiddleware } from '@blocksuite/store';
 
 import type { DatabaseBlockModel } from '../../database-block/index.js';
-import type { ListBlockModel, ParagraphBlockModel } from '../../models.js';
+import type { ListBlockModel } from '../../list-block/index.js';
+import type { ParagraphBlockModel } from '../../paragraph-block/index.js';
 import { DEFAULT_IMAGE_PROXY_ENDPOINT } from '../consts.js';
 
 export const replaceIdMiddleware: JobMiddleware = ({ slots, workspace }) => {

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -5,7 +5,8 @@ import { render, type TemplateResult } from 'lit';
 
 import type { EmbedLinkedDocBlockComponent } from '../../embed-linked-doc-block/embed-linked-doc-block.js';
 import type { EmbedSyncedDocCard } from '../../embed-synced-doc-block/components/embed-synced-doc-card.js';
-import type { ImageBlockModel, NoteBlockModel } from '../../models.js';
+import type { ImageBlockModel } from '../../image-block/index.js';
+import type { NoteBlockModel } from '../../note-block/index.js';
 import { Bound, getCommonBound } from '../../surface-block/utils/bound.js';
 import { deserializeXYWH } from '../../surface-block/utils/xywh.js';
 import type { SurfaceRefBlockModel } from '../../surface-ref-block/surface-ref-model.js';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -81,7 +81,6 @@ export * from './embed-youtube-block/index.js';
 export * from './frame-block/index.js';
 export * from './image-block/index.js';
 export * from './list-block/index.js';
-export * from './models.js';
 export * from './note-block/index.js';
 export * from './paragraph-block/index.js';
 export { EdgelessComponentToolbar } from './root-block/edgeless/components/component-toolbar/component-toolbar.js';
@@ -92,6 +91,7 @@ export type {
   TemplateManager,
 } from './root-block/edgeless/components/toolbar/template/template-type.js';
 export * from './root-block/index.js';
+export * from './schemas.js';
 export {
   Bound,
   BrushElementModel,

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -107,6 +107,7 @@ export {
   ShapeElementModel,
   ShapeStyle,
   StrokeStyle,
+  SurfaceBlockModel,
   TextElementModel,
 } from './surface-block/index.js';
 export { SurfaceBlockComponent } from './surface-block/surface-block.js';

--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -13,7 +13,7 @@ import {
 } from '@blocksuite/store';
 
 import { matchFlavours } from '../../../_common/utils/index.js';
-import type { CodeBlockModel } from '../../../models.js';
+import type { CodeBlockModel } from '../../../code-block/index.js';
 import type { ParagraphBlockModel } from '../../../paragraph-block/index.js';
 
 const findLast = (snapshot: BlockSnapshot): BlockSnapshot => {

--- a/packages/blocks/src/root-block/commands/text-crud/format-block.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/format-block.ts
@@ -4,7 +4,6 @@ import { INLINE_ROOT_ATTR, type InlineRootElement } from '@blocksuite/inline';
 
 import { FORMAT_BLOCK_SUPPORT_FLAVOURS } from '../../../_common/configs/text-format/consts.js';
 import type { AffineTextAttributes } from '../../../_common/inline/presets/affine-inline-specs.js';
-import type { Flavour } from '../../../models.js';
 
 // for block selection
 export const formatBlockCommand: Command<
@@ -39,7 +38,9 @@ export const formatBlockCommand: Command<
     .getSelectedBlocks({
       blockSelections,
       filter: el =>
-        FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+        FORMAT_BLOCK_SUPPORT_FLAVOURS.includes(
+          el.model.flavour as BlockSuite.Flavour
+        ),
       types: ['block'],
     })
     .inline((ctx, next) => {

--- a/packages/blocks/src/root-block/commands/text-crud/format-native.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/format-native.ts
@@ -6,7 +6,6 @@ import type { BlockElement } from '@blocksuite/lit';
 import { FORMAT_NATIVE_SUPPORT_FLAVOURS } from '../../../_common/configs/text-format/consts.js';
 import { BLOCK_ID_ATTR } from '../../../_common/consts.js';
 import type { AffineTextAttributes } from '../../../_common/inline/presets/affine-inline-specs.js';
-import type { Flavour } from '../../../models.js';
 
 // for native range
 export const formatNativeCommand: Command<
@@ -40,7 +39,7 @@ export const formatNativeCommand: Command<
       const blockElement = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
       if (blockElement) {
         return FORMAT_NATIVE_SUPPORT_FLAVOURS.includes(
-          blockElement.model.flavour as Flavour
+          blockElement.model.flavour as BlockSuite.Flavour
         );
       }
       return false;

--- a/packages/blocks/src/root-block/commands/text-crud/format-text.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/format-text.ts
@@ -5,7 +5,6 @@ import { INLINE_ROOT_ATTR, type InlineRootElement } from '@blocksuite/inline';
 import { FORMAT_TEXT_SUPPORT_FLAVOURS } from '../../../_common/configs/text-format/consts.js';
 import type { AffineTextAttributes } from '../../../_common/inline/presets/affine-inline-specs.js';
 import { clearMarksOnDiscontinuousInput } from '../../../_common/utils/inline-editor.js';
-import type { Flavour } from '../../../models.js';
 
 // for text selection
 export const formatTextCommand: Command<
@@ -35,7 +34,9 @@ export const formatTextCommand: Command<
     .getSelectedBlocks({
       textSelection,
       filter: el =>
-        FORMAT_TEXT_SUPPORT_FLAVOURS.includes(el.model.flavour as Flavour),
+        FORMAT_TEXT_SUPPORT_FLAVOURS.includes(
+          el.model.flavour as BlockSuite.Flavour
+        ),
       types: ['text'],
     })
     .inline((ctx, next) => {

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
@@ -1,7 +1,7 @@
 import { assertExists } from '@blocksuite/global/utils';
 import { Workspace } from '@blocksuite/store';
 
-import type { NoteBlockModel } from '../../../../models.js';
+import type { NoteBlockModel } from '../../../../note-block/index.js';
 import {
   CanvasTextFontFamily,
   CanvasTextFontStyle,

--- a/packages/blocks/src/root-block/edgeless/components/auto-connect/edgeless-index-label.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-connect/edgeless-index-label.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../_common/icons/edgeless.js';
 import { SmallDocIcon } from '../../../../_common/icons/text.js';
 import { requestConnectedFrame } from '../../../../_common/utils/event.js';
-import type { NoteBlockModel } from '../../../../models.js';
+import type { NoteBlockModel } from '../../../../note-block/index.js';
 import { Bound } from '../../../../surface-block/index.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/bookmark/edgeless-bookmark.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/bookmark/edgeless-bookmark.ts
@@ -2,7 +2,7 @@ import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { html } from 'lit/static-html.js';
 
-import type { BookmarkBlockModel } from '../../../../../models.js';
+import type { BookmarkBlockModel } from '../../../../../bookmark-block/index.js';
 import { Bound } from '../../../../../surface-block/index.js';
 import { EdgelessPortalBase } from '../edgeless-portal-base.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -28,8 +28,10 @@ import {
   NoteDisplayMode,
   type TopLevelBlockModel,
 } from '../../../../_common/utils/index.js';
-import type { SurfaceBlockComponent } from '../../../../index.js';
-import type { FrameBlockModel } from '../../../../models.js';
+import type {
+  FrameBlockModel,
+  SurfaceBlockComponent,
+} from '../../../../index.js';
 import type { NoteBlockModel } from '../../../../note-block/index.js';
 import type { GroupElementModel } from '../../../../surface-block/index.js';
 import { type EdgelessBlockType } from '../../../../surface-block/index.js';

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -28,8 +28,11 @@ import {
   SYNCED_MIN_HEIGHT,
   SYNCED_MIN_WIDTH,
 } from '../../../../embed-synced-doc-block/styles.js';
-import type { EmbedHtmlModel, EmbedSyncedDocModel } from '../../../../index.js';
-import type { BookmarkBlockModel } from '../../../../models.js';
+import type {
+  BookmarkBlockModel,
+  EmbedHtmlModel,
+  EmbedSyncedDocModel,
+} from '../../../../index.js';
 import { NoteBlockModel } from '../../../../note-block/note-model.js';
 import { normalizeTextBound } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { TextElementModel } from '../../../../surface-block/element-model/text.js';

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -30,6 +30,7 @@ import {
   isInsidePageEditor,
 } from '../../../_common/utils/query.js';
 import { isUrlInClipboard } from '../../../_common/utils/url.js';
+import type { AttachmentBlockModel } from '../../../attachment-block/index.js';
 import {
   type BookmarkBlockModel,
   BookmarkStyles,
@@ -43,7 +44,6 @@ import type { EmbedSyncedDocModel } from '../../../embed-synced-doc-block/embed-
 import type { EmbedYoutubeModel } from '../../../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../../../frame-block/frame-model.js';
 import type { ImageBlockModel } from '../../../image-block/image-model.js';
-import type { AttachmentBlockModel } from '../../../models.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { IBound } from '../../../surface-block/consts.js';
 import type { EdgelessElementType } from '../../../surface-block/edgeless-types.js';

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -38,9 +38,11 @@ import {
   SURFACE_IMAGE_CARD_HEIGHT,
   SURFACE_IMAGE_CARD_WIDTH,
 } from '../../image-block/components/image-card.js';
-import type { ImageBlockProps } from '../../image-block/image-model.js';
+import type {
+  ImageBlockModel,
+  ImageBlockProps,
+} from '../../image-block/image-model.js';
 import type { AttachmentBlockProps } from '../../index.js';
-import type { ImageBlockModel } from '../../models.js';
 import {
   Bound,
   type IBound,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -5,7 +5,7 @@ import { type BlockModel, Slot } from '@blocksuite/store';
 import type { EdgelessTool, TopLevelBlockModel } from '../../_common/types.js';
 import { last } from '../../_common/utils/iterable.js';
 import { clamp } from '../../_common/utils/math.js';
-import type { FrameBlockModel, SurfaceBlockModel } from '../../models.js';
+import type { FrameBlockModel } from '../../frame-block/index.js';
 import type { IBound } from '../../surface-block/consts.js';
 import type { EdgelessElementType } from '../../surface-block/edgeless-types.js';
 import type {
@@ -13,6 +13,7 @@ import type {
   CanvasElementType,
   ConnectorElementModel,
 } from '../../surface-block/element-model/index.js';
+import type { SurfaceBlockModel } from '../../surface-block/index.js';
 import {
   getCommonBound,
   GroupElementModel,

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -8,13 +8,11 @@ import type {
   TopLevelBlockModel,
 } from '../../_common/types.js';
 import { matchFlavours } from '../../_common/utils/model.js';
+import type { FrameBlockModel } from '../../frame-block/frame-model.js';
 import type { EdgelessRootService } from '../../index.js';
-import type {
-  FrameBlockModel,
-  NoteBlockModel,
-  SurfaceBlockModel,
-} from '../../models.js';
+import type { NoteBlockModel } from '../../note-block/note-model.js';
 import { Bound, Overlay, type RoughCanvas } from '../../surface-block/index.js';
+import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import { isFrameBlock } from './utils/query.js';
 

--- a/packages/blocks/src/root-block/edgeless/services/template.ts
+++ b/packages/blocks/src/root-block/edgeless/services/template.ts
@@ -325,7 +325,7 @@ export class TemplateJob {
         assertExists(modelData);
 
         doc.addBlock(
-          modelData.flavour as BlockSuite.ModelKeys,
+          modelData.flavour as BlockSuite.Flavour,
           {
             ...modelData.props,
             id: modelData.id,

--- a/packages/blocks/src/root-block/edgeless/type.ts
+++ b/packages/blocks/src/root-block/edgeless/type.ts
@@ -2,7 +2,6 @@ import type { EditorHost } from '@blocksuite/lit';
 import { BlockModel } from '@blocksuite/store';
 
 import type { EdgelessSelectableProps } from '../../_common/edgeless/mixin/edgeless-selectable.js';
-import type { SurfaceBlockModel } from '../../models.js';
 import type { ElementModel } from '../../surface-block/element-model/base.js';
 import type { GroupElementModel } from '../../surface-block/element-model/group.js';
 import {
@@ -13,6 +12,7 @@ import {
   polygonNearestPoint,
   rotatePoints,
 } from '../../surface-block/index.js';
+import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
 import { Bound } from '../../surface-block/utils/bound.js';
 import { PointLocation } from '../../surface-block/utils/point-location.js';
 import type { IVec } from '../../surface-block/utils/vec.js';

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -6,6 +6,7 @@ import {
   type EdgelessTool,
   type Selectable,
 } from '../../../_common/utils/index.js';
+import type { AttachmentBlockModel } from '../../../attachment-block/index.js';
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
 import type { EmbedFigmaModel } from '../../../embed-figma-block/embed-figma-model.js';
 import type { EmbedGithubModel } from '../../../embed-github-block/index.js';
@@ -16,7 +17,6 @@ import type { EmbedSyncedDocModel } from '../../../embed-synced-doc-block/embed-
 import type { EmbedYoutubeModel } from '../../../embed-youtube-block/embed-youtube-model.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
-import type { AttachmentBlockModel } from '../../../models.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
 import {
   Bound,

--- a/packages/blocks/src/root-block/utils/operations/element/block-level.ts
+++ b/packages/blocks/src/root-block/utils/operations/element/block-level.ts
@@ -6,13 +6,12 @@ import {
   asyncFocusRichText,
   asyncSetInlineRange,
 } from '../../../../_common/utils/selection.js';
-import type { Flavour } from '../../../../models.js';
 import { onModelTextUpdated } from '../../callback.js';
 import { mergeToCodeModel, transformModel } from '../model.js';
 
 export function updateBlockElementType(
   blockElements: BlockElement[],
-  flavour: Flavour,
+  flavour: BlockSuite.Flavour,
   type?: string
 ) {
   if (blockElements.length === 0) {

--- a/packages/blocks/src/root-block/utils/operations/model.ts
+++ b/packages/blocks/src/root-block/utils/operations/model.ts
@@ -2,8 +2,6 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { Doc } from '@blocksuite/store';
 import { type BlockModel, Text } from '@blocksuite/store';
 
-import type { Flavour } from '../../../models.js';
-
 /**
  * This file should only contain functions that are used to
  * operate on block models in store, which means that this operations
@@ -41,7 +39,7 @@ export function mergeToCodeModel(models: BlockModel[]) {
 
 export function transformModel(
   model: BlockModel,
-  flavour: Flavour,
+  flavour: BlockSuite.Flavour,
   props?: Parameters<Doc['addBlock']>[1]
 ) {
   const doc = model.doc;

--- a/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
@@ -8,7 +8,7 @@ import { ref, type RefOrCallback } from 'lit/directives/ref.js';
 import { whenHover } from '../../../../_common/components/hover/index.js';
 import { textConversionConfigs } from '../../../../_common/configs/text-conversion.js';
 import { ArrowDownIcon } from '../../../../_common/icons/index.js';
-import type { Flavour, ParagraphBlockModel } from '../../../../models.js';
+import type { ParagraphBlockModel } from '../../../../paragraph-block/index.js';
 import { isRootElement } from '../../../../root-block/utils/guard.js';
 import { updateBlockElementType } from '../../../../root-block/utils/operations/element/block-level.js';
 import type { AffineFormatBarWidget } from '../format-bar.js';
@@ -21,7 +21,7 @@ interface ParagraphPanelProps {
 
 const updateParagraphType = (
   selectedBlockElements: BlockElement[],
-  flavour: Flavour,
+  flavour: BlockSuite.Flavour,
   type?: string
 ) => {
   if (selectedBlockElements.length === 0) {

--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -14,12 +14,11 @@ import { REFERENCE_NODE } from '../../../_common/inline/presets/nodes/consts.js'
 import { createDefaultDoc } from '../../../_common/utils/init.js';
 import { getInlineEditorByModel } from '../../../_common/utils/query.js';
 import { isFuzzyMatch } from '../../../_common/utils/string.js';
-import type { Flavour } from '../../../models.js';
 import { showImportModal } from './import-doc/index.js';
 
 export type LinkedDocOptions = {
   triggerKeys: string[];
-  ignoreBlockTypes: Flavour[];
+  ignoreBlockTypes: BlockSuite.Flavour[];
   convertTriggerKey: boolean;
   getMenus: (ctx: {
     editorHost: EditorHost;

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -41,11 +41,11 @@ import { LoomIcon } from '../../../embed-loom-block/styles.js';
 import { YoutubeIcon } from '../../../embed-youtube-block/styles.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import { addSiblingImageBlock } from '../../../image-block/utils.js';
-import type { SurfaceBlockModel } from '../../../models.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
 import type { ParagraphBlockModel } from '../../../paragraph-block/index.js';
 import { onModelTextUpdated } from '../../../root-block/utils/index.js';
 import { updateBlockElementType } from '../../../root-block/utils/operations/element/block-level.js';
+import type { SurfaceBlockModel } from '../../../surface-block/index.js';
 import { CanvasElementType } from '../../../surface-block/index.js';
 import type { AffineLinkedDocWidget } from '../linked-doc/index.js';
 import {

--- a/packages/blocks/src/schemas.ts
+++ b/packages/blocks/src/schemas.ts
@@ -4,21 +4,11 @@
 import type { BlockSchema } from '@blocksuite/store';
 import type { z } from 'zod';
 
-import {
-  type AttachmentBlockModel,
-  AttachmentBlockSchema,
-} from './attachment-block/attachment-model.js';
-import type { BookmarkBlockModel } from './bookmark-block/bookmark-model.js';
+import { AttachmentBlockSchema } from './attachment-block/attachment-model.js';
 import { BookmarkBlockSchema } from './bookmark-block/bookmark-model.js';
-import {
-  type CodeBlockModel,
-  CodeBlockSchema,
-} from './code-block/code-model.js';
-import type { DataViewBlockModel } from './data-view-block/data-view-model.js';
+import { CodeBlockSchema } from './code-block/code-model.js';
 import { DataViewBlockSchema } from './data-view-block/data-view-model.js';
-import type { DatabaseBlockModel } from './database-block/database-model.js';
 import { DatabaseBlockSchema } from './database-block/database-model.js';
-import type { DividerBlockModel } from './divider-block/divider-model.js';
 import { DividerBlockSchema } from './divider-block/divider-model.js';
 import { EmbedFigmaBlockSpec } from './embed-figma-block/embed-figma-spec.js';
 import { EmbedGithubBlockSpec } from './embed-github-block/embed-github-spec.js';
@@ -27,38 +17,14 @@ import { EmbedLinkedDocBlockSpec } from './embed-linked-doc-block/embed-linked-d
 import { EmbedLoomBlockSpec } from './embed-loom-block/embed-loom-spec.js';
 import { EmbedSyncedDocBlockSpec } from './embed-synced-doc-block/embed-synced-doc-spec.js';
 import { EmbedYoutubeBlockSpec } from './embed-youtube-block/embed-youtube-spec.js';
-import type { FrameBlockModel } from './frame-block/frame-model.js';
 import { FrameBlockSchema } from './frame-block/frame-model.js';
-import type { ImageBlockModel } from './image-block/image-model.js';
 import { ImageBlockSchema } from './image-block/image-model.js';
-import type { ListBlockModel } from './list-block/list-model.js';
 import { ListBlockSchema } from './list-block/list-model.js';
-import type { NoteBlockModel } from './note-block/note-model.js';
 import { NoteBlockSchema } from './note-block/note-model.js';
-import type { ParagraphBlockModel } from './paragraph-block/paragraph-model.js';
 import { ParagraphBlockSchema } from './paragraph-block/paragraph-model.js';
-import type { RootBlockModel } from './root-block/root-model.js';
 import { RootBlockSchema } from './root-block/root-model.js';
-import type { SurfaceBlockModel } from './surface-block/surface-model.js';
 import { SurfaceBlockSchema } from './surface-block/surface-model.js';
-import type { SurfaceRefBlockModel } from './surface-ref-block/surface-ref-model.js';
 import { SurfaceRefBlockSchema } from './surface-ref-block/surface-ref-model.js';
-
-export type {
-  AttachmentBlockModel,
-  BookmarkBlockModel,
-  CodeBlockModel,
-  DatabaseBlockModel,
-  DataViewBlockModel,
-  DividerBlockModel,
-  FrameBlockModel,
-  ImageBlockModel,
-  ListBlockModel,
-  NoteBlockModel,
-  ParagraphBlockModel,
-  RootBlockModel,
-  SurfaceBlockModel,
-};
 
 /** Built-in first party block models built for affine */
 export const AffineSchemas: z.infer<typeof BlockSchema>[] = [
@@ -87,23 +53,3 @@ export const __unstableSchemas = [
   EmbedSyncedDocBlockSpec.schema,
   EmbedLoomBlockSpec.schema,
 ] satisfies z.infer<typeof BlockSchema>[];
-
-// TODO support dynamic register
-export type BlockSchemas = {
-  'affine:code': CodeBlockModel;
-  'affine:paragraph': ParagraphBlockModel;
-  'affine:page': RootBlockModel;
-  'affine:list': ListBlockModel;
-  'affine:note': NoteBlockModel;
-  'affine:divider': DividerBlockModel;
-  'affine:image': ImageBlockModel;
-  'affine:surface': SurfaceBlockModel;
-  'affine:frame': FrameBlockModel;
-  'affine:database': DatabaseBlockModel;
-  'affine:data-view': DataViewBlockModel;
-  'affine:bookmark': BookmarkBlockModel;
-  'affine:attachment': AttachmentBlockModel;
-  'affine:surface-ref': SurfaceRefBlockModel;
-};
-
-export type Flavour = keyof BlockSchemas;

--- a/packages/blocks/src/std.ts
+++ b/packages/blocks/src/std.ts
@@ -1,6 +1,0 @@
-/** Legacy entry used for AFFiNE ESM module compat */
-/// <reference types="@blocksuite/global" />
-import * as std from './_common/utils/index.js';
-
-export * from './_common/utils/index.js';
-export default std;

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -16,10 +16,11 @@ import {
 } from '../_common/icons/index.js';
 import { requestConnectedFrame } from '../_common/utils/event.js';
 import { buildPath } from '../_common/utils/query.js';
-import type { FrameBlockModel, SurfaceBlockModel } from '../models.js';
+import type { FrameBlockModel } from '../frame-block/index.js';
 import { getBackgroundGrid } from '../root-block/edgeless/utils/query.js';
 import type { Renderer } from '../surface-block/canvas-renderer/renderer.js';
 import type { ElementModel } from '../surface-block/element-model/base.js';
+import type { SurfaceBlockModel } from '../surface-block/index.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import { deserializeXYWH } from '../surface-block/utils/xywh.js';
 import type { SurfaceRefBlockModel } from './surface-ref-model.js';

--- a/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
@@ -13,7 +13,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { html as staticHtml, literal, unsafeStatic } from 'lit/static-html.js';
 
-import type { FrameBlockModel } from '../models.js';
+import type { FrameBlockModel } from '../frame-block/index.js';
 import type { EdgelessBlockModel } from '../root-block/edgeless/type.js';
 import { type EdgelessBlockType } from '../surface-block/edgeless-types.js';
 import type { GroupElementModel } from '../surface-block/element-model/group.js';

--- a/packages/blocks/src/surface-ref-block/utils.ts
+++ b/packages/blocks/src/surface-ref-block/utils.ts
@@ -1,7 +1,7 @@
 import type { Doc } from '@blocksuite/store';
 import { html } from 'lit';
 
-import type { SurfaceBlockModel } from '../models.js';
+import type { SurfaceBlockModel } from '../surface-block/index.js';
 
 export function getSurfaceBlock(doc: Doc) {
   return (

--- a/packages/framework/store/src/transformer/job.ts
+++ b/packages/framework/store/src/transformer/job.ts
@@ -192,7 +192,7 @@ export class Job {
     });
 
     doc.addBlock(
-      modelData.flavour as BlockSuite.ModelKeys,
+      modelData.flavour as BlockSuite.Flavour,
       { ...modelData.props, id: modelData.id },
       parent,
       index

--- a/packages/framework/store/src/workspace/doc.ts
+++ b/packages/framework/store/src/workspace/doc.ts
@@ -334,7 +334,7 @@ export class Doc extends Space<FlatBlockMap> {
     return ids;
   }
 
-  addBlock<Key extends BlockSuite.ModelKeys>(
+  addBlock<Key extends BlockSuite.Flavour>(
     flavour: Key,
     blockProps?: BlockSuite.ModelProps<BlockSuite.BlockModels[Key]>,
     parent?: BlockModel | string | null,
@@ -822,7 +822,7 @@ declare global {
   namespace BlockSuite {
     interface BlockModels {}
 
-    type ModelKeys = string & keyof BlockModels;
+    type Flavour = string & keyof BlockModels;
 
     type ModelProps<Model> = Partial<
       Model extends BlockModel<infer U> ? U : never

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas } from '@blocksuite/blocks/models';
+import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { AffineEditorContainer } from '@blocksuite/presets';

--- a/packages/playground/apps/dev-format.ts
+++ b/packages/playground/apps/dev-format.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas } from '@blocksuite/blocks/models';
+import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import * as globalUtils from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 

--- a/packages/playground/apps/starter/data/database.ts
+++ b/packages/playground/apps/starter/data/database.ts
@@ -1,4 +1,8 @@
-import type { ListType, ParagraphType } from '@blocksuite/blocks';
+import type {
+  DatabaseBlockModel,
+  ListType,
+  ParagraphType,
+} from '@blocksuite/blocks';
 import { checkboxPureColumnConfig } from '@blocksuite/blocks';
 import { datePureColumnConfig } from '@blocksuite/blocks';
 import { linkPureColumnConfig } from '@blocksuite/blocks';
@@ -6,7 +10,6 @@ import { multiSelectColumnConfig } from '@blocksuite/blocks';
 import { numberPureColumnConfig } from '@blocksuite/blocks';
 import { progressPureColumnConfig } from '@blocksuite/blocks';
 import { richTextPureColumnConfig } from '@blocksuite/blocks';
-import type { DatabaseBlockModel } from '@blocksuite/blocks/models';
 import { assertExists } from '@blocksuite/global/utils';
 import { Text, type Workspace } from '@blocksuite/store';
 

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas } from '@blocksuite/blocks/models';
+import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { AffineEditorContainer, CopilotPanel } from '@blocksuite/presets';

--- a/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
@@ -2,19 +2,18 @@ import type {
   BrushElementModel,
   GroupElementModel,
   ShapeElementModel,
+  SurfaceBlockModel,
 } from '@blocksuite/blocks';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { wait } from '../utils/common.js';
 import { setupEditor } from '../utils/setup.js';
 
-let model: BlockSuite.BlockModels['affine:surface'];
+let model: SurfaceBlockModel;
 
 beforeEach(async () => {
   const cleanup = await setupEditor('edgeless');
-  const models = doc.getBlockByFlavour(
-    'affine:surface'
-  ) as BlockSuite.BlockModels['affine:surface'][];
+  const models = doc.getBlockByFlavour('affine:surface') as SurfaceBlockModel[];
 
   model = models[0];
 

--- a/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
@@ -2,18 +2,19 @@ import type {
   BrushElementModel,
   GroupElementModel,
   ShapeElementModel,
-  SurfaceBlockModel,
 } from '@blocksuite/blocks';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { wait } from '../utils/common.js';
 import { setupEditor } from '../utils/setup.js';
 
-let model: SurfaceBlockModel;
+let model: BlockSuite.BlockModels['affine:surface'];
 
 beforeEach(async () => {
   const cleanup = await setupEditor('edgeless');
-  const models = doc.getBlockByFlavour('affine:surface') as SurfaceBlockModel[];
+  const models = doc.getBlockByFlavour(
+    'affine:surface'
+  ) as BlockSuite.BlockModels['affine:surface'][];
 
   model = models[0];
 

--- a/packages/presets/src/__tests__/utils/edgeless.ts
+++ b/packages/presets/src/__tests__/utils/edgeless.ts
@@ -3,7 +3,6 @@ import type {
   EdgelessRootBlockComponent,
   PageRootBlockComponent,
   SurfaceBlockComponent,
-  SurfaceBlockModel,
 } from '@blocksuite/blocks';
 import type { Doc } from '@blocksuite/store';
 
@@ -17,10 +16,6 @@ export function getSurface(doc: Doc, editor: AffineEditorContainer) {
     doc.root!.id,
     surfaceModel[0]!.id,
   ]) as SurfaceBlockComponent;
-}
-
-export function getSurfaceModel(doc: Doc) {
-  return doc.getBlockByFlavour('affine:surface')[0] as SurfaceBlockModel;
 }
 
 export function getDocRootBlock(

--- a/packages/presets/src/__tests__/utils/setup.ts
+++ b/packages/presets/src/__tests__/utils/setup.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
+import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlobStorage, type Doc, Text, Workspace } from '@blocksuite/store';
 import { createMemoryStorage, Generator, Schema } from '@blocksuite/store';

--- a/packages/presets/src/helpers/index.ts
+++ b/packages/presets/src/helpers/index.ts
@@ -1,4 +1,4 @@
-import { AffineSchemas } from '@blocksuite/blocks/models';
+import { AffineSchemas } from '@blocksuite/blocks/schemas';
 import { Schema, Workspace } from '@blocksuite/store';
 
 export function createEmptyDoc() {

--- a/scripts/node-import-test.ts
+++ b/scripts/node-import-test.ts
@@ -2,5 +2,4 @@
 
 import '../packages/framework/store/src/index';
 import '../packages/framework/block-std/src/index';
-import '../packages/blocks/src/models';
-import '../packages/blocks/src/std';
+import '../packages/blocks/src/schemas.js';

--- a/tests/utils/actions/block.ts
+++ b/tests/utils/actions/block.ts
@@ -1,4 +1,3 @@
-import type { Flavour } from '@blocks/models.js';
 import type { BlockElement } from '@lit/element/index.js';
 import type { Page } from '@playwright/test';
 
@@ -6,7 +5,7 @@ import { waitNextFrame } from './misc.js';
 
 export async function updateBlockType(
   page: Page,
-  flavour: Flavour,
+  flavour: BlockSuite.Flavour,
   type?: string
 ) {
   await page.evaluate(
@@ -32,7 +31,7 @@ export async function updateBlockType(
         type
       );
     },
-    [flavour, type] as [Flavour, string?]
+    [flavour, type] as [BlockSuite.Flavour, string?]
   );
   await waitNextFrame(page, 400);
 }


### PR DESCRIPTION
1. Rename `@blocksuite/blocks/models` to `@blocksuite/blocks/schemas`.
2. Remove legacy `@blocksuite/blocks/std`.