### PR TITLE
feat: move embed reload button

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -2,9 +2,13 @@ import './../button.js';
 
 import { WithDisposable } from '@blocksuite/lit';
 import { Slice } from '@blocksuite/store';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import {
+  isEmbedLinkedDocBlock,
+  isEmbedSyncedDocBlock,
+} from '../../../root-block/edgeless/utils/query.js';
 import {
   CopyIcon,
   DeleteIcon,
@@ -153,16 +157,19 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
             ${DuplicateIcon}
           </icon-button>
 
-          <icon-button
-            width="126px"
-            height="32px"
-            class="menu-item reload"
-            text="Reload"
-            ?disabled=${this._doc.readonly}
-            @click=${() => this._refreshData()}
-          >
-            ${RefreshIcon}
-          </icon-button>
+          ${isEmbedLinkedDocBlock(this._model) ||
+          isEmbedSyncedDocBlock(this._model)
+            ? nothing
+            : html`<icon-button
+                width="126px"
+                height="32px"
+                class="menu-item reload"
+                text="Reload"
+                ?disabled=${this._doc.readonly}
+                @click=${() => this._refreshData()}
+              >
+                ${RefreshIcon}
+              </icon-button>`}
 
           <div class="divider"></div>
 

--- a/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-toolbar.ts
@@ -43,7 +43,6 @@ import {
   LinkIcon,
   OpenIcon,
   PaletteIcon,
-  RefreshIcon,
 } from '../../icons/text.js';
 import { createLitPortal } from '../portal.js';
 import { toast } from '../toast.js';
@@ -420,11 +419,6 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
     this.abortController.abort();
   }
 
