### PR TITLE
fix: check disposable if exists

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -223,9 +223,11 @@ export class EdgelessRootBlockComponent extends BlockElement<
   private _initSlotEffects() {
     const { disposables, slots } = this;
 
-    disposables.add(listenToThemeChange(this, () => this.surface.refresh())!);
+    const disposable = listenToThemeChange(this, () => this.surface.refresh());
+    if (disposable) {
+      disposables.add(disposable);
+    }
 
-    disposables.add(this.tools);
     disposables.add(this.service.selection);
     disposables.add(
       slots.edgelessToolUpdated.on(tool => (this.edgelessTool = tool))


### PR DESCRIPTION
When editor unmonted, the return value of `listenToThemeChange` is undefined.

<img width="696" alt="image" src="https://github.com/toeverything/blocksuite/assets/58546692/66d825fe-833f-4237-860a-8209fd3832bb">
