### PR TITLE
fix(blocks): should not go proxy when it is an onsite image

### DIFF
--- a/packages/blocks/src/_common/adapters/utils.ts
+++ b/packages/blocks/src/_common/adapters/utils.ts
@@ -13,6 +13,9 @@ export const fetchImage = async (
     if (url.startsWith('data:')) {
       return await fetch(url, init);
     }
+    if (url.startsWith(window.location.origin)) {
+      return await fetch(url, init);
+    }
     return await fetch(proxy + '?url=' + encodeURIComponent(url), init)
       .then(res => {
         if (!res.ok) {


### PR DESCRIPTION
If in the AFFiNE desktop client, it should be necessary to determine the domain name of the AFFiNE.