-  private _refreshData() {
-    this.block.refreshData();
-    this.abortController.abort();
-  }
-
   private _toggleCardStyleMenu() {
     if (this._moreMenuAbortController) {
       this._moreMenuAbortController.abort();
@@ -616,18 +610,6 @@ export class EmbedCardToolbar extends WithDisposable(LitElement) {
         >
           ${CaptionIcon}
           <affine-tooltip .offset=${12}>${'Add Caption'}</affine-tooltip>
-        </icon-button>
-
-        <div class="divider"></div>
-
-        <icon-button
-          size="32px"
-          class="embed-card-toolbar-button reload"
-          ?disabled=${model.doc.readonly}
-          @click=${() => this._refreshData()}
-        >
-          ${RefreshIcon}
-          <affine-tooltip .offset=${12}>${'Reload'}</affine-tooltip>
         </icon-button>
 
         <div class="divider"></div>

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-attachment-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-attachment-button.ts
@@ -148,6 +148,7 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
         <div class="change-attachment-button card-style">
           <edgeless-tool-icon-button
             .tooltip=${this._showPopper ? '' : 'Card style'}
+            .iconContainerPadding=${2}
             ?disabled=${this._doc.readonly}
             @click=${() => this._cardStylePopper?.toggle()}
           >
@@ -168,6 +169,7 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           .tooltip=${'Add Caption'}
+          .iconContainerPadding=${2}
           class="change-attachment-button caption"
           ?disabled=${this._doc.readonly}
           @click=${() => this._showCaption()}

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-attachment-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-attachment-button.ts
@@ -12,11 +12,7 @@ import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
 } from '../../../../_common/consts.js';
-import {
-  CaptionIcon,
-  PaletteIcon,
-  RefreshIcon,
-} from '../../../../_common/icons/text.js';
+import { CaptionIcon, PaletteIcon } from '../../../../_common/icons/text.js';
 import type { EmbedCardStyle } from '../../../../_common/types.js';
 import { getEmbedCardIcons } from '../../../../_common/utils/url.js';
 import type {
@@ -123,10 +119,6 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
     this._blockElement?.captionElement.show();
   }
 
-  private _refreshData() {
-    this._blockElement?.refreshData();
-  }
-
   private _setCardStyle(style: EmbedCardStyle) {
     const bounds = Bound.deserialize(this.model.xywh);
     bounds.w = EMBED_CARD_WIDTH[style];
@@ -181,19 +173,6 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
           @click=${() => this._showCaption()}
         >
           ${CaptionIcon}
-        </edgeless-tool-icon-button>
-
-        <component-toolbar-menu-divider
-          .vertical=${true}
-        ></component-toolbar-menu-divider>
-
-        <edgeless-tool-icon-button
-          .tooltip=${'Reload'}
-          class="change-attachment-button reload"
-          ?disabled=${this._doc.readonly}
-          @click=${() => this._refreshData()}
-        >
-          ${RefreshIcon}
         </edgeless-tool-icon-button>
       </div>
     `;

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
@@ -38,7 +38,6 @@ import {
   ExpandFullIcon,
   OpenIcon,
   PaletteIcon,
-  RefreshIcon,
 } from '../../../../_common/icons/text.js';
 import type { EmbedCardStyle } from '../../../../_common/types.js';
 import { getEmbedCardIcons } from '../../../../_common/utils/url.js';
@@ -772,19 +771,6 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               ></edgeless-scale-panel>
             `
           : nothing}
-
-        <component-toolbar-menu-divider
-          .vertical=${true}
-        ></component-toolbar-menu-divider>
-
-        <edgeless-tool-icon-button
-          .tooltip=${'Reload'}
-          class="change-embed-card-button reload"
-          ?disabled=${this._doc.readonly}
-          @click=${this._refreshData}
-        >
-          ${RefreshIcon}
-        </edgeless-tool-icon-button>
       </div>
     `;
   }

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
@@ -610,6 +610,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
               <edgeless-tool-icon-button
                 .tooltip=${'Click to copy link'}
+                .iconContainerPadding=${2}
                 class="change-embed-card-button copy"
                 ?disabled=${this._doc.readonly}
                 @click=${this._copyUrl}
@@ -619,6 +620,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
               <edgeless-tool-icon-button
                 .tooltip=${'Edit'}
+                .iconContainerPadding=${2}
                 class="change-embed-card-button edit"
                 ?disabled=${this._doc.readonly}
                 @click=${() =>
@@ -643,6 +645,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               </div>
               <edgeless-tool-icon-button
                 .tooltip=${'Open'}
+                .iconContainerPadding=${2}
                 class="change-embed-card-button open"
                 @click=${this._open}
               >
@@ -658,6 +661,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
           ? html`
               <edgeless-tool-icon-button
                 .tooltip=${'Full screen'}
+                .iconContainerPadding=${2}
                 class="change-embed-card-button expand"
                 @click=${this._open}
               >
@@ -711,6 +715,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               <div class="change-embed-card-button card-style">
                 <edgeless-tool-icon-button
                   .tooltip=${this._showPopper ? '' : 'Card style'}
+                  .iconContainerPadding=${2}
                   ?disabled=${this._doc.readonly}
                   @click=${() => this._cardStylePopper?.toggle()}
                 >
@@ -734,6 +739,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           .tooltip=${'Add Caption'}
+          .iconContainerPadding=${2}
           class="change-embed-card-button caption"
           ?disabled=${this._doc.readonly}
           @click=${this._showCaption}

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-embed-card-button.ts
@@ -440,10 +440,6 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     this._blockElement?.captionElement?.show();
   }
 
-  private _refreshData() {
-    this._blockElement?.refreshData();
-  }
-
   private _copyUrl() {
     if (!('url' in this.model)) {
       return;

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-image-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-image-button.ts
@@ -7,7 +7,7 @@ import { WithDisposable } from '@blocksuite/lit';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { CaptionIcon, RefreshIcon } from '../../../../_common/icons/text.js';
+import { CaptionIcon } from '../../../../_common/icons/text.js';
 import type { ImageBlockComponent } from '../../../../image-block/image-block.js';
 import type { ImageBlockModel } from '../../../../image-block/image-model.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
@@ -70,10 +70,6 @@ export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
     this._blockElement?.captionElement.show();
   }
 
-  private _refreshData() {
-    this._blockElement?.refreshData();
-  }
-
   override render() {
     return html`
       <div class="change-image-container">
@@ -84,19 +80,6 @@ export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
           @click=${() => this._showCaption()}
         >
           ${CaptionIcon}
-        </edgeless-tool-icon-button>
-
-        <component-toolbar-menu-divider
-          .vertical=${true}
-        ></component-toolbar-menu-divider>
-
-        <edgeless-tool-icon-button
-          .tooltip=${'Reload'}
-          class="change-image-button reload"
-          ?disabled=${this._doc.readonly}
-          @click=${() => this._refreshData()}
-        >
-          ${RefreshIcon}
         </edgeless-tool-icon-button>
       </div>
     `;

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/more-button.ts
@@ -2,7 +2,9 @@ import '../buttons/tool-icon-button.js';
 import '../toolbar/shape/shape-menu.js';
 import '../../../../_common/components/menu-divider.js';
 
+import type { SurfaceSelection } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/lit';
+import type { BlockModel } from '@blocksuite/store';
 import { baseTheme } from '@toeverything/theme';
 import { css, html, LitElement, type TemplateResult, unsafeCSS } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -19,17 +21,45 @@ import {
   MoreDuplicateIcon,
   MoreHorizontalIcon,
   MoreVerticalIcon,
+  RefreshIcon,
   SendBackwardIcon,
   SendToBackIcon,
 } from '../../../../_common/icons/index.js';
 import { type ReorderingType } from '../../../../_common/utils/index.js';
+import type {
+  AttachmentBlockComponent,
+  BookmarkBlockComponent,
+  EmbedFigmaBlockComponent,
+  EmbedGithubBlockComponent,
+  EmbedLoomBlockComponent,
+  EmbedYoutubeBlockComponent,
+  ImageBlockComponent,
+} from '../../../../index.js';
 import { Bound } from '../../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import { removeContainedFrames } from '../../frame-manager.js';
 import { duplicate, splitElements } from '../../utils/clipboard-utils.js';
 import { deleteElements } from '../../utils/crud.js';
-import { isFrameBlock } from '../../utils/query.js';
+import {
+  isAttachmentBlock,
+  isBookmarkBlock,
+  isEmbeddedLinkBlock,
+  isFrameBlock,
+  isImageBlock,
+} from '../../utils/query.js';
 import { createButtonPopper } from '../utils.js';
+
+type EmbedLinkBlockComponent =
+  | EmbedGithubBlockComponent
+  | EmbedFigmaBlockComponent
+  | EmbedLoomBlockComponent
+  | EmbedYoutubeBlockComponent;
+
+type RefreshableBlockComponent =
+  | EmbedLinkBlockComponent
+  | ImageBlockComponent
+  | AttachmentBlockComponent
+  | BookmarkBlockComponent;
 
 type Action =
   | {
@@ -42,6 +72,7 @@ type Action =
         | 'create-group'
         | 'copy'
         | 'duplicate'
+        | 'reload'
         | ReorderingType;
       disabled?: boolean;
     }
@@ -49,31 +80,44 @@ type Action =
       type: 'divider';
     };
 
-const ACTIONS: Action[] = [
-  { icon: FrameIcon, name: 'Frame Section', type: 'create-frame' },
-  { icon: GroupIcon, name: 'Group Section', type: 'create-group' },
-  { type: 'divider' },
+const REORDER_ACTIONS: Action[] = [
   { icon: BringToFrontIcon, name: 'Bring to Front', type: 'front' },
   { icon: BringForwardIcon, name: 'Bring Forward', type: 'forward' },
   { icon: SendBackwardIcon, name: 'Send Backward', type: 'backward' },
   { icon: SendToBackIcon, name: 'Send to Back', type: 'back' },
-  { type: 'divider' },
-  { icon: MoreCopyIcon, name: 'Copy', type: 'copy' },
-  { icon: CopyAsPngIcon, name: 'Copy as PNG', type: 'copy-as-png' },
-  { icon: MoreDuplicateIcon, name: 'Duplicate', type: 'duplicate' },
-  { type: 'divider' },
-  { icon: MoreDeleteIcon, name: 'Delete', type: 'delete' },
 ];
 
-const FRAME_ACTIONS: Action[] = [
-  { icon: FrameIcon, name: 'Frame Section', type: 'create-frame' },
-  { type: 'divider' },
+const COPY_ACTIONS: Action[] = [
   { icon: MoreCopyIcon, name: 'Copy', type: 'copy' },
   { icon: CopyAsPngIcon, name: 'Copy as PNG', type: 'copy-as-png' },
   { icon: MoreDuplicateIcon, name: 'Duplicate', type: 'duplicate' },
-  { type: 'divider' },
-  { icon: MoreDeleteIcon, name: 'Delete', type: 'delete' },
 ];
+
+const DELETE_ACTION: Action = {
+  icon: MoreDeleteIcon,
+  name: 'Delete',
+  type: 'delete',
+};
+
+const FRAME_ACTION: Action = {
+  icon: FrameIcon,
+  name: 'Frame Section',
+  type: 'create-frame',
+};
+
+const GROUP_ACTION: Action = {
+  icon: GroupIcon,
+  name: 'Group Section',
+  type: 'create-group',
+};
+
+const RELOAD_ACTION: Action = {
+  icon: RefreshIcon,
+  name: 'Reload',
+  type: 'reload',
+};
+
+const ACTION_DIVIDER: Action = { type: 'divider' };
 
 function Actions(
   actions: Action[],
@@ -191,6 +235,40 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
   get surface() {
     return this.edgeless.surface;
   }
+
+  get view() {
+    return this.edgeless.host.view;
+  }
+
+  get _Actions(): Action[] {
+    const actions: Action[] = [
+      FRAME_ACTION,
+      GROUP_ACTION,
+      ACTION_DIVIDER,
+      ...REORDER_ACTIONS,
+      ACTION_DIVIDER,
+      ...COPY_ACTIONS,
+    ];
+    const refreshable = this.selection.elements.every(ele =>
+      this._refreshable(ele as BlockModel)
+    );
+    if (refreshable) {
+      actions.push(RELOAD_ACTION);
+    }
+    actions.push(ACTION_DIVIDER, DELETE_ACTION);
+    return actions;
+  }
+
+  get _FrameActions(): Action[] {
+    return [
+      FRAME_ACTION,
+      ACTION_DIVIDER,
+      ...COPY_ACTIONS,
+      ACTION_DIVIDER,
+      DELETE_ACTION,
+    ];
+  }
+
   private _delete() {
     this.doc.captureSync();
     deleteElements(this.surface, this.selection.elements);
@@ -198,6 +276,24 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     this.selection.set({
       elements: [],
       editing: false,
+    });
+  }
+
+  private _refreshable(ele: BlockModel) {
+    return (
+      isImageBlock(ele) ||
+      isBookmarkBlock(ele) ||
+      isAttachmentBlock(ele) ||
+      isEmbeddedLinkBlock(ele)
+    );
+  }
+
+  private _reload(selections: SurfaceSelection[]) {
+    selections.forEach(sel => {
+      const blockElement = this.view.viewFromPath('block', sel.path);
+      if (!!blockElement && this._refreshable(blockElement.model)) {
+        (blockElement as RefreshableBlockComponent).refreshData();
+      }
     });
   }
 
@@ -245,6 +341,9 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         });
         break;
       }
+      case 'reload':
+        this._reload(this.selection.selections);
+        break;
     }
     this._actionsMenuPopper?.hide();
   };
