### PR TITLE
fix: wait new host to insert markdown

### DIFF
--- a/packages/presets/src/ai/chat-panel/actions/actions-handle.ts
+++ b/packages/presets/src/ai/chat-panel/actions/actions-handle.ts
@@ -14,7 +14,6 @@ import {
   getElementsBound,
   NoteDisplayMode,
 } from '@blocksuite/blocks';
-import { Text } from '@blocksuite/store';
 
 import {
   CreateIcon,
@@ -103,7 +102,7 @@ export const PageEditorActions = [
   ...CommonActions,
   {
     icon: CreateIcon,
-    title: 'Create as a page',
+    title: 'Create as a doc',
     handler: (host: EditorHost, content: string) => {
       reportResponse('result:add-page');
       const newDoc = host.doc.collection.createDoc();
@@ -111,10 +110,22 @@ export const PageEditorActions = [
       const rootId = newDoc.addBlock('affine:page');
       newDoc.addBlock('affine:surface', {}, rootId);
       const noteId = newDoc.addBlock('affine:note', {}, rootId);
-      newDoc.addBlock('affine:paragraph', { text: new Text(content) }, noteId);
+
       host.spec.getService('affine:page').slots.docLinkClicked.emit({
         docId: newDoc.id,
       });
+      let complete = false;
+      (function addContent() {
+        if (complete) return;
+        const newHost = document.querySelector('editor-host');
+        // FIXME: this is a hack to wait for the host to be ready, now we don't have a way to know if the new host is ready
+        if (!newHost || newHost === host) {
+          setTimeout(addContent, 100);
+          return;
+        }
+        complete = true;
+        insertFromMarkdown(newHost, content, noteId, 0).catch(console.error);
+      })();
     },
   },
 ];


### PR DESCRIPTION
Fix https://linear.app/affine-design/issue/AFF-1001/create-as-a-page-之后，未识别-markdown-格式