### PR TITLE
fix(blocks): tooltip should be hidden after clicking the button

### DIFF
--- a/packages/blocks/src/_common/utils/button-popper.ts
+++ b/packages/blocks/src/_common/utils/button-popper.ts
@@ -28,6 +28,8 @@ export function listenClickAway(
   };
 }
 
+type Display = 'show' | 'hidden';
+
 const ATTR_SHOW = 'data-show';
 /**
  * Using attribute 'data-show' to control popper visibility.
@@ -44,14 +46,14 @@ const ATTR_SHOW = 'data-show';
 export function createButtonPopper(
   reference: HTMLElement,
   popperElement: HTMLElement,
-  stateUpdated: (state: { display: 'show' | 'hidden' }) => void = () => {
+  stateUpdated: (state: { display: Display }) => void = () => {
     /** DEFAULT EMPTY FUNCTION */
   },
   mainAxis?: number,
   crossAxis?: number,
   rootBoundary?: Rect | (() => Rect | undefined)
 ) {
-  let state = 'hidden';
+  let display: Display = 'hidden';
 
   const originMaxHeight = popperElement
     .computedStyleMap()
@@ -98,18 +100,16 @@ export function createButtonPopper(
 
   const show = () => {
     popperElement.setAttribute(ATTR_SHOW, '');
+    display = 'show';
+    stateUpdated({ display });
     compute();
-    state = 'show';
-    stateUpdated({ display: 'show' });
   };
 
   const hide = () => {
-    if (!popperElement) return;
     popperElement.removeAttribute(ATTR_SHOW);
-
+    display = 'hidden';
+    stateUpdated({ display });
     compute();
-    state = 'hidden';
-    stateUpdated({ display: 'hidden' });
   };
 
   const toggle = () => {
@@ -124,7 +124,7 @@ export function createButtonPopper(
 
   return {
     get state() {
-      return state;
+      return display;
     },
     show,
     hide,

--- a/packages/blocks/src/root-block/edgeless/components/buttons/menu-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/buttons/menu-button.ts
@@ -1,9 +1,9 @@
 import './tool-icon-button.js';
 
 import { WithDisposable } from '@blocksuite/block-std';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { type TemplateResult } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { createButtonPopper } from '../../../../_common/utils/button-popper.js';
@@ -41,21 +41,28 @@ export class EdgelessMenuButton extends WithDisposable(LitElement) {
   @query('.edgeless-component-panel-wrapper')
   private _panelWrapper!: HTMLDivElement;
 
+  @state()
+  private _showMenuPopper = false;
   private _menuPopper!: ReturnType<typeof createButtonPopper>;
   override firstUpdated() {
-    this._menuPopper = createButtonPopper(this, this._panelWrapper);
+    this._menuPopper = createButtonPopper(
+      this,
+      this._panelWrapper,
+      ({ display }) => {
+        this._showMenuPopper = display === 'show';
+      }
+    );
     this._disposables.add(this._menuPopper);
   }
 
   override render() {
-    const { iconInfo } = this;
+    const { iconInfo, _showMenuPopper } = this;
     const componentPanelStyles = styleMap({
       '--edgeless-component-panel-padding': `${this.padding}px`,
       '--edgeless-component-panel-gap': `${this.gap}px`,
     });
     return html`<edgeless-tool-icon-button
-        .tooltip=${iconInfo.tooltip}
-        .tipPosition=${'bottom'}
+        .tooltip=${_showMenuPopper ? nothing : iconInfo.tooltip}
         .iconContainerPadding=${2}
         @click=${() => this._menuPopper.toggle()}
       >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/add-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/add-group-button.ts
@@ -23,7 +23,6 @@ export class EdgelessAddGroupButton extends WithDisposable(LitElement) {
         this.edgeless.service.createGroupFromSelected();
       }}
       .tooltip=${'Group'}
-      .tipPosition=${'bottom'}
     >
       ${GroupIcon}<span
         style=${styleMap({

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -250,17 +250,18 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
   edgeless!: EdgelessRootBlockComponent;
 
   @state()
-  private _showPopper = false;
-
-  @state()
   private _embedScale = 1;
 
+  @state()
+  private _showCardStylePopper = false;
   @query('.change-embed-card-button.card-style')
   private _cardStyleButton!: HTMLDivElement;
-
   @query('card-style-panel')
   private _cardStylePanel!: HTMLDivElement;
+  private _cardStylePopper: ReturnType<typeof createButtonPopper> | null = null;
 
+  @state()
+  private _showEmbedScalePopper = false;
   @query('.embed-scale-button')
   private _embedScaleButton!: HTMLDivElement;
   @query('edgeless-scale-panel')
@@ -277,8 +278,6 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
   }
 
   private _embedOptions: EmbedOptions | null = null;
-
-  private _cardStylePopper: ReturnType<typeof createButtonPopper> | null = null;
 
   private get _rootService() {
     return this.std.spec.getService('affine:page');
@@ -584,7 +583,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
         this._cardStyleButton,
         this._cardStylePanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showCardStylePopper = display === 'show';
         }
       );
       this._disposables.add(this._cardStylePopper);
@@ -595,7 +594,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
         this._embedScaleButton,
         this._embedScalePanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showEmbedScalePopper = display === 'show';
         }
       );
       this._disposables.add(this._embedScalePopper);
@@ -728,7 +727,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
           ? html`
               <div class="change-embed-card-button card-style">
                 <edgeless-tool-icon-button
-                  .tooltip=${this._showPopper ? '' : 'Card style'}
+                  .tooltip=${this._showCardStylePopper ? nothing : 'Card style'}
                   .iconContainerPadding=${2}
                   ?disabled=${this._doc.readonly}
                   @click=${() => this._cardStylePopper?.toggle()}
@@ -767,7 +766,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               ></component-toolbar-menu-divider>
 
               <edgeless-tool-icon-button
-                .tooltip=${this._showPopper ? '' : 'Scale'}
+                .tooltip=${this._showEmbedScalePopper ? nothing : 'Scale'}
                 .iconContainerPadding=${0}
                 @click=${() => this._embedScalePopper?.toggle()}
               >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -168,7 +168,6 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
         ? html`
             <edgeless-tool-icon-button
               .tooltip=${'Insert into doc'}
-              .tipPosition=${'bottom'}
               @click=${this._insertIntoPage}
             >
               ${NoteIcon}
@@ -180,7 +179,6 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
 
             <edgeless-tool-icon-button
               .tooltip=${'Rename'}
-              .tipPosition=${'bottom'}
               .iconContainerPadding=${0}
               @click=${() =>
                 mountFrameTitleEditor(this.frames[0], this.edgeless)}
@@ -194,8 +192,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
 
       <edgeless-tool-icon-button
         class="fill-color-button"
-        .tooltip=${this._showPopper ? '' : 'Background'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showPopper ? nothing : 'Background'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._frameBackground?.toggle()}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-group-button.ts
@@ -85,7 +85,6 @@ export class EdgelessChangeGroupButton extends WithDisposable(LitElement) {
       ${groups.length === 1
         ? html` <edgeless-tool-icon-button
               .tooltip=${'Insert into Page'}
-              .tipPosition=${'bottom'}
               @click=${this._insertIntoPage}
             >
               ${NoteIcon}
@@ -96,7 +95,6 @@ export class EdgelessChangeGroupButton extends WithDisposable(LitElement) {
               class=${'edgeless-component-toolbar-group-rename-button'}
               @click=${() => mountGroupTitleEditor(groups[0], this.edgeless)}
               .tooltip=${'Rename'}
-              .tipPosition=${'bottom'}
             >
               ${RenameIcon}
             </edgeless-tool-icon-button>
@@ -111,7 +109,6 @@ export class EdgelessChangeGroupButton extends WithDisposable(LitElement) {
           groups.forEach(group => this.edgeless.service.ungroup(group));
         }}
         .tooltip=${'Ungroup'}
-        .tipPosition=${'bottom'}
       >
         ${UngroupButtonIcon}
       </edgeless-tool-icon-button>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
@@ -126,14 +126,11 @@ export class EdgelessChangeMindmapButton extends WithDisposable(LitElement) {
     return html`<div class="edgeless-change-mindmap-button">
       <edgeless-tool-icon-button
         class="mindmap-style-button"
-        .tooltip=${this._showStylePopper ? '' : 'Style'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showStylePopper ? nothing : 'Style'}
         .active=${false}
         .hoverState=${this._stylePopper?.state === 'show'}
         @click=${() => {
-          this._showStylePopper
-            ? this._stylePopper?.hide()
-            : this._stylePopper?.show();
+          this._stylePopper?.toggle();
           this.requestUpdate();
         }}
       >
@@ -153,15 +150,11 @@ export class EdgelessChangeMindmapButton extends WithDisposable(LitElement) {
 
       <edgeless-tool-icon-button
         class="mindmap-layout-button"
-        .tooltip=${this._showLayoutPopper ? '' : 'Layout'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showLayoutPopper ? nothing : 'Layout'}
         .active=${false}
         .hoverState=${this._layoutPopper?.state === 'show'}
         @click=${() => {
-          this._showLayoutPopper
-            ? this._layoutPopper?.hide()
-            : this._layoutPopper?.show();
-
+          this._layoutPopper?.toggle();
           this.requestUpdate();
         }}
       >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -187,14 +187,15 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   private _queryCache = false;
 
   @state()
-  private _showPopper = false;
-
+  private _showFillColorPopper = false;
   @query('.fill-color-button')
   private _fillColorButton!: HTMLDivElement;
   @query('edgeless-color-panel')
   private _fillColorMenu!: HTMLDivElement;
   private _fillColorPopper: ReturnType<typeof createButtonPopper> | null = null;
 
+  @state()
+  private _showBorderStylePopper = false;
   @query('.border-style-button')
   private _borderStyleButton!: HTMLDivElement;
   @query('.line-style-panel')
@@ -202,6 +203,8 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   private _borderStylePopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showBorderRadiusPopper = false;
   @query('.border-radius-button')
   private _borderRadiusButton!: HTMLDivElement;
   @query('edgeless-size-panel')
@@ -209,6 +212,8 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   private _borderRadiusPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showShadowTypePopper = false;
   @query('.shadow-style-button')
   private _shadowTypeButton!: HTMLDivElement;
   @query('edgeless-note-shadow-panel')
@@ -216,6 +221,8 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   private _shadowTypePopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showDisplayModePopper = false;
   @query('.display-mode-button-group')
   private _displayModeButtonGroup!: HTMLDivElement;
   @query('note-display-mode-panel')
@@ -223,6 +230,8 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   private _displayModePopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showNoteScalePopper = false;
   @query('.note-scale-button')
   private _noteScaleButton!: HTMLDivElement;
   @query('edgeless-scale-panel')
@@ -392,7 +401,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         this._displayModeButtonGroup,
         this._displayModePanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showDisplayModePopper = display === 'show';
         },
         -154,
         90
@@ -402,16 +411,17 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
       this._fillColorPopper = createButtonPopper(
         this._fillColorButton,
         this._fillColorMenu,
-        ({ display }) => (this._showPopper = display === 'show')
+        ({ display }) => {
+          this._showFillColorPopper = display === 'show';
+        }
       );
-
       this._disposables.add(this._fillColorPopper);
 
       this._shadowTypePopper = createButtonPopper(
         this._shadowTypeButton,
         this._shadowTypesPanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showShadowTypePopper = display === 'show';
         }
       );
       _disposables.add(this._shadowTypePopper);
@@ -420,7 +430,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         this._borderStyleButton,
         this._borderStylesPanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showBorderStylePopper = display === 'show';
         }
       );
       _disposables.add(this._borderStylePopper);
@@ -429,7 +439,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         this._borderRadiusButton,
         this._boderRadiusPanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showBorderRadiusPopper = display === 'show';
         }
       );
       _disposables.add(this._borderRadiusPopper);
@@ -438,7 +448,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         this._noteScaleButton,
         this._noteScalePanel,
         ({ display }) => {
-          this._showPopper = display === 'show';
+          this._showNoteScalePopper = display === 'show';
         }
       );
       _disposables.add(this._noteScalePopper);
@@ -461,7 +471,9 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         ? html`<div class="display-mode-button-group">
               <span class="display-mode-button-label">Show in</span>
               <edgeless-tool-icon-button
-                .tooltip=${this._showPopper ? '' : 'Display Mode'}
+                .tooltip=${this._showDisplayModePopper
+                  ? nothing
+                  : 'Display Mode'}
                 .iconContainerPadding=${0}
                 @click=${() => this._displayModePopper?.toggle()}
               >
@@ -489,7 +501,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
         : html`
             <edgeless-tool-icon-button
               class="fill-color-button"
-              .tooltip=${this._showPopper ? '' : 'Background'}
+              .tooltip=${this._showFillColorPopper ? nothing : 'Background'}
               .iconContainerPadding=${2}
               @click=${() => this._fillColorPopper?.toggle()}
             >
@@ -509,7 +521,9 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
 
             <div class="item shadow-style-button">
               <edgeless-tool-icon-button
-                .tooltip=${'Shadow Style'}
+                .tooltip=${this._showShadowTypePopper
+                  ? nothing
+                  : 'Shadow Style'}
                 .iconContainerPadding=${0}
                 .hover=${false}
                 @click=${() => this._shadowTypePopper?.toggle()}
@@ -527,7 +541,9 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
 
             <div class="item border-style-button">
               <edgeless-tool-icon-button
-                .tooltip=${this._showPopper ? '' : 'Border Style'}
+                .tooltip=${this._showBorderStylePopper
+                  ? nothing
+                  : 'Border Style'}
                 .iconContainerPadding=${0}
                 .hover=${false}
                 @click=${() => this._borderStylePopper?.toggle()}
@@ -545,7 +561,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
 
             <div class="item border-radius-button">
               <edgeless-tool-icon-button
-                .tooltip=${'Corners'}
+                .tooltip=${this._showBorderRadiusPopper ? nothing : 'Corners'}
                 .iconContainerPadding=${0}
                 .hover=${false}
                 @click=${() => this._borderRadiusPopper?.toggle()}
@@ -580,7 +596,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
       </edgeless-tool-icon-button>
 
       <edgeless-tool-icon-button
-        .tooltip=${this._showPopper ? '' : 'Scale'}
+        .tooltip=${this._showNoteScalePopper ? nothing : 'Scale'}
         .iconContainerPadding=${0}
         @click=${() => this._noteScalePopper?.toggle()}
       >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -239,26 +239,25 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
   edgeless!: EdgelessRootBlockComponent;
 
   @state()
-  private _showPopper = false;
-
+  private _showTypePanelPopper = false;
   @query('.change-shape-button')
   private _changeShapeButton!: EdgelessToolIconButton;
-
   @query('edgeless-shape-panel')
   private _shapePanel!: EdgelessShapePanel;
-
   private _shapePanelPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showStylelPanelPopper = false;
   @query('.shape-style-button')
   private _shapeStyleButton!: EdgelessToolIconButton;
-
   @query('.shape-style-panel-container')
   private _shapeStyleMenu!: HTMLDivElement;
-
   private _shapeStyleMenuPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showFillColorPanelPopper = false;
   @query('.fill-color-button')
   private _fillColorButton!: EdgelessToolIconButton;
   @query('.color-panel-container.fill-color')
@@ -266,6 +265,8 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
   private _fillColorMenuPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showStrokeColorPanelPopper = false;
   @query('.stroke-color-button')
   private _strokeColorButton!: EdgelessToolIconButton;
   @query('.color-panel-container.stroke-color')
@@ -273,6 +274,8 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
   private _strokeColorMenuPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showLineStylePanelPopper = false;
   @query('.line-styles-button')
   private _lineStylesButton!: EdgelessToolIconButton;
   @query('.line-style-panel')
@@ -374,7 +377,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
       this._changeShapeButton,
       this._shapePanel,
       ({ display }) => {
-        this._showPopper = display === 'show';
+        this._showTypePanelPopper = display === 'show';
       }
     );
     _disposables.add(this._shapePanelPopper);
@@ -396,7 +399,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
       this._fillColorButton,
       this._fillColorMenu,
       ({ display }) => {
-        this._showPopper = display === 'show';
+        this._showFillColorPanelPopper = display === 'show';
       }
     );
     _disposables.add(this._fillColorMenuPopper);
@@ -405,7 +408,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
       this._strokeColorButton,
       this._strokeColorMenu,
       ({ display }) => {
-        this._showPopper = display === 'show';
+        this._showStrokeColorPanelPopper = display === 'show';
       }
     );
     _disposables.add(this._strokeColorMenuPopper);
@@ -414,7 +417,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
       this._lineStylesButton,
       this._lineStylesPanel,
       ({ display }) => {
-        this._showPopper = display === 'show';
+        this._showLineStylePanelPopper = display === 'show';
       }
     );
     _disposables.add(this._lineStylesPanelPopper);
@@ -423,7 +426,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
       this._shapeStyleButton,
       this._shapeStyleMenu,
       ({ display }) => {
-        this._showPopper = display === 'show';
+        this._showStylelPanelPopper = display === 'show';
       }
     );
     _disposables.add(this._shapeStyleMenuPopper);
@@ -447,8 +450,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     return html`
       <div class="change-shape-toolbar-container">
         <edgeless-tool-icon-button
-          .tooltip=${this._showPopper ? '' : 'Switch Type'}
-          .tipPosition=${'bottom'}
+          .tooltip=${this._showTypePanelPopper ? nothing : 'Switch Type'}
           .active=${false}
           .iconContainerPadding=${ICON_BUTTON_PADDING_TWO}
           @click=${() => this._shapePanelPopper?.toggle()}
@@ -466,8 +468,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
         <component-toolbar-menu-divider></component-toolbar-menu-divider>
 
         <edgeless-tool-icon-button
-          .tooltip=${this._showPopper ? '' : 'Style'}
-          .tipPosition=${'bottom'}
+          .tooltip=${this._showStylelPanelPopper ? nothing : 'Style'}
           .active=${false}
           .iconContainerPadding=${ICON_BUTTON_PADDING_TWO}
           @click=${() => this._shapeStyleMenuPopper?.toggle()}
@@ -493,8 +494,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           class="fill-color-button"
-          .tooltip=${this._showPopper ? '' : 'Fill color'}
-          .tipPosition=${'bottom'}
+          .tooltip=${this._showFillColorPanelPopper ? nothing : 'Fill color'}
           .active=${false}
           .iconContainerPadding=${ICON_BUTTON_PADDING_TWO}
           @click=${() => this._fillColorMenuPopper?.toggle()}
@@ -516,8 +516,9 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           class="stroke-color-button"
-          .tooltip=${this._showPopper ? '' : 'Border color'}
-          .tipPosition=${'bottom'}
+          .tooltip=${this._showStrokeColorPanelPopper
+            ? nothing
+            : 'Border color'}
           .active=${false}
           .iconContainerPadding=${ICON_BUTTON_PADDING_TWO}
           @click=${() => this._strokeColorMenuPopper?.toggle()}
@@ -538,8 +539,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
 
         <edgeless-tool-icon-button
           class="border-styles-button"
-          .tooltip=${this._showPopper ? '' : 'Border style'}
-          .tipPosition=${'bottom'}
+          .tooltip=${this._showLineStylePanelPopper ? nothing : 'Border style'}
           .active=${false}
           .iconContainerPadding=${ICON_BUTTON_PADDING_TWO}
           @click=${() => this._lineStylesPanelPopper?.toggle()}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
@@ -155,16 +155,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
   edgeless!: EdgelessRootBlockComponent;
 
   @state()
-  private _textColorPopperShow = false;
-  @state()
-  private _fontSizePopperShow = false;
-  @state()
-  private _fontWeightPopperShow = false;
-  @state()
-  private _fontFamilyPopperShow = false;
-  @state()
-  private _textAlignPopperShow = false;
-
+  private _showTextColorPopper = false;
   @query('.text-color-button')
   private _textColorButton!: HTMLButtonElement;
   @query('.color-panel-container.text-color')
@@ -172,12 +163,16 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
   private _colorSelectorPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showTextAlignPopper = false;
   @query('.text-align-button')
   private _textAlignButton!: HTMLButtonElement;
   @query('.align-panel-container.text-align')
   private _textAlignMenu!: HTMLDivElement;
   private _textAlignPopper: ReturnType<typeof createButtonPopper> | null = null;
 
+  @state()
+  private _showFontFamilyPopper = false;
   @query('.text-font-family-button')
   private _textFontFamilyButton!: HTMLButtonElement;
   @query('.font-family-panel-container')
@@ -185,6 +180,8 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
   private _textFontFamilyPopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showFontSizePopper = false;
   @query('.text-font-size-button')
   private _textFontSizeButton!: HTMLButtonElement;
   @query('.font-size-panel-container')
@@ -192,6 +189,8 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
   private _textFontSizePopper: ReturnType<typeof createButtonPopper> | null =
     null;
 
+  @state()
+  private _showFontWeightPopper = false;
   @query('.text-font-weight-and-style-button')
   private _textFontWeightAndStyleButton!: HTMLButtonElement;
   @query('.font-weight-and-style-panel-container')
@@ -372,7 +371,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       this._textColorButton,
       this._textColorMenu,
       ({ display }) => {
-        this._textColorPopperShow = display === 'show';
+        this._showTextColorPopper = display === 'show';
       }
     );
     _disposables.add(this._colorSelectorPopper);
@@ -381,7 +380,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       this._textFontFamilyButton,
       this._textFontFamilyMenu,
       ({ display }) => {
-        this._fontFamilyPopperShow = display === 'show';
+        this._showFontFamilyPopper = display === 'show';
       }
     );
     _disposables.add(this._textFontFamilyPopper);
@@ -390,7 +389,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       this._textAlignButton,
       this._textAlignMenu,
       ({ display }) => {
-        this._textAlignPopperShow = display === 'show';
+        this._showTextAlignPopper = display === 'show';
       }
     );
     _disposables.add(this._textAlignPopper);
@@ -399,7 +398,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       this._textFontSizeButton,
       this._textFontSizeMenu,
       ({ display }) => {
-        this._fontSizePopperShow = display === 'show';
+        this._showFontSizePopper = display === 'show';
       }
     );
     _disposables.add(this._textFontSizePopper);
@@ -408,7 +407,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       this._textFontWeightAndStyleButton,
       this._textFontWeightAndStyleMenu,
       ({ display }) => {
-        this._fontWeightPopperShow = display === 'show';
+        this._showFontWeightPopper = display === 'show';
       }
     );
     _disposables.add(this._textFontWeightAndStylePopper);
@@ -433,8 +432,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
         ? nothing
         : html`<edgeless-tool-icon-button
               class="text-color-button"
-              .tooltip=${this._textColorPopperShow ? '' : 'Text Color'}
-              .tipPosition=${'bottom'}
+              .tooltip=${this._showTextColorPopper ? nothing : 'Text Color'}
               .active=${false}
               .activeMode=${'background'}
               .iconContainerPadding=${2}
@@ -457,8 +455,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
       <edgeless-tool-icon-button
         class="text-font-family-button"
-        .tooltip=${this._fontSizePopperShow ? '' : 'Font'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showFontFamilyPopper ? nothing : 'Font'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._textFontFamilyPopper?.toggle()}
@@ -480,8 +477,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
       ${this.elementType === 'shape'
         ? html`<edgeless-tool-icon-button
               class="text-color-button shape"
-              .tooltip=${this._textColorPopperShow ? '' : 'Text Color'}
-              .tipPosition=${'bottom'}
+              .tooltip=${this._showTextColorPopper ? nothing : 'Text Color'}
               .active=${false}
               .activeMode=${'background'}
               .iconContainerPadding=${2}
@@ -506,8 +502,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
       <edgeless-tool-icon-button
         class="text-font-size-button"
-        .tooltip=${this._fontFamilyPopperShow ? '' : 'Font Size'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showFontSizePopper ? nothing : 'Font Size'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._textFontSizePopper?.toggle()}
@@ -536,8 +531,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
         .disabled=${matchFontFaces.length === 1 &&
         matchFontFaces[0].style === selectedFontStyle &&
         matchFontFaces[0].weight === selectedFontWeight}
-        .tooltip=${this._fontWeightPopperShow ? '' : 'Font Style'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showFontWeightPopper ? nothing : 'Font Style'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._textFontWeightAndStylePopper?.toggle()}
@@ -572,8 +566,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
       <edgeless-tool-icon-button
         class="text-align-button"
-        .tooltip=${this._textAlignPopperShow ? '' : 'Alignment'}
-        .tipPosition=${'bottom'}
+        .tooltip=${this._showTextAlignPopper ? nothing : 'Alignment'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._textAlignPopper?.toggle()}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -354,15 +354,6 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
       }
     }
 
-    const last = buttons.at(-1);
-    if (
-      buttons.length > 0 &&
-      (typeof last === 'symbol' ||
-        !last?.strings[0].includes('component-toolbar-menu-divider'))
-    ) {
-      buttons.push(renderMenuDivider());
-    }
-
     const registeredEntries = this._registeredEntries
       .filter(entry => entry.when(elements))
       .map(entry => entry.render(this.edgeless));

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -6,7 +6,14 @@ import type { SurfaceSelection } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 import { baseTheme } from '@toeverything/theme';
-import { css, html, LitElement, type TemplateResult, unsafeCSS } from 'lit';
+import {
+  css,
+  html,
+  LitElement,
+  nothing,
+  type TemplateResult,
+  unsafeCSS,
+} from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -378,7 +385,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     );
     return html`
       <edgeless-tool-icon-button
-        .tooltip=${this._showPopper ? '' : 'More'}
+        .tooltip=${this._showPopper ? nothing : 'More'}
         .active=${false}
         .iconContainerPadding=${2}
         @click=${() => this._actionsMenuPopper?.toggle()}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/release-from-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/release-from-group-button.ts
@@ -36,11 +36,8 @@ export class EdgelessReleaseFromGroupButton extends WithDisposable(LitElement) {
   protected override render() {
     return html`<edgeless-tool-icon-button
       .iconContainerPadding=${2}
