### PR TITLE
feat(presets): error handling

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/types.ts
+++ b/packages/blocks/src/_common/components/ai-item/types.ts
@@ -24,3 +24,31 @@ export interface AISubItemConfig {
   type: string;
   handler?: (host: EditorHost) => void;
 }
+
+abstract class BaseAIError extends Error {
+  abstract readonly type: AIErrorType;
+}
+
+export enum AIErrorType {
+  PaymentRequired = 'PaymentRequired',
+  GeneralNetworkError = 'GeneralNetworkError',
+}
+
+// todo: move to presets
+// user has used up the quota
+export class PaymentRequiredError extends BaseAIError {
+  readonly type = AIErrorType.PaymentRequired;
+  constructor() {
+    super('Payment required');
+  }
+}
+
+// general 500x error
+export class GeneralNetworkError extends BaseAIError {
+  readonly type = AIErrorType.GeneralNetworkError;
+  constructor() {
+    super('Network error');
+  }
+}
+
+export type AIError = PaymentRequiredError | GeneralNetworkError;

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -19,6 +19,7 @@ import {
 import { customElement, property, query } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 
+import type { AIError } from '../../../_common/components/index.js';
 import type { AIPanelDiscardModal } from './components/discard-modal.js';
 import { toggleDiscardModal } from './components/discard-modal.js';
 import type {
@@ -34,7 +35,7 @@ export interface AffineAIPanelWidgetConfig {
   generateAnswer?: (props: {
     input: string;
     update: (answer: string) => void;
-    finish: (type: 'success' | 'error' | 'aborted') => void;
+    finish: (type: 'success' | 'error' | 'aborted', err?: AIError) => void;
     // Used to allow users to stop actively when generating
     signal: AbortSignal;
   }) => void;
@@ -171,11 +172,14 @@ export class AffineAIPanelWidget extends WidgetElement {
       this._answer = answer;
       this.requestUpdate();
     };
-    const finish = (type: 'success' | 'error' | 'aborted') => {
+    const finish = (type: 'success' | 'error' | 'aborted', err?: AIError) => {
+      assertExists(this.config);
       if (type === 'error') {
         this.state = 'error';
+        this.config.errorStateConfig.error = err;
       } else {
         this.state = 'finished';
+        this.config.errorStateConfig.error = undefined;
       }
 
       this._resetAbortController();

--- a/packages/blocks/src/root-block/widgets/ai-panel/components/state/error.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/state/error.ts
@@ -2,15 +2,19 @@ import { WithDisposable } from '@blocksuite/block-std';
 import { baseTheme } from '@toeverything/theme';
 import { css, html, LitElement, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { choose } from 'lit/directives/choose.js';
 
-import type {
-  AIItemConfig,
-  AIItemGroupConfig,
+import {
+  type AIError,
+  AIErrorType,
+  type AIItemConfig,
+  type AIItemGroupConfig,
 } from '../../../../../_common/components/index.js';
 
 export interface AIPanelErrorConfig {
   upgrade: () => void;
   responses: AIItemConfig[];
+  error?: AIError;
 }
 
 @customElement('ai-panel-error')
@@ -60,6 +64,10 @@ export class AIPanelError extends WithDisposable(LitElement) {
           font-style: normal;
           font-weight: 400;
           line-height: 22px; /* 157.143% */
+
+          a {
+            color: inherit;
+          }
         }
       }
       .upgrade {
@@ -95,20 +103,41 @@ export class AIPanelError extends WithDisposable(LitElement) {
 
   override render() {
     const groups: AIItemGroupConfig[] = [{ items: this.config.responses }];
-
-    return html`
-      <div class="error">
+    const errorTemplate = choose(
+      this.config.error?.type,
+      [
+        [
+          AIErrorType.PaymentRequired,
+          () => html`
+            <div class="answer-tip">
+              <div class="top">Answer</div>
+              <div class="bottom">
+                You’ve reached the current usage cap for GPT-4. You can
+                subscribe AFFiNE AI to continue AI experience!
+              </div>
+              <div @click=${this.config.upgrade} class="upgrade">
+                <div class="content">Upgrade</div>
+              </div>
+            </div>
+          `,
+        ],
+      ],
+      // default error handler
+      () => html`
         <div class="answer-tip">
           <div class="top">Answer</div>
           <div class="bottom">
             An error occurred, If this issue persists please let us know
-            contact@toeverything.info
+            <a href="mailto:contact@toeverything.info">
+              contact@toeverything.info
+            </a>
           </div>
         </div>
-        <div @click=${this.config.upgrade} class="upgrade">
-          <div class="content">Upgrade</div>
-        </div>
-      </div>
+      `
+    );
+
+    return html`
+      <div class="error">${errorTemplate}</div>
       ${this.config.responses.length > 0
         ? html`<ai-item-list .groups=${groups}></ai-item-list>`
         : nothing}

--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -1,5 +1,5 @@
 import type { EditorHost } from '@blocksuite/block-std';
-import type { AffineAIPanelWidget } from '@blocksuite/blocks';
+import type { AffineAIPanelWidget, AIError } from '@blocksuite/blocks';
 import { MindmapElementModel, NoteBlockModel } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import { Slice } from '@blocksuite/store';
@@ -148,7 +148,7 @@ function actionToGeneration<T extends keyof BlockSuitePresets.AIActions>(
       input: string;
       signal?: AbortSignal;
       update: (text: string) => void;
-      finish: (state: 'success' | 'error' | 'aborted') => void;
+      finish: (state: 'success' | 'error' | 'aborted', err?: AIError) => void;
     }) => {
       const selectedElements = getCopilotSelectedElems(host);
 

--- a/packages/presets/src/ai/actions/handler.ts
+++ b/packages/presets/src/ai/actions/handler.ts
@@ -3,6 +3,7 @@ import type {
   AffineAIPanelWidget,
   AffineAIPanelWidgetConfig,
 } from '@blocksuite/blocks';
+import type { AIError } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 
 import { getAIPanel } from '../ai-panel.js';
@@ -21,7 +22,7 @@ export function bindEventSource(
     signal,
   }: {
     update: (text: string) => void;
-    finish: (state: 'success' | 'error' | 'aborted') => void;
+    finish: (state: 'success' | 'error' | 'aborted', err?: AIError) => void;
     signal?: AbortSignal;
   }
 ) {
@@ -40,7 +41,7 @@ export function bindEventSource(
     if (err.name === 'AbortError') {
       finish('aborted');
     } else {
-      finish('error');
+      finish('error', err);
     }
   });
 }
@@ -98,7 +99,7 @@ export function actionToGenerateAnswer<
       input: string;
       signal?: AbortSignal;
       update: (text: string) => void;
-      finish: (state: 'success' | 'error' | 'aborted') => void;
+      finish: (state: 'success' | 'error' | 'aborted', err?: AIError) => void;
     }) => {
       const { selectedBlocks: blocks } = getSelections(host);
       if (!blocks || blocks.length === 0) return;

--- a/packages/presets/src/ai/ai-panel.ts
+++ b/packages/presets/src/ai/ai-panel.ts
@@ -166,10 +166,12 @@ export function buildAIPanelConfig(
             },
           ],
         },
-      ], // ???
+      ],
     },
     errorStateConfig: {
-      upgrade: () => {},
+      upgrade: () => {
+        AIProvider.slots.requestUpgradePlan.emit({ host: panel.host });
+      },
       responses: [],
     },
   };

