### PR TITLE
fix: avoid selection change when ai-panel display

### DIFF
--- a/packages/blocks/src/_specs/_specs.ts
+++ b/packages/blocks/src/_specs/_specs.ts
@@ -48,6 +48,7 @@ import { AFFINE_MODAL_WIDGET } from '../root-block/widgets/modal/modal.js';
 import { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from '../root-block/widgets/page-dragging-area/page-dragging-area.js';
 import { AFFINE_PIE_MENU_WIDGET } from '../root-block/widgets/pie-menu/index.js';
 import { AFFINE_SLASH_MENU_WIDGET } from '../root-block/widgets/slash-menu/index.js';
+import { AFFINE_VIEWPORT_OVERLAY_WIDGET } from '../root-block/widgets/viewport-overlay/viewport-overlay.js';
 import { SurfaceBlockSchema } from '../surface-block/surface-model.js';
 import { SurfacePageService } from '../surface-block/surface-page-service.js';
 import { SurfaceService } from '../surface-block/surface-service.js';
@@ -87,6 +88,9 @@ const DocPageSpec: BlockSpec<PageRootBlockWidgetName> = {
       [AFFINE_PAGE_DRAGGING_AREA_WIDGET]: literal`${unsafeStatic(
         AFFINE_PAGE_DRAGGING_AREA_WIDGET
       )}`,
+      [AFFINE_VIEWPORT_OVERLAY_WIDGET]: literal`${unsafeStatic(
+        AFFINE_VIEWPORT_OVERLAY_WIDGET
+      )}`,
     },
   },
 };
