### PR TITLE
fix(presets): filter out non text content in text preview

### DIFF
--- a/packages/presets/src/ai/messages/text.ts
+++ b/packages/presets/src/ai/messages/text.ts
@@ -1,7 +1,10 @@
-import { type EditorHost } from '@blocksuite/block-std';
+import { type EditorHost, WithDisposable } from '@blocksuite/block-std';
 import type { AffineAIPanelState } from '@blocksuite/blocks';
-import { type AffineAIPanelWidgetConfig } from '@blocksuite/blocks';
-import type { Doc } from '@blocksuite/store';
+import {
+  type AffineAIPanelWidgetConfig,
+  BlocksUtils,
+} from '@blocksuite/blocks';
+import type { BlockSelector, Doc } from '@blocksuite/store';
 import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -11,7 +14,7 @@ import { CustomPageEditorBlockSpecs } from '../utils/custom-specs.js';
 import { markDownToDoc } from '../utils/markdown-utils.js';
 
 @customElement('ai-answer-text-preview')
-export class AIAnswerTextPreview extends LitElement {
+export class AIAnswerTextPreview extends WithDisposable(LitElement) {
   static override styles = css`
     :host {
       width: 100%;
@@ -42,12 +45,26 @@ export class AIAnswerTextPreview extends LitElement {
 
   private _previewDoc: Doc | null = null;
 
+  private _selector: BlockSelector = block =>
+    BlocksUtils.matchFlavours(block.model, [
+      'affine:page',
+      'affine:note',
+      'affine:surface',
+      'affine:paragraph',
+      'affine:code',
+      'affine:list',
+      'affine:divider',
+    ]);
+
   override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
     if (changedProperties.has('answer')) {
       markDownToDoc(this.host, this.answer)
         .then(doc => {
-          this._previewDoc = doc;
+          this._previewDoc = doc.blockCollection.getDoc(this._selector);
+          this.disposables.add(() => {
+            doc.blockCollection.clearSelector(this._selector);
+          });
           this._previewDoc.awarenessStore.setReadonly(
             this._previewDoc.blockCollection,
             true

--- a/packages/presets/src/ai/utils/selection-utils.ts
+++ b/packages/presets/src/ai/utils/selection-utils.ts
@@ -109,9 +109,10 @@ export async function getSelectedTextContent(editorHost: EditorHost) {
   const selectedModels = getSelectedModels(editorHost);
   assertExists(selectedModels);
 
-  // Currently only filter out images
+  // Currently only filter out images and databases
   const selectedTextModels = selectedModels.filter(
-    model => !BlocksUtils.matchFlavours(model, ['affine:image'])
+    model =>
+      !BlocksUtils.matchFlavours(model, ['affine:image', 'affine:database'])
   );
   const drafts = selectedTextModels.map(toDraftModel);
   drafts.forEach(draft => traverse(draft, drafts));


### PR DESCRIPTION
To fix [AFF-922](https://linear.app/affine-design/issue/AFF-922/包含-database-的-ai-actions-直接显示非-database-操作内容的结果)