### PR TITLE
fix: catch error in ydoc transaction and doc getter

### DIFF
--- a/packages/framework/store/src/store/doc/block-collection.ts
+++ b/packages/framework/store/src/store/doc/block-collection.ts
@@ -284,13 +284,18 @@ export class BlockCollection extends Space<FlatBlockMap> {
       return;
     }
     event.keys.forEach((value, id) => {
-      if (value.action === 'add') {
-        this._handleYBlockAdd(id);
-        return;
-      }
-      if (value.action === 'delete') {
-        this._handleYBlockDelete(id);
-        return;
+      try {
+        if (value.action === 'add') {
+          this._handleYBlockAdd(id);
+          return;
+        }
+        if (value.action === 'delete') {
+          this._handleYBlockDelete(id);
+          return;
+        }
+      } catch (e) {
+        console.error('An error occurred while handling Yjs event:');
+        console.error(e);
       }
     });
   }

--- a/packages/framework/store/src/store/space.ts
+++ b/packages/framework/store/src/store/space.ts
@@ -107,6 +107,18 @@ export class Space<
    * If `shouldTransact` is `false`, the transaction will not be push to the history stack.
    */
   transact(fn: () => void, shouldTransact = true) {
-    this._ySpaceDoc.transact(fn, shouldTransact ? this.rootDoc.clientID : null);
+    this._ySpaceDoc.transact(
+      () => {
+        try {
+          fn();
+        } catch (e) {
+          console.error(
+            `An error occurred while Y.doc ${this._ySpaceDoc.guid} transacting:`
+          );
+          console.error(e);
+        }
+      },
+      shouldTransact ? this.rootDoc.clientID : null
+    );
   }
 }


### PR DESCRIPTION
If we throw errors in transactions of Y.Doc, the yjs data flow will be destroyed. So we log out the error to protect the data. 

We should also avoid to throw error directly in yjs event observers.