### PR TITLE
feat: support copy ai answer and fix ui issues

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/ai-item-list.ts
+++ b/packages/blocks/src/_common/components/ai-item/ai-item-list.ts
@@ -22,7 +22,7 @@ export class AIItemList extends WithDisposable(LitElement) {
     }
     .group-name {
       display: flex;
-      padding: 8px 12px;
+      padding: 4px calc(var(--item-padding, 8px) + 4px);
       align-items: center;
       color: var(--affine-text-secondary-color);
       text-align: justify;

--- a/packages/blocks/src/_common/components/ai-item/styles.ts
+++ b/packages/blocks/src/_common/components/ai-item/styles.ts
@@ -7,7 +7,7 @@ export const menuItemStyles = css`
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: 4px 12px;
+    padding: 4px var(--item-padding, 12px);
     gap: 4px;
     align-self: stretch;
     border-radius: 4px;
@@ -26,7 +26,9 @@ export const menuItemStyles = css`
   }
   .menu-item.discard:hover {
     background: var(--affine-background-error-color);
-    .item-icon {
+    .item-name,
+    .item-icon,
+    .enter-icon {
       color: var(--affine-error-color);
     }
   }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -20,6 +20,7 @@ import { deserializeXYWH } from './surface-block/index.js';
 export * from './_common/adapters/index.js';
 export * from './_common/components/ai-item/index.js';
 export type { SelectTag } from './_common/components/index.js';
+export { toast } from './_common/components/index.js';
 export {
   popTagSelect,
   RichText,

--- a/packages/blocks/src/root-block/widgets/ai-panel/components/discard-modal.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/discard-modal.ts
@@ -110,6 +110,7 @@ export class AIPanelDiscardModal extends LitElement {
     .modal-footer .discard:hover {
       color: var(--affine-error-color);
       border-color: var(--affine-error-color);
+      background: var(--affine-background-error-color);
     }
 
     .modal-footer .primary {

--- a/packages/blocks/src/root-block/widgets/ai-panel/components/state/answer.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/state/answer.ts
@@ -1,18 +1,22 @@
 import { WithDisposable } from '@blocksuite/block-std';
 import { baseTheme } from '@toeverything/theme';
 import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
-import type {
-  AIItemConfig,
-  AIItemGroupConfig,
-} from '../../../../../_common/components/ai-item/index.js';
+import type { AIItemGroupConfig } from '../../../../../_common/components/ai-item/index.js';
+import { AIDoneIcon } from '../../../../../_common/icons/ai.js';
 import { WarningIcon } from '../../../../../_common/icons/misc.js';
 import { CopyIcon } from '../../../../../_common/icons/text.js';
 
+export interface CopyConfig {
+  allowed: boolean;
+  onCopy: () => boolean | Promise<boolean>;
+}
+
 export type AIPanelAnswerConfig = {
-  responses: AIItemConfig[];
+  responses: AIItemGroupConfig[];
   actions: AIItemGroupConfig[];
+  copy?: CopyConfig;
 };
 
 @customElement('ai-panel-answer')
@@ -21,9 +25,10 @@ export class AIPanelAnswer extends WithDisposable(LitElement) {
     :host {
       width: 100%;
       display: flex;
+      box-sizing: border-box;
       flex-direction: column;
       gap: 8px;
-      padding: 12px 0px;
+      padding: 12px 8px;
     }
 
     .answer {
@@ -34,7 +39,7 @@ export class AIPanelAnswer extends WithDisposable(LitElement) {
       gap: 4px;
       align-self: stretch;
       font-family: ${unsafeCSS(baseTheme.fontSansFamily)};
-      padding: 0 12px;
+      padding: 0 8px;
     }
 
     .answer-head {
@@ -70,8 +75,9 @@ export class AIPanelAnswer extends WithDisposable(LitElement) {
       width: 100%;
       height: 22px;
       align-items: center;
+      justify-content: space-between;
       gap: 8px;
-      padding: 0 12px;
+      padding: 0 8px;
 
       color: var(--affine-text-secondary-color);
 
@@ -89,48 +95,52 @@ export class AIPanelAnswer extends WithDisposable(LitElement) {
       }
 
       .right {
-        /** TODO: need to implement answer copy action */
-        display: none;
+        display: flex;
         align-items: center;
-        gap: 16px;
 
-        .copy {
+        .copy,
+        .copied {
           display: flex;
           width: 20px;
           height: 20px;
           justify-content: center;
           align-items: center;
-
           border-radius: 8px;
-
-          &:hover {
-            background: var(--affine-hover-color);
-          }
+        }
+        .copy:hover {
+          color: var(--affine-icon-color);
+          background: var(--affine-hover-color);
+          cursor: pointer;
+        }
+        .copied {
+          color: var(--affine-brand-color);
         }
       }
     }
 
+    .response-list-container {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
     .response-list-container ai-item-list {
-      /* set item icon color outside ai-item */
+      /* set item style outside ai-item */
+      --item-padding: 4px;
       --item-icon-color: var(--affine-icon-secondary);
       --item-icon-hover-color: var(--affine-icon-color);
     }
   `;
-
   @property({ attribute: false })
   config!: AIPanelAnswerConfig;
 
   @property({ attribute: false })
   finish = true;
 
-  override render() {
-    const responseGroups: AIItemGroupConfig[] = [
-      {
-        name: 'Response',
-        items: this.config.responses,
-      },
-    ];
+  @state()
+  copied = false;
 
+  override render() {
     return html`
       <div class="answer">
         <div class="answer-head">Answer</div>
@@ -143,15 +153,34 @@ export class AIPanelAnswer extends WithDisposable(LitElement) {
             <div class="finish-tip">
               ${WarningIcon}
               <div class="text">AI outputs can be misleading or wrong</div>
-              <div class="right">
-                <div class="copy">${CopyIcon}</div>
-              </div>
+              ${this.config.copy?.allowed
+                ? html`<div class="right">
+                    ${this.copied
+                      ? html`<div class="copied">${AIDoneIcon}</div>`
+                      : html`<div
+                          class="copy"
+                          @click=${async () => {
+                            this.copied = !!(await this.config.copy?.onCopy());
+                          }}
+                        >
+                          ${CopyIcon}
+                          <affine-tooltip>Copy</affine-tooltip>
+                        </div>`}
+                  </div>`
+                : nothing}
             </div>
             ${this.config.responses.length > 0
               ? html`
                   <ai-panel-divider></ai-panel-divider>
                   <div class="response-list-container">
-                    <ai-item-list .groups=${responseGroups}></ai-item-list>
+                    ${this.config.responses.map(
+                      (group, index) => html`
+                        ${index !== 0
+                          ? html`<ai-panel-divider></ai-panel-divider>`
+                          : nothing}
+                        <ai-item-list .groups=${[group]}></ai-item-list>
+                      `
+                    )}
                   </div>
                 `
               : nothing}

--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
@@ -20,7 +20,7 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
     .edgeless-copilot-panel {
       box-sizing: border-box;
       padding: 8px;
-      min-width: 294px;
+      min-width: 320px;
       max-height: 374px;
       overflow-y: auto;
       background: var(--affine-background-overlay-panel-color);

--- a/packages/presets/src/ai/actions/consts.ts
+++ b/packages/presets/src/ai/actions/consts.ts
@@ -1,0 +1,8 @@
+export const EXCLUDING_COPY_ACTIONS = [
+  'brainstormMindmap',
+  'expandMindmap',
+  'makeItReal',
+  'createSlides',
+  'createImage',
+  'findActions',
+];

--- a/packages/presets/src/ai/actions/edgeless-response.ts
+++ b/packages/presets/src/ai/actions/edgeless-response.ts
@@ -1,16 +1,15 @@
 import type { EditorHost } from '@blocksuite/block-std';
 import type {
+  AffineAIPanelWidget,
+  AIItemConfig,
+  CopilotSelectionController,
   EdgelessCopilotWidget,
   EdgelessElementToolbarWidget,
-} from '@blocksuite/blocks';
-import {
-  type AffineAIPanelWidget,
-  type CopilotSelectionController,
-  type EdgelessModel,
-  type EdgelessRootService,
-  type MindmapElementModel,
-  type ShapeElementModel,
-  type SurfaceBlockModel,
+  EdgelessModel,
+  EdgelessRootService,
+  MindmapElementModel,
+  ShapeElementModel,
+  SurfaceBlockModel,
 } from '@blocksuite/blocks';
 import {
   AFFINE_EDGELESS_COPILOT_WIDGET,
@@ -26,8 +25,10 @@ import {
 import { insertFromMarkdown } from '../_common/markdown-utils.js';
 import { getSurfaceElementFromEditor } from '../_common/selection-utils.js';
 import { getAIPanel } from '../ai-panel.js';
+import { copyTextAnswer } from '../utils/editor-actions.js';
 import { fetchImageToFile } from '../utils/image.js';
 import { getEdgelessRootFromEditor } from '../utils/selection-utils.js';
+import { EXCLUDING_COPY_ACTIONS } from './consts.js';
 
 export type CtxRecord = {
   get(): Record<string, unknown>;
@@ -86,7 +87,7 @@ export function getCopilotSelectedElems(host: EditorHost): EdgelessModel[] {
 export function discard(
   panel: AffineAIPanelWidget,
   copilot: EdgelessCopilotWidget
-): FinishConfig['responses'][number] {
+): AIItemConfig {
   return {
     name: 'Discard',
     icon: DeleteIcon,
@@ -100,9 +101,7 @@ export function discard(
   };
 }
 
-export function retry(
-  panel: AffineAIPanelWidget
-): FinishConfig['responses'][number] {
+export function retry(panel: AffineAIPanelWidget): AIItemConfig {
   return {
     name: 'Retry',
     icon: ResetIcon,
@@ -116,7 +115,7 @@ export function createInsertResp(
   handler: (host: EditorHost, ctx: CtxRecord) => void,
   host: EditorHost,
   ctx: CtxRecord
-): FinishConfig['responses'][number] {
+): AIItemConfig {
   return {
     name: 'Insert below',
     icon: InsertBelowIcon,
@@ -311,10 +310,21 @@ export function actionToResponse<T extends keyof BlockSuitePresets.AIActions>(
 ): FinishConfig {
   return {
     responses: [
-      getResponseHandler(id, host, ctx),
-      retry(getAIPanel(host)),
-      discard(getAIPanel(host), getEdgelessCopilotWidget(host)),
+      {
+        name: 'Response',
+        items: [
+          getResponseHandler(id, host, ctx),
+          retry(getAIPanel(host)),
+          discard(getAIPanel(host), getEdgelessCopilotWidget(host)),
+        ],
+      },
     ],
     actions: [],
+    copy: {
+      allowed: !EXCLUDING_COPY_ACTIONS.includes(id),
+      onCopy: () => {
+        return copyTextAnswer(getAIPanel(host));
+      },
+    },
   };
 }

--- a/packages/presets/src/ai/ai-panel.ts
+++ b/packages/presets/src/ai/ai-panel.ts
@@ -13,7 +13,11 @@ import { assertExists } from '@blocksuite/global/utils';
 
 import { createTextRenderer } from './messages/text.js';
 import { AIProvider } from './provider.js';
-import { insertBelow, replace } from './utils/editor-actions.js';
+import {
+  copyTextAnswer,
+  insertBelow,
+  replace,
+} from './utils/editor-actions.js';
 import { getSelections } from './utils/selection-utils.js';
 
 export function buildTextResponseConfig(panel: AffineAIPanelWidget) {
@@ -55,7 +59,7 @@ export function buildTextResponseConfig(panel: AffineAIPanelWidget) {
   const _insertBelow = async () => {
     const selection = getSelection();
 
-    if (!selection) {
+    if (!selection || !panel.answer) {
       return;
     }
 
@@ -66,25 +70,52 @@ export function buildTextResponseConfig(panel: AffineAIPanelWidget) {
 
   return [
     {
-      name: 'Insert below',
-      icon: InsertBelowIcon,
-      handler: () => {
-        _insertBelow().catch(console.error);
-      },
+      name: 'Response',
+      items: [
+        {
+          name: 'Insert below',
+          icon: InsertBelowIcon,
+          handler: () => {
+            _insertBelow().catch(console.error);
+          },
+        },
+        {
+          name: 'Replace selection',
+          icon: ReplaceIcon,
+          handler: () => {
+            _replace().catch(console.error);
+          },
+        },
+      ],
     },
     {
-      name: 'Replace selection',
-      icon: ReplaceIcon,
-      handler: () => {
-        _replace().catch(console.error);
-      },
-    },
-    {
-      name: 'Discard',
-      icon: DiscardIcon,
-      handler: () => {
-        panel.discard();
-      },
+      name: '',
+      items: [
+        {
+          name: 'Continue in chat',
+          icon: ChatWithAIIcon,
+          handler: () => {
+            AIProvider.slots.requestContinueInChat.emit({
+              host: panel.host,
+              show: true,
+            });
+          },
+        },
+        {
+          name: 'Regenerate',
+          icon: ResetIcon,
+          handler: () => {
+            panel.generate();
+          },
+        },
+        {
+          name: 'Discard',
+          icon: DiscardIcon,
+          handler: () => {
+            panel.discard();
+          },
+        },
+      ],
     },
   ];
 }
@@ -96,30 +127,13 @@ export function buildAIPanelConfig(
     answerRenderer: createTextRenderer(panel.host),
     finishStateConfig: {
       responses: buildTextResponseConfig(panel),
-      actions: [
-        {
-          name: '',
-          items: [
-            {
-              name: 'Continue in chat',
-              icon: ChatWithAIIcon,
-              handler: () => {
-                AIProvider.slots.requestContinueInChat.emit({
-                  host: panel.host,
-                  show: true,
-                });
-              },
-            },
-            {
-              name: 'Regenerate',
-              icon: ResetIcon,
-              handler: () => {
-                panel.generate();
-              },
-            },
-          ],
+      actions: [], // ???
+      copy: {
+        allowed: true,
+        onCopy: () => {
+          return copyTextAnswer(panel);
         },
-      ],
+      },
     },
     errorStateConfig: {
       upgrade: () => {

--- a/packages/presets/src/ai/entries/edgeless/actions-config.ts
+++ b/packages/presets/src/ai/entries/edgeless/actions-config.ts
@@ -25,7 +25,7 @@ const translateSubItem = translateLangs.map(lang => {
 });
 
 export const docGroup: AIItemGroupConfig = {
-  name: 'doc',
+  name: 'doc with ai',
   items: [
     {
       name: 'Summary',
@@ -55,7 +55,7 @@ export const othersGroup: AIItemGroupConfig = {
 };
 
 export const editGroup: AIItemGroupConfig = {
-  name: 'edit',
+  name: 'edit with ai',
   items: [
     {
       name: 'Translate to',
@@ -97,7 +97,7 @@ export const editGroup: AIItemGroupConfig = {
 };
 
 export const draftGroup: AIItemGroupConfig = {
-  name: 'draft',
+  name: 'draft with ai',
   items: [
     {
       name: 'Write an article about this',
@@ -139,7 +139,7 @@ export const draftGroup: AIItemGroupConfig = {
 };
 
 export const mindmapGroup: AIItemGroupConfig = {
-  name: 'mindmap',
+  name: 'mindmap with ai',
   items: [
     {
       name: 'Expand from this mindmap node',
@@ -157,7 +157,7 @@ export const mindmapGroup: AIItemGroupConfig = {
 };
 
 export const presentationGroup: AIItemGroupConfig = {
-  name: 'presentation',
+  name: 'presentation with ai',
   items: [
     {
       name: 'Create a presentation',
@@ -169,7 +169,7 @@ export const presentationGroup: AIItemGroupConfig = {
 };
 
 export const createGroup: AIItemGroupConfig = {
-  name: 'create',
+  name: 'create with ai',
   items: [
     {
       name: 'Create an image',

--- a/packages/presets/src/ai/entries/edgeless/panel-config.ts
+++ b/packages/presets/src/ai/entries/edgeless/panel-config.ts
@@ -3,6 +3,7 @@ import type { AffineAIPanelWidget } from '@blocksuite/blocks';
 
 import { createTextRenderer } from '../../messages/text.js';
 import { AIProvider } from '../../provider.js';
+import { copyTextAnswer } from '../../utils/editor-actions.js';
 
 export function buildEdgelessPanelConfig(
   panel: AffineAIPanelWidget
@@ -12,6 +13,12 @@ export function buildEdgelessPanelConfig(
     finishStateConfig: {
       responses: buildDefaultResponse(panel),
       actions: [],
+      copy: {
+        allowed: true,
+        onCopy: () => {
+          return copyTextAnswer(panel);
+        },
+      },
     },
     errorStateConfig: {
       upgrade: () => {


### PR DESCRIPTION
Add copy config to AIPanelAnswerConfig:

```
export interface CopyConfig {
  allowed: boolean;
  onCopy: () => boolean | Promise<boolean>;
}
```

When an action response can be copied, can config it in finishStateConfig, different types of actions can be configured with different copy behaviors, which need to be implemented according to the specific type:

```
    finishStateConfig: {
      responses: buildDefaultResponse(panel),
      actions: [],
      copy: {
        allowed: true,
        onCopy: () => {
          return copyTextAnswer(panel);
        },
      },
    },
```

For example, for rich text response, copy rich text content to clipboard:

```
export const copyTextAnswer = async (panel: AffineAIPanelWidget) => {
  const host = panel.host;
  if (panel.state !== 'finished' || !panel.answer) {
    return false;
  }
  const previewDoc = await markDownToDoc(host, panel.answer);
  const models = previewDoc
    .getBlocksByFlavour('affine:note')
    .map(b => b.model)
    .flatMap(model => model.children);
  const slice = Slice.fromModels(previewDoc, models);
  await host.std.clipboard.copySlice(slice);
  return true;
};
```