### PR TITLE
fix: jumping to edgeless-editor by "View in Edgeless" in the default demo

### DIFF
--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -1,3 +1,4 @@
+import type { PageRootService } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import type { EditorHost } from '@blocksuite/lit';
 import { AffineEditorContainer } from '@blocksuite/presets';
@@ -24,8 +25,44 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   const specs = getExampleSpecs();
 
   const editor = new AffineEditorContainer();
-  editor.pageSpecs = specs.pageModeSpecs;
-  editor.edgelessSpecs = specs.edgelessModeSpecs;
+  editor.pageSpecs = [...specs.pageModeSpecs].map(spec => {
+    if (spec.schema.model.flavour === 'affine:page') {
+      const setup = spec.setup;
+      spec = {
+        ...spec,
+        setup: (slots, disposable) => {
+          setup?.(slots, disposable);
+          slots.mounted.once(({ service }) => {
+            disposable.add(
+              (<PageRootService>service).slots.editorModeSwitch.on(
+                switchQuickEdgelessMenu
+              )
+            );
+          });
+        },
+      };
+    }
+    return spec;
+  });
+  editor.edgelessSpecs = [...specs.edgelessModeSpecs].map(spec => {
+    if (spec.schema.model.flavour === 'affine:page') {
+      const setup = spec.setup;
+      spec = {
+        ...spec,
+        setup: (slots, disposable) => {
+          setup?.(slots, disposable);
+          slots.mounted.once(({ service }) => {
+            disposable.add(
+              (<PageRootService>service).slots.editorModeSwitch.on(
+                switchQuickEdgelessMenu
+              )
+            );
+          });
+        },
+      };
+    }
+    return spec;
+  });
   editor.doc = doc;
   editor.slots.docLinkClicked.on(({ docId }) => {
     const target = collection.getDoc(docId);
@@ -50,6 +87,10 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   quickEdgelessMenu.mode = defaultMode;
   quickEdgelessMenu.leftSidePanel = leftSidePanel;
   quickEdgelessMenu.docsPanel = docsPanel;
+
+  function switchQuickEdgelessMenu(mode: typeof defaultMode) {
+    quickEdgelessMenu.mode = mode;
+  }
 
   document.body.append(leftSidePanel);
   document.body.append(quickEdgelessMenu);

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -1,4 +1,3 @@
-import type { PageRootService } from '@blocksuite/blocks';
 import {
   AffineFormatBarWidget,
   EdgelessEditorBlockSpecs,
@@ -60,14 +59,6 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
           });
 
           disposable.add(onFormatBarConnected);
-
-          slots.mounted.once(({ service }) => {
-            disposable.add(
-              (<PageRootService>service).slots.editorModeSwitch.on(mode => {
-                editor.mode = mode;
-              })
-            );
-          });
         },
       };
     }
@@ -78,7 +69,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
       spec = {
         ...spec,
         setup: (slots, disposable) => {
-          slots.mounted.once(({ service }) => {
+          slots.mounted.once(() => {
             const onFormatBarConnected = slots.widgetConnected.on(view => {
               if (view.component instanceof AffineFormatBarWidget) {
                 configureFormatBar(view.component);
@@ -86,11 +77,6 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
             });
 
             disposable.add(onFormatBarConnected);
-            disposable.add(
-              (<PageRootService>service).slots.editorModeSwitch.on(mode => {
-                editor.mode = mode;
-              })
-            );
           });
         },
       };


### PR DESCRIPTION
The default demo's 'View in Edgeless' did not work because of two reasons:
1. The editorContainer's "mode" property lacked reactive to editorModeSwitch's emit.
2. The top-right quickEdgelessMenu's "mode" property lacked reactive to editorModeSwitch's emit. (for back to page mode)

So I fill in these two lacks.

Besides, "editorContainer's mode property's reactivity to mode change in PageRootService" is an inherent behavoir with regard to the stable PageRootService, so I move this realization into the EditorContainer class to avoid redundant outer configs.


before(default demo):

https://github.com/toeverything/blocksuite/assets/6285483/0f1526c3-80e5-41a0-a2ca-8ee5b1883437

after(default demo):

https://github.com/toeverything/blocksuite/assets/6285483/087ffc19-0c5b-4c50-8623-55e0c22b1c84


after(starter demo):

https://github.com/toeverything/blocksuite/assets/6285483/5910e455-8ecc-43af-91a9-98e360d99e31