--- a/packages/presets/src/ai/entries/edgeless/panel-config.ts
+++ b/packages/presets/src/ai/entries/edgeless/panel-config.ts
@@ -2,6 +2,7 @@ import type { AffineAIPanelWidgetConfig } from '@blocksuite/blocks';
 import type { AffineAIPanelWidget } from '@blocksuite/blocks';
 
 import { createTextRenderer } from '../../messages/text.js';
+import { AIProvider } from '../../provider.js';
 
 export function buildEdgelessPanelConfig(
   panel: AffineAIPanelWidget
@@ -13,7 +14,9 @@ export function buildEdgelessPanelConfig(
       actions: [],
     },
     errorStateConfig: {
-      upgrade: () => {},
+      upgrade: () => {
+        AIProvider.slots.requestUpgradePlan.emit({ host: panel.host });
+      },
       responses: [],
     },
   };

--- a/packages/presets/src/ai/provider.ts
+++ b/packages/presets/src/ai/provider.ts
@@ -26,6 +26,7 @@ export class AIProvider {
     // use case: when user selects "continue in chat" in an ask ai result panel
     // do we need to pass the context to the chat panel?
     requestContinueInChat: new Slot<{ host: EditorHost; show: boolean }>(),
+    requestUpgradePlan: new Slot<{ host: EditorHost }>(),
     // add more if needed
   };
 
@@ -57,29 +58,6 @@ export class AIProvider {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       AIProvider.instance.provideAction(id as any, action as any);
     }
-  }
-
-  /**
-   * @deprecated use `provide` instead
-   */
-  static provideAction<T extends keyof BlockSuitePresets.AIActions>(
-    id: T,
-    action: (
-      ...options: Parameters<BlockSuitePresets.AIActions[T]>
-    ) => ReturnType<BlockSuitePresets.AIActions[T]>
-  ): void {
-    if (AIProvider.instance.actions[id]) {
-      console.warn(`AI action ${id} is already provided`);
-    }
-    // @ts-expect-error todo: maybe fix this
-    AIProvider.instance.actions[id] = action;
-  }
-
-  /**
-   * @deprecated use `provide` instead
-   */
-  static provideUserInfo(fn: () => AIUserInfo | Promise<AIUserInfo> | null) {
-    AIProvider.instance.userInfoFn = fn;
   }
 
   private provideAction<T extends keyof BlockSuitePresets.AIActions>(


### PR DESCRIPTION
Added predefined `AIError` that will be throw by implementations of AIProvider's actions.

There are two types of errors for now: 
- PaymentRequiredError: reported if affine server returns 402 error
- GeneralNetworkError: all other errors

For callers of these actions, they will be required to handle these errors and render error prompt accordingly.
I have updated error handling logic & template in AIPanel in this PR.