### PR TITLE
fix(blocks): element toolbar should not be displayed when in copilot tool

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -212,7 +212,11 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
 
     _disposables.add(
       this.selection.slots.updated.on(() => {
-        if (this.selection.selectedIds.length === 0 || this.selection.editing) {
+        if (
+          this.selection.selectedIds.length === 0 ||
+          this.selection.editing ||
+          this.selection.inoperable
+        ) {
           this.toolbarVisible = false;
         } else {
           this.toolbarVisible = true;


### PR DESCRIPTION
<img width="530" alt="Screenshot 2024-04-17 at 20 28 18" src="https://github.com/toeverything/blocksuite/assets/27926/9327b7ec-4efa-4eed-954b-4101ed37833e">
