### PR TITLE
fix(edgeless): last selection was recovered unexpected after panning from default tool

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -1,6 +1,7 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { DisposableGroup, noop } from '@blocksuite/global/utils';
 
+import { type EdgelessTool } from '../../../../_common/utils/index.js';
 import {
   type DefaultTool,
   handleNativeRangeAtPoint,
@@ -409,6 +410,12 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     }
   };
 
+  private _clearLastSelecton = () => {
+    if (this.selection.empty) {
+      this.selection.clearLast();
+    }
+  };
+
   private _clearDraggingAreaDisposable = () => {
     if (this._draggingAreaDisposables) {
       this._draggingAreaDisposables.dispose();
@@ -665,7 +672,10 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     }
   }
 
-  beforeModeSwitch() {
+  beforeModeSwitch(edgelessTool?: EdgelessTool) {
+    if (edgelessTool?.type === 'pan') {
+      this._clearLastSelecton();
+    }
     this._stopAutoPanning();
     this._clearDraggingAreaDisposable();
     noop();

--- a/packages/blocks/src/root-block/edgeless/services/selection-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/services/selection-manager.ts
@@ -317,6 +317,10 @@ export class EdgelessSelectionManager {
     });
   }
 
+  clearLast() {
+    this.lastState = [];
+  }
+
   dispose() {
     this.disposable.dispose();
   }


### PR DESCRIPTION
edgeless problem: 

As demonstrated in the video below, when using default tool, I clicked on blank region and the selection is cleared right , but then, after panning, the last selection was recovered unexpected. 

https://github.com/toeverything/blocksuite/assets/6285483/0bf59811-676b-477f-a04b-3fbeab8085c6


fixed as follows:

Before changing default tool to panning tool, clear the last-selection if there's no selection. Thus unexpected last-selection will not be recovered.

https://github.com/toeverything/blocksuite/assets/6285483/557d274a-13b3-4bf4-835f-def854fadd6c

