### PR TITLE
fix(blocks): embed-car-caption overflow

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-caption.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-caption.ts
@@ -16,7 +16,8 @@ import type { EmbedToolbarBlockElement } from './type.js';
 export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
   static override styles = css`
     .affine-embed-card-caption {
-      display: inline-block;
+      display: inline-table;
+      resize: none;
       width: 100%;
       outline: none;
       border: 0;
@@ -134,7 +135,7 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
       return nothing;
     }
 
-    return html`<input
+    return html`<textarea
       .disabled=${this.block.doc.readonly}
       placeholder="Write a caption"
       class="affine-embed-card-caption"
@@ -150,7 +151,7 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
       @paste=${stopPropagation}
       @keydown=${this._onCaptionKeydown}
       @keyup=${stopPropagation}
-    />`;
+    ></textarea>`;
   }
 }
 

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -138,7 +138,7 @@ test('enter shortcut on focusing embed block and its caption', async ({
   await moveToImage(page);
   await assertImageOption(page);
 
-  const caption = page.locator('affine-image embed-card-caption input');
+  const caption = page.locator('affine-image embed-card-caption textarea');
   await focusCaption(page);
   await type(page, '123');
 
@@ -162,7 +162,7 @@ test('should support the enter key of image caption', async ({ page }) => {
   await moveToImage(page);
   await assertImageOption(page);
 
-  const caption = page.locator('affine-image embed-card-caption input');
+  const caption = page.locator('affine-image embed-card-caption textarea');
   await focusCaption(page);
   await type(page, 'abc123');
   await pressArrowLeft(page, 3);


### PR DESCRIPTION
Close #7024

- Use <textarea></textarea> for multiple lines input and wrapping. 
- Use display: inline-table to make the height of the textarea fit the content.

![image](https://github.com/toeverything/blocksuite/assets/20479050/01fe2afc-7156-4a55-9b46-dd339136e1df)
