### PR TITLE
feat(edgeless): font family panel refactoring

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -122,3 +122,4 @@ Example:
 - wumo, @wumo1016, 2024/2/27
 - Yuan Congzhou, @congzhou09, 2024/03/01
 - RhonJoe, @JunIce, 2024/03/04
+- Lebedev Konstantin, @RubaXa, 2024/04/04

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
@@ -1,21 +1,13 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { CanvasTextFontFamily } from '../../../../surface-block/consts.js';
+import {
+  CanvasTextFontFamily,
+  CanvasTextFontFamilyKey,
+  CanvasTextFontFamilyName,
+  type CanvasTextFontFamilyValueType,
+} from '../../../../surface-block/consts.js';
 import { wrapFontFamily } from '../../../../surface-block/utils/font.js';
-
-export const CanvasTextFontFamiliesNames: Record<
-  keyof typeof CanvasTextFontFamily,
-  string
-> = {
-  Inter: 'Inter',
-  Kalam: 'Kalam',
-  Satoshi: 'Satoshi',
-  Poppins: 'Poppins',
-  Lora: 'Lora',
-  BebasNeue: 'Bebas Neue',
-  OrelegaOne: 'Orelega One',
-};
 
 @customElement('edgeless-font-family-panel')
 export class EdgelessFontFamilyPanel extends LitElement {
@@ -41,12 +33,7 @@ export class EdgelessFontFamilyPanel extends LitElement {
   `;
 
   @property({ attribute: false })
-  value = CanvasTextFontFamily.Inter;
-
-  @property({ attribute: false })
-  options = Object.keys(
-    CanvasTextFontFamily
-  ) as (keyof typeof CanvasTextFontFamily)[];
+  value: CanvasTextFontFamilyValueType = CanvasTextFontFamily.Inter;
 
   @property({ attribute: false })
   onSelect?: (value: EdgelessFontFamilyPanel['value']) => void;
@@ -61,7 +48,7 @@ export class EdgelessFontFamilyPanel extends LitElement {
   override render() {
     return html`
       <div class="font-family-container">
-        ${this.options.map(key => {
+        ${CanvasTextFontFamilyKey.map(key => {
           const font = CanvasTextFontFamily[key];
 
           return html`
@@ -76,7 +63,7 @@ export class EdgelessFontFamilyPanel extends LitElement {
               }}
             >
               <div class="font-family-button">
-                ${CanvasTextFontFamiliesNames[key]}
+                ${CanvasTextFontFamilyName[key]}
               </div>
             </edgeless-tool-icon-button>
           `;

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
@@ -1,8 +1,21 @@
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { CanvasTextFontFamily } from '../../../../surface-block/consts.js';
 import { wrapFontFamily } from '../../../../surface-block/utils/font.js';
+
+export const CanvasTextFontFamiliesNames: Record<
+  keyof typeof CanvasTextFontFamily,
+  string
+> = {
+  Inter: 'Inter',
+  Kalam: 'Kalam',
+  Satoshi: 'Satoshi',
+  Poppins: 'Poppins',
+  Lora: 'Lora',
+  BebasNeue: 'Bebas Neue',
+  OrelegaOne: 'Orelega One',
+};
 
 @customElement('edgeless-font-family-panel')
 export class EdgelessFontFamilyPanel extends LitElement {
@@ -25,45 +38,15 @@ export class EdgelessFontFamilyPanel extends LitElement {
     .font-family-container edgeless-tool-icon-button {
       width: 100%;
     }
-
-    .inter {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.Inter))},
-        sans-serif;
-    }
-
-    .kalam {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.Kalam))},
-        sans-serif;
-    }
-
-    .satoshi {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.Satoshi))},
-        sans-serif;
-    }
-
-    .poppins {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.Poppins))},
-        sans-serif;
-    }
-
-    .lora {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.Lora))},
-        sans-serif;
-    }
-
-    .bebas-neue {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.BebasNeue))},
-        sans-serif;
-    }
-
-    .orelega-one {
-      font-family: ${unsafeCSS(wrapFontFamily(CanvasTextFontFamily.OrelegaOne))},
-        sans-serif;
-    }
   `;
 
   @property({ attribute: false })
   value = CanvasTextFontFamily.Inter;
+
+  @property({ attribute: false })
+  options = Object.keys(
+    CanvasTextFontFamily
+  ) as (keyof typeof CanvasTextFontFamily)[];
 
   @property({ attribute: false })
   onSelect?: (value: EdgelessFontFamilyPanel['value']) => void;
@@ -78,89 +61,25 @@ export class EdgelessFontFamilyPanel extends LitElement {
   override render() {
     return html`
       <div class="font-family-container">
