### PR TITLE
fix(page): handle delete or backspace align with embed block

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -23,7 +23,8 @@ import {
 } from '../../../_common/utils/selection.js';
 import type { ListBlockModel } from '../../../list-block/index.js';
 import type { RootBlockModel } from '../../../root-block/index.js';
-import type { ExtendedModel } from '../../types.js';
+import { EMBED_BLOCK_FLAVOUR_LIST } from '../../consts.js';
+import { type ExtendedModel } from '../../types.js';
 
 /**
  * Whether the block supports rendering its children.
@@ -647,6 +648,7 @@ function handleParagraphDeleteActions(
       'affine:bookmark',
       'affine:code',
       'affine:image',
+      ...EMBED_BLOCK_FLAVOUR_LIST,
     ])
   ) {
     doc.deleteBlock(model, {
@@ -866,6 +868,8 @@ function handleParagraphBlockForwardDelete(
       'affine:image',
       'affine:code',
       'affine:attachment',
+      'affine:bookmark',
+      ...EMBED_BLOCK_FLAVOUR_LIST,
     ];
 
     if (

--- a/packages/blocks/src/_common/consts.ts
+++ b/packages/blocks/src/_common/consts.ts
@@ -37,6 +37,16 @@ export const EMBED_CARD_HEIGHT: Record<EmbedCardStyle, number> = {
   syncedDoc: 455,
 };
 
+export const EMBED_BLOCK_FLAVOUR_LIST = [
+  'affine:embed-github',
+  'affine:embed-youtube',
+  'affine:embed-figma',
+  'affine:embed-linked-doc',
+  'affine:embed-synced-doc',
+  'affine:embed-html',
+  'affine:embed-loom',
+] as const;
+
 export const DEFAULT_IMAGE_PROXY_ENDPOINT =
   'https://affine-worker.toeverything.workers.dev/api/worker/image-proxy';
 


### PR DESCRIPTION
To close #6327 

Forward delete before embed block will be ignored. 

Pressing backspace when adjacent to an embed block will select the embed block.

