### PR TITLE
fix: copilot selection rect should be considered zoom

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/toolbar-entry.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/toolbar-entry.ts
@@ -50,9 +50,12 @@ export class EdgelessCopilotToolbarEntry extends WithDisposable(LitElement) {
     const selectedIds = selectedElements.map(e => e.id);
     this.edgeless.service.selection.clear();
 
-    const bounds = getElementsBound(selectedElements.map(e => e.elementBound));
-    currentController.dragStartPoint = [bounds.minX - 10, bounds.minY - 10];
-    currentController.dragLastPoint = [bounds.maxX + 10, bounds.maxY + 10];
+    const padding = 10 / this.edgeless.service.zoom;
+    const bounds = getElementsBound(
+      selectedElements.map(e => e.elementBound)
+    ).expand(padding);
+    currentController.dragStartPoint = bounds.tl as [number, number];
+    currentController.dragLastPoint = bounds.br as [number, number];
     this.edgeless.service.selection.set({
       elements: selectedIds,
       editing: false,


### PR DESCRIPTION
### before
<img width="140" alt="Screenshot 2024-04-23 at 17 37 05" src="https://github.com/toeverything/blocksuite/assets/27926/751580c7-f63c-4af2-acc9-eb7d51c9891e">

### after
<img width="188" alt="Screenshot 2024-04-23 at 17 36 31" src="https://github.com/toeverything/blocksuite/assets/27926/6bf97424-097e-4ec6-bddd-7b28f2cf88d7">
