### PR TITLE
fix: bash escape by ` in PR title linting

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -23,4 +23,9 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: echo "${{ github.event.pull_request.title }}" | npx commitlint -g ./.commitlintrc.json
+      - name: Check PR title
+        # Using an intermediate environment variable to prevent command injection
+        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$TITLE" | npx commitlint -g ./.commitlintrc.json


### PR DESCRIPTION
This pull request fixes an issue with bash escape in the PR title linting workflow.

This PR adds an intermediate environment variable to prevent command injection and ensures the PR title is properly checked using commitlint.

Credits to @random-dudde with https://github.com/toeverything/AFFiNE/pull/6640