-      @click=${() => {
-        this._releaseFromGroup();
-      }}
+      @click=${() => this._releaseFromGroup()}
       .tooltip=${'Release From Group'}
-      .tipPosition=${'bottom'}
     >
       ${ReleaseFromGroupButtonIcon}
     </edgeless-tool-icon-button> `;

--- a/tests/edgeless/element-toolbar.spec.ts
+++ b/tests/edgeless/element-toolbar.spec.ts
@@ -21,3 +21,43 @@ test('toolbar should appear when select note', async ({ page }) => {
   const toolbar = locatorComponentToolbar(page);
   await expect(toolbar).toBeVisible();
 });
+
+test('tooltip should be hidden after clicking on button', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  const { noteId } = await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+
+  await selectNoteInEdgeless(page, noteId);
+
+  const toolbar = locatorComponentToolbar(page);
+  const modeBtn = toolbar.locator(
+    '.display-mode-button-group edgeless-tool-icon-button'
+  );
+
+  await modeBtn.hover();
+  await expect(page.locator('.blocksuite-portal')).toBeVisible();
+
+  await modeBtn.click();
+  await expect(page.locator('.blocksuite-portal')).toBeHidden();
+  await expect(page.locator('note-display-mode-panel')).toBeVisible();
+
+  await modeBtn.click();
+  await expect(page.locator('.blocksuite-portal')).toBeVisible();
+  await expect(page.locator('note-display-mode-panel')).toBeHidden();
+
+  await modeBtn.click();
+  await expect(page.locator('.blocksuite-portal')).toBeHidden();
+  await expect(page.locator('note-display-mode-panel')).toBeVisible();
+
+  const colorBtn = toolbar.locator(
+    'edgeless-tool-icon-button.fill-color-button'
+  );
+
+  await colorBtn.hover();
+  await expect(page.locator('.blocksuite-portal')).toBeVisible();
+
+  await colorBtn.click();
+  await expect(page.locator('.blocksuite-portal')).toBeHidden();
+  await expect(page.locator('note-display-mode-panel')).toBeHidden();
+  await expect(page.locator('edgeless-color-panel')).toBeVisible();
+});


### PR DESCRIPTION
Closes: [BS-301](https://linear.app/affine-design/issue/BS-301/修复-element-toolbar-上-buttons-tooltip-的位置)

Don't use the same state in different poppers.


https://github.com/toeverything/blocksuite/assets/27926/4c769cd1-c123-4f42-ba41-aa6f20631911



https://github.com/toeverything/blocksuite/assets/27926/63356262-1043-4828-bba6-c63de4901561


