### PR TITLE
fix(edgeless): should check outside maxWidth constraint

### DIFF
--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
@@ -468,7 +468,7 @@ export function normalizeTextBound(
     attributes: delta.attributes,
   })) as TextDelta[];
   lines = deltaInsertsToChunks(insertDeltas);
-  if (!dragging && !text.hasMaxWidth) {
+  if (!dragging) {
     lines = deltaInsertsToChunks(deltas);
     const widestLineWidth = Math.max(
       ...yText


### PR DESCRIPTION
If there is a `maxWidth` constraint, it should be checked and reassigned outside.

```ts
bound.w = clamp(bound.w, 0, MAX_WIDTH)
```