### PR TITLE
refactor(edgeless): better rendering control using lit scheduleUpdate

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-portal-base.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-portal-base.ts
@@ -2,6 +2,7 @@ import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 import { property } from 'lit/decorators.js';
 
+import { requestConnectedFrame } from '../../../../_common/utils/event.js';
 import type { SurfaceBlockComponent } from '../../../../surface-block/surface-block.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 
@@ -20,8 +21,36 @@ export class EdgelessPortalBase<T extends BlockModel> extends WithDisposable(
   @property({ attribute: false })
   edgeless!: EdgelessRootBlockComponent;
 
+  @property({ attribute: false })
+  updatingSet!: Set<string>;
+
+  @property({ attribute: false })
+  concurrentUpdatingCount!: number;
+
   protected renderModel(model: T) {
     return this.surface.host.renderModel(model);
+  }
+
+  protected override scheduleUpdate(): void | Promise<unknown> {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const detect = () => {
+      if (this.updatingSet.size < this.concurrentUpdatingCount) {
+        this.updatingSet.add(this.model.id);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        super.scheduleUpdate();
+
+        requestConnectedFrame(() => {
+          this.updatingSet.delete(this.model.id);
+        }, this);
+        resolve();
+      } else {
+        requestConnectedFrame(detect, this);
+      }
+    };
+
+    detect();
+
+    return promise;
   }
 
   override connectedCallback(): void {

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/frame/edgeless-frame.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/frame/edgeless-frame.ts
@@ -212,6 +212,10 @@ export class EdgelessFramesContainer extends WithDisposable(ShadowlessElement) {
                   .model=${frame}
                   .surface=${this.surface}
                   .edgeless=${this.edgeless}
+                  .updatingSet=${this.edgeless.rootElementContainer
+                    .renderingSet}
+                  .concurrentUpdatingCount=${this.edgeless.rootElementContainer
+                    .concurrentRendering}
                 >
                 </edgeless-block-portal-frame>
               `


### PR DESCRIPTION
Lit allows users to override the `scheduleUpdate` method to change the rendering timing of elements, which is particularly suitable for rendering a large number of elements in batches to prevent blocking the main thread.