### PR TITLE
feat: add spec builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "engines": {
     "node": ">=18.19.0 <21.0.0"
   },
-  "packageManager": "pnpm@9.0.2",
+  "packageManager": "pnpm@9.1.0",
   "scripts": {
     "preview": "pnpm --filter @blocksuite/playground preview",
     "dev": "pnpm --filter @blocksuite/playground dev",

--- a/packages/blocks/src/_specs/spec-builder.ts
+++ b/packages/blocks/src/_specs/spec-builder.ts
@@ -1,0 +1,26 @@
+import type { BlockSpec, BlockSpecSlots } from '@blocksuite/block-std';
+import { assertExists, type DisposableGroup } from '@blocksuite/global/utils';
+
+export class SpecBuilder {
+  private readonly _value: BlockSpec[];
+  constructor(spec: BlockSpec[]) {
+    this._value = [...spec];
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  setup(
+    flavour: BlockSuite.Flavour,
+    setup: (slots: BlockSpecSlots, disposableGroup: DisposableGroup) => void
+  ) {
+    const spec = this._value.find(s => s.schema.model.flavour === flavour);
+    assertExists(spec, `BlockSpec not found for ${flavour}`);
+    const oldSetup = spec.setup;
+    spec.setup = (slots, disposableGroup) => {
+      oldSetup?.(slots, disposableGroup);
+      setup(slots, disposableGroup);
+    };
+  }
+}

--- a/packages/blocks/src/_specs/spec-provider.ts
+++ b/packages/blocks/src/_specs/spec-provider.ts
@@ -1,4 +1,7 @@
 import type { BlockSpec } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
+
+import { SpecBuilder } from './spec-builder.js';
 
 export class SpecProvider {
   static instance: SpecProvider;
@@ -25,7 +28,9 @@ export class SpecProvider {
   }
 
   getSpec(id: string) {
-    return this.specMap.get(id);
+    const spec = this.specMap.get(id);
+    assertExists(spec, `Spec not found for ${id}`);
+    return new SpecBuilder(spec);
   }
 
   clearSpec(id: string) {

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -388,8 +388,10 @@ export class AffineDragHandleWidget extends WidgetElement<
       const doc = this.doc.blockCollection.getDoc(selector);
 
       const previewSpec = SpecProvider.getInstance().getSpec('preview');
-      assertExists(previewSpec, 'Preview spec is not found');
-      const previewTemplate = this.host.renderSpecPortal(doc, previewSpec);
+      const previewTemplate = this.host.renderSpecPortal(
+        doc,
+        previewSpec.value
+      );
 
       const offset = this._calculatePreviewOffset(blockElements, state);
       const posX = state.raw.x - offset.x;

--- a/packages/blocks/src/surface-ref-block/portal/note.ts
+++ b/packages/blocks/src/surface-ref-block/portal/note.ts
@@ -4,7 +4,6 @@ import {
   ShadowlessElement,
   WithDisposable,
 } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
 import type { Block, BlockModel, Doc } from '@blocksuite/store';
 import { css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -61,8 +60,7 @@ export class SurfaceRefNotePortal extends WithDisposable(ShadowlessElement) {
   renderPreview(model: BlockModel) {
     const doc = model.doc.blockCollection.getDoc(this.selector);
     const previewSpec = SpecProvider.getInstance().getSpec('preview');
-    assertExists(previewSpec, 'Preview spec is not found');
-    return this.host.renderSpecPortal(doc, previewSpec);
+    return this.host.renderSpecPortal(doc, previewSpec.value);
   }
 
   override connectedCallback() {

--- a/packages/framework/global/src/exceptions/code.ts
+++ b/packages/framework/global/src/exceptions/code.ts
@@ -3,8 +3,8 @@ export enum ErrorCode {
   ValueNotExists,
   ValueNotInstanceOf,
   ValueNotEqual,
-  MIGRATION_ERROR,
-  SCHEMA_VALIDATE_ERROR,
+  MigrationError,
+  SchemaValidateError,
 
   // Fatal error should be greater than 10000
   DefaultFatalError = 10000,

--- a/packages/framework/store/src/schema/error.ts
+++ b/packages/framework/store/src/schema/error.ts
@@ -3,7 +3,7 @@ import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 export class MigrationError extends BlockSuiteError {
   constructor(description: string) {
     super(
-      ErrorCode.MIGRATION_ERROR,
+      ErrorCode.MigrationError,
       `Migration failed. Please report to https://github.com/toeverything/blocksuite/issues
           ${description}`
     );
@@ -13,7 +13,7 @@ export class MigrationError extends BlockSuiteError {
 export class SchemaValidateError extends BlockSuiteError {
   constructor(flavour: string, message: string) {
     super(
-      ErrorCode.SCHEMA_VALIDATE_ERROR,
+      ErrorCode.SchemaValidateError,
       `Invalid schema for ${flavour}: ${message}`
     );
   }


### PR DESCRIPTION
# Overview

Spec builder is a feature for users to build specs easier.

```ts
const specInstanceA = SpecProvider.getInstance().getSpec('affine:doc');

specInstanceA.setup('affine:paragraph', setupA);
specInstanceA.setup('affine:paragraph', setupB);

const specInstanceB = SpecProvider.getInstance().getSpec('affine:doc');

specInstanceA !== SpecInstanceB; // true

// usage
const renderedViewA = this.host.renderSpecPortal(doc, specInstanceA.value)
const renderedViewB = this.host.renderSpecPortal(doc, specInstanceB.value)
```