### PR TITLE
fix(blocks): redundant empty line in markdown list export

### DIFF
--- a/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
@@ -406,13 +406,9 @@ hhh
       ],
     };
     const markdown = `* aaa
-
   * bbb
-
     * ccc
-
   * ddd
-
 * eee
 `;
 
@@ -558,13 +554,9 @@ hhh
       ],
     };
     const markdown = `* [ ] aaa
-
   * [x] bbb
-
     * [ ] ccc
-
   - [x] ddd
-
 - [ ] eee
 `;
 
@@ -706,11 +698,8 @@ hhh
     };
 
     const markdown = `1. aaa
-
    1. bbb
-
    2. ccc
-
 2. ddd
 `;
 

--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -30,6 +30,7 @@ import type { Column } from '../../database-block/types.js';
 import { NoteDisplayMode } from '../types.js';
 import { getFilenameFromContentDisposition } from '../utils/header-value-parser.js';
 import { remarkGfm } from './gfm.js';
+import { join } from './stringify.js';
 import { fetchImage } from './utils.js';
 
 export type Markdown = string;
@@ -1013,6 +1014,7 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
       .use(remarkGfm)
       .use(remarkStringify, {
         resourceLink: true,
+        join,
       })
       .stringify(ast)
       .replace(/&#x20;\n/g, ' \n');

--- a/packages/blocks/src/_common/adapters/stringify.ts
+++ b/packages/blocks/src/_common/adapters/stringify.ts
@@ -1,0 +1,12 @@
+import type { Options } from 'remark-stringify';
+
+export const join: Options['join'] = [
+  (left, right, parent) => {
+    const adjacentListItems =
+      left.type === 'listItem' && right.type === 'listItem';
+    const nestedList = parent.type === 'listItem';
+
+    if (adjacentListItems || nestedList) return 0;
+    return;
+  },
+];

--- a/packages/blocks/src/_common/adapters/stringify.ts
+++ b/packages/blocks/src/_common/adapters/stringify.ts
@@ -2,11 +2,12 @@ import type { Options } from 'remark-stringify';
 
 export const join: Options['join'] = [
   (left, right, parent) => {
+    const adjacentLists = left.type === 'list' && right.type === 'list';
     const adjacentListItems =
       left.type === 'listItem' && right.type === 'listItem';
     const nestedList = parent.type === 'listItem';
 
-    if (adjacentListItems || nestedList) return 0;
+    if (adjacentListItems || nestedList || adjacentLists) return 0;
     return;
   },
 ];


### PR DESCRIPTION

![image](https://github.com/toeverything/blocksuite/assets/123532141/cc6f104c-fded-47c9-ad45-0a10817069aa)

# After
![image](https://github.com/toeverything/blocksuite/assets/123532141/236ce338-2ef5-43c7-bd32-dd2439fc7eb7)


- This is the style in which Notion exports markdown lists

I don't know if this will fix #6252 or not because I am not able to copy it as a markdown