### PR TITLE
fix(edgeless): fonts load and render in firefox

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-text-menu.ts
@@ -16,7 +16,6 @@ import {
 import type { CssVariableName } from '../../../../_common/theme/css-variables.js';
 import { countBy, maxBy } from '../../../../_common/utils/iterable.js';
 import {
-  getFontFacesByFontFamily,
   isFontStyleSupported,
   isFontWeightSupported,
 } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
@@ -35,6 +34,10 @@ import {
   normalizeShapeBound,
 } from '../../../../surface-block/index.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
+import {
+  getFontFacesByFontFamily,
+  wrapFontFamily,
+} from '../../../../surface-block/utils/font.js';
 import type { EdgelessAlignPanel } from '../panel/align-panel.js';
 import {
   type ColorEvent,
@@ -461,7 +464,8 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
         @click=${() => this._textFontFamilyPopper?.toggle()}
       >
         <div class="button-with-arrow-group">
-          <span style=${`font-family:"${selectedFontFamily}";`}>Aa</span
+          <span style=${`font-family:${wrapFontFamily(selectedFontFamily)};`}
+            >Aa</span
           >${SmallArrowDownIcon}
         </div>
       </edgeless-tool-icon-button>

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { CanvasTextFontFamily } from '../../../../surface-block/consts.js';
-import { wrapFontFamily } from '../../../../surface-block/elements/text/utils.js';
+import { wrapFontFamily } from '../../../../surface-block/utils/font.js';
 
 @customElement('edgeless-font-family-panel')
 export class EdgelessFontFamilyPanel extends LitElement {

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
@@ -7,7 +7,11 @@ import {
   CanvasTextFontStyle,
   CanvasTextFontWeight,
 } from '../../../../surface-block/consts.js';
-import { getFontFacesByFontFamily } from '../../../../surface-block/elements/text/utils.js';
+import {
+  getFontFaces,
+  getFontFacesByFontFamily,
+  isSameFontFamily,
+} from '../../../../surface-block/utils/font.js';
 
 @customElement('edgeless-font-weight-and-style-panel')
 export class EdgelessFontWeightAndStylePanel extends LitElement {
@@ -67,14 +71,11 @@ export class EdgelessFontWeightAndStylePanel extends LitElement {
     // Compatible with old data
     if (!CanvasTextFontFamilies.includes(this.fontFamily)) return false;
 
-    const fonts = document.fonts;
-    const fontFace = [...fonts.keys()].find(fontFace => {
-      return (
-        fontFace.family === this.fontFamily &&
-        fontFace.weight === fontWeight &&
-        fontFace.style === fontStyle
-      );
-    });
+    const fontFace = getFontFaces()
+      .filter(isSameFontFamily(this.fontFamily))
+      .find(fontFace => {
+        return fontFace.weight === fontWeight && fontFace.style === fontStyle;
+      });
 
     return !fontFace;
   }

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -6,10 +6,10 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { RichText } from '../../../../_common/components/rich-text/rich-text.js';
 import { isCssVariable } from '../../../../_common/theme/css-variables.js';
-import { wrapFontFamily } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import type { ShapeElementModel } from '../../../../surface-block/element-model/index.js';
 import { SHAPE_TEXT_PADDING } from '../../../../surface-block/elements/shape/consts.js';
 import { Bound, toRadian, Vec } from '../../../../surface-block/index.js';
+import { wrapFontFamily } from '../../../../surface-block/utils/font.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import { getSelectedRect } from '../../utils/query.js';
 

--- a/packages/blocks/src/root-block/font-loader/font-loader.ts
+++ b/packages/blocks/src/root-block/font-loader/font-loader.ts
@@ -1,9 +1,23 @@
+import { IS_FIREFOX } from '@blocksuite/global/env';
+
 export interface FontConfig {
   font: string;
   weight: string;
   url: string;
   style: string;
 }
+
+const initFontFace = IS_FIREFOX
+  ? ({ font, weight, url, style }: FontConfig) =>
+      new FontFace(`"${font}"`, `url(${url})`, {
+        weight,
+        style,
+      })
+  : ({ font, weight, url, style }: FontConfig) =>
+      new FontFace(font, `url(${url})`, {
+        weight,
+        style,
+      });
 
 export class FontLoader {
   readonly fontFaces: FontFace[] = [];
@@ -14,11 +28,8 @@ export class FontLoader {
 
   load(fonts: FontConfig[]) {
     this.fontFaces.push(
-      ...fonts.map(({ font, weight, url, style }) => {
-        const fontFace = new FontFace(font, `url(${url})`, {
-          weight,
-          style,
-        });
+      ...fonts.map(font => {
+        const fontFace = initFontFace(font);
         document.fonts.add(fontFace);
         fontFace.load().catch(console.error);
         return fontFace;

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
@@ -8,6 +8,10 @@ import type {
 import type { TextElementModel } from '../../../element-model/text.js';
 import type { Bound } from '../../../utils/bound.js';
 import {
+  getFontFacesByFontFamily,
+  wrapFontFamily,
+} from '../../../utils/font.js';
+import {
   getPointsFromBoundsWithRotation,
   rotatePoints,
 } from '../../../utils/math-utils.js';
@@ -78,10 +82,6 @@ export function getLineHeight(fontFamily: string, fontSize: number) {
   }
 
   return lineHeight;
-}
-
-export function wrapFontFamily(fontFamily: string): string {
-  return `"${fontFamily}"`;
 }
 
 function transformDelta(delta: TextDelta): (TextDelta | '\n')[] {
@@ -481,28 +481,6 @@ export function normalizeTextBound(
   bound.h = lineHeightPx * lines.length;
 
   return bound;
-}
-
-export function getFontFacesByFontFamily(
-  fontFamily: FontFamily | string
-): FontFace[] {
-  const fonts = document.fonts;
-  return (
-    [...fonts.keys()]
-      .filter(fontFace => {
-        return fontFace.family === fontFamily;
-      })
-      // remove duplicate font faces
-      .filter(
-        (item, index, arr) =>
-          arr.findIndex(
-            fontFace =>
-              fontFace.family === item.family &&
-              fontFace.weight === item.weight &&
-              fontFace.style === item.style
-          ) === index
-      )
-  );
 }
 
 export function isFontWeightSupported(

--- a/packages/blocks/src/surface-block/elements/text/utils.ts
+++ b/packages/blocks/src/surface-block/elements/text/utils.ts
@@ -1,6 +1,7 @@
 // something comes from https://github.com/excalidraw/excalidraw/blob/b1311a407a636c87ee0ca326fd20599d0ce4ba9b/src/utils.ts
 
 import type { CanvasTextFontFamily } from '../../consts.js';
+import { wrapFontFamily } from '../../utils/font.js';
 
 const RS_LTR_CHARS =
   'A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF' +
@@ -23,10 +24,6 @@ const getMeasureCtx = (function initMeasureContext() {
     return ctx!;
   };
 })();
-
-export function wrapFontFamily(fontFamily: CanvasTextFontFamily): string {
-  return `"${fontFamily}"`;
-}
 
 const cachedFontFamily = new Map<
   string,
@@ -302,26 +299,4 @@ export function wrapText(text: string, font: string, maxWidth: number): string {
     }
   });
   return lines.join('\n');
-}
-
-export function getFontFacesByFontFamily(
-  fontFamily: CanvasTextFontFamily
-): FontFace[] {
-  const fonts = document.fonts;
-  return (
-    [...fonts.keys()]
-      .filter(fontFace => {
-        return fontFace.family === fontFamily;
-      })
-      // remove duplicate font faces
-      .filter(
-        (item, index, arr) =>
-          arr.findIndex(
-            fontFace =>
-              fontFace.family === item.family &&
-              fontFace.weight === item.weight &&
-              fontFace.style === item.style
-          ) === index
-      )
-  );
 }

--- a/packages/blocks/src/surface-block/utils/font.ts
+++ b/packages/blocks/src/surface-block/utils/font.ts
@@ -1,0 +1,53 @@
+import { IS_FIREFOX } from '@blocksuite/global/env';
+
+import type { CanvasTextFontFamily } from '../consts.js';
+import type { FontFamily } from '../element-model/common.js';
+
+export function wrapFontFamily(
+  fontFamily: CanvasTextFontFamily | string
+): string {
+  return `"${fontFamily}"`;
+}
+
+export const getFontFaces = IS_FIREFOX
+  ? () => {
+      const keys = document.fonts.keys();
+      const fonts = [];
+      let done = false;
+      while (!done) {
+        const item = keys.next();
+        done = !!item.done;
+        if (item.value) {
+          fonts.push(item.value);
+        }
+      }
+      return fonts;
+    }
+  : () => [...document.fonts.keys()];
+
+export const isSameFontFamily = IS_FIREFOX
+  ? (fontFamily: CanvasTextFontFamily | FontFamily | string) =>
+      (fontFace: FontFace) =>
+        fontFace.family === `"${fontFamily}"`
+  : (fontFamily: CanvasTextFontFamily | FontFamily | string) =>
+      (fontFace: FontFace) =>
+        fontFace.family === fontFamily;
+
+export function getFontFacesByFontFamily(
+  fontFamily: CanvasTextFontFamily | FontFamily | string
+): FontFace[] {
+  return (
+    getFontFaces()
+      .filter(isSameFontFamily(fontFamily))
+      // remove duplicate font faces
+      .filter(
+        (item, index, arr) =>
+          arr.findIndex(
+            fontFace =>
+              fontFace.family === item.family &&
+              fontFace.weight === item.weight &&
+              fontFace.style === item.style
+          ) === index
+      )
+  );
+}


### PR DESCRIPTION
<img width="452" alt="Screenshot 2024-03-03 at 17 45 40" src="https://github.com/toeverything/blocksuite/assets/27926/177effa6-5dfa-4243-a730-8fdc683439b6">


The font family name should wrap in quotes. [CSS ident-tokens](https://www.w3.org/TR/css-syntax-3/#ident-token-diagram)
