### PR TITLE
fix(edgeless): copyAsPng on shape with rotation has cutoff edges

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -51,6 +51,7 @@ import { CanvasElementType } from '../../../surface-block/element-model/index.js
 import {
   type CanvasElement,
   type Connection,
+  getBoundsWithRotation,
   GroupElementModel,
 } from '../../../surface-block/index.js';
 import {
@@ -991,7 +992,7 @@ export class EdgelessClipboardController extends PageClipboard {
       bounds.push(Bound.deserialize(block.xywh));
     });
     shapes.forEach(shape => {
-      bounds.push(Bound.deserialize(shape.xywh));
+      bounds.push(getBoundsWithRotation(shape.elementBound));
     });
     const bound = getCommonBound(bounds);
     assertExists(bound, 'bound not exist');
@@ -1081,7 +1082,9 @@ export class EdgelessClipboardController extends PageClipboard {
     edgeless: EdgelessRootBlockComponent,
     bound: IBound,
     nodes?: TopLevelBlockModel[],
-    canvasElements: CanvasElement[] = []
+    canvasElements: CanvasElement[] = [],
+
+    withBackground = false
   ): Promise<HTMLCanvasElement | undefined> {
     const host = edgeless.host;
     const rootModel = this.doc.root;
@@ -1110,8 +1113,10 @@ export class EdgelessClipboardController extends PageClipboard {
     if (!ctx) return;
     ctx.scale(dpr, dpr);
 
-    ctx.fillStyle = window.getComputedStyle(container).backgroundColor;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    if (withBackground) {
+      ctx.fillStyle = window.getComputedStyle(container).backgroundColor;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
 
     const replaceImgSrcWithSvg = this._exportManager.replaceImgSrcWithSvg;
     const replaceRichTextWithSvgElementFunc =


### PR DESCRIPTION
# Fix
- Bounds of shapes copied should have rotation applied
- Background of copied image  should be transparent

# Before
![image](https://github.com/toeverything/blocksuite/assets/123532141/15dd6012-633d-428f-bfe1-fd67bf5d46a0)

# After
![image](https://github.com/toeverything/blocksuite/assets/123532141/cec62c26-93cb-4178-b356-bec79d4f584f)
