### PR TITLE
fix(edgeless): size panel width

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/panel/size-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/size-panel.ts
@@ -27,14 +27,14 @@ export class EdgelessSizePanel extends LitElement {
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      width: 64px;
+      width: 70px;
     }
 
     .size-button {
       display: flex;
       align-items: center;
       justify-content: start;
-      width: 64px;
+      width: 100%;
       height: 32px;
       padding: 0 8px;
     }
@@ -47,7 +47,7 @@ export class EdgelessSizePanel extends LitElement {
       text-align: justify;
       font-size: 15px;
       font-style: normal;
-      width: 48px;
+      width: 56px;
       height: 24px;
       font-weight: 400;
       line-height: 24px;
@@ -68,7 +68,7 @@ export class EdgelessSizePanel extends LitElement {
     }
 
     .size-input {
-      width: 48px;
+      width: 56px;
       height: 18px;
       border: 1px solid var(--affine-border-color);
       border-radius: 8px;


### PR DESCRIPTION
### Before
<img width="106" alt="Screenshot 2024-03-13 at 02 13 30" src="https://github.com/toeverything/blocksuite/assets/27926/79eacde3-f869-45a6-b414-a5d07232b390">


### After
<img width="102" alt="Screenshot 2024-03-13 at 02 12 34" src="https://github.com/toeverything/blocksuite/assets/27926/af045a14-61d9-4df5-a131-fb09afea463a">
