### PR TITLE
fix(blocks): update list number prefix when updating a block

### DIFF
--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -93,13 +93,6 @@ export class ListBlockComponent extends BlockElement<
     return result;
   }
 
-  override firstUpdated() {
-    this._updateFollowingListSiblings();
-    this.model.childrenUpdated.on(() => {
-      this._updateFollowingListSiblings();
-    });
-  }
-
   private _updateFollowingListSiblings() {
     this.updateComplete
       .then(() => {
@@ -120,6 +113,21 @@ export class ListBlockComponent extends BlockElement<
     bindContainerHotkey(this);
 
     this._inlineRangeProvider = getInlineRangeProvider(this);
+
+    this._updateFollowingListSiblings();
+    this.disposables.add(
+      this.model.childrenUpdated.on(() => {
+        this._updateFollowingListSiblings();
+      })
+    );
+    this.host.std.doc.slots.blockUpdated.on(e => {
+      if (e.type !== 'delete') return;
+      const deletedBlock = this.std.view.getBlock(e.id);
+      if (!deletedBlock) return;
+      if (this !== deletedBlock.nextElementSibling) return;
+      this._updateFollowingListSiblings();
+      return;
+    });
   }
 
   private _toggleChildren() {

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -120,14 +120,16 @@ export class ListBlockComponent extends BlockElement<
         this._updateFollowingListSiblings();
       })
     );
-    this.host.std.doc.slots.blockUpdated.on(e => {
-      if (e.type !== 'delete') return;
-      const deletedBlock = this.std.view.getBlock(e.id);
-      if (!deletedBlock) return;
-      if (this !== deletedBlock.nextElementSibling) return;
-      this._updateFollowingListSiblings();
-      return;
-    });
+    this.disposables.add(
+      this.host.std.doc.slots.blockUpdated.on(e => {
+        if (e.type !== 'delete') return;
+        const deletedBlock = this.std.view.getBlock(e.id);
+        if (!deletedBlock) return;
+        if (this !== deletedBlock.nextElementSibling) return;
+        this._updateFollowingListSiblings();
+        return;
+      })
+    );
   }
 
   private _toggleChildren() {


### PR DESCRIPTION
Fix https://github.com/toeverything/blocksuite/issues/6697

This pull request fixes the list number prefix expires by listening to the `blockUpdated` event.

https://github.com/toeverything/blocksuite/assets/18554747/ec8d6ce0-0a85-42b0-9114-081d40aebc29

## Limits

- Not work when reordering blocks by drag handle

https://github.com/toeverything/blocksuite/assets/18554747/d4e659b9-f0cc-4140-b0d1-dd0633743f28

- Not work in some cases of undo/redo

https://github.com/toeverything/blocksuite/assets/18554747/3a7e08de-5450-480d-8dab-1fe19486d374



