### PR TITLE
fix(blocks): should not show copilot panel when no element is selected

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
@@ -14,8 +14,11 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
   static override styles = css`
     :host {
       display: flex;
-      box-sizing: border-box;
       position: absolute;
+    }
+
+    .edgeless-copilot-panel {
+      box-sizing: border-box;
       padding: 8px;
       min-width: 294px;
       max-height: 374px;
@@ -24,10 +27,6 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
       box-shadow: var(--affine-shadow-2);
       border-radius: 8px;
       z-index: var(--affine-z-index-popover);
-    }
-
-    .edgeless-copilot-panel {
-      width: 100%;
     }
   `;
 


### PR DESCRIPTION
<img width="494" alt="Screenshot 2024-04-16 at 12 55 53" src="https://github.com/toeverything/blocksuite/assets/27926/cf620258-6078-42ea-8e95-5903aad8a7c7">
