### PR TITLE
fix(presets): auto scroll answer text to bottom when generating

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -803,6 +803,8 @@ export class EdgelessRootBlockComponent extends BlockElement<
     }
 
     this.keyboardManager = null;
+    this.components.toolbar?.remove();
+    this.components.toolbar = null;
   }
 
   override renderBlock() {

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -70,7 +70,10 @@ export class AffineAIPanelWidget extends WidgetElement {
       background: var(--affine-background-overlay-panel-color);
 
       /* light/toolbarShadow */
-      box-shadow: var(--affine-shadow-1);
+      box-shadow: var(
+        --affine-toolbar-shadow,
+        0px 6px 16px 0px rgba(0, 0, 0, 0.14)
+      );
 
       gap: 8px;
 

--- a/packages/blocks/src/root-block/widgets/ai-panel/components/divider.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/divider.ts
@@ -14,7 +14,7 @@ export class AIPanelDivider extends WithDisposable(LitElement) {
     }
     .divider {
       height: 0.5px;
-      background: #e3e2e4;
+      background: var(--affine-border-color);
       width: 100%;
     }
   `;

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -1,5 +1,6 @@
 export {
   AFFINE_AI_PANEL_WIDGET,
+  type AffineAIPanelState,
   AffineAIPanelWidget,
   type AffineAIPanelWidgetConfig,
 } from './ai-panel/ai-panel.js';

--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -54,7 +54,7 @@ function actionToRenderer<T extends keyof BlockSuitePresets.AIActions>(
     return createImageRenderer;
   }
 
-  return createTextRenderer(host);
+  return createTextRenderer(host, 320);
 }
 
 async function getTextFromSelected(host: EditorHost) {

--- a/packages/presets/src/ai/ai-panel.ts
+++ b/packages/presets/src/ai/ai-panel.ts
@@ -125,7 +125,7 @@ export function buildAIPanelConfig(
   panel: AffineAIPanelWidget
 ): AffineAIPanelWidgetConfig {
   return {
-    answerRenderer: createTextRenderer(panel.host),
+    answerRenderer: createTextRenderer(panel.host, 320),
     finishStateConfig: {
       responses: buildTextResponseConfig(panel),
       actions: [], // ???

--- a/packages/presets/src/ai/entries/edgeless/panel-config.ts
+++ b/packages/presets/src/ai/entries/edgeless/panel-config.ts
@@ -9,7 +9,7 @@ export function buildEdgelessPanelConfig(
   panel: AffineAIPanelWidget
 ): AffineAIPanelWidgetConfig {
   return {
-    answerRenderer: createTextRenderer(panel.host),
+    answerRenderer: createTextRenderer(panel.host, 320),
     finishStateConfig: {
       responses: buildDefaultResponse(panel),
       actions: [],

--- a/packages/presets/src/ai/messages/text.ts
+++ b/packages/presets/src/ai/messages/text.ts
@@ -1,22 +1,21 @@
 import { type EditorHost } from '@blocksuite/block-std';
+import type { AffineAIPanelState } from '@blocksuite/blocks';
 import { type AffineAIPanelWidgetConfig } from '@blocksuite/blocks';
 import type { Doc } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { keyed } from 'lit/directives/keyed.js';
 
 import { CustomPageEditorBlockSpecs } from '../utils/custom-specs.js';
 import { markDownToDoc } from '../utils/markdown-utils.js';
 
-@customElement('ai-answer-text')
-export class AIAnswerText extends LitElement {
+@customElement('ai-answer-text-preview')
+export class AIAnswerTextPreview extends LitElement {
   static override styles = css`
-    .ai-answer-text-container {
-      max-height: 340px;
+    :host {
       width: 100%;
       display: flex;
-      overflow-y: auto;
-      overflow-x: hidden;
       user-select: none;
     }
 
@@ -24,24 +23,11 @@ export class AIAnswerText extends LitElement {
       background: transparent;
       font-family: var(--affine-font-family);
       margin-top: 0;
+      margin-bottom: 0;
     }
 
     .ai-answer-text-editor .affine-page-root-block-container {
       padding: 0;
-    }
-
-    .ai-answer-text-container::-webkit-scrollbar {
-      width: 5px;
-      height: 100px;
-    }
-    .ai-answer-text-container::-webkit-scrollbar-thumb {
-      border-radius: 20px;
-    }
-    .ai-answer-text-container:hover::-webkit-scrollbar-thumb {
-      background-color: var(--affine-black-30);
-    }
-    .ai-answer-text-container::-webkit-scrollbar-corner {
-      display: none;
     }
   `;
 
@@ -77,13 +63,95 @@ export class AIAnswerText extends LitElement {
   override render() {
     if (!this._previewDoc) return nothing;
     return html`
-      <div class="ai-answer-text-container">
-        <div class="ai-answer-text-editor affine-page-viewport">
-          ${this.host.renderSpecPortal(
-            this._previewDoc,
-            CustomPageEditorBlockSpecs
-          )}
-        </div>
+      <div class="ai-answer-text-editor affine-page-viewport">
+        ${this.host.renderSpecPortal(
+          this._previewDoc,
+          CustomPageEditorBlockSpecs
+        )}
+      </div>
+    `;
+  }
+}
+
+@customElement('ai-answer-text')
+export class AIAnswerText extends LitElement {
+  static override styles = css`
+    .ai-answer-text-container {
+      overflow-y: auto;
+      overflow-x: hidden;
+      display: flex;
+      padding: 0;
+    }
+    .ai-answer-text-container.show-scrollbar::-webkit-scrollbar {
+      width: 5px;
+      height: 100px;
+    }
+    .ai-answer-text-container.show-scrollbar::-webkit-scrollbar-thumb {
+      border-radius: 20px;
+    }
+    .ai-answer-text-container.show-scrollbar:hover::-webkit-scrollbar-thumb {
+      background-color: var(--affine-black-30);
+    }
+    .ai-answer-text-container.show-scrollbar::-webkit-scrollbar-corner {
+      display: none;
+    }
+  `;
+
+  @property({ attribute: false })
+  host!: EditorHost;
+
+  @property({ attribute: false })
+  answer!: string;
+
+  @property({ attribute: false })
+  state?: AffineAIPanelState;
+
+  @property({ attribute: false })
+  maxHeight?: number;
+
+  @query('.ai-answer-text-container')
+  private _container!: HTMLDivElement;
+
+  private _onWheel(e: MouseEvent) {
+    e.stopPropagation();
+    if (this.state === 'generating') {
+      e.preventDefault();
+    }
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('answer')) {
+      requestAnimationFrame(() => {
+        if (!this._container) return;
+        this._container.scrollTop = this._container.scrollHeight;
+      });
+    }
+  }
+
+  override render() {
+    if (!this.answer) return nothing;
+    const classes = classMap({
+      'ai-answer-text-container': true,
+      'show-scrollbar': !!this.maxHeight,
+    });
+    return html`
+      <style>
+        .ai-answer-text-container {
+          max-height: ${this.maxHeight
+            ? Math.max(this.maxHeight, 200) + 'px'
+            : ''};
+        }
+      </style>
+      <div class=${classes} @wheel=${this._onWheel}>
+        ${keyed(
+          this.answer,
+          html`<ai-answer-text-preview
+            .host=${this.host}
+            .answer=${this.answer}
+          ></ai-answer-text-preview>`
+        )}
       </div>
     `;
   }
@@ -92,16 +160,20 @@ export class AIAnswerText extends LitElement {
 declare global {
   interface HTMLElementTagNameMap {
     'ai-answer-text': AIAnswerText;
+    'ai-answer-text-preview': AIAnswerTextPreview;
   }
 }
 
 export const createTextRenderer: (
-  host: EditorHost
-) => AffineAIPanelWidgetConfig['answerRenderer'] = host => {
-  return answer => {
-    return html`${keyed(
-      answer,
-      html`<ai-answer-text .host=${host} .answer=${answer}></ai-answer-text>`
-    )}`;
+  host: EditorHost,
+  maxHeight?: number
+) => AffineAIPanelWidgetConfig['answerRenderer'] = (host, maxHeight) => {
+  return (answer, state) => {
+    return html`<ai-answer-text
+      .host=${host}
+      .answer=${answer}
+      .state=${state}
+      .maxHeight=${maxHeight}
+    ></ai-answer-text>`;
   };
 };


### PR DESCRIPTION
Support auto-scroll to bottom when generating answer.

ai-answer-text element now support config maxHeight, when set maxHeight, the element will be scrollable.

```
export const createTextRenderer: (
  host: EditorHost,
  maxHeight?: number
) => AffineAIPanelWidgetConfig['answerRenderer'] = (host, maxHeight) => {
  return (answer, state) => {
    return html`<ai-answer-text
      .host=${host}
      .answer=${answer}
      .state=${state}
      .maxHeight=${maxHeight}
    ></ai-answer-text>`;
  };
};
```

When want the element to have a maximum height and can automatically scroll to the bottom, pass in maxHeight when calling createTextRenderer. 

```
createTextRenderer(host, 320);
```

When no need the maximum height and want to render all content, do not pass in maxHeight.

```
createTextRenderer(host);
```
