### PR TITLE
feat: disable embed view button when linked doc inside another embed synced doc

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
@@ -240,6 +240,13 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
     );
   }
 
+  private get _embedViewButtonDisabled() {
+    return (
+      isEmbedLinkedDocBlock(this._model) &&
+      !!this.block.closest('affine-embed-synced-doc-block')
+    );
+  }
+
   private _canShowCardStylePanel(
     model: BlockModel
   ): model is BookmarkBlockModel | EmbedGithubModel | EmbedLinkedDocModel {
@@ -541,7 +548,7 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
           <icon-button
             size="24px"
             class="embed-card-toolbar-button link"
-            hover="false"
+            .hover=${false}
             ?disabled=${model.doc.readonly}
             @click=${() => this._turnIntoInlineView()}
           >
@@ -556,7 +563,7 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
               card: true,
               'current-view': this._isCardView,
             })}
-            hover="false"
+            .hover=${false}
             ?disabled=${model.doc.readonly}
             @click=${() => this._convertToCardView()}
           >
@@ -573,8 +580,9 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
                     embed: true,
                     'current-view': this._isEmbedView,
                   })}
-                  hover="false"
-                  ?disabled=${model.doc.readonly}
+                  .hover=${false}
+                  ?disabled=${model.doc.readonly ||
+                  this._embedViewButtonDisabled}
                   @click=${() => this._convertToEmbedView()}
                 >
                   ${EmbedWebIcon}

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -114,6 +114,10 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     return doc;
   }
 
+  get _isInsideEmbedSyncedDocBlock() {
+    return !!this.blockElement.closest('affine-embed-synced-doc-block');
+  }
+
   private _openDoc() {
     const refDocId = this.referenceDocId;
     const blockElement = this.blockElement;
@@ -227,7 +231,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
               <icon-button
                 size="24px"
                 class="affine-reference-popover-view-selector-button link current-view"
-                hover="false"
+                .hover=${false}
               >
                 ${LinkIcon}
                 <affine-tooltip .offset=${12}>${'Inline view'}</affine-tooltip>
@@ -236,7 +240,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
               <icon-button
                 size="24px"
                 class="affine-reference-popover-view-selector-button embed"
-                hover="false"
+                .hover=${false}
                 @click=${() => this._convertToCardView()}
               >
                 ${BookmarkIcon}
@@ -248,8 +252,9 @@ export class ReferencePopup extends WithDisposable(LitElement) {
                     <icon-button
                       size="24px"
                       class="affine-reference-popover-view-selector-button embed"
-                      hover="false"
+                      .hover=${false}
                       @click=${() => this._convertToEmbedView()}
+                      ?disabled=${this._isInsideEmbedSyncedDocBlock}
                     >
                       ${EmbedWebIcon}
                       <affine-tooltip .offset=${12}


### PR DESCRIPTION
To close [AFF-626](https://linear.app/affine-design/issue/AFF-626/should-hide-the-embed-view-toolbar-entry-in-nested-synced-doc)

https://github.com/toeverything/blocksuite/assets/99816898/fb469f03-6a4e-4e33-8b2d-4b010e685a13

