### PR TITLE
fix(edgeless): menu-container scrolling in safari

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/common/slide-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/common/slide-menu.ts
@@ -25,6 +25,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
       width: var(--menu-width);
       overflow-x: auto;
       overscroll-behavior: none;
+      scrollbar-width: none;
       position: relative;
       height: calc(var(--menu-height) + 1px);
       box-sizing: border-box;
@@ -129,7 +130,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
   private _handleWheel(event: WheelEvent) {
     event.stopPropagation();
     this._menuContainer.scrollBy({
-      left: event.deltaY,
+      left: event.deltaX,
     });
   }
 
@@ -155,7 +156,7 @@ export class EdgelessSlideMenu extends WithDisposable(LitElement) {
           ${ArrowRightSmallIcon}
         </div>
         <div class="menu-container" style=${menuContainerStyles}>
-          <div class="slide-menu-content" @wheel="${this._handleWheel}">
+          <div class="slide-menu-content" @wheel=${this._handleWheel}>
             <slot></slot>
           </div>
         </div>


### PR DESCRIPTION
https://github.com/toeverything/blocksuite/blob/0beb354f4bead57a2cc4fe7b42db71db6641c600/packages/blocks/src/root-block/edgeless/components/toolbar/common/slide-menu.ts#L132

here should use `event.deltaX`
