### PR TITLE
fix(edgeless): incorrect position of make-it-real

### DIFF
--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -32,7 +32,10 @@ import { reportResponse } from '../utils/action-reporter.js';
 import { isMindmapChild, isMindMapRoot } from '../utils/edgeless.js';
 import { copyTextAnswer } from '../utils/editor-actions.js';
 import { getMarkdownFromSlice } from '../utils/markdown-utils.js';
-import { getSelectedNoteAnchor } from '../utils/selection-utils.js';
+import {
+  getSelectedNoteAnchor,
+  getSelections,
+} from '../utils/selection-utils.js';
 import { EXCLUDING_COPY_ACTIONS } from './consts.js';
 import { bindTextStream } from './doc-handler.js';
 import type { CtxRecord } from './edgeless-response.js';
@@ -344,6 +347,7 @@ export function actionToHandler<T extends keyof BlockSuitePresets.AIActions>(
     const edgelessCopilot = getEdgelessCopilotWidget(host);
     let internal: Record<string, unknown> = {};
     const selectedElements = getCopilotSelectedElems(host);
+    const { selectedBlocks } = getSelections(host);
     const ctx = {
       get() {
         return {
@@ -376,7 +380,9 @@ export function actionToHandler<T extends keyof BlockSuitePresets.AIActions>(
     let referenceElement = null;
     let togglePanel = () => Promise.resolve(isEmpty);
 
-    if (edgelessCopilot.visible && edgelessCopilot.selectionElem) {
+    if (selectedBlocks && selectedBlocks.length !== 0) {
+      referenceElement = selectedBlocks.at(-1);
+    } else if (edgelessCopilot.visible && edgelessCopilot.selectionElem) {
       referenceElement = edgelessCopilot.selectionElem;
     } else if (elementToolbar.toolbarVisible) {
       referenceElement = getElementToolbar(host);

--- a/packages/presets/src/ai/entries/format-bar/format-bar-ai-button.ts
+++ b/packages/presets/src/ai/entries/format-bar/format-bar-ai-button.ts
@@ -87,7 +87,7 @@ export class FormatBarAIButton extends WithDisposable(LitElement) {
       () => {
         if (this._edgeless) {
           const { left: x, top: y, width, height } = this._edgeless.viewport;
-          return { x, y, width, height: height - 50 };
+          return { x, y, width, height: height - 100 };
         }
         return;
       }


### PR DESCRIPTION
Close AFF-1024

- fix incorrect position of `ai-panel` toggled by edgeless copilot action of doc block in edgeless mode, such as Make-It-Real.

https://github.com/toeverything/blocksuite/assets/20479050/cff6f8ed-8aad-4226-8754-5efcfc131df3

https://github.com/toeverything/blocksuite/assets/20479050/044099fa-6e21-4a05-94fd-ef51ac6636a0


