### PR TITLE
fix(edgeless): connector modes display order issue

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-connector-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/component-toolbar/change-connector-button.ts
@@ -560,15 +560,6 @@ export class EdgelessChangeConnectorButton extends WithDisposable(LitElement) {
               ${StraightLineIcon}
             </edgeless-tool-icon-button>
             <edgeless-tool-icon-button
-              .tooltip=${'Elbowed'}
-              .iconContainerPadding=${2}
-              .active=${selectedMode === ConnectorMode.Orthogonal}
-              .activeMode=${'background'}
-              @click=${() => this._setConnectorMode(ConnectorMode.Orthogonal)}
-            >
-              ${ElbowedLineIcon}
-            </edgeless-tool-icon-button>
-            <edgeless-tool-icon-button
               .tooltip=${'Curve'}
               .iconContainerPadding=${2}
               .active=${selectedMode === ConnectorMode.Curve}
@@ -576,6 +567,15 @@ export class EdgelessChangeConnectorButton extends WithDisposable(LitElement) {
               @click=${() => this._setConnectorMode(ConnectorMode.Curve)}
             >
               ${CurveLineIcon}
+            </edgeless-tool-icon-button>
+            <edgeless-tool-icon-button
+              .tooltip=${'Elbowed'}
+              .iconContainerPadding=${2}
+              .active=${selectedMode === ConnectorMode.Orthogonal}
+              .activeMode=${'background'}
+              @click=${() => this._setConnectorMode(ConnectorMode.Orthogonal)}
+            >
+              ${ElbowedLineIcon}
             </edgeless-tool-icon-button>
           `}
         >


### PR DESCRIPTION
`connector component toolbar` should follow the order on the `edgeless-toolbar`:

<img width="169" alt="Screenshot 2024-04-03 at 18 15 54" src="https://github.com/toeverything/blocksuite/assets/27926/46c4ac19-a52c-48b6-8586-ea9dd1a1295c">

<img width="173" alt="Screenshot 2024-04-03 at 18 16 52" src="https://github.com/toeverything/blocksuite/assets/27926/0abd21d9-97b2-4589-8c80-5def6c4c37fd">

