### PR TITLE
feat(page): support import external images

### DIFF
--- a/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
@@ -37,7 +37,10 @@ export async function importMarkDown(workspace: Workspace, text: string) {
   });
   const mdAdapter = new MarkdownAdapter();
   mdAdapter.applyConfigs(job.adapterConfigs);
-  const snapshot = await mdAdapter.toDocSnapshot({ file: text });
+  const snapshot = await mdAdapter.toDocSnapshot({
+    file: text,
+    assets: job.assetsManager,
+  });
   const page = await job.snapshotToDoc(snapshot);
   return [page.id];
 }
@@ -49,7 +52,10 @@ export async function importHtml(workspace: Workspace, text: string) {
   });
   const htmlAdapter = new NotionHtmlAdapter();
   htmlAdapter.applyConfigs(job.adapterConfigs);
-  const snapshot = await htmlAdapter.toDocSnapshot({ file: text });
+  const snapshot = await htmlAdapter.toDocSnapshot({
+    file: text,
+    assets: job.assetsManager,
+  });
   const page = await job.snapshotToDoc(snapshot);
   return [page.id];
 }


### PR DESCRIPTION
To support #6063 , add `assets` param to `toDocSnapshot` func.

Btw when the time of import is too long , it should add some operation like loading animate to make ensure the page link are inserted.