### PR TITLE
fix(edgeless): connector missing c and x shortcuts

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -43,6 +43,24 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             mode: ConnectorMode.Straight,
           });
         },
+        x: () => {
+          rootElement.service.editSession.record('connector', {
+            mode: ConnectorMode.Orthogonal,
+          });
+          this._setEdgelessTool(rootElement, {
+            type: 'connector',
+            mode: ConnectorMode.Orthogonal,
+          });
+        },
+        c: () => {
+          rootElement.service.editSession.record('connector', {
+            mode: ConnectorMode.Curve,
+          });
+          this._setEdgelessTool(rootElement, {
+            type: 'connector',
+            mode: ConnectorMode.Curve,
+          });
+        },
         h: () => {
           this._setEdgelessTool(rootElement, {
             type: 'pan',


### PR DESCRIPTION

https://github.com/toeverything/blocksuite/assets/27926/d39f883f-7345-4aa0-a3da-538a21063a04

