### PR TITLE
fix: add missing slot in edgeless service

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -62,7 +62,6 @@ export class EdgelessRootService extends RootService {
       blocks: TopLevelBlockModel[];
       shapes: CanvasElement[];
     }>(),
-    docLinkClicked: new Slot<{ docId: string; blockId?: string }>(),
     readonlyUpdated: new Slot<boolean>(),
     draggingAreaUpdated: new Slot(),
     navigatorSettingUpdated: new Slot<{
@@ -76,6 +75,12 @@ export class EdgelessRootService extends RootService {
     elementResizeStart: new Slot(),
     elementResizeEnd: new Slot(),
     toggleNoteSlicer: new Slot(),
+
+    docLinkClicked: new Slot<{
+      docId: string;
+      blockId?: string;
+    }>(),
+    tagClicked: new Slot<{ tagId: string }>(),
     editorModeSwitch: new Slot<'edgeless' | 'page'>(),
   };
 


### PR DESCRIPTION
The tagClicked slot is missing on the edgeless page service. An error is thrown when trying to listen to that slot in AFFiNE.

![image](https://github.com/toeverything/blocksuite/assets/9301743/bee10f0b-8089-4f4a-ab5e-0613cff1954a)
