### PR TITLE
perf: avoid recalculate style

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -388,7 +388,10 @@ export class RichText extends WithDisposable(ShadowlessElement) {
       readonly: this.readonly,
     });
 
-    return html`<div class=${classes}></div>`;
+    return html`<div
+      contenteditable=${this.readonly ? 'false' : 'true'}
+      class=${classes}
+    ></div>`;
   }
 }
 

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -46,6 +46,8 @@ import { getHighLighter } from './utils/high-lighter.js';
 
 @customElement('affine-code')
 export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
+  static override styles = codeBlockStyles;
+
   @state()
   private _wrap = false;
 
@@ -492,9 +494,6 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
           wrap: this._wrap,
         })}
       >
-        <style>
-          ${codeBlockStyles}
-        </style>
         ${this._curLanguageButtonTemplate()}
         <div class="rich-text-container">
           <div contenteditable="false" id="line-numbers"></div>

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -11,6 +11,8 @@ import { dividerBlockStyles } from './styles.js';
 
 @customElement('affine-divider')
 export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
+  static override styles = dividerBlockStyles;
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -35,9 +37,6 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
 
     return html`
       <div class="affine-divider-block-container">
-        <style>
-          ${dividerBlockStyles}
-        </style>
         <hr />
 
         ${children}

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -25,6 +25,7 @@ export class ListBlockComponent extends BlockElement<
   ListBlockModel,
   ListBlockService
 > {
+  static override styles = listBlockStyles;
   get inlineManager() {
     const inlineManager = this.service?.inlineManager;
     assertExists(inlineManager);
@@ -190,9 +191,6 @@ export class ListBlockComponent extends BlockElement<
 
     return html`
       <div class=${'affine-list-block-container'}>
-        <style>
-          ${listBlockStyles}
-        </style>
         <div class=${`affine-list-rich-text-wrapper ${checked}`}>
           ${this._toggleTemplate(collapsed)} ${listIcon}
           <rich-text

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -22,6 +22,8 @@ export class ParagraphBlockComponent extends BlockElement<
   ParagraphBlockModel,
   ParagraphBlockService
 > {
+  static override styles = paragraphBlockStyles;
+
   get inlineManager() {
     const inlineManager = this.service?.inlineManager;
     assertExists(inlineManager);
@@ -136,9 +138,6 @@ export class ParagraphBlockComponent extends BlockElement<
 
     return html`
       <div class="affine-paragraph-block-container">
-        <style>
-          ${paragraphBlockStyles}
-        </style>
         <div class="affine-paragraph-rich-text-wrapper ${type}">
           <rich-text
             .yText=${this.model.text.yText}

--- a/packages/framework/inline/src/inline-editor.ts
+++ b/packages/framework/inline/src/inline-editor.ts
@@ -272,8 +272,15 @@ export class InlineEditor<
 
   setReadonly(isReadonly: boolean): void {
     const value = isReadonly ? 'false' : 'true';
-    this.rootElement.contentEditable = value;
-    this.eventSource.contentEditable = value;
+
+    if (this.rootElement.contentEditable !== value) {
+      this.rootElement.contentEditable = value;
+    }
+
+    if (this.eventSource.contentEditable !== value) {
+      this.eventSource.contentEditable = value;
+    }
+
     this._isReadonly = isReadonly;
   }
 

--- a/packages/presets/src/ai/messages/text.ts
+++ b/packages/presets/src/ai/messages/text.ts
@@ -3,6 +3,10 @@ import type { AffineAIPanelState } from '@blocksuite/blocks';
 import {
   type AffineAIPanelWidgetConfig,
   BlocksUtils,
+  CodeBlockComponent,
+  DividerBlockComponent,
+  ListBlockComponent,
+  ParagraphBlockComponent,
 } from '@blocksuite/blocks';
 import { type BlockSelector, type Doc } from '@blocksuite/store';
 import { css, html, LitElement, type PropertyValues } from 'lit';
@@ -12,6 +16,13 @@ import { keyed } from 'lit/directives/keyed.js';
 
 import { CustomPageEditorBlockSpecs } from '../utils/custom-specs.js';
 import { markDownToDoc } from '../utils/markdown-utils.js';
+
+const textBlockStyles = css`
+  ${ParagraphBlockComponent.styles}
+  ${ListBlockComponent.styles}
+  ${DividerBlockComponent.styles}
+  ${CodeBlockComponent.styles}
+`;
 
 @customElement('ai-answer-text')
 export class AIAnswerText extends WithDisposable(LitElement) {
@@ -75,6 +86,8 @@ export class AIAnswerText extends WithDisposable(LitElement) {
         white-space: pre;
       }
     }
+
+    ${textBlockStyles}
   `;
 
   @property({ attribute: false })


### PR DESCRIPTION
### Change
- Move `<style>` to static property to avoid style recalculation on each instance.
- Set initial `contenteditable` to the inline editor container to avoid later recalculation