### PR TITLE
fix(database): cant move to next kanban card if next group is empty

### DIFF
--- a/packages/blocks/src/database-block/data-view/view/presets/kanban/controller/selection.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/kanban/controller/selection.ts
@@ -578,9 +578,13 @@ function getNextGroupFocusElement(
     return group.group.key === selection.cards[0].groupKey;
   });
 
-  const nextGroupIndex = getNextGroupIndex(groupIndex);
+  let nextGroupIndex = getNextGroupIndex(groupIndex);
+  let nextGroup = groups[nextGroupIndex];
+  while (nextGroup.group.rows.length === 0) {
+    nextGroupIndex = getNextGroupIndex(nextGroupIndex);
+    nextGroup = groups[nextGroupIndex];
+  }
 
-  const nextGroup = groups[nextGroupIndex];
   const element =
     selection.selectionType === 'cell'
       ? getFocusCell(viewElement, selection)


### PR DESCRIPTION

https://github.com/toeverything/blocksuite/assets/123532141/583422d7-d390-435e-908b-803bd2757443

