### PR TITLE
fix(blocks): linked doc popover closes when paste text

### DIFF
--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -374,6 +374,14 @@ export async function asyncGetInlineEditorByModel(
   return richText.inlineEditor;
 }
 
+export function getCurrentInlineEditor(host: EditorHost) {
+  const selection = host.selection.find('text');
+  if (!selection) return null;
+  const block = host.doc.getBlock(selection.blockId);
+  assertExists(block);
+  return getInlineEditorByModel(host, block.model);
+}
+
 export function getModelByElement(element: Element): BlockModel {
   const closestBlock = element.closest(ATTR_SELECTOR);
   assertExists(closestBlock, 'Cannot find block element by element');

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -22,7 +22,6 @@ import { LinkedDocPopover } from './linked-doc-popover.js';
 
 export function showLinkedDocPopover({
   editorHost,
-  inlineEditor,
   range,
   container = document.body,
   abortController = new AbortController(),
@@ -30,7 +29,6 @@ export function showLinkedDocPopover({
   triggerKey,
 }: {
   editorHost: EditorHost;
-  inlineEditor: AffineInlineEditor;
   range: Range;
   container?: HTMLElement;
   abortController?: AbortController;
@@ -40,11 +38,7 @@ export function showLinkedDocPopover({
   const disposables = new DisposableGroup();
   abortController.signal.addEventListener('abort', () => disposables.dispose());
 
-  const linkedDoc = new LinkedDocPopover(
-    editorHost,
-    inlineEditor,
-    abortController
-  );
+  const linkedDoc = new LinkedDocPopover(editorHost, abortController);
   linkedDoc.options = options;
   linkedDoc.triggerKey = triggerKey;
   // Mount
@@ -105,15 +99,11 @@ export class AffineLinkedDocWidget extends WidgetElement {
     this.handleEvent('keyDown', this._onKeyDown);
   }
 
-  public showLinkedDoc = (
-    inlineEditor: AffineInlineEditor,
-    triggerKey: string
-  ) => {
+  public showLinkedDoc = (triggerKey: string) => {
     const curRange = getCurrentNativeRange();
     if (!curRange) return;
     showLinkedDocPopover({
       editorHost: this.host,
-      inlineEditor,
       range: curRange,
       options: this.options,
       triggerKey,
@@ -192,11 +182,11 @@ export class AffineLinkedDocWidget extends WidgetElement {
           length: 0,
         });
         inlineEditor.slots.inlineRangeApply.once(() => {
-          this.showLinkedDoc(inlineEditor, primaryTriggerKey);
+          this.showLinkedDoc(primaryTriggerKey);
         });
         return;
       }
-      this.showLinkedDoc(inlineEditor, matchedKey);
+      this.showLinkedDoc(matchedKey);
     });
   };
 }

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -213,12 +213,7 @@ export const menuGroups: SlashMenuOptions['menus'] = [
           const linkedDocWidget = widgetEle as AffineLinkedDocWidget;
           // Wait for range to be updated
           setTimeout(() => {
-            const inlineEditor = getInlineEditorByModel(
-              rootElement.host,
-              model
-            );
-            assertExists(inlineEditor);
-            linkedDocWidget.showLinkedDoc(inlineEditor, triggerKey);
+            linkedDocWidget.showLinkedDoc(triggerKey);
           });
         },
       },

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -1,5 +1,4 @@
 import { WithDisposable } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
 import { type BlockModel } from '@blocksuite/store';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -9,10 +8,7 @@ import {
   cleanSpecifiedTail,
   createKeydownObserver,
 } from '../../../_common/components/utils.js';
-import {
-  getRichTextByModel,
-  isControlledKeyboardEvent,
-} from '../../../_common/utils/index.js';
+import { isControlledKeyboardEvent } from '../../../_common/utils/index.js';
 import { isFuzzyMatch } from '../../../_common/utils/string.js';
 import type { RootBlockComponent } from '../../../root-block/types.js';
 import { styles } from './styles.js';
@@ -81,17 +77,6 @@ export class SlashMenu extends WithDisposable(LitElement) {
     });
     this._filterItems = this._updateItem('');
 
-    const richText = getRichTextByModel(this.host, this.model);
-    if (!richText) {
-      console.warn(
-        'Slash Menu may not work properly! No rich text found for model',
-        this.model
-      );
-      return;
-    }
-    const inlineEditor = richText.inlineEditor;
-    assertExists(inlineEditor, 'RichText InlineEditor not found');
-
     /**
      * Handle arrow key
      *
@@ -103,8 +88,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
      *   and if the following key is not the backspace key, the slash menu will be closed
      */
     createKeydownObserver({
-      target: inlineEditor.eventSource,
-      inlineEditor,
+      host: this.host,
       abortController: this.abortController,
       interceptor: (e, next) => {
         if (e.key === '/') {
@@ -262,11 +246,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
     // Need to remove the search string
     // We must to do clean the slash string before we do the action
     // Otherwise, the action may change the model and cause the slash string to be changed
-    cleanSpecifiedTail(
-      this.host,
-      this.model,
-      this.triggerKey + this._searchString
-    );
+    cleanSpecifiedTail(this.host, this.triggerKey + this._searchString);
     this.abortController.abort();
 
     const { action } = this._filterItems[index];


### PR DESCRIPTION
Close #6981
Fix the popover of linked-doc and slash-menu closes when pasting text.


https://github.com/toeverything/blocksuite/assets/20479050/72042498-a1d5-4956-9cb2-4a01f7e6306c

