### PR TITLE
fix: focusout event should focus at host when click empty space in edgeless

### DIFF
--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -116,6 +116,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
     this.std.mount();
     this.std.spec.applySpecs(this.specs);
     this.rangeManager = new RangeManager(this);
+    this.tabIndex = 0;
   }
 
   override disconnectedCallback() {


### PR DESCRIPTION
https://github.com/toeverything/blocksuite/blob/ddb1941db8f1d4e127a785dd833f105383df7327/packages/framework/block-std/src/event/dispatcher.ts#L319-L322

Add `tabindex = 0` to make sure `editor-host` is focused when clicking empty space in the edgeless. Otherwise, the `relatedTarget` would be an element outside the host which is not correct.