### PR TITLE
fix(edgeless): auto complete panel position when zooming in and out

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -436,8 +436,8 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
 
   private _getPanelPosition() {
     const { viewport } = this.edgeless.service;
-    const viewportRect = viewport.boundingClientRect;
-    const result = this._getTargetXYWH(PANEL_WIDTH, PANEL_HEIGHT);
+    const { boundingClientRect: viewportRect, zoom } = viewport;
+    const result = this._getTargetXYWH(PANEL_WIDTH / zoom, PANEL_HEIGHT / zoom);
     const pos = result ? result.xywh.slice(0, 2) : this.position;
     const coord = viewport.toViewCoord(pos[0], pos[1]);
     const { width, height } = viewportRect;


### PR DESCRIPTION
Related to #6579 


https://github.com/toeverything/blocksuite/assets/27926/8f121f67-bbf9-464d-8495-9f6ffd544f83

