### PR TITLE
fix: selecting multiple blocks and dragging will show multiple placeholders

### DIFF
--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -103,11 +103,14 @@ export class ParagraphBlockComponent extends BlockElement<
     )
       return;
 
+    const selection = this.host.selection.find('text');
+    const isCollapsed = selection?.isCollapsed() ?? false;
     if (
       this.doc.readonly ||
       this.inlineEditor.yTextLength > 0 ||
       this.inlineEditor.isComposing ||
       !this.selected ||
+      !isCollapsed ||
       this._isInDatabase()
     ) {
       this._placeholderContainer.classList.remove('visible');

--- a/tests/paragraph.spec.ts
+++ b/tests/paragraph.spec.ts
@@ -6,6 +6,7 @@ import {
   enterPlaygroundRoom,
   focusRichText,
   focusTitle,
+  getIndexCoordinate,
   initEmptyEdgelessState,
   initEmptyParagraphState,
   initThreeDividers,
@@ -1409,6 +1410,26 @@ test('should placeholder works', async ({ page }) => {
 
   await pressEnter(page);
   await expect(placeholder).toHaveCount(1);
+});
+
+test('should placeholder not show when multiple blocks are selected', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+  await pressEnter(page);
+  await assertRichTexts(page, ['', '']);
+  const coord = await getIndexCoordinate(page, [0, 0]);
+  // blur
+  await page.mouse.click(0, 0);
+  await page.mouse.move(coord.x - 26 - 24, coord.y - 10, { steps: 20 });
+  await page.mouse.down();
+  // ←
+  await page.mouse.move(coord.x + 20, coord.y + 50, { steps: 20 });
+  await page.mouse.up();
+  const placeholder = page.locator('.affine-paragraph-placeholder.visible');
+  await expect(placeholder).toBeHidden();
 });
 
 test('should placeholder not show at readonly mode', async ({ page }) => {


### PR DESCRIPTION
### What changed?
- the placeholder will be visible, only if the selection is text selection and collapsed
- add e2e test

Fix affine-design/issue/BS-312.

|  Before  | After |
|  ----  | ----  |
| ![截屏2024-05-17 19.02.32.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/54123270-fe12-4004-b99b-80d87196d106.png) | ![截屏2024-05-17 19.04.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/b09fbb99-9a5b-4d1d-9637-3175a5c21efc.png)|

### How to test?

Test the paragraph block in various states like editing, selecting, etc. Ensure the placeholder visibility is as expected.

---

