### PR TITLE
fix: ai panel input keyboard behavior

### DIFF
--- a/packages/blocks/src/root-block/widgets/ai-panel/components/state/input.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/state/input.ts
@@ -105,6 +105,27 @@ export class AIPanelInput extends WithDisposable(LitElement) {
     this.remove();
   };
 
+  private _onKeyDown = (e: KeyboardEvent) => {
+    e.stopPropagation();
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+      e.preventDefault();
+      this._sendToAI();
+    }
+  };
+
+  private _onInput = () => {
+    this._textarea.style.height = 'auto';
+    this._textarea.style.height = this._textarea.scrollHeight + 'px';
+
+    if (this._textarea.value.length > 0) {
+      this._arrow.dataset.active = '';
+      this._hasContent = true;
+    } else {
+      delete this._arrow.dataset.active;
+      this._hasContent = false;
+    }
+  };
+
   override updated(_changedProperties: Map<PropertyKey, unknown>): void {
     const result = super.updated(_changedProperties);
     this._textarea.style.height = this._textarea.scrollHeight + 'px';
@@ -126,25 +147,15 @@ export class AIPanelInput extends WithDisposable(LitElement) {
         <textarea
           placeholder="Ask AI to edit or generate..."
           rows="1"
-          @keydown=${(e: KeyboardEvent) => {
-            if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
-              e.preventDefault();
-              e.stopPropagation();
-              this._sendToAI();
-            }
-          }}
-          @input=${() => {
-            this._textarea.style.height = 'auto';
-            this._textarea.style.height = this._textarea.scrollHeight + 'px';
-
-            if (this._textarea.value.length > 0) {
-              this._arrow.dataset.active = '';
-              this._hasContent = true;
-            } else {
-              delete this._arrow.dataset.active;
-              this._hasContent = false;
-            }
-          }}
+          @keydown=${this._onKeyDown}
+          @input=${this._onInput}
+          @pointerdown=${stopPropagation}
+          @click=${stopPropagation}
+          @dblclick=${stopPropagation}
+          @cut=${stopPropagation}
+          @copy=${stopPropagation}
+          @paste=${stopPropagation}
+          @keyup=${stopPropagation}
         ></textarea>
         <div
           class="arrow"


### PR DESCRIPTION
To fix:

[AFF-927](https://linear.app/affine-design/issue/AFF-927/⌘z-撤回出现的输入框-bug)

[AFF-956](https://linear.app/affine-design/issue/AFF-956/copy-的文字不会进入-ai-input，会直接生成一个-block)

[AFF-960](https://linear.app/affine-design/issue/AFF-960/ai-panel-键盘导航导致编辑器移动)

