### PR TITLE
perf(edgeless): slice first block rendering to multiple parts

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -19,14 +19,10 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { html, literal, unsafeStatic } from 'lit/static-html.js';
 
 import {
-  batchToAnimationFrame,
   requestConnectedFrame,
+  requestThrottledConnectFrame,
 } from '../../../../_common/utils/event.js';
-import {
-  matchFlavours,
-  NoteDisplayMode,
-  type TopLevelBlockModel,
-} from '../../../../_common/utils/index.js';
+import { type TopLevelBlockModel } from '../../../../_common/utils/index.js';
 import type {
   FrameBlockModel,
   SurfaceBlockComponent,
@@ -56,6 +52,11 @@ const portalMap = new Map<EdgelessBlockType | RegExp, string>([
 export class EdgelessBlockPortalContainer extends WithDisposable(
   ShadowlessElement
 ) {
+  /**
+   * The increased number of blocks to render in each frame.
+   */
+  static RENDER_STEP = 5;
+
   static override styles = css`
     .affine-block-children-container.edgeless {
       user-select: none;
@@ -122,12 +123,6 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   canvasSlot!: HTMLDivElement;
 
   @state()
-  private _showIndexLabel = false;
-
-  @state()
-  private _toolbarVisible = false;
-
-  @state()
   private _isResizing = false;
 
   @state()
@@ -136,15 +131,15 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   @state()
   private _slicerAnchorNote: NoteBlockModel | null = null;
 
-  private _surfaceRefReferenceSet = new Set<string>();
-
   private _clearWillChangeId: null | ReturnType<typeof setTimeout> = null;
+
+  private _renderCounts = 10;
 
   get isDragging() {
     return this.selectedRect.dragging;
   }
 
-  refreshLayerViewport = batchToAnimationFrame(() => {
+  refreshLayerViewport = requestThrottledConnectFrame(() => {
     if (!this.edgeless || !this.edgeless.surface) return;
 
     const { service } = this.edgeless;
@@ -190,34 +185,6 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
     }
   }
 
-  private _updateReference() {
-    const { _surfaceRefReferenceSet, edgeless } = this;
-    edgeless.service.blocks
-      .filter(block => block.flavour === 'affine:note')
-      .forEach(note => {
-        note.children.forEach(model => {
-          if (matchFlavours(model, ['affine:surface-ref'])) {
-            _surfaceRefReferenceSet.add(model.reference);
-          }
-        });
-      });
-  }
-
-  private _updateIndexLabel() {
-    const { edgeless } = this;
-    const { elements } = edgeless.service.selection;
-    if (
-      !edgeless.service.selection.editing &&
-      elements.length === 1 &&
-      (isNoteBlock(elements[0]) ||
-        this._surfaceRefReferenceSet.has(elements[0].id))
-    ) {
-      this._showIndexLabel = true;
-    } else {
-      this._showIndexLabel = false;
-    }
-  }
-
   private _updateNoteSlicer() {
     const { edgeless } = this;
     const { elements } = edgeless.service.selection;
@@ -244,9 +211,7 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   }
 
   override firstUpdated() {
-    this._updateReference();
     const { _disposables, edgeless } = this;
-    const { doc } = edgeless;
 
     _disposables.add(
       edgeless.service.viewport.viewportUpdated.on(() => {
@@ -268,48 +233,8 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
     );
 
     _disposables.add(
-      doc.slots.blockUpdated.on(payload => {
-        const { type, flavour } = payload;
-        if (
-          (type === 'add' || type === 'delete') &&
-          (flavour === 'affine:surface-ref' || flavour === 'affine:note')
-        ) {
-          requestConnectedFrame(() => {
-            this._updateReference();
-            this._updateIndexLabel();
-          }, this);
-        }
-        // When note display mode is changed, we need to update the portal
-        if (
-          type === 'update' &&
-          flavour === 'affine:note' &&
-          payload.props.key === 'displayMode'
-        ) {
-          this.requestUpdate();
-        }
-
-        // When doc children is updated, we need to update the portal
-        if (
-          type === 'update' &&
-          flavour === 'affine:page' &&
-          payload.props.key === 'sys:children'
-        ) {
-          this.requestUpdate();
-        }
-      })
-    );
-
-    _disposables.add(
       edgeless.service.selection.slots.updated.on(() => {
-        const selection = edgeless.service.selection;
-
-        if (selection.selectedIds.length === 0 || selection.editing) {
-          this._toolbarVisible = false;
-        } else {
-          this._toolbarVisible = true;
-        }
         this._enableNoteSlicer = false;
-        this._updateIndexLabel();
         this._updateNoteSlicer();
       })
     );
@@ -327,19 +252,22 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
     );
 
     _disposables.add(
-      edgeless.surfaceBlockModel.elementUpdated.on(({ id, props }) => {
-        const element = edgeless.service.getElementById(id);
-        if (isNoteBlock(element) && props && props['displayMode']) {
-          this.requestUpdate();
-        }
-      })
-    );
-
-    _disposables.add(
       edgeless.slots.toggleNoteSlicer.on(() => {
         this._enableNoteSlicer = !this._enableNoteSlicer;
       })
     );
+  }
+
+  override updated() {
+    if (this._renderCounts < this.edgeless.service.layer.blocks.length) {
+      this._renderCounts += EdgelessBlockPortalContainer.RENDER_STEP;
+
+      setTimeout(() => {
+        this.isConnected && this.requestUpdate();
+      }, 16);
+    } else {
+      this._renderCounts = Number.MAX_SAFE_INTEGER;
+    }
   }
 
   override render() {
@@ -350,41 +278,9 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
 
     if (!surface) return nothing;
 
-    const notes = doc.root?.children.filter(child =>
-      matchFlavours(child, ['affine:note'])
-    ) as NoteBlockModel[];
     const layers = service.layer.layers;
-    const pageVisibleBlocks = new Map<AutoConnectElement, number>();
-    const edgelessOnlyNotesSet = new Set<NoteBlockModel>();
+    let count = 0;
 
-    notes.forEach(note => {
-      if (isNoteBlock(note)) {
-        if (note.displayMode === NoteDisplayMode.EdgelessOnly) {
-          edgelessOnlyNotesSet.add(note);
-        } else if (note.displayMode === NoteDisplayMode.DocAndEdgeless) {
-          pageVisibleBlocks.set(note, 1);
-        }
-      }
-
-      note.children.forEach(model => {
-        if (matchFlavours(model, ['affine:surface-ref'])) {
-          const reference = service.getElementById(
-            model.reference
-          ) as AutoConnectElement;
-
-          if (!reference) return;
-
-          if (!pageVisibleBlocks.has(reference)) {
-            pageVisibleBlocks.set(reference, 1);
-          } else {
-            pageVisibleBlocks.set(
-              reference,
-              pageVisibleBlocks.get(reference)! + 1
-            );
-          }
-        }
-      });
-    });
     return html`
       <div class="affine-block-children-container edgeless">
         <div
@@ -402,8 +298,23 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
           ${layers
             .filter(layer => layer.type === 'block')
             .map(layer => {
+              if (count >= this._renderCounts) {
+                return nothing;
+              }
+
+              const remains = Math.min(
+                this._renderCounts - count,
+                layer.elements.length
+              );
+              const elements = layer.elements.slice(
+                0,
+                remains
+              ) as TopLevelBlockModel[];
+
+              count += remains;
+
               return repeat(
-                layer.elements as TopLevelBlockModel[],
+                elements,
                 block => block.id,
                 (block, index) => {
                   const target = Array.from(portalMap.entries()).find(
@@ -422,8 +333,7 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
                   const [_, tagName] = target;
 
                   const tag = unsafeStatic(tagName);
-                  const zIndex =
-                    (layer.zIndexes as [number, number])[0] + index;
+                  const zIndex = layer.zIndex + index;
 
                   return html`<${tag}
                       data-index=${block.index}
@@ -433,8 +343,8 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
                       .surface=${surface}
                       .edgeless=${edgeless}
                       style=${styleMap({
-                        zIndex,
                         display: 'block',
+                        zIndex,
                         position: 'relative',
                       })}
                     ></${tag}>`;
@@ -456,17 +366,13 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
 
       <edgeless-selected-rect
         .edgeless=${edgeless}
-        .toolbarVisible=${this._toolbarVisible}
         .autoCompleteOff=${this._enableNoteSlicer}
       ></edgeless-selected-rect>
 
       ${!readonly
         ? html`<edgeless-index-label
-            .pageVisibleElementsMap=${pageVisibleBlocks}
-            .edgelessOnlyNotesSet=${edgelessOnlyNotesSet}
             .surface=${surface}
             .edgeless=${edgeless}
-            .show=${this._showIndexLabel}
           ></edgeless-index-label>`
         : nothing}
 

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -15,7 +15,7 @@ import type {
   Selectable,
 } from '../../../../_common/types.js';
 import {
-  batchToAnimationFrame,
+  requestThrottledConnectFrame,
   stopPropagation,
 } from '../../../../_common/utils/event.js';
 import { pickValues } from '../../../../_common/utils/iterable.js';
@@ -451,9 +451,6 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
   @property({ attribute: false })
   autoCompleteOff = false;
-
-  @property({ attribute: false })
-  toolbarVisible = false;
 
   private _resizeManager: HandleResizeManager;
   private _cursorRotate = 0;
@@ -895,7 +892,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     this.slots.cursorUpdated.emit(cursor);
   };
 
-  private _updateSelectedRect = batchToAnimationFrame(() => {
+  private _updateSelectedRect = requestThrottledConnectFrame(() => {
     const { zoom, selection, edgeless } = this;
 
     const elements = selection.elements;

--- a/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
@@ -8,7 +8,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { RemoteCursor } from '../../../_common/icons/edgeless.js';
 import type { Selectable } from '../../../_common/types.js';
-import { batchToAnimationFrame } from '../../../_common/utils/event.js';
+import { requestThrottledConnectFrame } from '../../../_common/utils/event.js';
 import { pickValues } from '../../../_common/utils/iterable.js';
 import type { EdgelessRootBlockComponent } from '../../../root-block/edgeless/edgeless-root-block.js';
 import {
@@ -182,7 +182,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<
       this._updateRemoteRects();
   };
 
-  private _updateTransform = batchToAnimationFrame(() => {
+  private _updateTransform = requestThrottledConnectFrame(() => {
     const { translateX, translateY } = this.edgeless.service.viewport;
 
     this.style.setProperty(

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -134,7 +134,7 @@ export class Renderer extends Viewport {
         }
 
         canvas.dataset.layerId = `[${layer.indexes[0]}--${layer.indexes[1]}]`;
-        canvas.style.setProperty('z-index', layer.zIndexes.toString());
+        canvas.style.setProperty('z-index', layer.zIndex.toString());
         canvases.push(canvas);
       }
 

--- a/packages/blocks/src/surface-block/grid.ts
+++ b/packages/blocks/src/surface-block/grid.ts
@@ -184,10 +184,13 @@ export class GridManager<T extends EdgelessModel> {
     return results;
   }
 
-  search(bound: IBound, strict = false): T[] {
+  search(bound: IBound, strict?: boolean, getSet?: false): T[];
+  search(bound: IBound, strict: boolean | undefined, getSet: true): Set<T>;
+  search(bound: IBound, strict = false, getSet: boolean = false): T[] | Set<T> {
     const results: Set<T> = this._searchExternal(bound, strict);
     const [minRow, maxRow, minCol, maxCol] = rangeFromBound(bound);
     const b = Bound.from(bound);
+
     for (let i = minRow; i <= maxRow; i++) {
       for (let j = minCol; j <= maxCol; j++) {
         const gridElements = this._getGrid(i, j);
@@ -203,6 +206,8 @@ export class GridManager<T extends EdgelessModel> {
         }
       }
     }
+
+    if (getSet) return results;
 
     // sort elements in set based on index
     const sorted = Array.from(results).sort(compare);

--- a/packages/blocks/src/surface-block/managers/layer-utils.ts
+++ b/packages/blocks/src/surface-block/managers/layer-utils.ts
@@ -8,30 +8,24 @@ import { GroupLikeModel } from '../element-model/base.js';
 import type { SurfaceBlockModel } from '../surface-model.js';
 import type { Layer } from './layer-manager.js';
 
-export function getLayerZIndex(layers: Layer[], layerIndex: number) {
+export function getLayerEndZIndex(layers: Layer[], layerIndex: number) {
   const layer = layers[layerIndex];
   return layer
     ? layer.type === 'block'
-      ? layer.zIndexes[1]
-      : layer.zIndexes
+      ? layer.zIndex + layer.elements.length - 1
+      : layer.zIndex
     : 1;
 }
 
-export function updateLayersIndex(layers: Layer[], startIdx: number) {
+export function updateLayersZIndex(layers: Layer[], startIdx: number) {
   const startLayer = layers[startIdx];
-  let curIndex =
-    startLayer.type === 'block' ? startLayer.zIndexes[1] : startLayer.zIndexes;
+  let curIndex = startLayer.zIndex;
 
   for (let i = startIdx; i < layers.length; ++i) {
     const curLayer = layers[i];
 
-    if (curLayer.type === 'block') {
-      curLayer.zIndexes = [curIndex, curIndex + curLayer.elements.length];
-      curIndex += curLayer.elements.length;
-    } else {
-      curLayer.zIndexes = curIndex;
-      curIndex += 1;
-    }
+    curLayer.zIndex = curIndex;
+    curIndex += curLayer.type === 'block' ? curLayer.elements.length : 1;
   }
 }
 

--- a/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
@@ -120,7 +120,7 @@ export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
           currentIdxOffset = 0;
         }
 
-        const zIndex = currentLayer.zIndexes[0] + currentIdxOffset++;
+        const zIndex = currentLayer.zIndex + currentIdxOffset++;
 
         return staticHtml`<${tag}
           .index=${index}


### PR DESCRIPTION
### Change
- split first blocks rendering into multiple parts
- move edgeless label update logic into `edgeless-index-label` component
- remove unecessary code from portal
- simplify layer `zIndex` property