### PR TITLE
fix: select all in page mode

### DIFF
--- a/packages/blocks/src/root-block/page/page-root-block.ts
+++ b/packages/blocks/src/root-block/page/page-root-block.ts
@@ -225,6 +225,28 @@ export class PageRootBlockComponent extends BlockElement<
     this.keyboardManager = new PageKeyboardManager(this);
 
     this.bindHotKey({
+      'Mod-a': () => {
+        const blocks = this.model.children
+          .filter(model => {
+            if (matchFlavours(model, ['affine:note'])) {
+              const note = model as NoteBlockModel;
+              if (note.displayMode === NoteDisplayMode.EdgelessOnly)
+                return false;
+
+              return true;
+            }
+            return false;
+          })
+          .flatMap(model => {
+            return model.children.map(child => {
+              return this.std.selection.create('block', {
+                path: [this.model.id, model.id, child.id],
+              });
+            });
+          });
+        this.std.selection.setGroup('note', blocks);
+        return true;
+      },
       ArrowUp: () => {
         const view = this.host.view;
         const selection = this.host.selection;

--- a/tests/selection/block.spec.ts
+++ b/tests/selection/block.spec.ts
@@ -16,6 +16,7 @@ import {
   getRichTextBoundingBox,
   initEmptyParagraphState,
   initImageState,
+  initMultipleNoteWithParagraphState,
   initParagraphsByCount,
   initThreeLists,
   initThreeParagraphs,
@@ -127,6 +128,24 @@ test('select all and delete by forwardDelete', async ({ page }) => {
   await focusRichText(page, 0);
   await type(page, 'abc');
   await assertRichTexts(page, ['abc']);
+});
+
+test('select all should work for multiple notes in doc mode', async ({
+  page,
+}) => {
+  const n = 4;
+  await enterPlaygroundRoom(page);
+  await initMultipleNoteWithParagraphState(page, undefined, n);
+
+  await focusRichText(page, 0);
+  await type(page, '123');
+  await focusRichText(page, 1);
+  await type(page, '456');
+  await selectAllByKeyboard(page);
+  await selectAllByKeyboard(page);
+  await selectAllByKeyboard(page);
+  const rects = page.locator('affine-block-selection').locator('visible=true');
+  await expect(rects).toHaveCount(n);
 });
 
 async function clickListIcon(page: Page, i = 0) {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -410,6 +410,39 @@ export async function initEmptyParagraphState(page: Page, rootId?: string) {
   return ids;
 }
 
+export async function initMultipleNoteWithParagraphState(
+  page: Page,
+  rootId?: string,
+  count = 2
+) {
+  const ids = await page.evaluate(
+    ({ rootId, count }) => {
+      const { doc } = window;
+      doc.captureSync();
+      if (!rootId) {
+        rootId = doc.addBlock('affine:page', {
+          title: new doc.Text(),
+        });
+      }
+
+      const ids = Array.from({ length: count })
+        .fill(0)
+        .map(() => {
+          const noteId = doc.addBlock('affine:note', {}, rootId);
+          const paragraphId = doc.addBlock('affine:paragraph', {}, noteId);
+          return { noteId, paragraphId };
+        });
+
+      // doc.addBlock('affine:surface', {}, rootId);
+      doc.captureSync();
+
+      return { rootId, ids };
+    },
+    { rootId, count }
+  );
+  return ids;
+}
+
 export async function initEmptyEdgelessState(page: Page) {
   const ids = await page.evaluate(() => {
     const { doc } = window;


### PR DESCRIPTION
Closes: [BS-55](https://linear.app/affine-design/issue/BS-55/note-分割后，全选功能在文档模式下也只对-page-note-生效了)