### PR TITLE
feat(page): add language detection

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -26,6 +26,7 @@
     "@types/mdast": "^4.0.3",
     "@types/sortablejs": "^1.15.8",
     "@types/webfontloader": "^1.6.38",
+    "@vscode/vscode-languagedetection": "^1.0.22",
     "buffer": "^6.0.3",
     "date-fns": "^3.3.1",
     "file-type": "^16.5.4",

--- a/packages/blocks/src/_specs/_specs.ts
+++ b/packages/blocks/src/_specs/_specs.ts
@@ -7,6 +7,7 @@ import { AttachmentService } from '../attachment-block/attachment-service.js';
 import { BookmarkService } from '../bookmark-block/bookmark-service.js';
 import { BookmarkBlockSchema } from '../bookmark-block/index.js';
 import { CodeBlockSchema } from '../code-block/code-model.js';
+import { CodeService } from '../code-block/code-service.js';
 import { DataViewBlockSchema } from '../data-view-block/index.js';
 import { DatabaseBlockSchema } from '../database-block/database-model.js';
 import { DatabaseService } from '../database-block/database-service.js';
@@ -154,6 +155,7 @@ const CommonFirstPartyBlockSpecs: BlockSpec[] = [
   },
   {
     schema: CodeBlockSchema,
+    service: CodeService,
     view: {
       component: literal`affine-code`,
     },

--- a/packages/blocks/src/code-block/clipboard/lang-detect-middleware.ts
+++ b/packages/blocks/src/code-block/clipboard/lang-detect-middleware.ts
@@ -27,7 +27,7 @@ export const languageDetectMiddleware = (
         textSelection.from.index === 0 &&
         textSelection.from.length === beforePastedText.length;
 
-      if (beforePastedText && !selectAll) {
+      if (beforePastedText.trim() && !selectAll) {
         // Only detect language when pasting text into an empty block
         return;
       }

--- a/packages/blocks/src/code-block/clipboard/lang-detect-middleware.ts
+++ b/packages/blocks/src/code-block/clipboard/lang-detect-middleware.ts
@@ -1,0 +1,56 @@
+import type { JobMiddleware } from '@blocksuite/store';
+
+import { matchFlavours } from '../../_common/utils/model.js';
+import type { CodeBlockComponent } from '../code-block.js';
+import { isPlaintext } from '../utils/code-languages.js';
+
+export const languageDetectMiddleware = (
+  host: CodeBlockComponent
+): JobMiddleware => {
+  const codeService = host.service;
+  // Since the paste should be handled in the same event loop,
+  // we only store the block id in a variable
+  let canGuessLangBlockId: string | null = null;
+  return ({ slots }) => {
+    slots.beforeImport.on(payload => {
+      if (
+        payload.type !== 'block' ||
+        payload.snapshot.flavour !== 'affine:code'
+      )
+        return;
+
+      const pastedModel = host.model;
+      const beforePastedText = pastedModel.text.yText.toString();
+      const textSelection = host.std.selection.find('text');
+      const selectAll =
+        textSelection &&
+        textSelection.from.index === 0 &&
+        textSelection.from.length === beforePastedText.length;
+
+      if (beforePastedText && !selectAll) {
+        // Only detect language when pasting text into an empty block
+        return;
+      }
+      // Mark the block as guessable
+      canGuessLangBlockId = payload.snapshot.id;
+    });
+    slots.afterImport.on(async payload => {
+      if (payload.type !== 'block') return;
+      const { model } = payload;
+      if (model.id !== canGuessLangBlockId) return;
+      canGuessLangBlockId = null;
+      if (!matchFlavours(model, ['affine:code'])) return;
+      // Only detect language for plaintext blocks
+      if (!isPlaintext(model.language)) return;
+
+      const detectionResult = await codeService.detectLanguage(model);
+      if (!detectionResult) {
+        return;
+      }
+      // Update the language of the block
+      model.doc.updateBlock(model, {
+        language: detectionResult.language.id,
+      });
+    });
+  };
+};

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -43,7 +43,10 @@ import {
 import { getHighLighter } from './utils/high-lighter.js';
 
 @customElement('affine-code')
-export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
+export class CodeBlockComponent extends BlockElement<
+  CodeBlockModel,
+  CodeService
+> {
   static override styles = css`
     code-block {
       position: relative;

--- a/packages/blocks/src/code-block/code-service.ts
+++ b/packages/blocks/src/code-block/code-service.ts
@@ -65,7 +65,6 @@ export class CodeService extends BlockService<CodeBlockModel> {
     const detectionResults =
       await this._languageDetector.queryLangConfidence(text);
 
-    // console.log(detectionResults.sort((a, b) => b.confidence - a.confidence));
     return detectionResults.reduce(
       (acc, { language, confidence }) => {
         acc[language.id] = confidence;

--- a/packages/blocks/src/code-block/code-service.ts
+++ b/packages/blocks/src/code-block/code-service.ts
@@ -1,0 +1,77 @@
+import { BlockService } from '@blocksuite/block-std';
+import { bundledLanguagesInfo } from 'shiki';
+
+import type { CodeBlockModel } from './code-model.js';
+import type { LanguageDetector } from './language-detection.js';
+import type { StrictLanguageInfo } from './utils/consts.js';
+
+export class CodeService extends BlockService<CodeBlockModel> {
+  private _languageDetector: LanguageDetector<StrictLanguageInfo> | null = null;
+  private _loading = false;
+
+  override mounted(): void {
+    super.mounted();
+    // requestIdleCallback(() => {
+    //   void this.loadLanguageDetector();
+    // });
+  }
+
+  override unmounted(): void {
+    super.unmounted();
+    this._languageDetector?.dispose();
+    this._languageDetector = null;
+  }
+
+  async loadLanguageDetector() {
+    if (this._languageDetector || this._loading) {
+      // Already loaded or loading
+      return;
+    }
+    try {
+      this._loading = true;
+      const { createLanguageDetector } = await import(
+        './language-detection.js'
+      );
+      this._languageDetector = createLanguageDetector({
+        supportedLangs: bundledLanguagesInfo as StrictLanguageInfo[],
+        modelOperationsOptions: {
+          maxContentSize: 3000,
+        },
+      });
+      await this._languageDetector?.loadModel();
+    } catch (error) {
+      // Reset the language detector to null so that it can be reloaded later
+      this._languageDetector = null;
+      console.error('Failed to load language detector', error);
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  async detectLanguage(model: CodeBlockModel) {
+    const text = model.text.yText.toString();
+    if (!text || !this._languageDetector || !this._languageDetector.isReady()) {
+      return null;
+    }
+    return this._languageDetector.detectLanguages(text);
+  }
+
+  async queryLangConfidence(model: CodeBlockModel) {
+    const text = model.text.yText.toString();
+    if (!text || !this._languageDetector || !this._languageDetector.isReady()) {
+      return {} as Record<StrictLanguageInfo['id'], number>;
+    }
+
+    const detectionResults =
+      await this._languageDetector.queryLangConfidence(text);
+
+    // console.log(detectionResults.sort((a, b) => b.confidence - a.confidence));
+    return detectionResults.reduce(
+      (acc, { language, confidence }) => {
+        acc[language.id] = confidence;
+        return acc;
+      },
+      {} as Record<StrictLanguageInfo['id'], number>
+    );
+  }
+}

--- a/packages/blocks/src/code-block/components/lang-list.ts
+++ b/packages/blocks/src/code-block/components/lang-list.ts
@@ -11,7 +11,6 @@ import { createLitPortal } from '../../_common/components/portal.js';
 import { scrollbarStyle } from '../../_common/components/utils.js';
 import { PAGE_HEADER_HEIGHT } from '../../_common/consts.js';
 import { DoneIcon, SearchIcon } from '../../_common/icons/index.js';
-import { getLanguagePriority } from '../utils/code-languages.js';
 import {
   PLAIN_TEXT_LANG_INFO,
   type StrictLanguageInfo,
@@ -126,6 +125,14 @@ export class LangList extends LitElement {
     `;
   }
 
+  /**
+   * A function to get the priority of a language.
+   *
+   * The higher the number, the higher the priority.
+   */
+  @property({ attribute: false })
+  getLangPriority: (lang: StrictLanguageInfo) => number = () => 0;
+
   @property({ attribute: false })
   currentLanguageId!: BundledLanguage | PlainTextLanguage;
 
@@ -181,17 +188,7 @@ export class LangList extends LitElement {
           )
         );
       })
-      .sort(
-        (a, b) =>
-          getLanguagePriority(
-            a.id as BundledLanguage,
-            this.currentLanguageId === a.id
-          ) -
-          getLanguagePriority(
-            b.id as BundledLanguage,
-            this.currentLanguageId === b.id
-          )
-      );
+      .sort((a, b) => this.getLangPriority(b) - this.getLangPriority(a));
 
     const onLanguageSelect = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
@@ -269,11 +266,13 @@ export function createLangList({
   currentLanguage,
   onSelectLanguage,
   referenceElement,
+  getLangPriority,
 }: {
   referenceElement: Element;
   abortController: AbortController;
   currentLanguage: StrictLanguageInfo;
   onSelectLanguage: (lang: StrictLanguageInfo | null) => void;
+  getLangPriority?: (l: StrictLanguageInfo) => number;
 }) {
   const MAX_LANG_SELECT_HEIGHT = 440;
   const portalPadding = {
@@ -289,6 +288,9 @@ export function createLangList({
         onSelectLanguage(lang);
       };
       langList.onClose = () => abortController.abort();
+      if (getLangPriority) {
+        langList.getLangPriority = getLangPriority;
+      }
       positionSlot.on(({ placement }) => {
         langList.placement = placement;
       });

--- a/packages/blocks/src/code-block/language-detection.ts
+++ b/packages/blocks/src/code-block/language-detection.ts
@@ -97,11 +97,7 @@ export const createLanguageDetector = <Lang extends BundledLanguageInfo>({
   // See https://github.com/microsoft/vscode-languagedetection#advanced-options
   const modelOperations = new ModelOperations({
     modelJsonLoaderFunc: async () => {
-      return import('@vscode/vscode-languagedetection/model/model.json', {
-        with: {
-          type: 'json',
-        },
-      });
+      return import('@vscode/vscode-languagedetection/model/model.json');
     },
     weightsLoaderFunc: async () => {
       const url =

--- a/packages/blocks/src/code-block/language-detection.ts
+++ b/packages/blocks/src/code-block/language-detection.ts
@@ -173,7 +173,7 @@ export const createLanguageDetector = <Lang extends BundledLanguageInfo>({
     modelOperations,
     loadModel,
     isReady: () => {
-      // @ts-expect-error
+      // @ts-expect-error The `_model` is private but we need to check if it is ready
       return !!modelOperations._model;
     },
     queryLangConfidence,

--- a/packages/blocks/src/code-block/language-detection.ts
+++ b/packages/blocks/src/code-block/language-detection.ts
@@ -1,0 +1,189 @@
+import type {
+  ModelOperationsOptions,
+  ModelResult,
+} from '@vscode/vscode-languagedetection';
+import { ModelOperations } from '@vscode/vscode-languagedetection';
+import type { BundledLanguageInfo } from 'shiki';
+
+/*---------------------------------------------------------------------------------------------
+ *  Ported from https://github.com/microsoft/vscode/blob/19ecb4b8337d0871f0a204853003a609d716b04e/src/vs/workbench/services/languageDetection/browser/languageDetectionSimpleWorker.ts
+ *
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const expectedRelativeConfidence = 0.2;
+const positiveConfidenceCorrectionBucket1 = 0.05;
+const positiveConfidenceCorrectionBucket2 = 0.025;
+const negativeConfidenceCorrection = 0.5;
+
+const adjustLanguageConfidence = (modelResult: ModelResult): ModelResult => {
+  switch (modelResult.languageId) {
+    // For the following languages, we increase the confidence because
+    // these are commonly used languages in VS Code and supported
+    // by the model.
+    case 'js':
+    case 'html':
+    case 'json':
+    case 'ts':
+    case 'css':
+    case 'py':
+    case 'xml':
+    case 'php':
+      modelResult.confidence += positiveConfidenceCorrectionBucket1;
+      break;
+    // case 'yaml': // YAML has been know to cause incorrect language detection because the language is pretty simple. We don't want to increase the confidence for this.
+    case 'cpp':
+    case 'sh':
+    case 'java':
+    case 'cs':
+    case 'c':
+      modelResult.confidence += positiveConfidenceCorrectionBucket2;
+      break;
+
+    // For the following languages, we need to be extra confident that the language is correct because
+    // we've had issues like #131912 that caused incorrect guesses. To enforce this, we subtract the
+    // negativeConfidenceCorrection from the confidence.
+
+    // languages that are provided by default in VS Code
+    case 'bat':
+    case 'ini':
+    case 'makefile':
+    case 'sql':
+    // languages that aren't provided by default in VS Code
+    // eslint-disable-next-line no-fallthrough -- There is no a fallthrough here!
+    case 'csv':
+    case 'toml':
+      // Other considerations for negativeConfidenceCorrection that
+      // aren't built in but suported by the model include:
+      // * Assembly, TeX - These languages didn't have clear language modes in the community
+      // * Markdown, Dockerfile - These languages are simple but they embed other languages
+      modelResult.confidence -= negativeConfidenceCorrection;
+      break;
+
+    default:
+      break;
+  }
+  return modelResult;
+};
+
+// --------------------------------------------------------------------------------------------
+
+export type DetectionOptions = {
+  expectedRelativeConfidence: number;
+  // langBiases: Record<string, number>;
+};
+
+export type DetectionResult<T> = {
+  language: T;
+  confidence: number;
+};
+
+export type LanguageDetector<Lang extends BundledLanguageInfo> = ReturnType<
+  typeof createLanguageDetector<Lang>
+>;
+
+const DEFAULT_DETECTION_OPTIONS: DetectionOptions = {
+  expectedRelativeConfidence: expectedRelativeConfidence,
+};
+
+export const createLanguageDetector = <Lang extends BundledLanguageInfo>({
+  supportedLangs = [],
+  modelOperationsOptions,
+}: {
+  modelOperationsOptions?: ModelOperationsOptions;
+  supportedLangs?: Lang[];
+} = {}) => {
+  // See https://github.com/microsoft/vscode-languagedetection#advanced-options
+  const modelOperations = new ModelOperations({
+    modelJsonLoaderFunc: async () => {
+      return import('@vscode/vscode-languagedetection/model/model.json', {
+        with: {
+          type: 'json',
+        },
+      });
+    },
+    weightsLoaderFunc: async () => {
+      const url =
+        'https://unpkg.com/@vscode/vscode-languagedetection@1.0.21/model/group1-shard1of1.bin';
+      // 'https://cdn.jsdelivr.net/npm/@vscode/vscode-languagedetection@1.0.21/model/group1-shard1of1.bin';
+      const response = await fetch(url);
+      const buffer = await response.arrayBuffer();
+      return buffer;
+    },
+    ...modelOperationsOptions,
+  });
+
+  const loadModel = async () => {
+    if (
+      'loadModel' in modelOperations &&
+      // @ts-expect-error https://github.com/microsoft/vscode-languagedetection/issues/22
+      typeof modelOperations.loadModel === 'function'
+    ) {
+      // @ts-expect-error we check it above so it is safe!
+      await modelOperations.loadModel();
+    } else {
+      console.warn('`loadModel` is not supported! Please check the version!');
+      await modelOperations.runModel('');
+    }
+  };
+
+  const queryLangConfidence = async (text: string) => {
+    const modelResults = await modelOperations.runModel(text);
+    const normalizedModelResults = modelResults
+      .map(modelResult => adjustLanguageConfidence(modelResult))
+      .map(modelResult => {
+        const lang = supportedLangs.find(
+          l =>
+            l.id === modelResult.languageId ||
+            l.aliases?.includes(modelResult.languageId)
+        );
+        if (!lang) {
+          return null;
+        }
+        return {
+          language: lang,
+          confidence: modelResult.confidence,
+        } satisfies DetectionResult<Lang>;
+      })
+      .filter(Boolean) as DetectionResult<Lang>[];
+
+    return normalizedModelResults;
+  };
+
+  const detectLanguages = async (
+    sampleContent: string,
+    opts: Partial<DetectionOptions> = DEFAULT_DETECTION_OPTIONS
+  ): Promise<DetectionResult<Lang> | null> => {
+    const options = { ...DEFAULT_DETECTION_OPTIONS, ...opts };
+    const modelResults = (await queryLangConfidence(sampleContent)).sort(
+      (a, b) => b.confidence - a.confidence
+    );
+    const mostPossibleLang = modelResults.at(0);
+
+    if (
+      !mostPossibleLang ||
+      mostPossibleLang.confidence < options.expectedRelativeConfidence
+    )
+      return null;
+
+    return {
+      language: mostPossibleLang.language,
+      confidence: mostPossibleLang.confidence,
+    };
+  };
+
+  return {
+    modelOperations,
+    loadModel,
+    isReady: () => {
+      // @ts-expect-error
+      return !!modelOperations._model;
+    },
+    queryLangConfidence,
+    detectLanguages,
+    dispose: () => {
+      modelOperations.dispose();
+    },
+  };
+};

--- a/packages/blocks/src/code-block/utils/code-languages.ts
+++ b/packages/blocks/src/code-block/utils/code-languages.ts
@@ -92,6 +92,14 @@ export function getPopularLangPriority(lang: string) {
   return POPULAR_LANGUAGES_MAP[lang] ?? 0;
 }
 
+/**
+ * Check if a language is plaintext.
+ *
+ * PLEASE USE `isPlaintext` INSTEAD OF `isPlainLang`.
+ *
+ * The `isPlainLang` no check for `Plain Text`, which used in the code block.
+ * It's was a design mistake to use `Plain Text` as a language id.
+ */
 export function isPlaintext(lang: string) {
   return isPlainLang(lang) || PLAIN_TEXT_LANG_INFO.id === lang;
 }

--- a/packages/blocks/src/code-block/utils/code-languages.ts
+++ b/packages/blocks/src/code-block/utils/code-languages.ts
@@ -77,23 +77,19 @@ const PopularLanguages: BundledLanguage[] = [
   'vue',
 ];
 
-const POPULAR_LANGUAGES_MAP: Partial<Record<BundledLanguage, number>> =
-  PopularLanguages.reduce((acc, lang, i) => {
+const POPULAR_LANGUAGES_MAP: Partial<Record<string, number>> =
+  PopularLanguages.reverse().reduce((acc, lang, i) => {
     return {
       [lang]: i,
       ...acc,
     };
   }, {});
 
-export function getLanguagePriority(
-  lang: BundledLanguage,
-  isCurrentLanguage = false
-) {
-  if (isCurrentLanguage) {
-    // Important to show the current language first
-    return -Infinity;
-  }
-  return POPULAR_LANGUAGES_MAP[lang] ?? Infinity;
+/**
+ * Bigger number means more popular.
+ */
+export function getPopularLangPriority(lang: string) {
+  return POPULAR_LANGUAGES_MAP[lang] ?? 0;
 }
 
 export function isPlaintext(lang: string) {

--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -14,6 +14,7 @@ import {
 
 import { matchFlavours } from '../../../_common/utils/index.js';
 import type { CodeBlockModel } from '../../../code-block/index.js';
+import { FALLBACK_LANG } from '../../../code-block/utils/consts.js';
 import type { ParagraphBlockModel } from '../../../paragraph-block/index.js';
 
 const findLast = (snapshot: BlockSnapshot): BlockSnapshot => {
@@ -129,7 +130,7 @@ class PasteTr {
 
     this.firstSnapshot.flavour = this.fromPointState.model.flavour;
     const toLanguage = (this.fromPointState.model as CodeBlockModel).language;
-    if (toLanguage !== 'Plain Text') {
+    if (toLanguage !== FALLBACK_LANG) {
       this.firstSnapshot.props.language = toLanguage;
     }
     const deltas: DeltaOperation[] = [...fromDelta];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@types/webfontloader':
         specifier: ^1.6.38
         version: 1.6.38
+      '@vscode/vscode-languagedetection':
+        specifier: ^1.0.22
+        version: 1.0.22
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2499,6 +2502,11 @@ packages:
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
+
+  /@vscode/vscode-languagedetection@1.0.22:
+    resolution: {integrity: sha512-rQ/BgMyLuIXSmbA0MSkIPHtcOw14QkeDbAq19sjvaS9LTRr905yij0S8lsyqN5JgOsbtIx7pAcyOxFMzPmqhZQ==}
+    hasBin: true
+    dev: false
 
   /@vscode/web-custom-data@0.4.9:
     resolution: {integrity: sha512-QeCJFISE/RiTG0NECX6DYmVRPVb0jdyaUrhY0JqNMv9ruUYtYqxxQfv3PSjogb+zNghmwgXLSYuQKk6G+Xnaig==}


### PR DESCRIPTION
This pull request introduces a new feature that automatically detects the language of code blocks.

The feature utilizes machine learning (AI!) to predict the language. (Power by [guesslang](https://github.com/yoeo/guesslang))

The language detection will be triggered in the following scenarios:

- Nothing will happen if
  - The detect language module has not been loaded. (This module will only load when a code block is connected to the page.)
  - The detection confidence is lower than 20%. (You can inspect the confidence in the [guesslang playground](https://guesslang.waterwater.moe/))
- Code block will set the language automatically when
  - Text pasted into an empty plaintext code block.
  - Text is pasted into a code block and the user selects **all** text within the plaintext code block.
- When a user attempts to select a language for a code block. It will offer a language recommendation.


https://github.com/toeverything/blocksuite/assets/18554747/b1107382-32e1-4593-9ce4-dd148958809d

~~Automatic language selection when pasting code from other editors is helpful for users, but it is blocked by https://github.com/toeverything/blocksuite/issues/6366.~~

## Trade-offs

- Despite making this module lazy-load, it will still add an extra 800kb of dependencies to the codebase.
- The model (700kb) is loaded from the CDN, resulting in slow loading times initially.

<img width="1109" alt="Screenshot 2024-03-05 at 05 22 58" src="https://github.com/toeverything/blocksuite/assets/18554747/204cf4e9-a22b-4157-97d2-9fbf5213647c">

## Size Report

### Bundles

| Entry          | Size                 | Gzip                  | Brotli                 |
| -------------- | -------------------- | --------------------- | ---------------------- |
| examples/basic | 14 MB (**+46.4 kB**) | 2.9 MB (**+10.7 kB**) | 1.79 MB (**+5.63 kB**) |


### Packages

| Name   | Size                 | Gzip                  | Brotli                |
| ------ | -------------------- | --------------------- | --------------------- |
| blocks | 2.2 MB (**+5.8 kB**) | 513 kB (**+2.01 kB**) | 374 kB (**+1.14 kB**) |
| editor | 84 B                 | 89 B                  | 63 B                  |
| store  | 83 B                 | 88 B                  | 63 B                  |
| inline | 84 B                 | 88 B                  | 63 B                  |