### PR TITLE
fix: only display hostname in bookmark

### DIFF
--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -47,6 +47,15 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
     this.bookmark.open();
   }
 
+  private _getHostName(url: string) {
+    try {
+      return new URL(url).hostname;
+    } catch (e) {
+      console.error(e);
+      return url;
+    }
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
 
@@ -140,7 +149,7 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
             ${descriptionText}
           </div>
           <div class="affine-bookmark-content-url" @click=${this.bookmark.open}>
-            <span>${url}</span>
+            <span>${this._getHostName(url)}</span>
             <div class="affine-bookmark-content-url-icon">${OpenIcon}</div>
           </div>
         </div>


### PR DESCRIPTION
<img width="864" alt="Screenshot 2024-03-18 at 15 09 26" src="https://github.com/toeverything/blocksuite/assets/99816898/0ba9b918-60eb-420f-b776-9123c8b31e90">
