### PR TITLE
fix(edgeless): imporve ai pannel position in edgeless

### DIFF
--- a/packages/presets/src/ai/entries/format-bar/setup-format-bar.ts
+++ b/packages/presets/src/ai/entries/format-bar/setup-format-bar.ts
@@ -1,3 +1,5 @@
+import './format-bar-ai-button.js';
+
 import {
   type AffineFormatBarWidget,
   toolbarDefaultConfig,
@@ -5,7 +7,6 @@ import {
 import { html, type TemplateResult } from 'lit';
 
 import { AIItemGroups } from './config.js';
-import { FormatBarAIButton } from './format-bar-ai-button.js';
 
 export function setupFormatBarEntry(formatBar: AffineFormatBarWidget) {
   toolbarDefaultConfig(formatBar);
@@ -14,10 +15,10 @@ export function setupFormatBarEntry(formatBar: AffineFormatBarWidget) {
       {
         type: 'custom' as const,
         render(formatBar: AffineFormatBarWidget): TemplateResult | null {
-          const askAIButton = new FormatBarAIButton();
-          askAIButton.host = formatBar.host;
-          askAIButton.actionGroups = AIItemGroups;
-          return html`${askAIButton}`;
+          return html` <format-bar-ai-button
+            .host=${formatBar.host}
+            .actionGroups=${AIItemGroups}
+          ></format-bar-ai-button>`;
         },
       },
       { type: 'divider' },


### PR DESCRIPTION
- Fix inline ai pannel can not popup in edgeless.

https://github.com/toeverything/blocksuite/assets/20479050/781774de-8887-42e4-aa28-389df01dd19f



- Imporve position of inline ai pannel in edgeless (AFF-1024)

![after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/05f59c0f-124f-4898-8ec3-d44b4e5afb54.png)

