### PR TITLE
fix(database): slow first rendering of the Database Block

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -214,8 +214,11 @@ export class RichText extends WithDisposable(ShadowlessElement) {
       })
     );
 
-    inlineEditor.mount(this.inlineEditorContainer, this.inlineEventSource);
-    inlineEditor.setReadonly(this.readonly);
+    inlineEditor.mount(
+      this.inlineEditorContainer,
+      this.inlineEventSource,
+      this.readonly
+    );
   }
 
   private _onStackItemAdded = (event: { stackItem: RichTextStackItem }) => {

--- a/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
@@ -148,7 +148,6 @@ export class RichTextCell extends BaseCellRenderer<Y.Text> {
 
   override render() {
     if (!this.service) return nothing;
-
     return html`<rich-text
       .yText=${this.value}
       .inlineEventSource=${this.topContenteditableElement}
@@ -222,8 +221,7 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
   get topContenteditableElement() {
     const databaseBlock =
       this.closest<DatabaseBlockComponent>('affine-database');
-    assertExists(databaseBlock);
-    return databaseBlock.topContenteditableElement;
+    return databaseBlock?.topContenteditableElement;
   }
 
   override connectedCallback() {
@@ -337,7 +335,6 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
 
   override render() {
     if (!this.service) return nothing;
-
     return html`<rich-text
       .yText=${this.value}
       .inlineEventSource=${this.topContenteditableElement}

--- a/packages/blocks/src/database-block/common/datasource/block-renderer.ts
+++ b/packages/blocks/src/database-block/common/datasource/block-renderer.ts
@@ -1,6 +1,5 @@
 import type { EditorHost } from '@blocksuite/block-std';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
 import { css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -56,8 +55,7 @@ export class BlockRenderer
   get topContenteditableElement() {
     const databaseBlock =
       this.closest<DatabaseBlockComponent>('affine-database');
-    assertExists(databaseBlock);
-    return databaseBlock.topContenteditableElement;
+    return databaseBlock?.topContenteditableElement;
   }
 
   public override connectedCallback() {

--- a/packages/blocks/src/database-block/common/header/title.ts
+++ b/packages/blocks/src/database-block/common/header/title.ts
@@ -75,8 +75,7 @@ export class DatabaseTitle extends WithDisposable(ShadowlessElement) {
   get topContenteditableElement() {
     const databaseBlock =
       this.closest<DatabaseBlockComponent>('affine-database');
-    assertExists(databaseBlock);
-    return databaseBlock.topContenteditableElement;
+    return databaseBlock?.topContenteditableElement;
   }
 
   override firstUpdated() {

--- a/packages/framework/inline/src/inline-editor.ts
+++ b/packages/framework/inline/src/inline-editor.ts
@@ -227,17 +227,19 @@ export class InlineEditor<
     this.slots.inlineRangeUpdate.on(this.rangeService.onInlineRangeUpdated);
   }
 
-  mount(rootElement: HTMLElement, eventSource: HTMLElement = rootElement) {
+  mount(
+    rootElement: HTMLElement,
+    eventSource: HTMLElement = rootElement,
+    isReadonly = false
+  ) {
     const inlineRoot = rootElement as InlineRootElement<TextAttributes>;
     inlineRoot.inlineEditor = this;
     this._rootElement = inlineRoot;
     this._eventSource = eventSource;
-    render(nothing, this._rootElement);
-    this._rootElement.contentEditable = 'true';
-    this._rootElement.style.outline = 'none';
-    this._eventSource.contentEditable = 'true';
     this._eventSource.style.outline = 'none';
     this._rootElement.dataset.vRoot = 'true';
+    this.setReadonly(isReadonly);
+    render(nothing, this._rootElement);
 
     this._bindYTextObserver();
 
@@ -269,8 +271,9 @@ export class InlineEditor<
   }
 
   setReadonly(isReadonly: boolean): void {
-    this.rootElement.contentEditable = isReadonly ? 'false' : 'true';
-    this.eventSource.contentEditable = isReadonly ? 'false' : 'true';
+    const value = isReadonly ? 'false' : 'true';
+    this.rootElement.contentEditable = value;
+    this.eventSource.contentEditable = value;
     this._isReadonly = isReadonly;
   }
 


### PR DESCRIPTION
Avoid unnecessary contenteditable assignments

before:
![image](https://github.com/toeverything/blocksuite/assets/17165520/5d1e4c12-1438-4dd8-b037-1a2215432ba4)


after:
![image](https://github.com/toeverything/blocksuite/assets/17165520/2b099165-58a6-43f3-9601-d9866bdd1ac4)
