### PR TITLE
fix(page): image not found after import notion file

### DIFF
--- a/packages/blocks/src/_common/adapters/notion-html.ts
+++ b/packages/blocks/src/_common/adapters/notion-html.ts
@@ -584,7 +584,11 @@ export class NotionHtmlAdapter extends BaseAdapter<NotionHtml> {
                 }
               });
             } else {
-              const res = await fetch(imageURL);
+              const res = await fetchImage(
+                imageURL,
+                undefined,
+                this.configs.get('imageProxy') as string
+              );
               const clonedRes = res.clone();
               const name =
                 getFilenameFromContentDisposition(

--- a/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/import-doc/import-doc.ts
@@ -121,6 +121,7 @@ export async function importNotion(workspace: Workspace, file: File) {
         file: await zipFile.files[file].async('text'),
         pageId: pageMap.get(file),
         pageMap,
+        assets: job.assetsManager,
       });
       const page = await job.snapshotToDoc(snapshot);
       pageIds.push(page.id);


### PR DESCRIPTION
Fix [#6038](https://github.com/toeverything/AFFiNE/issues/6038)

Add assets to store images and add image proxy worker to avoid CORS.