### PR TITLE
fix: browser window resize causes image deformation

### DIFF
--- a/packages/blocks/src/image-block/components/page-image-block.ts
+++ b/packages/blocks/src/image-block/components/page-image-block.ts
@@ -251,7 +251,6 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
     if (this._isDragging && this.resizeImg) {
       return {
         width: this.resizeImg.style.width,
-        height: this.resizeImg.style.height,
       };
     }
 
@@ -265,7 +264,6 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
 
     return {
       width: `${width}px`,
-      height: `${height}px`,
     };
   }
 

--- a/packages/blocks/src/image-block/image-resize-manager.ts
+++ b/packages/blocks/src/image-block/image-resize-manager.ts
@@ -71,7 +71,6 @@ export class ImageResizeManager {
 
     requestAnimationFrame(() => {
       activeImgContainer.style.width = (width / this._zoom).toFixed(2) + 'px';
-      activeImgContainer.style.height = (height / this._zoom).toFixed(2) + 'px';
     });
   }
 


### PR DESCRIPTION
### TL;DR

This pull request removes the height property from the image css style. No matter how the browser window size changes, images can keep in shape with their original aspect ratio.

Close affine-design/issue/BS-304.

| Before      | After |
| ----------- | ----------- |
| <img width="200" alt="截屏2024-05-14 17 10 31" src="https://github.com/toeverything/blocksuite/assets/12724894/cecace88-7475-4af4-b13f-a5a6e2df5ffa">| <img width="186" alt="截屏2024-05-14 17 10 43" src="https://github.com/toeverything/blocksuite/assets/12724894/b0eab4dd-f42a-488b-84a0-0a5a0b109ec9">|

### What changed?

The height property was removed from two different places in the code base:
1. In the `ImageBlockPageComponent` class, it was removed from the `style` of  resizable image container div.
2. In the `ImageResizeManager` class, it was removed from the `style` of dragging image container.

### How to test?

Incorporate these changes into your local codebase, and try to resize the browser window. You should now see that the height is automatically adjusted according to the width.

### Why make this change?

This change helps the images maintain their aspect ratio when being resized. By removing the explicit height, the browser's default behaviour of maintaining the aspect ratio kicks in and thus helps prevent any distortions during resizing operation.

---

