### PR TITLE
fix(blocks): copilot panel needs to fill the width of the host

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
@@ -25,6 +25,10 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
       border-radius: 8px;
       z-index: var(--affine-z-index-popover);
     }
+
+    .edgeless-copilot-panel {
+      width: 100%;
+    }
   `;
 
   @property({ attribute: false })


### PR DESCRIPTION
<img width="316" alt="Screenshot 2024-04-15 at 13 36 29" src="https://github.com/toeverything/blocksuite/assets/27926/39fb030d-5d93-4e9c-8060-ca5ac6dba2db">
