### PR TITLE
feat(presets): add edgeless actions to doc mode

### DIFF
--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -116,6 +116,7 @@ export {
   ElementModel,
   fitContent,
   generateKeyBetween,
+  getElementsBound,
   GroupElementModel,
   MindmapElementModel,
   MindmapRootBlock,

--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -27,6 +27,7 @@ import { AIProvider } from '../provider.js';
 import { isMindmapChild, isMindMapRoot } from '../utils/edgeless.js';
 import { copyTextAnswer } from '../utils/editor-actions.js';
 import { getMarkdownFromSlice } from '../utils/markdown-utils.js';
+import { getSelectedNoteAnchor } from '../utils/selection-utils.js';
 import { EXCLUDING_COPY_ACTIONS } from './consts.js';
 import type { CtxRecord } from './edgeless-response.js';
 import {
@@ -37,16 +38,15 @@ import {
 } from './edgeless-response.js';
 import { bindEventSource } from './handler.js';
 
-type AnwserRenderer = Exclude<
-  AffineAIPanelWidget['config'],
-  null
+type AnswerRenderer = NonNullable<
+  AffineAIPanelWidget['config']
 >['answerRenderer'];
 
 function actionToRenderer<T extends keyof BlockSuitePresets.AIActions>(
   id: T,
   host: EditorHost,
   ctx: CtxRecord
-): AnwserRenderer {
+): AnswerRenderer {
   if (id === 'brainstormMindmap' || id === 'expandMindmap') {
     const selectedElements = ctx.get()['selectedElements'] as EdgelessModel[];
 
@@ -287,13 +287,23 @@ export function actionToHandler<T extends keyof BlockSuitePresets.AIActions>(
         .catch(console.error);
     };
 
-    if (edgelessCopilot.visible) {
+    const elementToolbar = getElementToolbar(host);
+    if (edgelessCopilot.visible && edgelessCopilot.selectionElem) {
       aiPanel.toggle(
         edgelessCopilot.selectionElem,
         getCopilotSelectedElems(host).length ? 'placeholder' : undefined
       );
-    } else {
+    } else if (elementToolbar.toolbarVisible) {
       aiPanel.toggle(getElementToolbar(host), 'placeholder');
+    } else if (selectedElements.length > 0) {
+      const lastSelected = selectedElements.at(-1)!.id;
+      const selectedPortal = getSelectedNoteAnchor(host, lastSelected);
+      if (selectedPortal) {
+        aiPanel.toggle(
+          selectedPortal,
+          getCopilotSelectedElems(host).length ? 'placeholder' : undefined
+        );
+      }
     }
   };
 }

--- a/packages/presets/src/ai/actions/edgeless-response.ts
+++ b/packages/presets/src/ai/actions/edgeless-response.ts
@@ -85,9 +85,9 @@ export function getTriggerEntry(host: EditorHost) {
 
 export function getCopilotSelectedElems(host: EditorHost): EdgelessModel[] {
   const service = getService(host);
-  const copilogWidget = getEdgelessCopilotWidget(host);
+  const copilotWidget = getEdgelessCopilotWidget(host);
 
-  if (copilogWidget.visible) {
+  if (copilotWidget.visible) {
     return (service.tool.controllers['copilot'] as CopilotSelectionController)
       .selectedElements;
   }

--- a/packages/presets/src/ai/actions/handler.ts
+++ b/packages/presets/src/ai/actions/handler.ts
@@ -60,11 +60,10 @@ export function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
     let stream: BlockSuitePresets.TextStream | undefined;
     return {
       async *[Symbol.asyncIterator]() {
-        const panel = getAIPanel(host);
         const selections = getSelections(host);
         const [markdown, attachments] = await Promise.all([
-          getSelectedTextContent(panel.host),
-          getSelectedImagesAsBlobs(panel.host),
+          getSelectedTextContent(host),
+          getSelectedImagesAsBlobs(host),
         ]);
         // for now if there are more than one selected blocks, we will not omit the attachments
         const sendAttachments =

--- a/packages/presets/src/ai/entries/format-bar/config.ts
+++ b/packages/presets/src/ai/entries/format-bar/config.ts
@@ -1,4 +1,8 @@
-import type { Chain, InitCommandCtx } from '@blocksuite/block-std';
+import type { Chain, EditorHost, InitCommandCtx } from '@blocksuite/block-std';
+import type {
+  CopilotSelectionController,
+  EdgelessElementToolbarWidget,
+} from '@blocksuite/blocks';
 import {
   AIDoneIcon,
   type AIItemGroupConfig,
@@ -6,7 +10,9 @@ import {
   AISearchIcon,
   type AISubItemConfig,
   ChatWithAIIcon,
+  EDGELESS_ELEMENT_TOOLBAR_WIDGET,
   ExplainIcon,
+  getElementsBound,
   ImproveWritingIcon,
   LanguageIcon,
   LongerIcon,
@@ -16,10 +22,16 @@ import {
   ToneIcon,
 } from '@blocksuite/blocks';
 
+import { actionToHandler as edgelessActionToHandler } from '../../actions/edgeless-handler.js';
 import { actionToHandler } from '../../actions/handler.js';
 import { textTones, translateLangs } from '../../actions/types.js';
 import { getAIPanel } from '../../ai-panel.js';
 import { AIProvider } from '../../provider.js';
+import {
+  getSelectedImagesAsBlobs,
+  getSelectedTextContent,
+  getSelections,
+} from '../../utils/selection-utils.js';
 
 export const translateSubItem: AISubItemConfig[] = translateLangs.map(lang => {
   return {
@@ -154,6 +166,61 @@ const DraftAIGroup: AIItemGroupConfig = {
   ],
 };
 
+// actions that initiated from a note in edgeless mode
+// 1. when running in doc mode, call requestRunInEdgeless (let affine to show toast)
+// 2. when running in edgeless mode
+//    a. get selected in the note and let the edgeless action to handle it
+//    b. insert the result using the note shape
+function edgelessHandler<T extends keyof BlockSuitePresets.AIActions>(
+  id: T,
+  variants?: Omit<
+    Parameters<BlockSuitePresets.AIActions[T]>[0],
+    keyof BlockSuitePresets.AITextActionOptions
+  >
+) {
+  return (host: EditorHost) => {
+    if (host.doc.root?.id === undefined) return;
+    const edgeless = (
+      host.view.getWidget(
+        EDGELESS_ELEMENT_TOOLBAR_WIDGET,
+        host.doc.root.id
+      ) as EdgelessElementToolbarWidget
+    )?.edgeless;
+
+    if (!edgeless) {
+      AIProvider.slots.requestRunInEdgeless.emit({ host });
+    } else {
+      edgeless.tools.setEdgelessTool({ type: 'copilot' });
+      const currentController = edgeless.tools.controllers[
+        'copilot'
+      ] as CopilotSelectionController;
+      const selectedElements = edgeless.service.selection.elements;
+      const padding = 10 / edgeless.service.zoom;
+      const bounds = getElementsBound(
+        selectedElements.map(e => e.elementBound)
+      ).expand(padding);
+      currentController.dragStartPoint = bounds.tl as [number, number];
+      currentController.dragLastPoint = bounds.br as [number, number];
+      currentController.draggingAreaUpdated.emit(false); // do not show edgeless panel
+
+      return edgelessActionToHandler(id, variants, async () => {
+        const selections = getSelections(host);
+        const [markdown, attachments] = await Promise.all([
+          getSelectedTextContent(host),
+          getSelectedImagesAsBlobs(host),
+        ]);
+        // for now if there are more than one selected blocks, we will not omit the attachments
+        const sendAttachments =
+          selections?.selectedBlocks?.length === 1 && attachments.length > 0;
+        return {
+          attachments: sendAttachments ? attachments : undefined,
+          content: sendAttachments ? '' : markdown,
+        };
+      })(host);
+    }
+  };
+}
+
 const ReviewWIthAIGroup: AIItemGroupConfig = {
   name: 'review with ai',
   items: [
@@ -225,12 +292,29 @@ const GenerateWithAIGroup: AIItemGroupConfig = {
         );
       },
     },
-    // todo: missing "generate an image" action
+    {
+      name: 'Generate an image',
+      icon: AIPenIcon,
+      showWhen: textBlockShowWhen,
+      handler: edgelessHandler('createImage'),
+    },
     {
       name: 'Generate outline',
       icon: AIPenIcon,
       showWhen: textBlockShowWhen,
       handler: actionToHandler('writeOutline'),
+    },
+    {
+      name: 'Brainstorm ideas with mind map',
+      icon: AIPenIcon,
+      showWhen: textBlockShowWhen,
+      handler: edgelessHandler('brainstormMindmap'),
+    },
+    {
+      name: 'Generate presentation',
+      icon: AIPenIcon,
+      showWhen: textBlockShowWhen,
+      handler: edgelessHandler('createSlides'),
     },
     {
       name: 'Find actions',

--- a/packages/presets/src/ai/provider.ts
+++ b/packages/presets/src/ai/provider.ts
@@ -29,6 +29,8 @@ export class AIProvider {
     requestContinueInChat: new Slot<{ host: EditorHost; show: boolean }>(),
     requestLogin: new Slot<{ host: EditorHost }>(),
     requestUpgradePlan: new Slot<{ host: EditorHost }>(),
+    // when an action is requested to run in edgeless mode (show a toast in affine)
+    requestRunInEdgeless: new Slot<{ host: EditorHost }>(),
     // stream of AI actions
     actions: new Slot<{
       action: keyof BlockSuitePresets.AIActions;

--- a/packages/presets/src/ai/utils/selection-utils.ts
+++ b/packages/presets/src/ai/utils/selection-utils.ts
@@ -191,3 +191,7 @@ export const getSelectedImagesAsBlobs = async (host: EditorHost) => {
   );
   return blobs.filter((blob): blob is File => !!blob);
 };
+
+export const getSelectedNoteAnchor = (host: EditorHost, id: string) => {
+  return host.querySelector(`[data-portal-block-id="${id}"] .note-background`);
+};


### PR DESCRIPTION
Added `Generate an image`, `Brainstorm ideas with mind map` and `Generate presentation` to doc mode.

When invoked in Doc mode, an event will be emitted in requestRunInEdgeless

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/T2klNLEk0wxLh4NRDzhk/e3994078-1123-4a13-ab5b-9634ced3da6c.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/T2klNLEk0wxLh4NRDzhk/e3994078-1123-4a13-ab5b-9634ced3da6c.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/e3994078-1123-4a13-ab5b-9634ced3da6c.mp4">Kapture 2024-04-27 at 16.18.38.mp4</video>

