### PR TITLE
fix(blocks): getCurrentNativeRange should not throw an error when the range count is 0

### DIFF
--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -35,6 +35,10 @@ export const createKeydownObserver = ({
     // Wait for text update
     await sleep(0);
     const range = getCurrentNativeRange();
+    if (!range) {
+      abortController.abort();
+      return;
+    }
     if (range.startContainer !== range.endContainer) {
       console.warn(
         'Failed to parse query! Current range is not collapsed.',

--- a/packages/blocks/src/_common/utils/selection.ts
+++ b/packages/blocks/src/_common/utils/selection.ts
@@ -279,15 +279,11 @@ export function getCurrentNativeRange(selection = window.getSelection()) {
   if (!selection) {
     throw new Error('Failed to get current range, selection is null');
   }
-  // Before the user has clicked a freshly loaded doc, the rangeCount is 0.
-  // The rangeCount will usually be 1.
-  // But scripting can be used to make the selection contain more than one range.
-  // See https://developer.mozilla.org/en-US/docs/Web/API/Selection/rangeCount for more details.
   if (selection.rangeCount === 0) {
-    throw new Error('Failed to get current range, rangeCount is 0');
+    return null;
   }
   if (selection.rangeCount > 1) {
-    console.warn('getCurrentRange may be wrong, rangeCount > 1');
+    console.warn('getCurrentNativeRange may be wrong, rangeCount > 1');
   }
   return selection.getRangeAt(0);
 }

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -729,6 +729,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     // When current selection is TextSelection, should cover all the blocks in native range
     if (selections.length > 0 && includeTextSelection(selections)) {
       const range = getCurrentNativeRange();
+      if (!range) return [];
       blockElements = this._rangeManager.getSelectedBlockElementsByRange(
         range,
         {

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -110,6 +110,7 @@ export class AffineLinkedDocWidget extends WidgetElement {
     triggerKey: string
   ) => {
     const curRange = getCurrentNativeRange();
+    if (!curRange) return;
     showLinkedDocPopover({
       editorHost: this.host,
       inlineEditor,

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -146,6 +146,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
       // Wait for dom update, see this case https://github.com/toeverything/blocksuite/issues/2611
       requestAnimationFrame(() => {
         const curRange = getCurrentNativeRange();
+        if (!curRange) return;
         showSlashMenu({
           rootElement,
           model,


### PR DESCRIPTION
Close #6613
Close BS-157