### PR TITLE
fix: copy empty code block failure

### DIFF
--- a/packages/blocks/src/_common/adapters/html.ts
+++ b/packages/blocks/src/_common/adapters/html.ts
@@ -1,4 +1,3 @@
-import { assertEquals } from '@blocksuite/global/utils';
 import type { DeltaInsert } from '@blocksuite/inline';
 import type {
   FromBlockSnapshotPayload,
@@ -1089,7 +1088,21 @@ export class HtmlAdapter extends BaseAdapter<Html> {
     deltas = deltas.reduce((acc, cur) => {
       return mergeDeltas(acc, cur, { force: true });
     }, [] as DeltaInsert<object>[]);
-    assertEquals(deltas.length, 1, 'Delta length should be 1 in code block');
+    if (!deltas.length) {
+      return [
+        {
+          type: 'element',
+          tagName: 'span',
+          children: [
+            {
+              type: 'text',
+              value: '',
+            },
+          ],
+        },
+      ] as ElementContent[];
+    }
+
     const delta = deltas[0];
     if (typeof rawLang == 'string') {
       rawLang = rawLang.toLowerCase();

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -433,31 +433,25 @@ test.skip('use keyboard copy inside code block copy', async ({ page }) => {
   );
 });
 
-test.fixme(
-  'use code block copy menu of code block copy whole code block',
-  async ({ page }) => {
-    await enterPlaygroundRoom(page);
-    await initEmptyCodeBlockState(page, { language: 'javascript' });
-    await focusRichText(page);
+test('code block has content, click code block copy menu, copy whole code block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyCodeBlockState(page, { language: 'javascript' });
+  await focusRichText(page);
+  await page.keyboard.type('use');
+  await pressEnterWithShortkey(page);
 
-    await page.keyboard.type('use');
-    await pressEnterWithShortkey(page);
+  const codeBlockController = getCodeBlock(page);
+  await codeBlockController.codeBlock.hover();
+  await expect(codeBlockController.copyButton).toBeVisible();
+  await codeBlockController.copyButton.click();
 
-    const codeBlockPosition = await getCenterPosition(page, 'affine-code');
-    await page.mouse.move(codeBlockPosition.x, codeBlockPosition.y);
-
-    const position = await getCenterPosition(
-      page,
-      '.affine-codeblock-option > icon-button:nth-child(1)'
-    );
-
-    await page.mouse.click(position.x, position.y);
-
-    await focusRichText(page, 1);
-    await pasteByKeyboard(page);
-    await assertStoreMatchJSX(
-      page,
-      /*xml*/ `
+  await focusRichText(page, 1);
+  await pasteByKeyboard(page);
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
 <affine:page>
   <affine:note
     prop:background="--affine-background-secondary-color"
@@ -487,9 +481,57 @@ test.fixme(
     />
   </affine:note>
 </affine:page>`
-    );
-  }
-);
+  );
+});
+
+test('code block is empty, click code block copy menu, copy the empty code block', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyCodeBlockState(page, { language: 'javascript' });
+  await focusRichText(page);
+
+  await pressEnterWithShortkey(page);
+
+  const codeBlockController = getCodeBlock(page);
+  await codeBlockController.codeBlock.hover();
+  await expect(codeBlockController.copyButton).toBeVisible();
+  await codeBlockController.copyButton.click();
+
+  await focusRichText(page, 1);
+  await pasteByKeyboard(page);
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:page>
+  <affine:note
+    prop:background="--affine-background-secondary-color"
+    prop:displayMode="both"
+    prop:edgeless={
+      Object {
+        "style": Object {
+          "borderRadius": 8,
+          "borderSize": 4,
+          "borderStyle": "solid",
+          "shadowType": "--affine-note-shadow-box",
+        },
+      }
+    }
+    prop:hidden={false}
+    prop:index="a0"
+  >
+    <affine:code
+      prop:language="javascript"
+      prop:wrap={false}
+    />
+    <affine:code
+      prop:language="javascript"
+      prop:wrap={false}
+    />
+  </affine:note>
+</affine:page>`
+  );
+});
 
 test('code block copy button can work', async ({ page }) => {
   await enterPlaygroundRoom(page);


### PR DESCRIPTION
### TL;DR

This PR modifies the behavior of the HtmlAdapter when dealing with empty code block.

Empty code block is a valid schema and its child node `text.delta` is an empty array. 

![截屏2024-05-16 18.28.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/51f50664-a723-4ddb-8876-1209b8cc4141.png)

![截屏2024-05-16 18.27.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/01d42369-5736-4dc8-bb61-5a51c51e9624.png)


### What changed?
- if `text.delta` is an empty array, return empty span element
- add e2e test for empty code block copy case

### How to test?

Pull the changes, insert a code block and click copy button.

---

