### PR TITLE
feat: create zod union

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -124,3 +124,4 @@ Example:
 - RhonJoe, @JunIce, 2024/03/04
 - Lebedev Konstantin, @RubaXa, 2024/04/04
 - GambleMeow, @GambleMeow, 2024/04/10
+- Shcherbakov Sergey, @F4lkr4m, 2024/04/24

--- a/packages/blocks/src/_common/edgeless/note/consts.ts
+++ b/packages/blocks/src/_common/edgeless/note/consts.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { createZodUnion } from '../../utils/index.js';
 
 export const NOTE_COLORS = [
   '--affine-background-secondary-color',
@@ -9,14 +9,7 @@ export const NOTE_COLORS = [
   '--affine-tag-purple',
 ] as const;
 
-export const NoteColorsSchema = z.union([
-  z.literal('--affine-background-secondary-color'),
-  z.literal('--affine-tag-yellow'),
-  z.literal('--affine-tag-red'),
-  z.literal('--affine-tag-green'),
-  z.literal('--affine-tag-blue'),
-  z.literal('--affine-tag-purple'),
-]);
+export const NoteColorsSchema = createZodUnion(NOTE_COLORS);
 
 export const DEFAULT_NOTE_COLOR = NOTE_COLORS[0];
 
@@ -29,11 +22,4 @@ export const NOTE_SHADOWS = [
   `--affine-note-shadow-film`,
 ] as const;
 
-export const NoteShadowsSchema = z.union([
-  z.literal(''),
-  z.literal('--affine-note-shadow-box'),
-  z.literal('--affine-note-shadow-sticker'),
-  z.literal('--affine-note-shadow-paper'),
-  z.literal('--affine-note-shadow-float'),
-  z.literal('--affine-note-shadow-film'),
-]);
+export const NoteShadowsSchema = createZodUnion(NOTE_SHADOWS);

--- a/packages/blocks/src/_common/utils/index.ts
+++ b/packages/blocks/src/_common/utils/index.ts
@@ -8,6 +8,7 @@ export * from './query.js';
 export * from './rect.js';
 export * from './reordering.js';
 export * from './selection.js';
+export * from './zod.js';
 // Compat with SSR
 export * from '../types.js';
 export * from './event.js';

--- a/packages/blocks/src/_common/utils/zod.ts
+++ b/packages/blocks/src/_common/utils/zod.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+type MappedZodLiterals<T extends readonly z.Primitive[]> = {
+  readonly [K in keyof T]: z.ZodLiteral<T[K]>;
+};
+
+function createManyUnion<
+  A extends Readonly<[z.Primitive, z.Primitive, ...z.Primitive[]]>,
+>(literals: A) {
+  return z.union(
+    literals.map(value => z.literal(value)) as MappedZodLiterals<A>
+  );
+}
+
+export function createZodUnion<T extends readonly []>(values: T): z.ZodNever;
+export function createZodUnion<T extends readonly [z.Primitive]>(
+  values: T
+): z.ZodLiteral<T[0]>;
+export function createZodUnion<
+  T extends readonly [z.Primitive, z.Primitive, ...z.Primitive[]],
+>(values: T): z.ZodUnion<MappedZodLiterals<T>>;
+
+/**
+ * Creating Zod literal union from array
+ * @example
+ * const arr = [1, 2, 3] as const;
+ * createUnionSchemaFromArray(arr); //  z.ZodUnion<readonly [z.ZodLiteral<1>, z.ZodLiteral<2>, z.ZodLiteral<3>]>
+ *
+ * const arr = ['a', 'b', 'c'] as const;
+ * createUnionSchemaFromArray(arr); // z.ZodUnion<readonly [z.ZodLiteral<"a">, z.ZodLiteral<"b">, z.ZodLiteral<"c">]>
+ */
+export function createZodUnion<T extends readonly z.Primitive[]>(values: T) {
+  if (values.length > 1) {
+    return createManyUnion(
+      values as T & [z.Primitive, z.Primitive, ...z.Primitive[]]
+    );
+  }
+  if (values.length === 1) {
+    return z.literal(values[0]);
+  }
+  return z.never();
+}

--- a/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
@@ -2,10 +2,10 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { z } from 'zod';
 
 import { TransparentIcon } from '../../../../_common/icons/index.js';
 import type { CssVariableName } from '../../../../_common/theme/css-variables.js';
+import { createZodUnion } from '../../../../_common/utils/index.js';
 import { getThemeMode } from '../../../../_common/utils/query.js';
 export class ColorEvent extends Event {
   detail: CssVariableName;
@@ -38,20 +38,7 @@ export const LINE_COLORS = [
   '--affine-palette-line-white',
 ] as const;
 
-export const LineColorsSchema = z.union([
-  z.literal('--affine-palette-line-yellow'),
-  z.literal('--affine-palette-line-orange'),
-  z.literal('--affine-palette-line-tangerine'),
-  z.literal('--affine-palette-line-red'),
-  z.literal('--affine-palette-line-magenta'),
-  z.literal('--affine-palette-line-purple'),
-  z.literal('--affine-palette-line-green'),
-  z.literal('--affine-palette-line-blue'),
-  z.literal('--affine-palette-line-navy'),
-  z.literal('--affine-palette-line-black'),
-  z.literal('--affine-palette-line-grey'),
-  z.literal('--affine-palette-line-white'),
-]);
+export const LineColorsSchema = createZodUnion(LINE_COLORS);
 
 export const GET_DEFAULT_LINE_COLOR = () =>
   getThemeMode() === 'dark' ? LINE_COLORS[11] : LINE_COLORS[9];

--- a/packages/blocks/src/surface-block/elements/shape/consts.ts
+++ b/packages/blocks/src/surface-block/elements/shape/consts.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod';
-
+import { createZodUnion } from '../../../_common/utils/index.js';
 import type { StrokeStyle } from '../../consts.js';
 
 export enum ShapeType {
@@ -43,20 +42,7 @@ export const FILL_COLORS = [
 ] as const;
 export const DEFAULT_SHAPE_FILL_COLOR = FILL_COLORS[0];
 
-export const FillColorsSchema = z.union([
-  z.literal('--affine-palette-shape-yellow'),
-  z.literal('--affine-palette-shape-orange'),
-  z.literal('--affine-palette-shape-tangerine'),
-  z.literal('--affine-palette-shape-red'),
-  z.literal('--affine-palette-shape-magenta'),
-  z.literal('--affine-palette-shape-purple'),
-  z.literal('--affine-palette-shape-green'),
-  z.literal('--affine-palette-shape-blue'),
-  z.literal('--affine-palette-shape-navy'),
-  z.literal('--affine-palette-shape-black'),
-  z.literal('--affine-palette-shape-white'),
-  z.literal('--affine-palette-transparent'),
-]);
+export const FillColorsSchema = createZodUnion(FILL_COLORS);
 
 export const STROKE_COLORS = [
   '--affine-palette-line-yellow',
@@ -77,17 +63,4 @@ export const DEFAULT_SHAPE_STROKE_COLOR = STROKE_COLORS[0];
 
 export const DEFAULT_SHAPE_TEXT_COLOR = STROKE_COLORS[9];
 
-export const StrokeColorsSchema = z.union([
-  z.literal('--affine-palette-line-yellow'),
-  z.literal('--affine-palette-line-orange'),
-  z.literal('--affine-palette-line-tangerine'),
-  z.literal('--affine-palette-line-red'),
-  z.literal('--affine-palette-line-magenta'),
-  z.literal('--affine-palette-line-purple'),
-  z.literal('--affine-palette-line-green'),
-  z.literal('--affine-palette-line-blue'),
-  z.literal('--affine-palette-line-navy'),
-  z.literal('--affine-palette-line-black'),
-  z.literal('--affine-palette-line-white'),
-  z.literal('--affine-palette-transparent'),
-]);
+export const StrokeColorsSchema = createZodUnion(STROKE_COLORS);


### PR DESCRIPTION
## **Add util function for creating zod union from arrays**

example: _packages/blocks/src/\_common/consts_:
<img width="554" alt="image" src="https://github.com/toeverything/blocksuite/assets/31344471/3ce1afd6-2a79-47ed-8545-d8d625702989">

The example shows that when creating a zod scheme, there are repetitions of values from the array. Such use leads to an unguaranteed schema change when changing the values of this array.
This can be avoided using createZodUnion utility

+simplification of the code
+ensuring an up-to-date scheme

<img width="562" alt="image" src="https://github.com/toeverything/blocksuite/assets/31344471/1bb7ba29-c46c-43e8-b4e6-d55ccc58d870">
