### PR TITLE
refactor(presets): add photo engine to AIProvider

### DIFF
--- a/packages/playground/apps/default/specs-examples/ai/provider.ts
+++ b/packages/playground/apps/default/specs-examples/ai/provider.ts
@@ -292,4 +292,30 @@ export function setupAIProvider() {
       prompt,
     });
   });
+
+  // example implementation. does not work without key.
+  AIProvider.provide('photoEngine', {
+    async searchImages(options): Promise<string[]> {
+      const url = new URL('https://api.unsplash.com/search/photos');
+      const unsplashKey = 'placeholder';
+      url.searchParams.set('client_id', unsplashKey ?? '');
+      url.searchParams.set('query', options.query);
+      const result: {
+        results: {
+          urls: {
+            regular: string;
+          };
+        }[];
+      } = await fetch(url.toString()).then(res => res.json());
+      return result.results.map(r => {
+        const url = new URL(r.urls.regular);
+        url.searchParams.set('fit', 'crop');
+        url.searchParams.set('crop', 'edges');
+        url.searchParams.set('dpr', '3');
+        url.searchParams.set('w', `${options.width}`);
+        url.searchParams.set('w', `${options.height}`);
+        return url.toString();
+      });
+    },
+  });
 }

--- a/packages/presets/src/ai/actions/types.ts
+++ b/packages/presets/src/ai/actions/types.ts
@@ -166,5 +166,13 @@ declare global {
         docId?: string
       ) => Promise<AIHistory[] | undefined>;
     }
+
+    interface AIPhotoEngineService {
+      searchImages(options: {
+        width: number;
+        height: number;
+        query: string;
+      }): Promise<string[]>;
+    }
   }
 }

--- a/packages/presets/src/ai/provider.ts
+++ b/packages/presets/src/ai/provider.ts
@@ -21,6 +21,7 @@ export class AIProvider {
   private readonly actions: Partial<BlockSuitePresets.AIActions> = {};
   private userInfoFn: () => AIUserInfo | Promise<AIUserInfo> | null = () =>
     null;
+  private photoEngine: BlockSuitePresets.AIPhotoEngineService | null = null;
   private histories: BlockSuitePresets.AIHistoryService | null = null;
   private readonly slots = {
     // use case: when user selects "continue in chat" in an ask ai result panel
@@ -28,14 +29,6 @@ export class AIProvider {
     requestContinueInChat: new Slot<{ host: EditorHost; show: boolean }>(),
     // add more if needed
   };
-
-  // actions:
-  static provide<T extends keyof BlockSuitePresets.AIActions>(
-    id: T,
-    action: (
-      ...options: Parameters<BlockSuitePresets.AIActions[T]>
-    ) => ReturnType<BlockSuitePresets.AIActions[T]>
-  ): void;
 
   static provide(
     id: 'userInfo',
@@ -47,12 +40,28 @@ export class AIProvider {
     service: BlockSuitePresets.AIHistoryService
   ): void;
 
+  static provide(
+    id: 'photoEngine',
+    engine: BlockSuitePresets.AIPhotoEngineService
+  ): void;
+
+  // actions:
+  static provide<T extends keyof BlockSuitePresets.AIActions>(
+    id: T,
+    action: (
+      ...options: Parameters<BlockSuitePresets.AIActions[T]>
+    ) => ReturnType<BlockSuitePresets.AIActions[T]>
+  ): void;
+
   static provide(id: unknown, action: unknown) {
     if (id === 'userInfo') {
       AIProvider.instance.userInfoFn = action as () => AIUserInfo;
     } else if (id === 'histories') {
       AIProvider.instance.histories =
         action as BlockSuitePresets.AIHistoryService;
+    } else if (id === 'photoEngine') {
+      AIProvider.instance.photoEngine =
+        action as BlockSuitePresets.AIPhotoEngineService;
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       AIProvider.instance.provideAction(id as any, action as any);
@@ -95,6 +104,10 @@ export class AIProvider {
     this.actions[id] = action;
   }
 
+  static get slots() {
+    return AIProvider.instance.slots;
+  }
+
   static get actions() {
     return AIProvider.instance.actions;
   }
@@ -103,8 +116,8 @@ export class AIProvider {
     return AIProvider.instance.userInfoFn();
   }
 
-  static get slots() {
-    return AIProvider.instance.slots;
+  static get photoEngine() {
+    return AIProvider.instance.photoEngine;
   }
 
   static get histories() {

--- a/packages/presets/src/ai/slides/template.ts
+++ b/packages/presets/src/ai/slides/template.ts
@@ -1,6 +1,8 @@
 import { Bound } from '@blocksuite/blocks';
 import { nanoid } from '@blocksuite/store';
 
+import { AIProvider } from '../provider.js';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const replaceText = (text: Record<string, string>, template: any) => {
   if (template != null && typeof template === 'object') {
@@ -19,27 +21,17 @@ const replaceText = (text: Record<string, string>, template: any) => {
 const getImageUrlByKeyword =
   (keyword: string) =>
   async (w: number, h: number): Promise<string> => {
-    const url = new URL('https://api.unsplash.com/search/photos');
-    const unsplashKey = 'BONl2qMSdMLIexsUIOmi7Bh2dSO8hBUZQq2sUR0E4Jc'; //params.get('unsplashKey');
-    url.searchParams.set('client_id', unsplashKey ?? '');
-    url.searchParams.set('query', keyword);
-    const result: {
-      results: {
-        urls: {
-          regular: string;
-        };
-      }[];
-    } = await fetch(url.toString()).then(res => res.json());
-    const randomImage =
-      result.results[Math.floor(Math.random() * result.results.length)].urls
-        .regular;
-    const image = new URL(randomImage);
-    image.searchParams.set('fit', 'crop');
-    image.searchParams.set('crop', 'edges');
-    image.searchParams.set('dpr', '3');
-    image.searchParams.set('w', `${w}`);
-    image.searchParams.set('height', `${h}`);
-    return image.toString();
+    const photos = await AIProvider.photoEngine?.searchImages({
+      query: keyword,
+      width: w,
+      height: h,
+    });
+
+    if (photos == null || photos.length === 0) {
+      return ''; // fixme: give a default image
+    }
+
+    return photos[Math.floor(Math.random() * photos.length)];
   };
 
 const getImages = async (


### PR DESCRIPTION
abstract unsplash api through new `PhotoEngine` service.
Pending merge until we have a remote api defined in affine server @darkskygit 

https://app.graphite.dev/github/pr/toeverything/AFFiNE/6574/fix-core-provide-photoengine