@@ -125,6 +129,9 @@ const EdgelessPageSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
         AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET
       )}`,
       [EDGELESS_ELEMENT_TOOLBAR_WIDGET]: literal`${unsafeStatic(EDGELESS_ELEMENT_TOOLBAR_WIDGET)}`,
+      [AFFINE_VIEWPORT_OVERLAY_WIDGET]: literal`${unsafeStatic(
+        AFFINE_VIEWPORT_OVERLAY_WIDGET
+      )}`,
     },
   },
 };

--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -15,6 +15,7 @@ import type { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from './widgets/page-dragging-a
 import type { AFFINE_PIE_MENU_ID_EDGELESS_TOOLS } from './widgets/pie-menu/config.js';
 import type { AFFINE_PIE_MENU_WIDGET } from './widgets/pie-menu/index.js';
 import type { AFFINE_SLASH_MENU_WIDGET } from './widgets/slash-menu/index.js';
+import type { AFFINE_VIEWPORT_OVERLAY_WIDGET } from './widgets/viewport-overlay/viewport-overlay.js';
 
 export type PageRootBlockWidgetName =
   // | typeof AFFINE_BLOCK_HUB_WIDGET
@@ -25,7 +26,8 @@ export type PageRootBlockWidgetName =
   | typeof AFFINE_PAGE_DRAGGING_AREA_WIDGET
   | typeof AFFINE_DRAG_HANDLE_WIDGET
   | typeof AFFINE_FORMAT_BAR_WIDGET
-  | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET;
+  | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
+  | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET;
 
 export type EdgelessRootBlockWidgetName =
   // | typeof AFFINE_BLOCK_HUB_WIDGET
@@ -39,7 +41,8 @@ export type EdgelessRootBlockWidgetName =
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET
-  | typeof EDGELESS_ELEMENT_TOOLBAR_WIDGET;
+  | typeof EDGELESS_ELEMENT_TOOLBAR_WIDGET
+  | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET;
 
 export type RootBlockComponent =
   | PageRootBlockComponent

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -9,12 +9,16 @@ import {
   type ReferenceElement,
 } from '@floating-ui/dom';
 import { css, html, nothing, type PropertyValues } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 
 import type { AIError } from '../../../_common/components/index.js';
 import { stopPropagation } from '../../../_common/utils/event.js';
-import type { AffineViewportOverlayWidget } from '../viewport-overlay/viewport-overlay.js';
+import { AFFINE_FORMAT_BAR_WIDGET } from '../format-bar/format-bar.js';
+import {
+  AFFINE_VIEWPORT_OVERLAY_WIDGET,
+  type AffineViewportOverlayWidget,
+} from '../viewport-overlay/viewport-overlay.js';
 import type { AIPanelDiscardModal } from './components/discard-modal.js';
 import { toggleDiscardModal } from './components/discard-modal.js';
 import type { AffineAIPanelState, AffineAIPanelWidgetConfig } from './type.js';
@@ -75,14 +79,11 @@ export class AffineAIPanelWidget extends WidgetElement {
   @property()
   state: AffineAIPanelState = 'hidden';
 
-  @query('.mock-selection-container')
-  mockSelectionContainer!: HTMLDivElement;
-
   get viewportOverlayWidget() {
     const rootId = this.host.doc.root?.id;
     return rootId
       ? (this.host.view.getWidget(
-          'affine-viewport-overlay-widget',
+          AFFINE_VIEWPORT_OVERLAY_WIDGET,
           rootId
         ) as AffineViewportOverlayWidget)
       : null;
@@ -346,7 +347,7 @@ export class AffineAIPanelWidget extends WidgetElement {
       // tell format bar to show or hide
       const rootBlockId = this.host.doc.root?.id;
       const formatBar = rootBlockId
-        ? this.host.view.getWidget('affine-format-bar-widget', rootBlockId)
+        ? this.host.view.getWidget(AFFINE_FORMAT_BAR_WIDGET, rootBlockId)
         : null;
 
       if (formatBar) {

--- a/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
+++ b/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
@@ -2,6 +2,7 @@ import { WidgetElement } from '@blocksuite/block-std';
 import { css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 import type { PageRootBlockComponent, RootBlockModel } from '../../index.js';
 
@@ -17,8 +18,6 @@ export class AffineViewportOverlayWidget extends WidgetElement<
       position: absolute;
       top: 0;
       left: 0;
-      width: 100vw;
-      height: 100%;
       background: transparent;
       pointer-events: none;
       z-index: calc(var(--affine-z-index-popover) - 1);
@@ -74,7 +73,11 @@ export class AffineViewportOverlayWidget extends WidgetElement<
       'affine-viewport-overlay-widget': true,
       lock: this._lockViewport,
     });
-    return html` <div class=${classes}></div> `;
+    const style = styleMap({
+      width: `${this._lockViewport ? '100vw' : '0'}`,
+      height: `${this._lockViewport ? '100%' : '0'}`,
+    });
+    return html` <div class=${classes} style=${style}></div> `;
   }
 }
 

--- a/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
+++ b/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
@@ -1,0 +1,85 @@
+import { WidgetElement } from '@blocksuite/block-std';
+import { css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import type { PageRootBlockComponent, RootBlockModel } from '../../index.js';
+
+export const AFFINE_VIEWPORT_OVERLAY_WIDGET = 'affine-viewport-overlay-widget';
+
+@customElement(AFFINE_VIEWPORT_OVERLAY_WIDGET)
+export class AffineViewportOverlayWidget extends WidgetElement<
+  RootBlockModel,
+  PageRootBlockComponent
+> {
+  static override styles = css`
+    .affine-viewport-overlay-widget {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100%;
+      background: transparent;
+      pointer-events: none;
+      z-index: calc(var(--affine-z-index-popover) - 1);
+    }
+
+    .affine-viewport-overlay-widget.lock {
+      pointer-events: auto;
+    }
+  `;
+
+  @state()
+  private _lockViewport = false;
+
+  lock() {
+    this._lockViewport = true;
+  }
+
+  unlock() {
+    this._lockViewport = false;
+  }
+
+  toggleLock() {
+    this._lockViewport = !this._lockViewport;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.handleEvent(
+      'dragStart',
+      () => {
+        return this._lockViewport;
+      },
+      { global: true }
+    );
+    this.handleEvent(
+      'pointerDown',
+      () => {
+        return this._lockViewport;
+      },
+      { global: true }
+    );
+    this.handleEvent(
+      'click',
+      () => {
+        return this._lockViewport;
+      },
+      { global: true }
+    );
+  }
+
+  override render() {
+    const classes = classMap({
+      'affine-viewport-overlay-widget': true,
+      lock: this._lockViewport,
+    });
+    return html` <div class=${classes}></div> `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AFFINE_VIEWPORT_OVERLAY_WIDGET]: AffineViewportOverlayWidget;
+  }
+}


### PR DESCRIPTION
To fixed [TOV-834](https://linear.app/affine-design/issue/TOV-834/激活-ai-panel-后需要将-focus-保持在-ai-panel)

- [x] Add an affine-viewport-overlay-widget to avoid selection change when some panel/dialog/modal opened. By preventing the dragStart, pointerDown, and click event to dispatch when viewport widget is locked.

Before, when ai-panel opened and has generated some content, if user click or drag outside of the ai panel, the selection will be changed, then the response actions will be wired, for example, insert below or replace the wrong blocks.

https://github.com/toeverything/blocksuite/assets/99816898/a8c1d89b-0058-4bd8-85ca-75cd624dcca4

Now can lock the viewport when ai-panel opened by calling affineViewportOverlayWidget.lock().

https://github.com/toeverything/blocksuite/assets/99816898/958ab7b7-07a9-440c-8129-3fcf192881a3