@@ -268,8 +367,8 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
 
     const actions = Actions(
       selection.elements.some(ele => isFrameBlock(ele))
-        ? FRAME_ACTIONS
-        : ACTIONS,
+        ? this._FrameActions
+        : this._Actions,
       this._runAction
     );
     return html`

--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/more-button.ts
@@ -269,7 +269,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     ];
   }
 
-  private _delete() {
+  private _delete = () => {
     this.doc.captureSync();
     deleteElements(this.surface, this.selection.elements);
 
@@ -277,7 +277,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       elements: [],
       editing: false,
     });
-  }
+  };
 
   private _refreshable(ele: BlockModel) {
     return (
@@ -288,14 +288,14 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     );
   }
 
-  private _reload(selections: SurfaceSelection[]) {
+  private _reload = (selections: SurfaceSelection[]) => {
     selections.forEach(sel => {
       const blockElement = this.view.viewFromPath('block', sel.path);
       if (!!blockElement && this._refreshable(blockElement.model)) {
         (blockElement as RefreshableBlockComponent).refreshData();
       }
     });
-  }
+  };
 
   private _runAction = async ({ type }: Action) => {
     const selection = this.edgeless.service.selection;

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -86,6 +86,16 @@ export function isEmbeddedBlock(
   );
 }
 
+export function isEmbeddedLinkBlock(
+  element: BlockModel | EdgelessModel | null
+) {
+  return (
+    isEmbeddedBlock(element) &&
+    !isEmbedSyncedDocBlock(element) &&
+    !isEmbedLinkedDocBlock(element)
+  );
+}
+
 export function isEmbedGithubBlock(
   element: BlockModel | EdgelessModel | null
 ): element is EmbedGithubModel {


### PR DESCRIPTION
[AFF-747](https://linear.app/affine-design/issue/AFF-747/remove-the-reload-button-of-toolbar-in-both-card-view-and-embed-view)

Remove synced/linked doc reload button.
Move embedded link blocks reload button to more button popup menu. 