### PR TITLE
perf(edgeless): filter icons in line-width-panel

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/line-width-panel.ts
@@ -38,7 +38,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
 
     .line-width-panel {
       display: flex;
-      flex-direction: row-reverse;
+      flex-direction: row;
       align-items: center;
       justify-content: space-between;
       position: relative;
@@ -174,20 +174,21 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
     }
     const dragHandleRect = this._dragHandle.getBoundingClientRect();
     const dragHandleCenterX = dragHandleRect.left + dragHandleRect.width / 2;
-    const icons = Array.from(this._lineWidthIcons);
-
     // All the icons located at the left of the drag handle should be filled with the icon color.
-    const leftIcons = icons.filter(icon => {
-      const iconRect = icon.getBoundingClientRect();
-      const iconCenterX = iconRect.left + iconRect.width / 2;
-      return iconCenterX < dragHandleCenterX;
-    });
+    const leftIcons = [];
     // All the icons located at the right of the drag handle should be filled with the border color.
-    const rightIcons = icons.filter(icon => {
-      const iconRect = icon.getBoundingClientRect();
-      const iconCenterX = iconRect.left + iconRect.width / 2;
-      return iconCenterX > dragHandleCenterX;
-    });
+    const rightIcons = [];
+
+    for (const icon of this._lineWidthIcons) {
+      const { left, width } = icon.getBoundingClientRect();
+      const centerX = left + width / 2;
+      if (centerX < dragHandleCenterX) {
+        leftIcons.push(icon);
+      } else {
+        rightIcons.push(icon);
+      }
+    }
+
     leftIcons.forEach(
       icon => (icon.style.backgroundColor = 'var(--affine-icon-color)')
     );
@@ -316,7 +317,7 @@ export class EdgelessLineWidthPanel extends WithDisposable(LitElement) {
   }
 
   override render() {
-    return html` <style>
+    return html`<style>
         .line-width-panel {
           opacity: ${this.disable ? '0.5' : '1'};
         }

--- a/tests/edgeless/brush.spec.ts
+++ b/tests/edgeless/brush.spec.ts
@@ -164,36 +164,30 @@ test('change brush element size by component-toolbar', async ({ page }) => {
   // change to line width 12
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 6);
-
-  await assertEdgelessSelectedRect(page, [99, 99, 102, 102]);
+  await assertEdgelessSelectedRect(page, [94, 94, 112, 112]);
 
   // change to line width 10
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 5);
-
-  await assertEdgelessSelectedRect(page, [98, 98, 104, 104]);
+  await assertEdgelessSelectedRect(page, [95, 95, 110, 110]);
 
   // change to line width 8
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 4);
-
-  await assertEdgelessSelectedRect(page, [97, 97, 106, 106]);
+  await assertEdgelessSelectedRect(page, [96, 96, 108, 108]);
 
   // change to line width 6
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 3);
-
-  await assertEdgelessSelectedRect(page, [96, 96, 108, 108]);
+  await assertEdgelessSelectedRect(page, [97, 97, 106, 106]);
 
   // change to line width 4
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 2);
-
-  await assertEdgelessSelectedRect(page, [95, 95, 110, 110]);
+  await assertEdgelessSelectedRect(page, [98, 98, 104, 104]);
 
   // change to line width 2
   await page.mouse.click(110, 110);
   await updateExistedBrushElementSize(page, 1);
-
-  await assertEdgelessSelectedRect(page, [94, 94, 112, 112]);
+  await assertEdgelessSelectedRect(page, [99, 99, 102, 102]);
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -483,12 +483,12 @@ export async function selectBrushColor(page: Page, color: CssVariableName) {
 
 export async function selectBrushSize(page: Page, size: string) {
   const sizeIndexMap: { [key: string]: number } = {
-    two: 6,
-    four: 5,
-    six: 4,
-    eight: 3,
-    ten: 2,
-    twelve: 1,
+    two: 1,
+    four: 2,
+    six: 3,
+    eight: 4,
+    ten: 5,
+    twelve: 6,
   };
   const sizeButton = page.locator(
     `edgeless-brush-menu .line-width-panel .line-width-button:nth-child(${sizeIndexMap[size]})`


### PR DESCRIPTION
1. `flex-direction` does not need to be `row-reverse`
2. filter icons in a single loop