### PR TITLE
fix(edgeless): fix laggy selection & legacy template rendering

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -346,7 +346,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
     });
     this.edgeless.service.selection.set({
       elements: [id],
-      editing: true,
+      editing: false,
     });
   }
 

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -200,8 +200,6 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
   }
 
   private _onPointerDown = (e: PointerEvent, type: Direction) => {
-    if (!isShape(this.current)) return;
-
     const { service } = this.edgeless;
     const viewportRect = service.viewport.boundingClientRect;
     const start = service.viewport.toModelCoord(
@@ -219,6 +217,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
         e.clientY - viewportRect.top
       );
       if (Vec.dist(start, point) > 8 && !this._isMoving) {
+        if (!isShape(this.current)) return;
         this._isMoving = true;
         const { startPosition } = getPosition(type);
         connector = this._addConnector(

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -200,6 +200,8 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
   }
 
   private _onPointerDown = (e: PointerEvent, type: Direction) => {
+    if (!isShape(this.current)) return;
+
     const { service } = this.edgeless;
     const viewportRect = service.viewport.boundingClientRect;
     const start = service.viewport.toModelCoord(
@@ -218,7 +220,6 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
       );
       if (Vec.dist(start, point) > 8 && !this._isMoving) {
         this._isMoving = true;
-        if (!isShape(this.current)) return;
         const { startPosition } = getPosition(type);
         connector = this._addConnector(
           {

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -157,21 +157,6 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
   @query('affine-note')
   private _affineNote!: HTMLDivElement;
 
-  private _handleEditingTransition() {
-    const selection = this.edgeless.service.selection;
-
-    this._editing = selection.has(this.model.id) && selection.editing;
-    this._disposables.add(
-      selection.slots.updated.on(() => {
-        if (selection.has(this.model.id) && selection.editing) {
-          this._editing = true;
-        } else {
-          this._editing = false;
-        }
-      })
-    );
-  }
-
   private get _isShowCollapsedContent() {
     return this.model.edgeless.collapse && (this._isResizing || this._isHover);
   }
@@ -255,8 +240,6 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
     const { _disposables, edgeless } = this;
     const selection = this.edgeless.service.selection;
 
-    this._handleEditingTransition();
-
     _disposables.add(
       edgeless.slots.elementResizeStart.on(() => {
         if (selection.elements.includes(this.model as EdgelessBlockModel)) {
@@ -282,6 +265,23 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
     });
     observer.observe(this, { childList: true, subtree: true });
     _disposables.add(() => observer.disconnect());
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    const selection = this.edgeless.service.selection;
+
+    this._editing = selection.has(this.model.id) && selection.editing;
+    this._disposables.add(
+      selection.slots.updated.on(() => {
+        if (selection.has(this.model.id) && selection.editing) {
+          this._editing = true;
+        } else {
+          this._editing = false;
+        }
+      })
+    );
   }
 
   override render() {

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -159,6 +159,8 @@ export class EdgelessBlockPortalNote extends EdgelessPortalBase<NoteBlockModel> 
 
   private _handleEditingTransition() {
     const selection = this.edgeless.service.selection;
+
+    this._editing = selection.has(this.model.id) && selection.editing;
     this._disposables.add(
       selection.slots.updated.on(() => {
         if (selection.has(this.model.id) && selection.editing) {

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -896,7 +896,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     const [width, height] = [rect.width * zoom, rect.height * zoom];
 
     let rotate = 0;
-    if (elements.length === 1) {
+    if (elements.length === 1 && elements[0].rotate) {
       rotate = elements[0].rotate;
     }
 
@@ -905,8 +905,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       height: height,
       borderWidth: selection.editing ? 2 : 1,
       borderStyle: 'solid',
-      left: left,
-      top: top,
+      left,
+      top,
       rotate,
     };
   }, this);
@@ -942,6 +942,10 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   };
 
   private _updateOnViewportChange = () => {
+    if (this.selection.empty) {
+      return;
+    }
+
     this._updateSelectedRect();
     this._updateMode();
   };

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
@@ -16,6 +16,29 @@ export function brush(
     matrix.translateSelf(cx, cy).rotateSelf(rotate).translateSelf(-cx, -cy)
   );
 
-  ctx.fillStyle = renderer.getVariableColor(color);
-  ctx.fill(model.path2d);
+  const cacheContent = renderer.requestCacheContent(model, [
+    model.commands,
+    color,
+  ]);
+
+  if (cacheContent.dirty) {
+    renderAtCache(cacheContent.ctx, renderer, model, renderer.zoom);
+  }
+
+  ctx.drawImage(cacheContent.canvas, 0, 0, w, h);
+}
+
+export function renderAtCache(
+  ctx: CanvasRenderingContext2D,
+  renderer: Renderer,
+  model: BrushElementModel,
+  zoom: number
+) {
+  const scale = window.devicePixelRatio * zoom;
+  ctx.canvas.width = model.w * scale;
+  ctx.canvas.height = model.h * scale;
+  ctx.scale(scale, scale);
+
+  ctx.fillStyle = renderer.getVariableColor(model.color);
+  ctx.fill(new Path2D(model.commands));
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
@@ -1,7 +1,5 @@
 import type { BrushElementModel } from '../../../element-model/brush.js';
-import { getSvgPathFromStroke } from '../../../utils/math-utils.js';
 import type { Renderer } from '../../renderer.js';
-import { getSolidStrokePoints } from './utils.js';
 
 export function brush(
   model: BrushElementModel,
@@ -9,7 +7,7 @@ export function brush(
   matrix: DOMMatrix,
   renderer: Renderer
 ) {
-  const { points, lineWidth, color, rotate } = model;
+  const { color, rotate } = model;
   const [, , w, h] = model.deserializedXYWH;
   const cx = w / 2;
   const cy = h / 2;
@@ -18,10 +16,6 @@ export function brush(
     matrix.translateSelf(cx, cy).rotateSelf(rotate).translateSelf(-cx, -cy)
   );
 
-  const stroke = getSolidStrokePoints(points, lineWidth);
-  const commands = getSvgPathFromStroke(stroke);
-  const path = new Path2D(commands);
-
   ctx.fillStyle = renderer.getVariableColor(color);
-  ctx.fill(path);
+  ctx.fill(model.path2d);
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/brush/index.ts
@@ -16,29 +16,6 @@ export function brush(
     matrix.translateSelf(cx, cy).rotateSelf(rotate).translateSelf(-cx, -cy)
   );
 
-  const cacheContent = renderer.requestCacheContent(model, [
-    model.commands,
-    color,
-  ]);
-
-  if (cacheContent.dirty) {
-    renderAtCache(cacheContent.ctx, renderer, model, renderer.zoom);
-  }
-
-  ctx.drawImage(cacheContent.canvas, 0, 0, w, h);
-}
-
-export function renderAtCache(
-  ctx: CanvasRenderingContext2D,
-  renderer: Renderer,
-  model: BrushElementModel,
-  zoom: number
-) {
-  const scale = window.devicePixelRatio * zoom;
-  ctx.canvas.width = model.w * scale;
-  ctx.canvas.height = model.h * scale;
-  ctx.scale(scale, scale);
-
-  ctx.fillStyle = renderer.getVariableColor(model.color);
+  ctx.fillStyle = renderer.getVariableColor(color);
   ctx.fill(new Path2D(model.commands));
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/index.ts
@@ -39,11 +39,11 @@ export function text(
     fontSize,
     fontFamily,
   });
-  const horizontalOffset =
-    textAlign === 'center' ? w / 2 : textAlign === 'right' ? w : 0;
   const deltas = wrapTextDeltas(model.text, font, w);
   const lines = deltaInsertsToChunks(deltas);
   const lineHeightPx = getLineHeight(fontFamily, fontSize);
+  const horizontalOffset =
+    textAlign === 'center' ? w / 2 : textAlign === 'right' ? w : 0;
 
   ctx.font = font;
   ctx.fillStyle = renderer.getVariableColor(color);
@@ -81,54 +81,4 @@ export function text(
       }
     }
   }
-}
-
-export function renderAtCache(
-  ctx: CanvasRenderingContext2D,
-  renderer: Renderer,
-  model: TextElementModel,
-  params: {
-    font: string;
-  }
-) {
-  const { font } = params;
-  const { w, h, textAlign, color, fontFamily, fontSize } = model;
-  const deltas = wrapTextDeltas(model.text, font, w);
-  const lines = deltaInsertsToChunks(deltas);
-  const lineHeightPx = getLineHeight(fontFamily, fontSize);
-  const horizontalOffset =
-    textAlign === 'center' ? w / 2 : textAlign === 'right' ? w : 0;
-  const scale = window.devicePixelRatio * renderer.zoom;
-
-  ctx.canvas.width = w * scale;
-  ctx.canvas.height = h * scale;
-
-  ctx.scale(scale, scale);
-
-  ctx.save();
-  ctx.font = font;
-  ctx.fillStyle = renderer.getVariableColor(color);
-  ctx.textAlign = textAlign;
-  ctx.textBaseline = 'ideographic';
-
-  for (const [lineIndex, line] of lines.entries()) {
-    let beforeTextWidth = 0;
-
-    for (const delta of line) {
-      const str = delta.insert;
-      // 0.5 comes from v-line padding
-      const offset =
-        textAlign === 'center' ? 0 : textAlign === 'right' ? -0.5 : 0.5;
-
-      ctx.fillText(
-        str,
-        horizontalOffset + beforeTextWidth + offset,
-        (lineIndex + 1) * lineHeightPx
-      );
-
-      beforeTextWidth += getTextWidth(str, font);
-    }
-  }
-
-  ctx.restore();
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -203,15 +203,16 @@ export class Renderer extends Viewport {
     }
 
     const cache = this._cacheCanvas.get(model.id)!;
-    const { canvas, deps: oldDeps } = cache;
+    const { canvas, deps: oldDeps, scale: oldScale } = cache;
 
     cache.deps = deps;
+    cache.scale = window.devicePixelRatio * this.zoom;
 
     return {
       canvas,
       ctx: canvas.getContext('2d') as CanvasRenderingContext2D,
       dirty:
-        cache.scale < window.devicePixelRatio * this.zoom ||
+        oldScale < cache.scale ||
         !oldDeps.every((dep, idx) => dep === deps[idx]),
     };
   }

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -331,6 +331,10 @@ export class Renderer extends Viewport {
   }
 
   public removeOverlay(overlay: Overlay) {
+    if (!this._overlays.has(overlay)) {
+      return;
+    }
+
     overlay.setRenderer(null);
     this._overlays.delete(overlay);
     this._shouldUpdate = true;

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -53,10 +53,6 @@ export class Renderer extends Viewport {
   private _overlays: Set<Overlay> = new Set();
   private _shouldUpdate = false;
   private _disposables = new DisposableGroup();
-  private _cacheCanvas: Map<
-    string,
-    { canvas: HTMLCanvasElement; deps: unknown[]; scale: number }
-  > = new Map();
 
   get stackingCanvas() {
     return this._stackingCanvas;
@@ -177,44 +173,6 @@ export class Renderer extends Viewport {
 
     this._resetSize();
     this._loop();
-  }
-
-  requestCacheContent(
-    model: ElementModel,
-    deps: unknown[] = []
-  ): {
-    canvas: HTMLCanvasElement;
-    ctx: CanvasRenderingContext2D;
-    dirty: boolean;
-  } {
-    if (!this._cacheCanvas.has(model.id)) {
-      const canvas = document.createElement('canvas');
-      this._cacheCanvas.set(model.id, {
-        canvas: canvas,
-        deps: deps,
-        scale: window.devicePixelRatio * this.zoom,
-      });
-
-      return {
-        canvas,
-        ctx: canvas.getContext('2d') as CanvasRenderingContext2D,
-        dirty: true,
-      };
-    }
-
-    const cache = this._cacheCanvas.get(model.id)!;
-    const { canvas, deps: oldDeps, scale: oldScale } = cache;
-
-    cache.deps = deps;
-    cache.scale = window.devicePixelRatio * this.zoom;
-
-    return {
-      canvas,
-      ctx: canvas.getContext('2d') as CanvasRenderingContext2D,
-      dirty:
-        oldScale < cache.scale ||
-        !oldDeps.every((dep, idx) => dep === deps[idx]),
-    };
   }
 
   private _resetSize() {

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -1,3 +1,4 @@
+import { DisposableGroup } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { type Y } from '@blocksuite/store';
 
@@ -63,7 +64,7 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
     props: Record<string, unknown>;
     oldValues: Record<string, unknown>;
   }) => void;
-  protected _observerDisposable: Record<string | symbol, () => void> = {};
+  protected _disposable = new DisposableGroup();
 
   yMap: Y.Map<unknown>;
   surface!: SurfaceBlockModel;
@@ -109,7 +110,7 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
     this._stashed = stashedStore as Map<keyof Props, unknown>;
     this._onChange = onChange;
 
-    // base class property field is assigned before yMap is set
+    // base class properties is initialized before yMap has been set
     // so we need to manually assign the default value here
     this.index = 'a0';
     this.seed = randomSeed();

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -19,7 +19,11 @@ import {
 } from '../utils/math-utils.js';
 import { PointLocation } from '../utils/point-location.js';
 import type { IVec } from '../utils/vec.js';
-import { deserializeXYWH, type SerializedXYWH } from '../utils/xywh.js';
+import {
+  deserializeXYWH,
+  type SerializedXYWH,
+  type XYWH,
+} from '../utils/xywh.js';
 import {
   convertProps,
   getDeriveProperties,
@@ -120,8 +124,16 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
     return true;
   }
 
+  private _lastXYWH: SerializedXYWH = '[0,0,0,0]';
+
   get deserializedXYWH() {
-    return deserializeXYWH(this.xywh);
+    if (this.xywh !== this._lastXYWH) {
+      const xywh = this.xywh;
+      this._local.set('deserializedXYWH', deserializeXYWH(xywh));
+      this._lastXYWH = xywh;
+    }
+
+    return this._local.get('deserializedXYWH') as XYWH;
   }
 
   get x() {

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -29,6 +29,7 @@ import {
   getDeriveProperties,
   local,
   updateDerivedProp,
+  watch,
   yfield,
 } from './decorators.js';
 import type { OmitFunctionsAndKeysAndReadOnly } from './utility-type.js';
@@ -91,11 +92,22 @@ export abstract class ElementModel<Props extends BaseProps = BaseProps>
   @local()
   opacity: number = 1;
 
+  @watch((_, instance) => {
+    instance['_local'].delete('externalBound');
+  })
   @local()
   externalXYWH: SerializedXYWH | undefined = undefined;
 
   get externalBound(): Bound | null {
-    return this.externalXYWH ? Bound.deserialize(this.externalXYWH) : null;
+    if (!this._local.has('externalBound')) {
+      const bound = this.externalXYWH
+        ? Bound.deserialize(this.externalXYWH)
+        : null;
+
+      this._local.set('externalBound', bound);
+    }
+
+    return this._local.get('externalBound') as Bound | null;
   }
 
   constructor(options: {

--- a/packages/blocks/src/surface-block/element-model/brush.ts
+++ b/packages/blocks/src/surface-block/element-model/brush.ts
@@ -82,7 +82,7 @@ export class BrushElementModel extends ElementModel<BrushProps> {
   @yfield()
   xywh: SerializedXYWH = '[0,0,0,0]';
 
-  @yfield()
+  @yfield(0)
   rotate: number = 0;
 
   @yfield()

--- a/packages/blocks/src/surface-block/element-model/brush.ts
+++ b/packages/blocks/src/surface-block/element-model/brush.ts
@@ -36,7 +36,7 @@ export class BrushElementModel extends ElementModel<BrushProps> {
   }
 
   @watch((_, instance: BrushElementModel) => {
-    instance['_local'].delete('path2d');
+    instance['_local'].delete('commands');
   })
   @derive((points: number[][], instance: BrushElementModel) => {
     const lineWidth = instance.lineWidth;
@@ -89,22 +89,21 @@ export class BrushElementModel extends ElementModel<BrushProps> {
   color: string = '#000000';
 
   /**
-   * path2d is local property and its value is calculated lazily.
+   * The SVG path commands for the brush.
    */
-  get path2d() {
-    if (!this._local.has('path2d')) {
+  get commands() {
+    if (!this._local.has('commands')) {
       const stroke = getSolidStrokePoints(this.points, this.lineWidth);
       const commands = getSvgPathFromStroke(stroke);
-      const path = new Path2D(commands);
 
-      this._local.set('path2d', path);
+      this._local.set('commands', commands);
     }
 
-    return this._local.get('path2d');
+    return this._local.get('commands') as string;
   }
 
   @watch((_, instance: BrushElementModel) => {
-    instance['_local'].delete('path2d');
+    instance['_local'].delete('commands');
   })
   @derive((lineWidth: number, instance: BrushElementModel) => {
     if (lineWidth === instance.lineWidth) return {};

--- a/packages/blocks/src/surface-block/element-model/decorators.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators.ts
@@ -255,6 +255,7 @@ export function convertProps(
 }
 
 const observeSymbol = Symbol('observe');
+const observerDisposableSymbol = Symbol('observerDisposable');
 
 /**
  * A decorator to observe the y type property.
@@ -295,7 +296,10 @@ function startObserve(
 ) {
   const observeFn = getObserveMeta(prototype, prop as string)!;
   // @ts-ignore
-  const observerDisposable = receiver[observeSymbol] ?? {};
+  const observerDisposable = receiver[observerDisposableSymbol] ?? {};
+
+  // @ts-ignore
+  receiver[observerDisposableSymbol] = observerDisposable;
 
   if (observerDisposable[prop]) {
     observerDisposable[prop]();
@@ -345,7 +349,7 @@ export function initializedObservers(
 
   receiver['_disposable'].add(() => {
     // @ts-ignore
-    Object.values(receiver[observeSymbol] ?? {}).forEach(dispose =>
+    Object.values(receiver[observerDisposableSymbol] ?? {}).forEach(dispose =>
       (dispose as () => void)()
     );
   });

--- a/packages/blocks/src/surface-block/element-model/decorators.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators.ts
@@ -61,13 +61,19 @@ export function yfield(fallback?: unknown): PropertyDecorator {
           this._preserved.set(prop as string, val);
         }
 
-        updateObserver(prototype, prop as string, this);
+        startObserve(prototype, prop as string, this);
         updateDerivedProp(derivedProps, this);
       },
     });
   };
 }
 
+/**
+ * A decorator to mark the property as a local property.
+ *
+ * The local property act like it is a yfield property, but it's not synced to the Y map.
+ * Updating local property will also trigger the `elementUpdated` slot of the surface model
+ */
 export function local(): PropertyDecorator {
   return function localDecorator(prototype: unknown, prop: string | symbol) {
     // @ts-ignore
@@ -135,9 +141,22 @@ export function getDeriveProperties(
 ) {
   if (state.derive || state.creating) return null;
 
-  const deriveFn = getDerivedMeta(prototype, prop as string)!;
+  const deriveFns = getDerivedMeta(prototype, prop as string)!;
 
-  return deriveFn ? deriveFn(propValue, receiver) : null;
+  return deriveFns
+    ? deriveFns.reduce(
+        (derivedProps, fn) => {
+          const props = fn(propValue, receiver);
+
+          Object.entries(props).forEach(([key, value]) => {
+            derivedProps[key] = value;
+          });
+
+          return derivedProps;
+        },
+        {} as Record<string, unknown>
+      )
+    : null;
 }
 
 export function updateDerivedProp(
@@ -157,16 +176,24 @@ export function updateDerivedProp(
 function getDerivedMeta(
   target: unknown,
   prop: string | symbol
-): null | ((propValue: unknown, instance: unknown) => Record<string, unknown>) {
+):
+  | null
+  | ((propValue: unknown, instance: unknown) => Record<string, unknown>)[] {
   // @ts-ignore
   return target[deriveSymbol]?.[prop] ?? null;
 }
 
 /**
  * The derive decorator is used to derive other properties' update when the
- * decorated property is updated.
- * The decorator function will be called before the decorated property is updated.
- * The decorator function will not execute in model creation.
+ * decorated property is updated through assignment in the local.
+ *
+ * Note:
+ * 1. The first argument of the function is the new value of the decorated property
+ *    before the `convert` decorator is called.
+ * 2. The decorator function will execute after the decorated property has been updated.
+ * 3. The decorator function will not execute in model creation.
+ * 4. The decorator function will not execute if the decorated property is updated through
+ *    the Y map. That is to say, if other peers update the property will not trigger this decorator
  * @param fn
  * @returns
  */
@@ -178,7 +205,13 @@ export function derive<T extends ElementModel>(
   ) => Record<string, unknown>
 ): PropertyDecorator {
   return function deriveDecorator(target: unknown, prop: string | symbol) {
-    setObjectMeta(deriveSymbol, target, prop as string, fn);
+    const derived = getDerivedMeta(target, prop as string);
+
+    if (Array.isArray(derived)) {
+      derived.push(fn as (typeof derived)[0]);
+    } else {
+      setObjectMeta(deriveSymbol, target, prop as string, [fn]);
+    }
   };
 }
 
@@ -187,7 +220,9 @@ const convertSymbol = Symbol('convert');
 /**
  * The convert decorator is used to convert the property value before it's
  * set to the Y map.
- * This decorator function will not execute in model creation.
+ *
+ * Note:
+ * 1. This decorator function will not execute in model creation.
  * @param fn
  * @returns
  */
@@ -221,6 +256,15 @@ export function convertProps(
 
 const observeSymbol = Symbol('observe');
 
+/**
+ * A decorator to observe the y type property.
+ * You can think of it is just a decorator version of 'observe' method of Y.Array and Y.Map.
+ *
+ * The observer function start to observe the property when the model is mounted. And it will
+ * re-observe the property automatically when the value is altered.
+ * @param fn
+ * @returns
+ */
 export function observe<T extends ElementModel>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: (event: any, instance: T, type: 'modified' | 'altered') => void
@@ -244,51 +288,113 @@ function getObserveMeta(
   return target[observeSymbol]?.[prop] ?? null;
 }
 
-function updateObserver(
+function startObserve(
   prototype: unknown,
   prop: string | symbol,
   receiver: ElementModel
 ) {
   const observeFn = getObserveMeta(prototype, prop as string)!;
-  const observerDisposable = receiver['_observerDisposable'] ?? {};
+  // @ts-ignore
+  const observerDisposable = receiver[observeSymbol] ?? {};
 
   if (observerDisposable[prop]) {
     observerDisposable[prop]();
     delete observerDisposable[prop];
   }
 
-  if (observeFn) {
-    const value = receiver[prop as keyof ElementModel];
+  if (!observeFn) {
+    return;
+  }
 
-    observeFn(null, receiver, 'altered');
+  const value = receiver[prop as keyof ElementModel];
+
+  observeFn(null, receiver, 'altered');
+
+  // @ts-ignore
+  try {
+    const fn = (event: unknown) => {
+      observeFn(event, receiver, 'modified');
+    };
 
     // @ts-ignore
-    try {
-      const fn = (event: unknown) => {
-        observeFn(event, receiver, 'modified');
-      };
-
+    value.observe(fn);
+    // @ts-ignore
+    observerDisposable[prop] = () => {
       // @ts-ignore
-      value.observe(fn);
-      receiver['_observerDisposable'][prop] = () => {
-        // @ts-ignore
-        value.unobserve(fn);
-      };
-    } catch {
-      throw new Error(
-        `Failed to observe "${prop.toString()}" of ${
-          receiver.type
-        } element, make sure it's a Y type.`
-      );
-    }
+      value.unobserve(fn);
+    };
+  } catch {
+    throw new Error(
+      `Failed to observe "${prop.toString()}" of ${
+        receiver.type
+      } element, make sure it's a Y type.`
+    );
   }
 }
 
-export function initFieldObservers(prototype: unknown, receiver: ElementModel) {
+export function initializedObservers(
+  prototype: unknown,
+  receiver: ElementModel
+) {
   // @ts-ignore
   const observers = prototype[observeSymbol] ?? {};
 
   Object.keys(observers).forEach(prop => {
-    updateObserver(prototype, prop, receiver);
+    startObserve(prototype, prop, receiver);
+  });
+
+  receiver['_disposable'].add(() => {
+    // @ts-ignore
+    Object.values(receiver[observeSymbol] ?? {}).forEach(dispose =>
+      (dispose as () => void)()
+    );
+  });
+}
+
+const watchSymbol = Symbol('watch');
+
+export function watch<T extends ElementModel>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (propValue: any, instance: T) => void
+) {
+  return function watchDecorator(target: unknown, prop: string | symbol) {
+    setObjectMeta(watchSymbol, target, prop, fn);
+  };
+}
+
+function getWatchMeta(
+  target: unknown,
+  prop: string | symbol
+): null | ((propValue: unknown, instance: unknown) => void) {
+  // @ts-ignore
+  return target[watchSymbol]?.[prop] ?? null;
+}
+
+function startWatch(
+  prototype: unknown,
+  prop: string | symbol,
+  receiver: ElementModel
+) {
+  const watchFn = getWatchMeta(prototype, prop as string)!;
+
+  if (!watchFn) return;
+
+  watchFn(undefined, receiver);
+
+  receiver['_disposable'].add(
+    receiver.surface.elementUpdated.on(payload => {
+      if (payload.id === receiver.id && prop in payload.props) {
+        watchFn(payload.oldValues[prop as string], receiver);
+      }
+    })
+  );
+}
+
+export function initializeWatchers(prototype: unknown, receiver: ElementModel) {
+  // @ts-ignore
+  const watchers = prototype[watchSymbol] ?? {};
+
+  Object.keys(watchers).forEach(prop => {
+    startWatch(prototype, prop, receiver);
   });
 }

--- a/packages/blocks/src/surface-block/element-model/shape.ts
+++ b/packages/blocks/src/surface-block/element-model/shape.ts
@@ -106,10 +106,10 @@ export class ShapeElementModel extends ElementModel<ShapeProps> {
   @yfield()
   strokeStyle: StrokeStyle = 'solid';
 
-  @yfield()
+  @yfield('General')
   shapeStyle: ShapeStyle = 'General';
 
-  @yfield()
+  @yfield(DEFAULT_ROUGHNESS)
   roughness: number = DEFAULT_ROUGHNESS;
 
   @yfield()

--- a/packages/blocks/src/surface-block/element-model/shape.ts
+++ b/packages/blocks/src/surface-block/element-model/shape.ts
@@ -82,7 +82,7 @@ export class ShapeElementModel extends ElementModel<ShapeProps> {
   @yfield()
   xywh: SerializedXYWH = '[0,0,100,100]';
 
-  @yfield()
+  @yfield(0)
   rotate: number = 0;
 
   @yfield()

--- a/packages/blocks/src/surface-block/element-model/text.ts
+++ b/packages/blocks/src/surface-block/element-model/text.ts
@@ -41,7 +41,7 @@ export class TextElementModel extends ElementModel<TextElementProps> {
   @yfield()
   xywh: SerializedXYWH = '[0,0,16,16]';
 
-  @yfield()
+  @yfield(0)
   rotate: number = 0;
 
   @yfield()

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -160,7 +160,9 @@ export class SurfaceBlockComponent extends BlockElement<
     });
 
     this._disposables.add(
-      this.model.elementUpdated.on(() => {
+      this.model.elementUpdated.on(payload => {
+        // ignore externalXYWH update cause it's updated by the renderer
+        if (payload.props['externalXYWH']) return;
         this._renderer.refresh();
       })
     );
@@ -171,11 +173,6 @@ export class SurfaceBlockComponent extends BlockElement<
     );
     this._disposables.add(
       this.model.elementRemoved.on(() => {
-        this._renderer.refresh();
-      })
-    );
-    this._disposables.add(
-      this.edgeless.service.selection.slots.updated.on(() => {
         this._renderer.refresh();
       })
     );

--- a/packages/framework/store/src/transformer/job.ts
+++ b/packages/framework/store/src/transformer/job.ts
@@ -234,6 +234,18 @@ export class Job {
     return modelData;
   };
 
+  walk = (snapshot: DocSnapshot, callback: (block: BlockSnapshot) => void) => {
+    const walk = (block: BlockSnapshot) => {
+      callback(block);
+
+      if (block.children) {
+        block.children.forEach(walk);
+      }
+    };
+
+    walk(snapshot.blocks);
+  };
+
   snapshotToBlock = async (
     snapshot: BlockSnapshot,
     doc: Doc,


### PR DESCRIPTION
### Change
- Add new method `walk` into transformer `Job` to traverse a template (use to modify the snapshot content before importing start)
- Add property fallback to fix legacy template rendering
- Add `watch` decorator to watch element property change
- Add new local property `commands` to brush to avoid double computation
- Fix laggy multi-selection