### PR TITLE
feat(blocks): unify session and local storage

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -257,7 +257,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
     const { shapeStyle, strokeColor, fillColor, strokeWidth, roughness } =
       isShape(this.currentSource)
         ? this.currentSource
-        : this.edgeless.service.editSession.getLastProps('shape');
+        : this.edgeless.service.editPropsStore.getLastProps('shape');
 
     const computedStyle = getComputedStyle(this.edgeless);
     const stroke = computedStyle.getPropertyValue(strokeColor);

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
@@ -323,7 +323,7 @@ export function createShapeElement(
 
   const props = isShape(current)
     ? current.serialize()
-    : edgeless.service.editSession.getLastProps('shape');
+    : edgeless.service.editPropsStore.getLastProps('shape');
 
   const id = service.addElement('shape', {
     ...props,

--- a/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
@@ -207,7 +207,8 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
     if (!this.edgeless) return;
 
     this.fillScreen =
-      this.edgeless.service.editSession.getItem('presentFillScreen') ?? false;
+      this.edgeless.service.editPropsStore.getItem('presentFillScreen') ??
+      false;
   }
 
   private _getViewportWH = (referencedModel: RefElement) => {

--- a/packages/blocks/src/root-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
+++ b/packages/blocks/src/root-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
@@ -32,10 +32,10 @@ export class EdgelessNavigatorBlackBackground extends WithDisposable(
   private _blackBackground = false;
 
   private _tryLoadBlackBackground() {
-    const value = this.edgeless.service.editSession.getItem(
+    const value = this.edgeless.service.editPropsStore.getItem(
       'presentBlackBackground'
     );
-    this._blackBackground = value ? value : true;
+    this._blackBackground = value ?? true;
   }
 
   override firstUpdated() {
@@ -49,7 +49,7 @@ export class EdgelessNavigatorBlackBackground extends WithDisposable(
     _disposables.add(
       edgeless.slots.navigatorSettingUpdated.on(({ blackBackground }) => {
         if (blackBackground !== undefined) {
-          this.edgeless.service.editSession.setItem(
+          this.edgeless.service.editPropsStore.setItem(
             'presentBlackBackground',
             blackBackground
           );

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -72,7 +72,7 @@ export class EdgelessBrushToolButton extends EdgelessToolButton<
       this._menu.element.edgeless = this.edgeless;
       this.updateMenu();
       this._menu.element.onChange = (props: Record<string, unknown>) => {
-        this.edgeless.service.editSession.record(this._type, props);
+        this.edgeless.service.editPropsStore.record(this._type, props);
       };
     }
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -68,7 +68,7 @@ export class EdgelessConnectorToolButton extends EdgelessToolButton<
       this._menu.element.edgeless = this.edgeless;
       this.updateMenu();
       this._menu.element.onChange = (props: Record<string, unknown>) => {
-        this.edgeless.service.editSession.record(this._type, props);
+        this.edgeless.service.editPropsStore.record(this._type, props);
       };
     }
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar-button.ts
@@ -44,7 +44,7 @@ export class EdgelessToolButton<
     super.connectedCallback();
     const { _disposables, edgeless } = this;
 
-    const attributes = edgeless.service.editSession.getLastProps(this._type);
+    const attributes = edgeless.service.editPropsStore.getLastProps(this._type);
 
     this._states.forEach(key => {
       const value = attributes[key];
@@ -75,7 +75,7 @@ export class EdgelessToolButton<
 
   protected initLastPropsSlot() {
     this._disposables.add(
-      this.edgeless.service.editSession.slots.lastPropsUpdated.on(
+      this.edgeless.service.editPropsStore.slots.lastPropsUpdated.on(
         ({ type, props }) => {
           if (type === this._type) {
             this._states.forEach(_key => {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -245,7 +245,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
 
   private _tryLoadNavigatorStateLocalRecord() {
     this._navigatorMode =
-      this.edgeless.service.editSession.getItem('presentFillScreen') === true
+      this.edgeless.service.editPropsStore.getItem('presentFillScreen') === true
         ? 'fill'
         : 'fit';
   }
@@ -255,7 +255,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     const { slots } = edgeless;
 
     this._hideToolbar =
-      !!this.edgeless.service.editSession.getItem('presentHideToolbar');
+      !!this.edgeless.service.editPropsStore.getItem('presentHideToolbar');
 
     edgeless.bindHotKey(
       {
@@ -370,7 +370,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       this.edgeless.slots.navigatorSettingUpdated.emit({
         hideToolbar: this._hideToolbar,
       });
-      this.edgeless.service.editSession.setItem(
+      this.edgeless.service.editPropsStore.setItem(
         'presentHideToolbar',
         this._hideToolbar
       );

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/frame/navigator-setting-button.ts
@@ -73,10 +73,10 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
   > | null = null;
 
   private _tryRestoreSettings() {
-    const blackBackground = this.edgeless.service.editSession.getItem(
+    const blackBackground = this.edgeless.service.editPropsStore.getItem(
       'presentBlackBackground'
     );
-    this.blackBackground = blackBackground ? blackBackground : true;
+    this.blackBackground = blackBackground ?? true;
   }
 
   private _onBlackBackgroundChange = (checked: boolean) => {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -141,14 +141,14 @@ export class EdgelessShapeToolButton extends EdgelessToolButton<
           props.shapeType = 'rect';
           props.radius = 0.1;
         }
-        this.edgeless.service.editSession.record(this._type, props);
+        this.edgeless.service.editPropsStore.record(this._type, props);
       };
     }
   }
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.edgeless.service.editSession.slots.lastPropsUpdated.on(
+    this.edgeless.service.editPropsStore.slots.lastPropsUpdated.on(
       ({ type, props }) => {
         if (type === 'shape' && props.shapeType) {
           let { shapeType } = props;
@@ -163,7 +163,7 @@ export class EdgelessShapeToolButton extends EdgelessToolButton<
 
   protected override initLastPropsSlot(): void {
     this._disposables.add(
-      this.edgeless.service.editSession.slots.lastPropsUpdated.on(
+      this.edgeless.service.editPropsStore.slots.lastPropsUpdated.on(
         ({ type, props }) => {
           if (type === this._type) {
             this._states.forEach(_key => {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
@@ -227,7 +227,7 @@ export class EdgelessTemplatePanel extends WithDisposable(LitElement) {
     this.addEventListener('keydown', stopPropagation, false);
     this._disposables.add(() => {
       if (this._currentCategory) {
-        this.edgeless.service.editSession.setItem(
+        this.edgeless.service.editPropsStore.setItem(
           'templateCache',
           this._currentCategory
         );
@@ -307,7 +307,7 @@ export class EdgelessTemplatePanel extends WithDisposable(LitElement) {
   }
 
   private _getLocalSelectedCategory() {
-    return this.edgeless.service.editSession.getItem('templateCache');
+    return this.edgeless.service.editPropsStore.getItem('templateCache');
   }
 
   private _createTemplateJob(type: string) {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/text/text-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/text/text-tool-button.ts
@@ -51,7 +51,7 @@ export class EdgelessTextToolButton extends EdgelessToolButton<
       this.updateMenu();
       this._menu.element.edgeless = this.edgeless;
       this._menu.element.onChange = (props: Record<string, unknown>) => {
-        this.edgeless.service.editSession.record(this._type, props);
+        this.edgeless.service.editPropsStore.record(this._type, props);
       };
     }
   }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
@@ -104,7 +104,7 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     this._clearOverlay();
 
     const attributes =
-      this._edgeless.service.editSession.getLastProps('affine:note');
+      this._edgeless.service.editPropsStore.getLastProps('affine:note');
     const background = attributes.background;
     this._draggingNoteOverlay = new DraggingNoteOverlay(
       this._edgeless,
@@ -212,7 +212,7 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     if (newTool.type !== 'affine:note') return;
 
     const attributes =
-      this._edgeless.service.editSession.getLastProps('affine:note');
+      this._edgeless.service.editPropsStore.getLastProps('affine:note');
     const background = attributes.background;
     this._noteOverlay = new NoteOverlay(this._edgeless, background);
     this._noteOverlay.text = newTool.tip;

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
@@ -46,7 +46,8 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
     height: number
   ): string {
     const { viewport } = this._service;
-    const attributes = this._edgeless.service.editSession.getLastProps('shape');
+    const attributes =
+      this._edgeless.service.editPropsStore.getLastProps('shape');
     const { shapeType } = this.tool;
     if (shapeType === 'rect' && attributes.radius > 0) {
       width += 40;
@@ -306,7 +307,8 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
   createOverlay() {
     this.clearOverlay();
     const options = SHAPE_OVERLAY_OPTIONS;
-    const attributes = this._edgeless.service.editSession.getLastProps('shape');
+    const attributes =
+      this._edgeless.service.editPropsStore.getLastProps('shape');
     options.stroke = attributes.strokeColor;
     options.fill = attributes.fillColor;
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -47,7 +47,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           });
         },
         c: () => {
-          rootElement.service.editSession.record('connector', {
+          rootElement.service.editPropsStore.record('connector', {
             mode: ConnectorMode.Straight,
           });
           this._setEdgelessTool(rootElement, {
@@ -147,7 +147,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
         s: () => {
           const attributes =
-            rootElement.service.editSession.getLastProps('shape');
+            rootElement.service.editPropsStore.getLastProps('shape');
           this._setEdgelessTool(rootElement, {
             type: 'shape',
             shapeType: attributes.shapeType,
@@ -201,7 +201,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             return;
           }
 
-          const attr = rootElement.service.editSession.getLastProps('shape');
+          const attr = rootElement.service.editPropsStore.getLastProps('shape');
 
           const nextShapeType = getNextShapeType(
             attr.radius > 0 && attr.shapeType === ShapeType.Rect

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -693,7 +693,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
 
     const run = () => {
       const viewport =
-        this.service.editSession.getItem('viewport') ??
+        this.service.editPropsStore.getItem('viewport') ??
         this.service.getFitToScreenData();
 
       if ('xywh' in viewport) {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -123,7 +123,7 @@ export class EdgelessRootService extends RootService {
   override unmounted() {
     super.unmounted();
 
-    this.editSession.setItem('viewport', {
+    this.editPropsStore.setItem('viewport', {
       centerX: this.viewport.centerX,
       centerY: this.viewport.centerY,
       zoom: this.viewport.zoom,
@@ -249,7 +249,7 @@ export class EdgelessRootService extends RootService {
     // @ts-ignore
     props['type'] = type;
 
-    this.editSession.apply(
+    this.editPropsStore.apply(
       type as CanvasElementType,
       props as Record<string, unknown>
     );
@@ -265,7 +265,7 @@ export class EdgelessRootService extends RootService {
   ) {
     props['index'] = this.generateIndex(flavour);
 
-    this.editSession.apply(flavour as EdgelessElementType, props);
+    this.editPropsStore.apply(flavour as EdgelessElementType, props);
 
     return this.doc.addBlock(flavour as never, props, parent, parentIndex);
   }
@@ -279,14 +279,14 @@ export class EdgelessRootService extends RootService {
   updateElement(id: string, props: Record<string, unknown>) {
     const element = this._surface.getElementById(id);
     if (element) {
-      this.editSession.record(element.type as EdgelessElementType, props);
+      this.editPropsStore.record(element.type as EdgelessElementType, props);
       this._surface.updateElement(id, props);
       return;
     }
 
     const block = this.doc.getBlockById(id);
     if (block) {
-      this.editSession.record(block.flavour as EdgelessElementType, props);
+      this.editPropsStore.record(block.flavour as EdgelessElementType, props);
       this.doc.updateBlock(block, props);
     }
   }

--- a/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
@@ -30,5 +30,5 @@ export function updateShapeProps(
           radius: 0,
         };
 
-  edgeless.service.editSession.record('shape', props);
+  edgeless.service.editPropsStore.record('shape', props);
 }

--- a/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
+++ b/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
@@ -12,7 +12,7 @@ export class RemoteColorManager {
   }
 
   constructor(public readonly host: EditorHost) {
-    const sessionColor = this.rootService.editSession.getItem('remoteColor');
+    const sessionColor = this.rootService.editPropsStore.getItem('remoteColor');
     if (sessionColor) {
       this.awareness.awareness.setLocalStateField('color', sessionColor);
       return;
@@ -20,7 +20,7 @@ export class RemoteColorManager {
 
     const pickColor = multiPlayersColor.pick();
     this.awareness.awareness.setLocalStateField('color', pickColor);
-    this.rootService.editSession.setItem('remoteColor', pickColor);
+    this.rootService.editPropsStore.setItem('remoteColor', pickColor);
   }
 
   get(id: number) {
@@ -31,7 +31,7 @@ export class RemoteColorManager {
 
     if (id !== this.awareness.awareness.clientID) return null;
 
-    const sessionColor = this.rootService.editSession.getItem('remoteColor');
+    const sessionColor = this.rootService.editPropsStore.getItem('remoteColor');
     if (sessionColor) {
       this.awareness.awareness.setLocalStateField('color', sessionColor);
       return sessionColor;
@@ -39,7 +39,7 @@ export class RemoteColorManager {
 
     const pickColor = multiPlayersColor.pick();
     this.awareness.awareness.setLocalStateField('color', pickColor);
-    this.rootService.editSession.setItem('remoteColor', pickColor);
+    this.rootService.editPropsStore.setItem('remoteColor', pickColor);
     return pickColor;
   }
 }

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -19,7 +19,7 @@ import { matchFlavours } from '../_common/utils/model.js';
 import { asyncFocusRichText } from '../_common/utils/selection.js';
 import type { NoteBlockModel } from '../note-block/note-model.js';
 import { CanvasTextFonts } from '../surface-block/consts.js';
-import { EditSessionStorage } from '../surface-block/managers/edit-session.js';
+import { EditPropsStore } from '../surface-block/managers/edit-session.js';
 import {
   copySelectedModelsCommand,
   deleteSelectedModelsCommand,
@@ -49,7 +49,7 @@ export type EmbedOptions = {
 
 export class RootService extends BlockService<RootBlockModel> {
   readonly fontLoader = new FontLoader();
-  readonly editSession: EditSessionStorage = new EditSessionStorage(this);
+  readonly editPropsStore: EditPropsStore = new EditPropsStore(this);
   public readonly copilot = new Copilot();
 
   fileDropManager!: FileDropManager;
@@ -116,7 +116,7 @@ export class RootService extends BlockService<RootBlockModel> {
   };
 
   override unmounted() {
-    this.editSession.dispose();
+    this.editPropsStore.dispose();
     this.fontLoader.clear();
   }
 

--- a/packages/blocks/src/root-block/widgets/pie-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/config.ts
@@ -77,7 +77,7 @@ pie.expandableCommand({
       label: 'Pen Color',
       active: getActiveConnectorStrokeColor,
       onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-        rootElement.service.editSession.record('brush', {
+        rootElement.service.editPropsStore.record('brush', {
           color: color as LastProps['brush']['color'],
         });
       },
@@ -216,7 +216,7 @@ pie.colorPicker({
   label: 'Line Color',
   active: getActiveConnectorStrokeColor,
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editSession.record('connector', {
+    rootElement.service.editPropsStore.record('connector', {
       stroke: color as LastProps['connector']['stroke'],
     });
   },
@@ -262,7 +262,8 @@ shapes.forEach(shape => {
   pie.command({
     label: shape.label,
     icon: ({ rootElement }) => {
-      const attributes = rootElement.service.editSession.getLastProps('shape');
+      const attributes =
+        rootElement.service.editPropsStore.getLastProps('shape');
       return shape.icon(attributes.shapeStyle);
     },
 
@@ -271,7 +272,7 @@ shapes.forEach(shape => {
         type: 'shape',
         shapeType: shape.type,
       });
-      rootElement.service.editSession.record('shape', {
+      rootElement.service.editPropsStore.record('shape', {
         shapeType: shape.type,
       });
       updateShapeOverlay(rootElement);
@@ -283,7 +284,7 @@ pie.command({
   label: 'Toggle Style',
   icon: ({ rootElement }) => {
     const { shapeStyle } =
-      rootElement.service.editSession.getLastProps('shape');
+      rootElement.service.editPropsStore.getLastProps('shape');
     return shapeStyle === ShapeStyle.General
       ? ScribbledStyleIcon
       : GeneralStyleIcon;
@@ -291,13 +292,13 @@ pie.command({
 
   action: ({ rootElement }) => {
     const { shapeStyle } =
-      rootElement.service.editSession.getLastProps('shape');
+      rootElement.service.editPropsStore.getLastProps('shape');
     const toggleType =
       shapeStyle === ShapeStyle.General
         ? ShapeStyle.Scribbled
         : ShapeStyle.General;
 
-    rootElement.service.editSession.record('shape', {
+    rootElement.service.editPropsStore.record('shape', {
       shapeStyle: toggleType,
     });
 
@@ -309,7 +310,7 @@ pie.colorPicker({
   label: 'Fill',
   active: getActiveShapeColor('fill'),
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editSession.record('shape', {
+    rootElement.service.editPropsStore.record('shape', {
       fillColor: color as LastProps['shape']['fillColor'],
     });
     updateShapeOverlay(rootElement);
@@ -322,7 +323,7 @@ pie.colorPicker({
   hollow: true,
   active: getActiveShapeColor('stroke'),
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editSession.record('shape', {
+    rootElement.service.editPropsStore.record('shape', {
       strokeColor: color as LastProps['shape']['strokeColor'],
     });
     updateShapeOverlay(rootElement);

--- a/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
@@ -24,7 +24,7 @@ export function updateShapeOverlay(rootElement: EdgelessRootBlockComponent) {
 export function getActiveShapeColor(type: 'fill' | 'stroke') {
   return ({ rootElement }: PieMenuContext) => {
     if (rootElement instanceof EdgelessRootBlockComponent) {
-      const props = rootElement.service.editSession.getLastProps('shape');
+      const props = rootElement.service.editPropsStore.getLastProps('shape');
       if (type == 'fill') return props.fillColor;
       else return props.strokeColor;
     }
@@ -34,7 +34,7 @@ export function getActiveShapeColor(type: 'fill' | 'stroke') {
 
 export function getActiveConnectorStrokeColor({ rootElement }: PieMenuContext) {
   if (rootElement instanceof EdgelessRootBlockComponent) {
-    const props = rootElement.service.editSession.getLastProps('connector');
+    const props = rootElement.service.editPropsStore.getLastProps('connector');
     return props.stroke;
   }
   return '';

--- a/packages/blocks/src/surface-block/managers/edit-session.ts
+++ b/packages/blocks/src/surface-block/managers/edit-session.ts
@@ -131,21 +131,34 @@ const SessionPropsSchema = z.object({
         .optional(),
     }),
   ]),
-  presentBlackBackground: z.boolean(),
-  presentFillScreen: z.boolean(),
-  presentHideToolbar: z.boolean(),
   templateCache: z.string(),
   remoteColor: z.string(),
   showBidirectional: z.boolean(),
 });
 
+const LocalPropsSchema = z.object({
+  presentBlackBackground: z.boolean(),
+  presentFillScreen: z.boolean(),
+  presentHideToolbar: z.boolean(),
+});
+
 type SessionProps = z.infer<typeof SessionPropsSchema>;
+type LocalProps = z.infer<typeof LocalPropsSchema>;
+type StorageProps = SessionProps & LocalProps;
+
+function isLocalProp(key: string): key is keyof LocalProps {
+  return key in LocalPropsSchema.shape;
+}
+
+function isSessionProp(key: string): key is keyof SessionProps {
+  return key in SessionPropsSchema.shape;
+}
 
 export type SerializedViewport = z.infer<
   typeof SessionPropsSchema.shape.viewport
 >;
 
-export class EditSessionStorage {
+export class EditPropsStore {
   private _lastProps: LastProps = {
     connector: {
       frontEndpointStyle: DEFAULT_FRONT_END_POINT_STYLE,
@@ -239,7 +252,7 @@ export class EditSessionStorage {
     deepAssign(props, lastProps);
   }
 
-  private _getKey<T extends keyof SessionProps>(key: T) {
+  private _getKey<T extends keyof StorageProps>(key: T) {
     const id = this._service.doc.id;
     switch (key) {
       case 'viewport':
@@ -261,20 +274,33 @@ export class EditSessionStorage {
     }
   }
 
-  setItem<T extends keyof SessionProps>(key: T, value: SessionProps[T]) {
-    sessionStorage.setItem(this._getKey(key), JSON.stringify(value));
+  setItem<T extends keyof StorageProps>(key: T, value: StorageProps[T]) {
+    this._getStorage(key).setItem(this._getKey(key), JSON.stringify(value));
   }
 
-  getItem<T extends keyof SessionProps>(key: T) {
+  getItem<T extends keyof StorageProps>(key: T) {
     try {
-      const value = sessionStorage.getItem(this._getKey(key));
+      const storage = this._getStorage(key);
+      const value = storage.getItem(this._getKey(key));
       if (!value) return null;
-      return SessionPropsSchema.shape[key].parse(
-        JSON.parse(value)
-      ) as SessionProps[T];
+      if (isLocalProp(key)) {
+        return LocalPropsSchema.shape[key].parse(
+          JSON.parse(value)
+        ) as StorageProps[T];
+      } else if (isSessionProp(key)) {
+        return SessionPropsSchema.shape[key].parse(
+          JSON.parse(value)
+        ) as StorageProps[T];
+      } else {
+        return null;
+      }
     } catch {
       return null;
     }
+  }
+
+  private _getStorage<T extends keyof StorageProps>(key: T) {
+    return isSessionProp(key) ? sessionStorage : localStorage;
   }
 
   dispose() {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -495,7 +495,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     };
     const pageService = this.std.spec.getService('affine:page');
 
-    pageService.editSession.setItem('viewport', viewport);
+    pageService.editPropsStore.setItem('viewport', viewport);
     pageService.slots.editorModeSwitch.emit('edgeless');
   }
 

--- a/packages/presets/src/fragments/bi-directional-link/bi-directional-link-panel.ts
+++ b/packages/presets/src/fragments/bi-directional-link/bi-directional-link-panel.ts
@@ -245,13 +245,13 @@ export class BiDirectionalLinkPanel extends WithDisposable(LitElement) {
     );
 
     const rootService = this._host.spec.getService('affine:page');
-    this._show = !!rootService.editSession.getItem('showBidirectional');
+    this._show = !!rootService.editPropsStore.getItem('showBidirectional');
   }
 
   private _toggleShow() {
     this._show = !this._show;
     const rootService = this._host.spec.getService('affine:page');
-    rootService.editSession.setItem('showBidirectional', this._show);
+    rootService.editPropsStore.setItem('showBidirectional', this._show);
   }
 
   private get _host() {

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -251,7 +251,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
       };
 
       const rootService = this.editorHost.spec.getService('affine:page');
-      rootService.editSession.setItem('viewport', viewport);
+      rootService.editPropsStore.setItem('viewport', viewport);
       rootService.slots.editorModeSwitch.emit('edgeless');
     } else {
       this.edgeless.service.viewport.setViewportByBound(

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -147,7 +147,7 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
   private _tryLoadNavigatorStateLocalRecord() {
     this._navigatorMode = this.editorHost.spec
       .getService('affine:page')
-      .editSession.getItem('presentFillScreen')
+      .editPropsStore.getItem('presentFillScreen')
       ? 'fill'
       : 'fit';
   }

--- a/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
@@ -90,12 +90,12 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
   }
 
   private _tryRestoreSettings() {
-    const { editSession } = this._rootService;
-    const blackBackground = editSession.getItem('presentBlackBackground');
+    const { editPropsStore } = this._rootService;
+    const blackBackground = editPropsStore.getItem('presentBlackBackground');
 
-    this.blackBackground = blackBackground ? blackBackground : true;
-    this.fillScreen = editSession.getItem('presentFillScreen') ?? false;
-    this.hideToolbar = editSession.getItem('presentHideToolbar') ?? false;
+    this.blackBackground = blackBackground ?? true;
+    this.fillScreen = editPropsStore.getItem('presentFillScreen') ?? false;
+    this.hideToolbar = editPropsStore.getItem('presentHideToolbar') ?? false;
   }
 
   private _onBlackBackgroundChange = (checked: boolean) => {
@@ -110,7 +110,10 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
     this.edgeless?.slots.navigatorSettingUpdated.emit({
       fillScreen: this.fillScreen,
     });
-    this._rootService.editSession.setItem('presentFillScreen', this.fillScreen);
+    this._rootService.editPropsStore.setItem(
+      'presentFillScreen',
+      this.fillScreen
+    );
   };
 
   private _onHideToolBarChange = (checked: boolean) => {
@@ -118,7 +121,7 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
     this.edgeless?.slots.navigatorSettingUpdated.emit({
       hideToolbar: this.hideToolbar,
     });
-    this._rootService.editSession.setItem(
+    this._rootService.editPropsStore.setItem(
       'presentHideToolbar',
       this.hideToolbar
     );

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -303,7 +303,7 @@ export async function assertEdgelessShapeType(page: Page, type: ShapeName) {
     const shapeType = container.edgelessTool.shapeType;
     if (
       shapeType === 'rect' &&
-      container.service.editSession.getLastProps('shape').radius > 0
+      container.service.editPropsStore.getLastProps('shape').radius > 0
     )
       return 'roundedRect';
 


### PR DESCRIPTION
Unify typed local storage with session storage 

## Usage 
```typescript
const SessionPropsSchema = z.object({
  viewport: z.union([
    z.object({
      centerX: z.number(),
      centerY: z.number(),
      zoom: z.number(),
    }),
    z.object({
      xywh: z.string(),
      padding: z
        .tuple([z.number(), z.number(), z.number(), z.number()])
        .optional(),
    }),
  ]),
  templateCache: z.string(),
  remoteColor: z.string(),
  showBidirectional: z.boolean(),
});

const LocalPropsSchema = z.object({
  presentBlackBackground: z.boolean(),
  presentFillScreen: z.boolean(),
  presentHideToolbar: z.boolean(),
});
```

If we want to record another field in local storage, just config it in LocalPropsSchema. Then it's done.
We got typed interface and the field will stored in localStorage.
Same for sessionStorage.
