### PR TITLE
feat(edgeless): remove the kerning information stored in a font

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
@@ -34,6 +34,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       top: 0;
       z-index: 10;
       transform-origin: left top;
+      font-kerning: none;
       border: ${EdgelessTextEditor.BORDER_WIDTH}px solid
         var(--affine-primary-color, #1e96eb);
       border-radius: 4px;


### PR DESCRIPTION
Removal of kerning information stored in the font for better matching of display and measurement of "text" width when switching to editing mode and back.