### PR TITLE
fix(blocks): root service maybe undefined when service mounted

### DIFF
--- a/packages/blocks/src/embed-figma-block/embed-figma-service.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-service.ts
@@ -10,7 +10,7 @@ export class EmbedFigmaBlockService extends BlockService<EmbedFigmaModel> {
   override mounted() {
     super.mounted();
 
-    this.specSlots.viewConnected.once(() => {
+    this.std.spec.slots.afterApply.once(() => {
       const rootService = this.std.spec.getService('affine:page');
       rootService.registerEmbedBlockOptions({
         flavour: this.flavour,

--- a/packages/blocks/src/embed-figma-block/embed-figma-service.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-service.ts
@@ -10,12 +10,14 @@ export class EmbedFigmaBlockService extends BlockService<EmbedFigmaModel> {
   override mounted() {
     super.mounted();
 
-    const rootService = this.std.spec.getService('affine:page');
-    rootService.registerEmbedBlockOptions({
-      flavour: this.flavour,
-      urlRegex: figmaUrlRegex,
-      styles: EmbedFigmaStyles,
-      viewType: 'embed',
+    this.specSlots.viewConnected.once(() => {
+      const rootService = this.std.spec.getService('affine:page');
+      rootService.registerEmbedBlockOptions({
+        flavour: this.flavour,
+        urlRegex: figmaUrlRegex,
+        styles: EmbedFigmaStyles,
+        viewType: 'embed',
+      });
     });
   }
 }

--- a/packages/blocks/src/embed-github-block/embed-github-service.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-service.ts
@@ -25,12 +25,14 @@ export class EmbedGithubBlockService extends BlockService<EmbedGithubModel> {
   override mounted() {
     super.mounted();
 
-    const rootService = this.std.spec.getService('affine:page');
-    rootService.registerEmbedBlockOptions({
-      flavour: this.flavour,
-      urlRegex: githubUrlRegex,
-      styles: EmbedGithubStyles,
-      viewType: 'card',
+    this.specSlots.viewConnected.once(() => {
+      const rootService = this.std.spec.getService('affine:page');
+      rootService.registerEmbedBlockOptions({
+        flavour: this.flavour,
+        urlRegex: githubUrlRegex,
+        styles: EmbedGithubStyles,
+        viewType: 'card',
+      });
     });
   }
 

--- a/packages/blocks/src/embed-github-block/embed-github-service.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-service.ts
@@ -25,7 +25,7 @@ export class EmbedGithubBlockService extends BlockService<EmbedGithubModel> {
   override mounted() {
     super.mounted();
 
-    this.specSlots.viewConnected.once(() => {
+    this.std.spec.slots.afterApply.once(() => {
       const rootService = this.std.spec.getService('affine:page');
       rootService.registerEmbedBlockOptions({
         flavour: this.flavour,

--- a/packages/blocks/src/embed-loom-block/embed-loom-service.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-service.ts
@@ -18,12 +18,14 @@ export class EmbedLoomBlockService extends BlockService<EmbedLoomModel> {
   override mounted() {
     super.mounted();
 
-    const rootService = this.std.spec.getService('affine:page');
-    rootService.registerEmbedBlockOptions({
-      flavour: this.flavour,
-      urlRegex: loomUrlRegex,
-      styles: EmbedLoomStyles,
-      viewType: 'embed',
+    this.specSlots.viewConnected.once(() => {
+      const rootService = this.std.spec.getService('affine:page');
+      rootService.registerEmbedBlockOptions({
+        flavour: this.flavour,
+        urlRegex: loomUrlRegex,
+        styles: EmbedLoomStyles,
+        viewType: 'embed',
+      });
     });
   }
 

--- a/packages/blocks/src/embed-loom-block/embed-loom-service.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-service.ts
@@ -18,7 +18,7 @@ export class EmbedLoomBlockService extends BlockService<EmbedLoomModel> {
   override mounted() {
     super.mounted();
 
-    this.specSlots.viewConnected.once(() => {
+    this.std.spec.slots.afterApply.once(() => {
       const rootService = this.std.spec.getService('affine:page');
       rootService.registerEmbedBlockOptions({
         flavour: this.flavour,

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
@@ -21,7 +21,7 @@ export class EmbedYoutubeBlockService extends BlockService<EmbedYoutubeModel> {
   override mounted() {
     super.mounted();
 
-    this.specSlots.viewConnected.once(() => {
+    this.std.spec.slots.afterApply.once(() => {
       const rootService = this.std.spec.getService('affine:page');
       rootService.registerEmbedBlockOptions({
         flavour: this.flavour,

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-service.ts
@@ -21,12 +21,14 @@ export class EmbedYoutubeBlockService extends BlockService<EmbedYoutubeModel> {
   override mounted() {
     super.mounted();
 
-    const rootService = this.std.spec.getService('affine:page');
-    rootService.registerEmbedBlockOptions({
-      flavour: this.flavour,
-      urlRegex: youtubeUrlRegex,
-      styles: EmbedYoutubeStyles,
-      viewType: 'embed',
+    this.specSlots.viewConnected.once(() => {
+      const rootService = this.std.spec.getService('affine:page');
+      rootService.registerEmbedBlockOptions({
+        flavour: this.flavour,
+        urlRegex: youtubeUrlRegex,
+        styles: EmbedYoutubeStyles,
+        viewType: 'embed',
+      });
     });
   }
 

--- a/packages/framework/block-std/src/spec/spec-store.ts
+++ b/packages/framework/block-std/src/spec/spec-store.ts
@@ -12,12 +12,17 @@ export class SpecStore {
   constructor(public std: BlockSuite.Std) {}
 
   readonly slots = {
+    beforeApply: new Slot(),
+    beforeMount: new Slot(),
+    beforeUnmount: new Slot(),
     afterApply: new Slot(),
     afterMount: new Slot(),
     afterUnmount: new Slot(),
   };
 
   mount() {
+    this.slots.beforeMount.emit();
+
     if (this._disposables.disposed) {
       this._disposables = new DisposableGroup();
     }
@@ -26,6 +31,8 @@ export class SpecStore {
   }
 
   unmount() {
+    this.slots.beforeUnmount.emit();
+
     this._services.forEach(service => {
       service.dispose();
       service.unmounted();
@@ -37,6 +44,8 @@ export class SpecStore {
   }
 
   applySpecs(specs: BlockSpec[]) {
+    this.slots.beforeApply.emit();
+
     const oldSpecs = this._specs;
     const newSpecs = this._buildSpecMap(specs);
     this._diffServices(oldSpecs, newSpecs);

--- a/packages/framework/block-std/src/spec/spec-store.ts
+++ b/packages/framework/block-std/src/spec/spec-store.ts
@@ -1,4 +1,4 @@
-import { DisposableGroup } from '@blocksuite/global/utils';
+import { DisposableGroup, Slot } from '@blocksuite/global/utils';
 
 import { BlockService } from '../service/index.js';
 import type { BlockSpec } from './index.js';
@@ -11,10 +11,18 @@ export class SpecStore {
 
   constructor(public std: BlockSuite.Std) {}
 
+  readonly slots = {
+    afterApply: new Slot(),
+    afterMount: new Slot(),
+    afterUnmount: new Slot(),
+  };
+
   mount() {
     if (this._disposables.disposed) {
       this._disposables = new DisposableGroup();
     }
+
+    this.slots.afterMount.emit();
   }
 
   unmount() {
@@ -24,6 +32,8 @@ export class SpecStore {
     });
     this._services.clear();
     this._disposables.dispose();
+
+    this.slots.afterUnmount.emit();
   }
 
   applySpecs(specs: BlockSpec[]) {
@@ -31,6 +41,8 @@ export class SpecStore {
     const newSpecs = this._buildSpecMap(specs);
     this._diffServices(oldSpecs, newSpecs);
     this._specs = newSpecs;
+
+    this.slots.afterApply.emit();
   }
 
   getView(flavour: string) {


### PR DESCRIPTION
The old implementation relies on the loading order of specs, assuming that the root spec comes before the embed spec