### PR TITLE
refactor: remove the split of internal schemas

### DIFF
--- a/packages/blocks/src/schemas.ts
+++ b/packages/blocks/src/schemas.ts
@@ -40,9 +40,6 @@ export const AffineSchemas: z.infer<typeof BlockSchema>[] = [
   FrameBlockSchema,
   DatabaseBlockSchema,
   SurfaceRefBlockSchema,
-];
-
-export const __unstableSchemas = [
   DataViewBlockSchema,
   AttachmentBlockSchema,
   EmbedYoutubeBlockSpec.schema,
@@ -52,4 +49,4 @@ export const __unstableSchemas = [
   EmbedLinkedDocBlockSpec.schema,
   EmbedSyncedDocBlockSpec.schema,
   EmbedLoomBlockSpec.schema,
-] satisfies z.infer<typeof BlockSchema>[];
+];

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -1,4 +1,3 @@
-import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { AffineEditorContainer } from '@blocksuite/presets';

--- a/packages/playground/apps/default/utils/workspace.ts
+++ b/packages/playground/apps/default/utils/workspace.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks';
+import { AffineSchemas } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import {
   type BlobStorage,
@@ -26,7 +26,7 @@ export async function createDefaultDocWorkspace() {
   ];
   const idGenerator: Generator = Generator.NanoID;
   const schema = new Schema();
-  schema.register(AffineSchemas).register(__unstableSchemas);
+  schema.register(AffineSchemas);
 
   const params = new URLSearchParams(location.search);
   let docSources: StoreOptions['docSources'] = {

--- a/packages/playground/apps/dev-format.ts
+++ b/packages/playground/apps/dev-format.ts
@@ -1,4 +1,3 @@
-import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import * as globalUtils from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -1,4 +1,3 @@
-import { __unstableSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { AffineEditorContainer, CopilotPanel } from '@blocksuite/presets';

--- a/packages/playground/apps/starter/utils/workspace.ts
+++ b/packages/playground/apps/starter/utils/workspace.ts
@@ -1,8 +1,4 @@
-import {
-  __unstableSchemas,
-  AffineSchemas,
-  TestUtils,
-} from '@blocksuite/blocks';
+import { AffineSchemas, TestUtils } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import type { Doc } from '@blocksuite/store';
 import {
@@ -43,7 +39,7 @@ export function createStarterDocWorkspace() {
   }
 
   const schema = new Schema();
-  schema.register(AffineSchemas).register(__unstableSchemas);
+  schema.register(AffineSchemas);
   const idGenerator = isE2E ? Generator.AutoIncrement : Generator.NanoID;
 
   let docSources: StoreOptions['docSources'];

--- a/packages/presets/src/__tests__/utils/setup.ts
+++ b/packages/presets/src/__tests__/utils/setup.ts
@@ -1,4 +1,4 @@
-import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/schemas';
+import { AffineSchemas } from '@blocksuite/blocks/schemas';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlobStorage, type Doc, Text, Workspace } from '@blocksuite/store';
 import { createMemoryStorage, Generator, Schema } from '@blocksuite/store';
@@ -10,7 +10,7 @@ function createWorkspaceOptions() {
   const schema = new Schema();
   const room = Math.random().toString(16).slice(2, 8);
 
-  schema.register(AffineSchemas).register(__unstableSchemas);
+  schema.register(AffineSchemas);
 
   const idGenerator: Generator = Generator.AutoIncrement; // works only in single user mode
 


### PR DESCRIPTION
Close #6317

This removes the legacy `__unstableSchemas`. For internal testing, we should switch to feature flags instead.


Note that this list of block schemas could be override as show in https://blocksuite.io/guide/working-with-block-tree.html#defining-new-blocks