-        <edgeless-tool-icon-button
-          class="inter"
-          .active=${this.value === CanvasTextFontFamily.Inter}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.Inter);
-          }}
-        >
-          <div class="font-family-button">Inter</div>
-        </edgeless-tool-icon-button>
+        ${this.options.map(key => {
+          const font = CanvasTextFontFamily[key];
 
-        <edgeless-tool-icon-button
-          class="kalam"
-          .active=${this.value === CanvasTextFontFamily.Kalam}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.Kalam);
-          }}
-        >
-          <div class="font-family-button">Kalam</div>
-        </edgeless-tool-icon-button>
-
-        <edgeless-tool-icon-button
-          class="satoshi"
-          .active=${this.value === CanvasTextFontFamily.Satoshi}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.Satoshi);
-          }}
-        >
-          <div class="font-family-button">Satoshi</div>
-        </edgeless-tool-icon-button>
-
-        <edgeless-tool-icon-button
-          class="poppins"
-          .active=${this.value === CanvasTextFontFamily.Poppins}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.Poppins);
-          }}
-        >
-          <div class="font-family-button">Poppins</div>
-        </edgeless-tool-icon-button>
-
-        <edgeless-tool-icon-button
-          class="lora"
-          .active=${this.value === CanvasTextFontFamily.Lora}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.Lora);
-          }}
-        >
-          <div class="font-family-button">Lora</div>
-        </edgeless-tool-icon-button>
-
-        <edgeless-tool-icon-button
-          class="bebas-neue"
-          .active=${this.value === CanvasTextFontFamily.BebasNeue}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.BebasNeue);
-          }}
-        >
-          <div class="font-family-button">Bebas Neue</div>
-        </edgeless-tool-icon-button>
-
-        <edgeless-tool-icon-button
-          class="orelega-one"
-          .active=${this.value === CanvasTextFontFamily.OrelegaOne}
-          .activeMode=${'background'}
-          .iconContainerPadding=${2}
-          @click=${() => {
-            this._onSelect(CanvasTextFontFamily.OrelegaOne);
-          }}
-        >
-          <div class="font-family-button">Orelega One</div>
-        </edgeless-tool-icon-button>
+          return html`
+            <edgeless-tool-icon-button
+              style="font-family: ${wrapFontFamily(font)}"
+              .active=${this.value === font}
+              .activeMode=${'background'}
+              .iconContainerPadding=${2}
+              @click=${() => {
+                this._onSelect(font);
+              }}
+            >
+              <div class="font-family-button">
+                ${CanvasTextFontFamiliesNames[key]}
+              </div>
+            </edgeless-tool-icon-button>
+          `;
+        })}
       </div>
     `;
   }

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-family-panel.ts
@@ -66,6 +66,7 @@ export class EdgelessFontFamilyPanel extends LitElement {
 
           return html`
             <edgeless-tool-icon-button
+              class="${key.toLowerCase()}"
               style="font-family: ${wrapFontFamily(font)}"
               .active=${this.value === font}
               .activeMode=${'background'}

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
@@ -2,8 +2,8 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import {
-  CanvasTextFontFamilies,
   CanvasTextFontFamily,
+  CanvasTextFontFamilyValue,
   CanvasTextFontStyle,
   CanvasTextFontWeight,
 } from '../../../../surface-block/consts.js';
