### PR TITLE
fix(presets): chat input support image paste

### DIFF
--- a/packages/presets/src/ai/chat-panel/chat-panel-input.ts
+++ b/packages/presets/src/ai/chat-panel/chat-panel-input.ts
@@ -221,6 +221,10 @@ export class ChatPanelInput extends WithDisposable(LitElement) {
     }
   };
 
+  private _addImages(images: File[]) {
+    this.images = [...this.images, ...images].slice(0, MaximumImageCount);
+  }
+
   protected override render() {
     return html`<style>
         .chat-panel-send svg rect {
@@ -300,6 +304,19 @@ export class ChatPanelInput extends WithDisposable(LitElement) {
           @blur=${() => {
             this.focused = false;
           }}
+          @paste=${(event: ClipboardEvent) => {
+            const items = event.clipboardData?.items;
+            if (!items) return;
+
+            for (const index in items) {
+              const item = items[index];
+              if (item.kind === 'file' && item.type.indexOf('image') >= 0) {
+                const blob = item.getAsFile();
+                if (!blob) continue;
+                this._addImages([blob]);
+              }
+            }
+          }}
         ></textarea>
         <div class="chat-panel-input-actions">
           <div
@@ -310,10 +327,7 @@ export class ChatPanelInput extends WithDisposable(LitElement) {
                 multiple: true,
               });
               if (!images) return;
-              this.images = [...this.images, ...images].slice(
-                0,
-                MaximumImageCount
-              );
+              this._addImages(images);
             }}
           >
             ${ImageIcon}


### PR DESCRIPTION
Fix https://linear.app/affine-design/issue/AFF-1029/chat-panel-需要支持图片粘贴事件