### PR TITLE
fix(edgeless): auto-complete displays incorrect shape

### DIFF
--- a/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
@@ -2,7 +2,9 @@ import { DisposableGroup, noop, Slot } from '@blocksuite/global/utils';
 
 import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { ShapeStyle } from '../../../surface-block/element-model/shape.js';
+import { shapeMethods } from '../../../surface-block/element-model/shape.js';
 import {
+  Bound,
   type Options,
   Overlay,
   type RoughCanvas,
@@ -22,31 +24,6 @@ import {
   SHAPE_OVERLAY_OFFSET_Y,
   SHAPE_OVERLAY_WIDTH,
 } from '../utils/consts.js';
-
-const drawRectangle = (ctx: CanvasRenderingContext2D, xywh: XYWH) => {
-  const [x, y, w, h] = xywh;
-  ctx.rect(x, y, w, h);
-};
-
-const drawTriangle = (ctx: CanvasRenderingContext2D, xywh: XYWH) => {
-  const [x, y, w, h] = xywh;
-  ctx.moveTo(x + w / 2, y);
-  ctx.lineTo(x, y + h);
-  ctx.lineTo(x + w, y + h);
-};
-
-const drawDiamond = (ctx: CanvasRenderingContext2D, xywh: XYWH) => {
-  const [x, y, w, h] = xywh;
-  ctx.lineTo(x + w / 2, y);
-  ctx.lineTo(x + w, y + h / 2);
-  ctx.lineTo(x + w / 2, y + h);
-  ctx.lineTo(x, y + h / 2);
-};
-
-const drawEllipse = (ctx: CanvasRenderingContext2D, xywh: XYWH) => {
-  const [x, y, w, h] = xywh;
-  ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, 2 * Math.PI);
-};
 
 const drawRoundedRect = (ctx: CanvasRenderingContext2D, xywh: XYWH) => {
   const [x, y, w, h] = xywh;
@@ -74,18 +51,19 @@ const drawGeneralShape = (
 
   ctx.beginPath();
 
+  const bound = Bound.fromXYWH(xywh);
   switch (type) {
     case 'rect':
-      drawRectangle(ctx, xywh);
+      shapeMethods.rect.draw(ctx, bound);
       break;
     case 'triangle':
-      drawTriangle(ctx, xywh);
+      shapeMethods.rect.draw(ctx, bound);
       break;
     case 'diamond':
-      drawDiamond(ctx, xywh);
+      shapeMethods.diamond.draw(ctx, bound);
       break;
     case 'ellipse':
-      drawEllipse(ctx, xywh);
+      shapeMethods.ellipse.draw(ctx, bound);
       break;
     case 'roundedRect':
       drawRoundedRect(ctx, xywh);
@@ -191,13 +169,13 @@ export class RoundedRectShape extends Shape {
       const y0 = y + r;
       const y1 = y + h - r;
       const path = `
-          M${x0},${y} L${x1},${y} 
-          A${r},${r} 0 0 1 ${x1},${y0} 
-          L${x1},${y1} 
-          A${r},${r} 0 0 1 ${x1 - r},${y1} 
-          L${x0 + r},${y1} 
-          A${r},${r} 0 0 1 ${x0},${y1 - r} 
-          L${x0},${y0} 
+          M${x0},${y} L${x1},${y}
+          A${r},${r} 0 0 1 ${x1},${y0}
+          L${x1},${y1}
+          A${r},${r} 0 0 1 ${x1 - r},${y1}
+          L${x0 + r},${y1}
+          A${r},${r} 0 0 1 ${x0},${y1 - r}
+          L${x0},${y0}
           A${r},${r} 0 0 1 ${x0 + r},${y}
         `;
 

--- a/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
@@ -25,6 +25,24 @@ export const diamond = {
       [x + w / 2, y + h],
     ];
   },
+  draw(ctx: CanvasRenderingContext2D, { x, y, w, h, rotate = 0 }: IBound) {
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate((rotate * Math.PI) / 180);
+    ctx.translate(-cx, -cy);
+
+    ctx.beginPath();
+    ctx.moveTo(x, y + h / 2);
+    ctx.lineTo(x + w / 2, y);
+    ctx.lineTo(x + w, y + h / 2);
+    ctx.lineTo(x + w / 2, y + h);
+    ctx.closePath();
+
+    ctx.restore();
+  },
 
   hitTest(
     this: ShapeElementModel,

--- a/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
@@ -21,6 +21,20 @@ export const ellipse = {
       [x + w / 2, y + h],
     ];
   },
+  draw(ctx: CanvasRenderingContext2D, { x, y, w, h, rotate = 0 }: IBound) {
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate((rotate * Math.PI) / 180);
+    ctx.translate(-cx, -cy);
+
+    ctx.beginPath();
+    ctx.ellipse(cx, cy, w / 2, h / 2, 0, 0, 2 * Math.PI);
+
+    ctx.restore();
+  },
   hitTest(
     this: ShapeElementModel,
     x: number,

--- a/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
@@ -25,6 +25,14 @@ export const rect = {
       [x, y + h],
     ];
   },
+  draw(ctx: CanvasRenderingContext2D, { x, y, w, h, rotate = 0 }: IBound) {
+    ctx.save();
+    ctx.translate(x + w / 2, y + h / 2);
+    ctx.rotate((rotate * Math.PI) / 180);
+    ctx.translate(-x - w / 2, -y - h / 2);
+    ctx.rect(x, y, w, h);
+    ctx.restore();
+  },
   hitTest(
     this: ShapeElementModel,
     x: number,

--- a/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
@@ -23,6 +23,23 @@ export const triangle = {
       [x + w, y + h],
     ];
   },
+  draw(ctx: CanvasRenderingContext2D, { x, y, w, h, rotate = 0 }: IBound) {
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate((rotate * Math.PI) / 180);
+    ctx.translate(-cx, -cy);
+
+    ctx.beginPath();
+    ctx.moveTo(x, y + h);
+    ctx.lineTo(x + w / 2, y);
+    ctx.lineTo(x + w, y + h);
+    ctx.closePath();
+
+    ctx.restore();
+  },
   hitTest(
     this: ShapeElementModel,
     x: number,


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/6322

This pull request adds a draw function to the shape utils.

This allows the `AutoCompleteOverlay` to render different shapes.

<img width="684" alt="Screenshot 2024-02-29 at 17 32 00" src="https://github.com/toeverything/blocksuite/assets/18554747/3c9644d6-46bc-4b8d-bf72-98cdce87ae69">

