### PR TITLE
fix(edgeless): general shape for triangle

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -122,3 +122,4 @@ Example:
 - wumo, @wumo1016, 2024/2/27
 - Yuan Congzhou, @congzhou09, 2024/03/01
 - RhonJoe, @JunIce, 2024/03/04
+- Lebedev Konstantin, @RubaXa, 2024/03/28

--- a/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
@@ -57,7 +57,7 @@ const drawGeneralShape = (
       shapeMethods.rect.draw(ctx, bound);
       break;
     case 'triangle':
-      shapeMethods.rect.draw(ctx, bound);
+      shapeMethods.triangle.draw(ctx, bound);
       break;
     case 'diamond':
       shapeMethods.diamond.draw(ctx, bound);


### PR DESCRIPTION
**Problem**
Now, when you select a `triangle`, a `rect` is drawn under the cursor