### PR TITLE
fix(edgeless): improve element toolbar bottom position

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -283,7 +283,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
     top < 0 && (top = y + bound.h * viewport.zoom + offset);
 
     left = clamp(x, 10, width - 10);
-    top = clamp(top, 10, height - 100);
+    top = clamp(top, 10, height - 150);
 
     this.left = left;
     this.top = top;


### PR DESCRIPTION
Close issue #6963
Shrink the maximum boundary of `element-toolbar-widget` to above the `edgeless-toolbar`.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/8e4a6f6f-5725-46bd-ac2b-4019119463f1.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/c8298add-a3d2-43b8-9bb5-a5fb72716004.png)

