### PR TITLE
fix(edgeless): position should be calculated after the update is complete

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/component-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/component-toolbar.ts
@@ -388,9 +388,8 @@ export class EdgelessComponentToolbar extends WithDisposable(LitElement) {
   }
 
   protected override async updated(_changedProperties: PropertyValues) {
-    const [left, top] = this._computePosition();
-
     await this.updateComplete;
+    const [left, top] = this._computePosition();
     this.left = left;
     this.top = top;
   }


### PR DESCRIPTION
### Before

https://github.com/toeverything/blocksuite/assets/27926/3d8c4d7c-26d3-45ac-bd69-fc9fab58a9e7


### After

https://github.com/toeverything/blocksuite/assets/27926/b7805c12-bc39-4ed9-b841-7fbad365d5f3

