### PR TITLE
fix(blocks): the IME sometimes break because of placeholder

### DIFF
--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -154,9 +154,6 @@ export class ParagraphBlockComponent extends BlockElement<
           ${paragraphBlockStyles}
         </style>
         <div class="affine-paragraph-rich-text-wrapper ${type}">
-          <div contenteditable="false" class="affine-paragraph-placeholder">
-            ${getPlaceholder(this.model)}
-          </div>
           <rich-text
             .yText=${this.model.text.yText}
             .inlineEventSource=${this.topContenteditableElement ?? nothing}
@@ -170,6 +167,9 @@ export class ParagraphBlockComponent extends BlockElement<
             .enableClipboard=${false}
             .enableUndoRedo=${false}
           ></rich-text>
+          <div contenteditable="false" class="affine-paragraph-placeholder">
+            ${getPlaceholder(this.model)}
+          </div>
         </div>
 
         ${children}


### PR DESCRIPTION
IME sometimes break because of placeholder (not reproduced in firefox)

import snapshot: 
[doc_home.bs (1).zip](https://github.com/toeverything/blocksuite/files/14941593/doc_home.bs.1.zip)

before:

https://github.com/toeverything/blocksuite/assets/50035259/bf255c9a-437d-4801-8f04-acaadd8d02e7


after:

https://github.com/toeverything/blocksuite/assets/50035259/2171375d-7475-4437-a64b-92f1af23ad24