### PR TITLE
fix(page): skip adding reference node when importing notion zip

### DIFF
--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -135,9 +135,6 @@ export const getMenus: (ctx: {
                 editorHost,
                 `Successfully imported ${options.importedCount} Doc${options.importedCount > 1 ? 's' : ''}.`
               );
-              if (options.importedCount === 0) {
-                return;
-              }
               for (const docId of docIds) {
                 insertLinkedNode({
                   editorHost,

--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -125,14 +125,17 @@ export const getMenus: (ctx: {
           name: 'Import',
           icon: ImportIcon,
           action: () => {
-            const onSuccess = (docIds: string[]) => {
+            const onSuccess = (
+              docIds: string[],
+              options: {
+                importedCount: number;
+              }
+            ) => {
               toast(
                 editorHost,
-                `Successfully imported ${docIds.length} Doc${
-                  docIds.length > 1 ? 's' : ''
-                }.`
+                `Successfully imported ${options.importedCount} Doc${options.importedCount > 1 ? 's' : ''}.`
               );
-              if (docIds.length === 0) {
+              if (options.importedCount === 0) {
                 return;
               }
               for (const docId of docIds) {

--- a/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
@@ -23,7 +23,7 @@ import { styles } from './styles.js';
 
 export type OnSuccessHandler = (
   pageIds: string[],
-  isWorkspaceFile: boolean
+  options: { isWorkspaceFile: boolean; importedCount: number }
 ) => void;
 
 export type OnFailHandler = (message: string) => void;
@@ -199,8 +199,18 @@ export class ImportDoc extends WithDisposable(LitElement) {
     this.abortController.abort();
   }
 
-  private _onImportSuccess(pageIds: string[], isWorkspaceFile = false) {
-    this.onSuccess?.(pageIds, isWorkspaceFile);
+  private _onImportSuccess(
+    pageIds: string[],
+    options: { isWorkspaceFile?: boolean; importedCount?: number } = {}
+  ) {
+    const {
+      isWorkspaceFile = false,
+      importedCount: pagesImportedCount = pageIds.length,
+    } = options;
+    this.onSuccess?.(pageIds, {
+      isWorkspaceFile,
+      importedCount: pagesImportedCount,
+    });
   }
 
   private _onFail(message: string) {
@@ -281,7 +291,10 @@ export class ImportDoc extends WithDisposable(LitElement) {
       );
       return;
     }
-    this._onImportSuccess(pageIds, isWorkspaceFile);
+    this._onImportSuccess([pageIds[0]], {
+      isWorkspaceFile,
+      importedCount: pageIds.length,
+    });
   }
 
   private _openLearnImportLink(event: MouseEvent) {


### PR DESCRIPTION
This commit will break AFFiNE as `showImportModal` is referenced in AFFiNE.
```diff
export type OnSuccessHandler = (
  pageIds: string[],
-  isWorkspaceFile: boolean
+  options: { isWorkspaceFile: boolean; importedCount: number }
) => void;
```
A fix will be introduced to AFFiNE later.