### PR TITLE
fix(edgeless): incorrect cursor style of selected rect

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -876,7 +876,12 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
             angle = calcAngleWithRotation(
               target,
               point,
-              new DOMRect(left, top, width, height),
+              new DOMRect(
+                left + this.edgeless.viewport.left,
+                top + this.edgeless.viewport.top,
+                width,
+                height
+              ),
               this._selectedRect.rotate
             );
           }

--- a/tests/edgeless/resizing.spec.ts
+++ b/tests/edgeless/resizing.spec.ts
@@ -10,7 +10,10 @@ import {
   initEmptyEdgelessState,
   resizeElementByHandle,
 } from '../utils/actions/index.js';
-import { assertEdgelessSelectedRect } from '../utils/asserts.js';
+import {
+  assertEdgelessSelectedReactCursor,
+  assertEdgelessSelectedRect,
+} from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
 test.describe('resizing shapes and aspect ratio will be maintained', () => {
@@ -74,5 +77,123 @@ test.describe('resizing shapes and aspect ratio will be maintained', () => {
 
     await page.mouse.move(320, 220);
     await assertEdgelessSelectedRect(page, [310, 210, 356, 188]);
+  });
+});
+
+test.describe('cursor style', () => {
+  test('editor is aligned at the start of viewport', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
+
+    await addBasicRectShapeElement(
+      page,
+      { x: 200, y: 200 },
+      { x: 300, y: 300 }
+    );
+    await page.mouse.click(250, 250);
+    await assertEdgelessSelectedRect(page, [200, 200, 100, 100]);
+
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'right',
+      cursor: 'ew-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'left',
+      cursor: 'ew-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-left',
+      cursor: 'nwse-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-right',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-left',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-right',
+      cursor: 'nwse-resize',
+    });
+  });
+
+  test('editor is not aligned at the start of viewport', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+    await zoomResetByKeyboard(page);
+
+    await page.addStyleTag({
+      content: 'body { padding: 100px 150px; }',
+    });
+
+    await addBasicRectShapeElement(
+      page,
+      { x: 200, y: 200 },
+      { x: 300, y: 300 }
+    );
+    await page.mouse.click(250, 250);
+    await assertEdgelessSelectedRect(page, [200, 200, 100, 100]);
+
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'right',
+      cursor: 'ew-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'left',
+      cursor: 'ew-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-left',
+      cursor: 'nwse-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-right',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-left',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-right',
+      cursor: 'nwse-resize',
+    });
   });
 });

--- a/tests/edgeless/rotation.spec.ts
+++ b/tests/edgeless/rotation.spec.ts
@@ -8,6 +8,7 @@ import {
   switchEditorMode,
 } from '../utils/actions/index.js';
 import {
+  assertEdgelessSelectedReactCursor,
   assertEdgelessSelectedRect,
   assertEdgelessSelectedRectRotation,
 } from '../utils/asserts.js';
@@ -164,5 +165,63 @@ test.describe('rotation', () => {
 
     await resizeElementByHandle(page, { x: 20, y: 10 }, 'bottom-right');
     await assertEdgelessSelectedRect(page, [105, 95, 200, 100]);
+  });
+});
+
+test.describe('cursor style', () => {
+  test('update resize cursor direction after rotating', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+
+    await addBasicRectShapeElement(
+      page,
+      { x: 100, y: 100 },
+      { x: 200, y: 200 }
+    );
+
+    await rotateElementByHandle(page, 45, 'top-left');
+    await assertEdgelessSelectedRectRotation(page, 45);
+
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'right',
+      cursor: 'nwse-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom',
+      cursor: 'nesw-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'left',
+      cursor: 'nwse-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-right',
+      cursor: 'ew-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'top-left',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-right',
+      cursor: 'ns-resize',
+    });
+    await assertEdgelessSelectedReactCursor(page, {
+      mode: 'resize',
+      handle: 'bottom-left',
+      cursor: 'ew-resize',
+    });
   });
 });

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -843,6 +843,42 @@ export async function assertEdgelessSelectedRectRotation(page: Page, deg = 0) {
   expect(transform).toMatch(r);
 }
 
+export async function assertEdgelessSelectedReactCursor(
+  page: Page,
+  expected: (
+    | {
+        mode: 'resize';
+        handle:
+          | 'top'
+          | 'right'
+          | 'bottom'
+          | 'left'
+          | 'top-left'
+          | 'top-right'
+          | 'bottom-right'
+          | 'bottom-left';
+      }
+    | {
+        mode: 'rotate';
+        handle: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left';
+      }
+  ) & {
+    cursor: string;
+  }
+) {
+  const editor = getEditorLocator(page);
+  const selectedRect = editor
+    .locator('edgeless-selected-rect')
+    .locator('.affine-edgeless-selected-rect');
+
+  const handle = selectedRect
+    .getByLabel(expected.handle, { exact: true })
+    .locator(`.${expected.mode}`);
+
+  await handle.hover();
+  await expect(handle).toHaveCSS('cursor', expected.cursor);
+}
+
 export async function assertEdgelessNonSelectedRect(page: Page) {
   const rect = page.locator('edgeless-selected-rect');
   await expect(rect).toBeHidden();


### PR DESCRIPTION
Fix incorrect cursor style of the selected rectangle due to mismatched coordinates.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/36e763ca-1ea1-4f23-92da-24cecccf684a.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/73f3345f-438b-4fac-8446-e795435333e7.png)