@@ -69,7 +69,7 @@ export class EdgelessFontWeightAndStylePanel extends LitElement {
     fontStyle: CanvasTextFontStyle = CanvasTextFontStyle.Normal
   ) {
     // Compatible with old data
-    if (!CanvasTextFontFamilies.includes(this.fontFamily)) return false;
+    if (!CanvasTextFontFamilyValue.includes(this.fontFamily)) return false;
 
     const fontFace = getFontFaces()
       .filter(isSameFontFamily(this.fontFamily))

--- a/packages/blocks/src/surface-block/consts.ts
+++ b/packages/blocks/src/surface-block/consts.ts
@@ -36,16 +36,33 @@ export interface IModelCoord {
   y: number;
 }
 
-export enum CanvasTextFontFamily {
-  Inter = 'blocksuite:surface:Inter',
-  Kalam = 'blocksuite:surface:Kalam',
-  Satoshi = 'blocksuite:surface:Satoshi',
-  Poppins = 'blocksuite:surface:Poppins',
-  Lora = 'blocksuite:surface:Lora',
-  BebasNeue = 'blocksuite:surface:BebasNeue',
-  OrelegaOne = 'blocksuite:surface:OrelegaOne',
-}
-export const CanvasTextFontFamilies = Object.values(CanvasTextFontFamily);
+export const CanvasTextFontFamily = {
+  Inter: 'blocksuite:surface:Inter',
+  Kalam: 'blocksuite:surface:Kalam',
+  Satoshi: 'blocksuite:surface:Satoshi',
+  Poppins: 'blocksuite:surface:Poppins',
+  Lora: 'blocksuite:surface:Lora',
+  BebasNeue: 'blocksuite:surface:BebasNeue',
+  OrelegaOne: 'blocksuite:surface:OrelegaOne',
+} as const;
+export type CanvasTextFontFamilyKeyType = keyof typeof CanvasTextFontFamily;
+export type CanvasTextFontFamilyValueType =
+  (typeof CanvasTextFontFamily)[CanvasTextFontFamilyKeyType];
+
+export const CanvasTextFontFamilyKey: CanvasTextFontFamilyKeyType[] =
+  Object.keys(CanvasTextFontFamily) as CanvasTextFontFamilyKeyType[];
+export const CanvasTextFontFamilyValue: CanvasTextFontFamilyValueType[] =
+  Object.values(CanvasTextFontFamily);
+
+export const CanvasTextFontFamilyName = {
+  Inter: 'Inter',
+  Kalam: 'Kalam',
+  Satoshi: 'Satoshi',
+  Poppins: 'Poppins',
+  Lora: 'Lora',
+  BebasNeue: 'Bebas Neue',
+  OrelegaOne: 'Orelega One',
+} as const satisfies Record<CanvasTextFontFamilyKeyType, string>;
 
 export enum CanvasTextFontWeight {
   Light = '300',

--- a/packages/blocks/src/surface-block/elements/shape/types.ts
+++ b/packages/blocks/src/surface-block/elements/shape/types.ts
@@ -1,7 +1,7 @@
 import type { Y } from '@blocksuite/store';
 
 import type {
-  CanvasTextFontFamily,
+  CanvasTextFontFamilyValueType,
   CanvasTextFontStyle,
   CanvasTextFontWeight,
   ShapeStyle,
@@ -28,7 +28,7 @@ export interface IShape extends ISurfaceElement {
   text?: Y.Text;
   color?: string;
   fontSize?: SHAPE_TEXT_FONT_SIZE;
-  fontFamily?: CanvasTextFontFamily;
+  fontFamily?: CanvasTextFontFamilyValueType;
   fontWeight?: CanvasTextFontWeight;
   fontStyle?: CanvasTextFontStyle;
   textAlign?: TextAlign;

--- a/packages/blocks/src/surface-block/elements/text/utils.ts
+++ b/packages/blocks/src/surface-block/elements/text/utils.ts
@@ -1,6 +1,6 @@
 // something comes from https://github.com/excalidraw/excalidraw/blob/b1311a407a636c87ee0ca326fd20599d0ce4ba9b/src/utils.ts
 
-import type { CanvasTextFontFamily } from '../../consts.js';
+import type { CanvasTextFontFamilyValueType } from '../../consts.js';
 import { wrapFontFamily } from '../../utils/font.js';
 
 const RS_LTR_CHARS =
@@ -33,7 +33,7 @@ const cachedFontFamily = new Map<
   }
 >();
 export function getLineHeight(
-  fontFamily: CanvasTextFontFamily,
+  fontFamily: CanvasTextFontFamilyValueType,
   fontSize: number
 ) {
   const ctx = getMeasureCtx();
@@ -67,7 +67,7 @@ export function getFontString({
   fontStyle: string;
   fontWeight: string;
   fontSize: number;
-  fontFamily: CanvasTextFontFamily;
+  fontFamily: CanvasTextFontFamilyValueType;
 }): string {
   const lineHeight = getLineHeight(fontFamily, fontSize);
   return `${fontStyle} ${fontWeight} ${fontSize}px/${lineHeight}px ${wrapFontFamily(

--- a/packages/blocks/src/surface-block/utils/font.ts
+++ b/packages/blocks/src/surface-block/utils/font.ts
@@ -1,10 +1,10 @@
 import { IS_FIREFOX } from '@blocksuite/global/env';
 
-import type { CanvasTextFontFamily } from '../consts.js';
+import type { CanvasTextFontFamilyValueType } from '../consts.js';
 import type { FontFamily } from '../element-model/common.js';
 
 export function wrapFontFamily(
-  fontFamily: CanvasTextFontFamily | string
+  fontFamily: CanvasTextFontFamilyValueType | string
 ): string {
   return `"${fontFamily}"`;
 }
@@ -26,15 +26,15 @@ export const getFontFaces = IS_FIREFOX
   : () => [...document.fonts.keys()];
 
 export const isSameFontFamily = IS_FIREFOX
-  ? (fontFamily: CanvasTextFontFamily | FontFamily | string) =>
+  ? (fontFamily: CanvasTextFontFamilyValueType | FontFamily | string) =>
       (fontFace: FontFace) =>
         fontFace.family === `"${fontFamily}"`
-  : (fontFamily: CanvasTextFontFamily | FontFamily | string) =>
+  : (fontFamily: CanvasTextFontFamilyValueType | FontFamily | string) =>
       (fontFace: FontFace) =>
         fontFace.family === fontFamily;
 
 export function getFontFacesByFontFamily(
-  fontFamily: CanvasTextFontFamily | FontFamily | string
+  fontFamily: CanvasTextFontFamilyValueType | FontFamily | string
 ): FontFace[] {
   return (
     getFontFaces()


### PR DESCRIPTION
**Basic moments**

- Created `CanvasTextFontFamiliesNames` for maps each font family to its name for easier reference.
- Changing the rendering of the buttons to use the `options` property, which contains all available font families, instead of hardcoded values.

These changes improve code readability and maintainability by reducing repetition and centralizing font family names in one place.