### PR TITLE
fix(database): incorrect position of detail panel

### DIFF
--- a/packages/blocks/src/_specs/_specs.ts
+++ b/packages/blocks/src/_specs/_specs.ts
@@ -40,6 +40,7 @@ import { AFFINE_EDGELESS_COPILOT_WIDGET } from '../root-block/widgets/edgeless-c
 import { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from '../root-block/widgets/edgeless-remote-selection/index.js';
 import { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from '../root-block/widgets/edgeless-zoom-toolbar/index.js';
 import { AFFINE_FORMAT_BAR_WIDGET } from '../root-block/widgets/format-bar/format-bar.js';
+import { AFFINE_INNER_MODAL_WIDGET } from '../root-block/widgets/inner-modal/inner-modal.js';
 import { AFFINE_LINKED_DOC_WIDGET } from '../root-block/widgets/linked-doc/index.js';
 import { AFFINE_MODAL_WIDGET } from '../root-block/widgets/modal/modal.js';
 import { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from '../root-block/widgets/page-dragging-area/page-dragging-area.js';
@@ -63,6 +64,7 @@ const DocPageSpec: BlockSpec<PageRootBlockWidgetName> = {
       //   AFFINE_BLOCK_HUB_WIDGET
       // )}`,
       [AFFINE_MODAL_WIDGET]: literal`${unsafeStatic(AFFINE_MODAL_WIDGET)}`,
+      [AFFINE_INNER_MODAL_WIDGET]: literal`${unsafeStatic(AFFINE_INNER_MODAL_WIDGET)}`,
       [AFFINE_SLASH_MENU_WIDGET]: literal`${unsafeStatic(
         AFFINE_SLASH_MENU_WIDGET
       )}`,
@@ -95,6 +97,7 @@ const EdgelessPageSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
       //   AFFINE_BLOCK_HUB_WIDGET
       // )}`,
       [AFFINE_MODAL_WIDGET]: literal`${unsafeStatic(AFFINE_MODAL_WIDGET)}`,
+      [AFFINE_INNER_MODAL_WIDGET]: literal`${unsafeStatic(AFFINE_INNER_MODAL_WIDGET)}`,
       [AFFINE_PIE_MENU_WIDGET]: literal`${unsafeStatic(AFFINE_PIE_MENU_WIDGET)}`,
       [AFFINE_SLASH_MENU_WIDGET]: literal`${unsafeStatic(
         AFFINE_SLASH_MENU_WIDGET

--- a/packages/blocks/src/database-block/common/base-data-view.ts
+++ b/packages/blocks/src/database-block/common/base-data-view.ts
@@ -10,6 +10,7 @@ import { property } from 'lit/decorators.js';
 
 import type { UniComponent } from '../../_common/components/uni-component/uni-component.js';
 import type { DataViewSelection } from '../../_common/utils/index.js';
+import type { DataViewNative } from '../data-view.js';
 import type { InsertToPosition } from '../types.js';
 import type { DataViewExpose, DataViewProps } from './data-view.js';
 import type { DataViewManager } from './data-view-manager.js';
@@ -27,6 +28,8 @@ export abstract class BaseDataView<
   @property({ attribute: false })
   header!: UniComponent<{ viewMethods: DataViewExpose; view: T }>;
 
+  @property({ attribute: false })
+  dataViewEle!: DataViewNative;
   @property({ attribute: false })
   view!: T;
 

--- a/packages/blocks/src/database-block/common/data-view.ts
+++ b/packages/blocks/src/database-block/common/data-view.ts
@@ -8,6 +8,7 @@ import type { Doc } from '@blocksuite/store';
 
 import type { UniComponent } from '../../_common/components/uni-component/uni-component.js';
 import type { DataViewSelection } from '../../_common/utils/index.js';
+import type { DataViewNative } from '../data-view.js';
 import type { DatabaseBlockModel } from '../database-model.js';
 import type { InsertToPosition } from '../types.js';
 import type { DataViewManager } from './data-view-manager.js';
@@ -20,6 +21,8 @@ export interface DataViewProps<
   T extends DataViewManager = DataViewManager,
   Selection extends DataViewSelection = DataViewSelection,
 > {
+  dataViewEle: DataViewNative;
+
   header?: DataViewHeaderComponentProp<T>;
 
   view: T;

--- a/packages/blocks/src/database-block/common/detail/field.ts
+++ b/packages/blocks/src/database-block/common/detail/field.ts
@@ -43,6 +43,7 @@ export class RecordField extends WithDisposable(ShadowlessElement) {
       width: 116px;
       border-radius: 4px;
       cursor: pointer;
+      user-select: none;
     }
 
     .field-left:hover {

--- a/packages/blocks/src/database-block/common/detail/layout.ts
+++ b/packages/blocks/src/database-block/common/detail/layout.ts
@@ -1,12 +1,16 @@
 import { ShadowlessElement } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import { autoUpdate, computePosition, size } from '@floating-ui/dom';
+import {
+  autoUpdate,
+  computePosition,
+  type ReferenceElement,
+  size,
+} from '@floating-ui/dom';
 import { css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { createModal } from '../../../_common/components/menu/index.js';
 import { CrossIcon } from '../../../_common/icons/index.js';
-import type { RootBlockComponent } from '../../../index.js';
 import type { DataViewManager } from '../data-view-manager.js';
 import { RecordDetail } from './detail.js';
 
@@ -89,18 +93,18 @@ class SideLayoutModal extends ShadowlessElement {
 }
 
 export const popSideDetail = (ops: {
-  rootElement: RootBlockComponent | null;
+  attachTo: HTMLElement;
+  target: ReferenceElement;
   view: DataViewManager;
   rowId: string;
   onClose?: () => void;
 }) => {
-  const rootElement = ops.rootElement;
+  const rootElement = ops.attachTo;
   assertExists(rootElement);
-  const block = findFirstBlockParent(rootElement) ?? rootElement;
   const modal = createModal(rootElement);
-  // fit to the size of the page element
-  const cancel = autoUpdate(block, modal, () => {
-    computePosition(block, modal, {
+  // fit to the size of the body element
+  const cancel = autoUpdate(ops.target, modal, () => {
+    computePosition(ops.target, modal, {
       middleware: [
         size({
           apply: ({ rects }) => {
@@ -131,10 +135,4 @@ export const popSideDetail = (ops: {
   };
   modal.onclick = close;
   modal.append(sideContainer);
-};
-const findFirstBlockParent = (ele: HTMLElement | null) => {
-  while (ele && ele.computedStyleMap().get('display')?.toString() !== 'block') {
-    ele = ele.parentElement;
-  }
-  return ele;
 };

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -6,8 +6,7 @@ import './common/header/tools/tools.js';
 import './common/filter/filter-bar.js';
 import './data-view.js';
 
-import { PathFinder } from '@blocksuite/block-std';
-import { BlockElement, RangeManager } from '@blocksuite/block-std';
+import { BlockElement, PathFinder, RangeManager } from '@blocksuite/block-std';
 import { Slot } from '@blocksuite/global/utils';
 import { Slice } from '@blocksuite/store';
 import { css, nothing, unsafeCSS } from 'lit';
@@ -32,6 +31,8 @@ import {
   captureEventTarget,
   getDropResult,
 } from '../root-block/widgets/drag-handle/utils.js';
+import type { AffineInnerModalWidget } from '../root-block/widgets/inner-modal/inner-modal.js';
+import { AFFINE_INNER_MODAL_WIDGET } from '../root-block/widgets/inner-modal/inner-modal.js';
 import { dataViewCommonStyle } from './common/css-variable.js';
 import type { DataViewProps, DataViewTypes } from './common/data-view.js';
 import { type DataViewExpose } from './common/data-view.js';
@@ -67,6 +68,7 @@ export class DatabaseBlockComponent extends BlockElement<
       background-color: var(--affine-hover-color);
       border-radius: 4px;
     }
+
     .database-ops {
       margin-top: 4px;
       padding: 2px;
@@ -74,11 +76,13 @@ export class DatabaseBlockComponent extends BlockElement<
       display: flex;
       cursor: pointer;
     }
+
     .database-ops svg {
       width: 16px;
       height: 16px;
       color: var(--affine-icon-color);
     }
+
     .database-ops:hover {
       background-color: var(--affine-hover-color);
     }
@@ -169,11 +173,12 @@ export class DatabaseBlockComponent extends BlockElement<
       },
     });
   };
+
   private renderDatabaseOps() {
     if (this.doc.readonly) {
       return nothing;
     }
-    return html`<div class="database-ops" @click="${this._clickDatabaseOps}">
+    return html` <div class="database-ops" @click="${this._clickDatabaseOps}">
       ${MoreHorizontalIcon}
     </div>`;
   }
@@ -292,7 +297,7 @@ export class DatabaseBlockComponent extends BlockElement<
     ></affine-database-title>`;
   };
   private renderReference = () => {
-    return html`<div></div>`;
+    return html` <div></div>`;
   };
 
   headerComponent = defineUniComponent(
@@ -359,6 +364,12 @@ export class DatabaseBlockComponent extends BlockElement<
     };
   };
 
+  get innerModalWidget() {
+    return this.rootElement.widgetElements[
+      AFFINE_INNER_MODAL_WIDGET
+    ] as AffineInnerModalWidget;
+  }
+
   override renderBlock() {
     const config: DataViewNativeConfig = {
       bindHotkey: this._bindHotkey,
@@ -371,6 +382,9 @@ export class DatabaseBlockComponent extends BlockElement<
       headerComponent: this.headerComponent,
       onDrag: this.onDrag,
       std: this.std,
+      detailPanelConfig: {
+        target: () => this.innerModalWidget.target,
+      },
     };
     return html`
       <div contenteditable="false" style="position: relative">
@@ -380,7 +394,7 @@ export class DatabaseBlockComponent extends BlockElement<
         ></affine-data-view-native>
 
         <affine-block-selection
-          .block=${this}
+          .block="${this}"
           style="z-index: 1"
         ></affine-block-selection>
       </div>

--- a/packages/blocks/src/database-block/kanban/card.ts
+++ b/packages/blocks/src/database-block/kanban/card.ts
@@ -9,8 +9,7 @@ import { html } from 'lit/static-html.js';
 
 import { positionToVRect } from '../../_common/components/menu/index.js';
 import { MoreHorizontalIcon, NewEditIcon } from '../../_common/icons/index.js';
-import { getRootByElement } from '../../_common/utils/query.js';
-import { popSideDetail } from '../common/detail/layout.js';
+import type { DataViewNative } from '../data-view.js';
 import type {
   DataViewKanbanColumnManager,
   DataViewKanbanManager,
@@ -123,6 +122,8 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
   @property({ attribute: false })
+  dataViewEle!: DataViewNative;
+  @property({ attribute: false })
   view!: DataViewKanbanManager;
   @property({ attribute: false })
   groupKey!: string;
@@ -157,9 +158,7 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
       if (selection) {
         selection.selection = undefined;
       }
-      const rootElement = getRootByElement(this);
-      popSideDetail({
-        rootElement,
+      this.dataViewEle.openDetailPanel({
         view: this.view,
         rowId: this.cardId,
         onClose: () => {
@@ -266,9 +265,8 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
   private clickEdit = (e: MouseEvent) => {
     e.stopPropagation();
     const selection = this.getSelection();
-    const rootElement = getRootByElement(this);
     if (selection) {
-      openDetail(rootElement, this.cardId, selection);
+      openDetail(this.dataViewEle, this.cardId, selection);
     }
   };
 
@@ -290,8 +288,7 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
           },
         ],
       };
-      const rootElement = getRootByElement(this);
-      popCardMenu(rootElement, ele, this.cardId, selection);
+      popCardMenu(this.dataViewEle, ele, this.cardId, selection);
     }
   };
   private contextMenu = (e: MouseEvent) => {
@@ -308,9 +305,8 @@ export class KanbanCard extends WithDisposable(ShadowlessElement) {
           },
         ],
       };
-      const rootElement = getRootByElement(this);
       popCardMenu(
-        rootElement,
+        this.dataViewEle,
         positionToVRect(e.x, e.y),
         this.cardId,
         selection

--- a/packages/blocks/src/database-block/kanban/group.ts
+++ b/packages/blocks/src/database-block/kanban/group.ts
@@ -10,6 +10,7 @@ import { popFilterableSimpleMenu } from '../../_common/components/menu/index.js'
 import { AddCursorIcon } from '../../_common/icons/index.js';
 import { GroupTitle } from '../common/group-by/group-title.js';
 import type { GroupData } from '../common/group-by/helper.js';
+import type { DataViewNative } from '../data-view.js';
 import type { DataViewKanbanManager } from './kanban-view-manager.js';
 
 const styles = css`
@@ -97,6 +98,8 @@ export class KanbanGroup extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
   @property({ attribute: false })
+  dataViewEle!: DataViewNative;
+  @property({ attribute: false })
   view!: DataViewKanbanManager;
   @property({ attribute: false })
   group!: GroupData;
@@ -171,6 +174,7 @@ export class KanbanGroup extends WithDisposable(ShadowlessElement) {
               <affine-data-view-kanban-card
                 data-card-id="${id}"
                 .groupKey="${this.group.key}"
+                .dataViewEle="${this.dataViewEle}"
                 .view="${this.view}"
                 .cardId="${id}"
               ></affine-data-view-kanban-card>

--- a/packages/blocks/src/database-block/kanban/kanban-view.ts
+++ b/packages/blocks/src/database-block/kanban/kanban-view.ts
@@ -210,6 +210,7 @@ export class DataViewKanban extends BaseDataView<
           group => {
             return html` <affine-data-view-kanban-group
               data-key="${group.key}"
+              .dataViewEle="${this.dataViewEle}"
               .view="${this.view}"
               .group="${group}"
             ></affine-data-view-kanban-group>`;

--- a/packages/blocks/src/database-block/kanban/menu.ts
+++ b/packages/blocks/src/database-block/kanban/menu.ts
@@ -9,19 +9,17 @@ import {
   MoveLeftIcon,
   MoveRightIcon,
 } from '../../_common/icons/index.js';
-import type { RootBlockComponent } from '../../index.js';
-import { popSideDetail } from '../common/detail/layout.js';
+import type { DataViewNative } from '../data-view.js';
 import type { KanbanSelectionController } from './controller/selection.js';
 
 export const openDetail = (
-  rootElement: RootBlockComponent | null,
+  dataViewEle: DataViewNative,
   rowId: string,
   selection: KanbanSelectionController
 ) => {
   const old = selection.selection;
   selection.selection = undefined;
-  popSideDetail({
-    rootElement,
+  dataViewEle.openDetailPanel({
     view: selection.view,
     rowId: rowId,
     onClose: () => {
@@ -31,7 +29,7 @@ export const openDetail = (
 };
 
 export const popCardMenu = (
-  rootElement: RootBlockComponent | null,
+  dataViewEle: DataViewNative,
   ele: ReferenceElement,
   rowId: string,
   selection: KanbanSelectionController
@@ -42,7 +40,7 @@ export const popCardMenu = (
       name: 'Expand Card',
       icon: ExpandFullIcon,
       select: () => {
-        openDetail(rootElement, rowId, selection);
+        openDetail(dataViewEle, rowId, selection);
       },
     },
     {

--- a/packages/blocks/src/database-block/table/components/menu.ts
+++ b/packages/blocks/src/database-block/table/components/menu.ts
@@ -8,19 +8,17 @@ import {
   MoveLeftIcon,
   MoveRightIcon,
 } from '../../../_common/icons/index.js';
-import type { RootBlockComponent } from '../../../root-block/types.js';
-import { popSideDetail } from '../../common/detail/layout.js';
+import type { DataViewNative } from '../../data-view.js';
 import type { TableSelectionController } from '../controller/selection.js';
 
 export const openDetail = (
-  rootElement: RootBlockComponent | null,
+  dataViewEle: DataViewNative,
   rowId: string,
   selection: TableSelectionController
 ) => {
   const old = selection.selection;
   selection.selection = undefined;
-  popSideDetail({
-    rootElement,
+  dataViewEle.openDetailPanel({
     view: selection.host.view,
     rowId: rowId,
     onClose: () => {
@@ -30,7 +28,7 @@ export const openDetail = (
 };
 
 export const popRowMenu = (
-  rootElement: RootBlockComponent | null,
+  dataViewEle: DataViewNative,
   ele: ReferenceElement,
   rowId: string,
   selection: TableSelectionController
@@ -41,7 +39,7 @@ export const popRowMenu = (
       name: 'Expand Row',
       icon: ExpandFullIcon,
       select: () => {
-        openDetail(rootElement, rowId, selection);
+        openDetail(dataViewEle, rowId, selection);
       },
     },
     // {

--- a/packages/blocks/src/database-block/table/components/row.ts
+++ b/packages/blocks/src/database-block/table/components/row.ts
@@ -10,10 +10,8 @@ import {
   MoreHorizontalIcon,
   NewEditIcon,
 } from '../../../_common/icons/index.js';
-import {
-  getRootByElement,
-  type TableViewSelection,
-} from '../../../_common/utils/index.js';
+import { type TableViewSelection } from '../../../_common/utils/index.js';
+import type { DataViewNative } from '../../data-view.js';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../consts.js';
 import type { DataViewTableManager } from '../table-view-manager.js';
 import { openDetail, popRowMenu } from './menu.js';
@@ -100,6 +98,8 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
     return this.closest('affine-database-table')?.selectionController;
   }
   @property({ attribute: false })
+  dataViewEle!: DataViewNative;
+  @property({ attribute: false })
   view!: DataViewTableManager;
   @property({ attribute: false })
   rowIndex!: number;
@@ -136,8 +136,12 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
       },
       isEditing: false,
     };
-    const rootElement = getRootByElement(this);
-    popRowMenu(rootElement, positionToVRect(e.x, e.y), this.rowId, selection);
+    popRowMenu(
+      this.dataViewEle,
+      positionToVRect(e.x, e.y),
+      this.rowId,
+      selection
+    );
   };
 
   public override connectedCallback() {
@@ -211,8 +215,7 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
               },
               isEditing: false,
             });
-            const rootElement = getRootByElement(this);
-            openDetail(rootElement, this.rowId, this.selectionController);
+            openDetail(this.dataViewEle, this.rowId, this.selectionController);
           };
           const openMenu = (e: MouseEvent) => {
             if (!this.selectionController) {
@@ -231,8 +234,12 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
               },
               isEditing: false,
             });
-            const rootElement = getRootByElement(this);
-            popRowMenu(rootElement, ele, this.rowId, this.selectionController);
+            popRowMenu(
+              this.dataViewEle,
+              ele,
+              this.rowId,
+              this.selectionController
+            );
           };
           return html`
             <div>

--- a/packages/blocks/src/database-block/table/controller/hotkeys.ts
+++ b/packages/blocks/src/database-block/table/controller/hotkeys.ts
@@ -1,6 +1,5 @@
 import type { ReactiveController } from 'lit';
 
-import { getRootByElement } from '../../../_common/utils/query.js';
 import { popRowMenu } from '../components/menu.js';
 import type { DataViewTable } from '../table-view.js';
 
@@ -230,8 +229,12 @@ export class TableHotkeysController implements ReactiveController {
           );
           if (cell) {
             context.get('keyboardState').raw.preventDefault();
-            const rootElement = getRootByElement(cell);
-            popRowMenu(rootElement, cell, cell.rowId, this.selectionController);
+            popRowMenu(
+              this.host.dataViewEle,
+              cell,
+              cell.rowId,
+              this.selectionController
+            );
           }
         },
       })

--- a/packages/blocks/src/database-block/table/group.ts
+++ b/packages/blocks/src/database-block/table/group.ts
@@ -8,6 +8,7 @@ import { popFilterableSimpleMenu } from '../../_common/components/menu/index.js'
 import { PlusIcon } from '../../_common/icons/index.js';
 import { GroupTitle } from '../common/group-by/group-title.js';
 import type { GroupData } from '../common/group-by/helper.js';
+import type { DataViewNative } from '../data-view.js';
 import { LEFT_TOOL_BAR_WIDTH } from './consts.js';
 import type { DataViewTable } from './table-view.js';
 import type { DataViewTableManager } from './table-view-manager.js';
@@ -52,6 +53,8 @@ const styles = css`
 export class TableGroup extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
+  @property({ attribute: false })
+  dataViewEle!: DataViewNative;
   @property({ attribute: false })
   view!: DataViewTableManager;
   @property({ attribute: false })
@@ -142,6 +145,7 @@ export class TableGroup extends WithDisposable(ShadowlessElement) {
             return html`<data-view-table-row
               data-row-index="${idx}"
               data-row-id="${id}"
+              .dataViewEle="${this.dataViewEle}"
               .view="${this.view}"
               .rowId="${id}"
               .rowIndex="${idx}"

--- a/packages/blocks/src/database-block/table/table-view.ts
+++ b/packages/blocks/src/database-block/table/table-view.ts
@@ -224,6 +224,7 @@ export class DataViewTable extends BaseDataView<
           ${groupHelper.groups.map(group => {
             return html`<affine-data-view-table-group
               data-group-key="${group.key}"
+              .dataViewEle="${this.dataViewEle}"
               .view="${this.view}"
               .viewEle="${this}"
               .group="${group}"

--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -8,6 +8,7 @@ import type { AFFINE_EDGELESS_COPILOT_WIDGET } from './widgets/edgeless-copilot/
 import type { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from './widgets/edgeless-remote-selection/index.js';
 import type { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from './widgets/edgeless-zoom-toolbar/index.js';
 import type { AFFINE_FORMAT_BAR_WIDGET } from './widgets/format-bar/format-bar.js';
+import type { AFFINE_INNER_MODAL_WIDGET } from './widgets/inner-modal/inner-modal.js';
 import type { AFFINE_LINKED_DOC_WIDGET } from './widgets/linked-doc/index.js';
 import type { AFFINE_MODAL_WIDGET } from './widgets/modal/modal.js';
 import type { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from './widgets/page-dragging-area/page-dragging-area.js';
@@ -18,6 +19,7 @@ import type { AFFINE_SLASH_MENU_WIDGET } from './widgets/slash-menu/index.js';
 export type PageRootBlockWidgetName =
   // | typeof AFFINE_BLOCK_HUB_WIDGET
   | typeof AFFINE_MODAL_WIDGET
+  | typeof AFFINE_INNER_MODAL_WIDGET
   | typeof AFFINE_SLASH_MENU_WIDGET
   | typeof AFFINE_LINKED_DOC_WIDGET
   | typeof AFFINE_PAGE_DRAGGING_AREA_WIDGET
@@ -28,6 +30,7 @@ export type PageRootBlockWidgetName =
 export type EdgelessRootBlockWidgetName =
   // | typeof AFFINE_BLOCK_HUB_WIDGET
   | typeof AFFINE_MODAL_WIDGET
+  | typeof AFFINE_INNER_MODAL_WIDGET
   | typeof AFFINE_PIE_MENU_WIDGET
   | typeof AFFINE_SLASH_MENU_WIDGET
   | typeof AFFINE_LINKED_DOC_WIDGET

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -11,6 +11,7 @@ export { AffineEdgelessZoomToolbarWidget } from './edgeless-zoom-toolbar/index.j
 export { toolbarDefaultConfig } from './format-bar/config.js';
 export { AffineFormatBarWidget } from './format-bar/format-bar.js';
 export { AffineImageToolbarWidget } from './image-toolbar/image-toolbar.js';
+export { AffineInnerModalWidget } from './inner-modal/inner-modal.js';
 export {
   // It's used in the AFFiNE!
   showImportModal,

--- a/packages/blocks/src/root-block/widgets/inner-modal/inner-modal.ts
+++ b/packages/blocks/src/root-block/widgets/inner-modal/inner-modal.ts
@@ -1,0 +1,66 @@
+import { WidgetElement } from '@blocksuite/block-std';
+import {
+  autoUpdate,
+  computePosition,
+  type FloatingElement,
+  type ReferenceElement,
+  size,
+} from '@floating-ui/dom';
+import { nothing } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+export const AFFINE_INNER_MODAL_WIDGET = 'affine-inner-modal-widget';
+
+@customElement(AFFINE_INNER_MODAL_WIDGET)
+export class AffineInnerModalWidget extends WidgetElement {
+  private _getTarget?: () => ReferenceElement;
+
+  setTarget(fn: () => ReferenceElement) {
+    this._getTarget = fn;
+  }
+
+  get target(): ReferenceElement {
+    if (this._getTarget) {
+      return this._getTarget();
+    }
+    return document.body;
+  }
+
+  open(
+    modal: FloatingElement,
+    ops: { onClose?: () => void }
+  ): { close(): void } {
+    const cancel = autoUpdate(this.target, modal, () => {
+      computePosition(this.target, modal, {
+        middleware: [
+          size({
+            apply: ({ rects }) => {
+              Object.assign(modal.style, {
+                left: `${rects.reference.x}px`,
+                top: `${rects.reference.y}px`,
+                width: `${rects.reference.width}px`,
+                height: `${rects.reference.height}px`,
+              });
+            },
+          }),
+        ],
+      }).catch(console.error);
+    });
+    const close = () => {
+      modal.remove();
+      ops.onClose?.();
+      cancel();
+    };
+    return { close };
+  }
+
+  override render() {
+    return nothing;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AFFINE_INNER_MODAL_WIDGET]: AffineInnerModalWidget;
+  }
+}


### PR DESCRIPTION
close: https://github.com/toeverything/blocksuite/issues/6337
close: AFF-732
close: BS-146, BS-207
By default it will fit over the entire `document.body`.
Can be overridden externally.

example:
```ts
{
  schema: RootBlockSchema,
  service: PageRootService,
  view: {
    component: literal`affine-page-root`,
    widgets: {
      [AFFINE_INNER_MODAL_WIDGET]: literal`${unsafeStatic(AFFINE_INNER_MODAL_WIDGET)}`,
    },
  },
  setup: function(slots) {
    slots.widgetConnected.on(({ component }) => {
      if (component instanceof AffineInnerModalWidget) {
        component.setTarget(() => {
          return document.body.querySelector('.xxx') ?? document.body;
        });
      }
    });
  },
}
```