### PR TITLE
fix(blocks): use requestAnimationFrame to update selection

### DIFF
--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -309,7 +309,7 @@ export class KeymapController implements ReactiveController {
           to: null,
         });
 
-        selection.setGroup('note', [sel]);
+        requestAnimationFrame(() => selection.setGroup('note', [sel]));
 
         return next();
       })


### PR DESCRIPTION
Closes #6411 
CC @Flrande 

The `page-image-block` also uses this wrapper.
https://github.com/toeverything/blocksuite/blob/047acfd2cb4e2305fba524be47ea67555ed1224e/packages/blocks/src/image-block/components/page-image-block.ts#L103-L118