### PR TITLE
fix(blocks): allow users to enter prompt words when content is missing

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
@@ -229,18 +229,20 @@ export class EdgelessCopilotWidget extends WidgetElement<
 
     this._disposables.add(
       this.edgeless.service.viewport.viewportUpdated.on(() => {
+        if (!this._visible) return;
+
         this._updateSelection(CopilotSelectionTool.area);
       })
     );
 
     this._disposables.add(
       this.edgeless.slots.edgelessToolUpdated.on(({ type }) => {
-        if (type !== 'copilot') {
-          this._visible = false;
-          this._clickOutsideOff = null;
-          this._copilotPanel?.remove();
-          this._copilotPanel = null;
-        }
+        if (!this._visible || type === 'copilot') return;
+
+        this._visible = false;
+        this._clickOutsideOff = null;
+        this._copilotPanel?.remove();
+        this._copilotPanel = null;
       })
     );
   }

--- a/packages/presets/src/ai/entries/edgeless/actions-config.ts
+++ b/packages/presets/src/ai/entries/edgeless/actions-config.ts
@@ -230,7 +230,7 @@ const generateGroup: AIItemGroupConfig = {
       name: 'Generate an image',
       icon: AIImageIcon,
       showWhen: () => true,
-      handler: actionToHandler('createImage', undefined, async host => {
+      handler: actionToHandler('createImage', undefined, async (host, ctx) => {
         const selectedElements = getCopilotSelectedElems(host);
         const len = selectedElements.length;
 
@@ -245,16 +245,20 @@ const generateGroup: AIItemGroupConfig = {
           };
         }
 
+        let content = (ctx.get()['content'] as string) || '';
+
+        // get user input
+        if (content.length === 0) {
+          const aiPanel = getAIPanel(host);
+          content = aiPanel.inputText?.trim() || '';
+        }
+
         const {
-          notes,
           images,
           shapes,
-          frames: _,
+          notes: _,
+          frames: __,
         } = BlocksUtils.splitElements(selectedElements);
-
-        const content = (
-          await getContentFromSelected(host, [...notes, ...shapes])
-        ).trim();
 
         const pureShapes = shapes.filter(
           e =>
@@ -355,10 +359,10 @@ const generateGroup: AIItemGroupConfig = {
           return;
         }
 
-        // single note, text or shape(text)
-        if (f + i === 0 && n + s === 1) {
+        // single note, text, shape(text) or image(caption)
+        if (f === 0 && n + s + i === 1) {
           const content = (
-            await getContentFromSelected(host, [...notes, ...shapes])
+            await getContentFromSelected(host, [...notes, ...shapes, ...images])
           ).trim();
           if (!content) return;
           return {


### PR DESCRIPTION
Closes: [AFF-1008](https://linear.app/affine-design/issue/AFF-1008/图生图：当选区中没有-content-时，允许用户输入-prompt)