### PR TITLE
fix(presets): should not send attachments when multiple blocks selected

### DIFF
--- a/packages/presets/src/ai/actions/handler.ts
+++ b/packages/presets/src/ai/actions/handler.ts
@@ -60,14 +60,17 @@ export function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
     return {
       async *[Symbol.asyncIterator]() {
         const panel = getAIPanel(host);
+        const selections = getSelections(host);
         const [markdown, attachments] = await Promise.all([
           getSelectedTextContent(panel.host),
           getSelectedImagesAsBlobs(panel.host),
         ]);
+        // for now if there are more than one selected blocks, we will not omit the attachments
+        const sendAttachments = selections?.selectedBlocks?.length === 1;
         const options = {
           ...variants,
-          attachments,
-          input: markdown,
+          attachments: sendAttachments ? attachments : undefined,
+          input: sendAttachments ? '' : markdown,
           stream: true,
           docId: host.doc.id,
           workspaceId: host.doc.collection.id,


### PR DESCRIPTION
our used model does not support vision + text at the moment (except chat)