### PR TITLE
fix(database): soft enter removes next character

### DIFF
--- a/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
@@ -340,7 +340,7 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
 
       this.column.captureSync();
       const text = new Text(this.inlineEditor.yText);
-      text.replace(inlineRange.index, 0, '\n');
+      text.replace(inlineRange.index, inlineRange.length, '\n');
       this.inlineEditor.setInlineRange({
         index: inlineRange.index + 1,
         length: 0,

--- a/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/common/columns/rich-text/cell-renderer.ts
@@ -340,7 +340,7 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
 
       this.column.captureSync();
       const text = new Text(this.inlineEditor.yText);
-      text.replace(inlineRange.index, length, '\n');
+      text.replace(inlineRange.index, 0, '\n');
       this.inlineEditor.setInlineRange({
         index: inlineRange.index + 1,
         length: 0,


### PR DESCRIPTION
https://github.com/toeverything/blocksuite/assets/123532141/b507b3a2-32b9-49de-a228-d63f22b80edb

It was using window.length instead of inlineRange.length

