### PR TITLE
test: add test for legacy template

### DIFF
--- a/packages/blocks/src/surface-block/surface-model.ts
+++ b/packages/blocks/src/surface-block/surface-model.ts
@@ -63,11 +63,11 @@ const migration = {
           const target = element.get('target');
           const sourceId = source['id'];
           const targetId = target['id'];
-          if (!source['position'] && (!sourceId || !value.get(sourceId))) {
+          if (!source['position'] && !sourceId) {
             value.delete(key);
             return;
           }
-          if (!target['position'] && (!targetId || !value.get(targetId))) {
+          if (!target['position'] && !targetId) {
             value.delete(key);
             return;
           }

--- a/packages/presets/src/__tests__/main/snapshot.spec.ts
+++ b/packages/presets/src/__tests__/main/snapshot.spec.ts
@@ -1,0 +1,101 @@
+import type { SurfaceBlockModel } from '@blocksuite/blocks';
+import { beforeEach, expect, test } from 'vitest';
+
+import { wait } from '../utils/common.js';
+import { setupEditor } from '../utils/setup.js';
+
+beforeEach(async () => {
+  const cleanup = await setupEditor('page');
+
+  return cleanup;
+});
+
+const xywhPattern = /\[(\s*\d(\.\d)?\s*,){4}(\s*\d(\.\d)?\s*)\]/;
+
+test('snapshot 1 importing', async () => {
+  const pageService = window.editor.host.std.spec.getService('affine:page');
+  const transformer = pageService.transformers.zip;
+
+  const snapshotFile = await fetch(
+    'https://test.affineassets.com/test-snapshot-1.zip'
+  )
+    .then(res => res.blob())
+    .catch(e => {
+      console.error(e);
+      throw e;
+    });
+  const [newDoc] = await transformer.importDocs(
+    window.editor.doc.workspace,
+    snapshotFile
+  );
+
+  editor.doc = newDoc;
+  await wait();
+
+  const surface = newDoc.getBlockByFlavour(
+    'affine:surface'
+  )[0] as SurfaceBlockModel;
+  const surfaceElements = [...surface['_elementModels']].map(
+    ([_, { model }]) => model
+  );
+
+  expect(surfaceElements.length).toBe(25);
+
+  surfaceElements.forEach(element => {
+    for (const field in element) {
+      const value = element[field as keyof typeof element];
+
+      if (field === 'xywh') {
+        expect(value).toMatch(xywhPattern);
+      }
+
+      expect(value).not.toBeUndefined();
+      expect(value).not.toBeNull();
+      expect(value).not.toBeNaN();
+    }
+  });
+});
+
+test('snapshot 2 importing', async () => {
+  const pageService = window.editor.host.std.spec.getService('affine:page');
+  const transformer = pageService.transformers.zip;
+
+  const snapshotFile = await fetch(
+    'https://test.affineassets.com/test-snapshot-2%20(onboarding).zip'
+  )
+    .then(res => res.blob())
+    .catch(e => {
+      console.error(e);
+      throw e;
+    });
+  const [newDoc] = await transformer.importDocs(
+    window.editor.doc.workspace,
+    snapshotFile
+  );
+
+  editor.doc = newDoc;
+  await wait();
+
+  const surface = newDoc.getBlockByFlavour(
+    'affine:surface'
+  )[0] as SurfaceBlockModel;
+  const surfaceElements = [...surface['_elementModels']].map(
+    ([_, { model }]) => model
+  );
+
+  expect(surfaceElements.length).toBe(174);
+
+  surfaceElements.forEach(element => {
+    for (const field in element) {
+      const value = element[field as keyof typeof element];
+
+      if (field === 'xywh') {
+        expect(value).toMatch(xywhPattern);
+      }
+
+      expect(value).not.toBeUndefined();
+      expect(value).not.toBeNull();
+      expect(value).not.toBeNaN();
+    }
+  });
+});


### PR DESCRIPTION
I uploaded two onboarding template snapshots from AFFiNE and used them as a legacy template rendering test. The test checks the properties of every surface element to ensure they are not nullish values. Additionally, the xywh property should match the correct pattern, and the counts of surface elements should also match the snapshot JSON. And, of course, there should be no error during the render process.