### PR TITLE
fix(edgeless): curve path bounding box

### DIFF
--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -17,6 +17,10 @@ import { ConnectorMode } from '../element-model/connector.js';
 import { AStarRunner } from '../utils/a-star.js';
 import { Bound, getBoundFromPoints } from '../utils/bound.js';
 import {
+  getBezierCurveBoundingBox,
+  getBezierParameters,
+} from '../utils/curve.js';
+import {
   almostEqual,
   clamp,
   getBoundsWithRotation,
@@ -1132,8 +1136,10 @@ export class ConnectorPathGenerator {
     path?: PointLocation[]
   ) {
     const points = path ?? this._generateConnectorPath(connector) ?? [];
-
-    const bound = getBoundFromPoints(points);
+    const bound =
+      connector.mode === ConnectorMode.Curve
+        ? getBezierCurveBoundingBox(getBezierParameters(points))
+        : getBoundFromPoints(points);
     const relativePoints = points.map(p => {
       return p.setVec(Vec.sub(p, [bound.x, bound.y]));
     });

--- a/tests/edgeless/clipboard.spec.ts
+++ b/tests/edgeless/clipboard.spec.ts
@@ -127,7 +127,7 @@ test.describe('connector clipboard', () => {
     await createConnectorElement(page, [50, 50], [250, 50]);
 
     await copyByKeyboard(page);
-    const move = await toViewCoord(page, [150, -49.5]);
+    const move = await toViewCoord(page, [150, -50]);
     await page.mouse.move(move[0], move[1]);
     await pasteByKeyboard(page, false);
     await waitNextFrame(page);


### PR DESCRIPTION
Curve cannot be selected in the area outside the current dotted box.
<img width="386" alt="Screenshot 2024-04-07 at 15 00 04" src="https://github.com/toeverything/blocksuite/assets/27926/f84c01f4-22c5-4a0f-8319-64c01680bfb4">

https://github.com/toeverything/blocksuite/assets/27926/12b2cf69-1efd-4c8b-bf5f-9f08df0c2a82


