### PR TITLE
feat(std): add exec method to CommandManager

### DIFF
--- a/packages/framework/block-std/src/__tests__/command.unit.spec.ts
+++ b/packages/framework/block-std/src/__tests__/command.unit.spec.ts
@@ -193,6 +193,35 @@ describe('CommandManager', () => {
     expect(success).toBeTruthy();
   });
 
+  test('can execute a single command with `exec`', () => {
+    const command1: Command1 = vi.fn((_ctx, next) =>
+      next({ commandData1: (_ctx.command1Option ?? '') + '123' })
+    );
+    const command2: Command2 = vi.fn((_ctx, next) =>
+      next({ commandData2: 'cmd2' })
+    );
+    const command3: Command3 = vi.fn((_ctx, next) => next());
+
+    commandManager.add('command1', command1);
+    commandManager.add('command2', command2);
+    commandManager.add('command3', command3);
+
+    const result1 = commandManager.exec('command1');
+    const result2 = commandManager.exec('command1', {
+      command1Option: 'test',
+    });
+    const result3 = commandManager.exec('command2');
+    const result4 = commandManager.exec('command3');
+
+    expect(command1).toHaveBeenCalled();
+    expect(command2).toHaveBeenCalled();
+    expect(command3).toHaveBeenCalled();
+    expect(result1).toEqual({ commandData1: '123' });
+    expect(result2).toEqual({ commandData1: 'test123' });
+    expect(result3).toEqual({ commandData2: 'cmd2' });
+    expect(result4).toEqual({});
+  });
+
   test('should not continue with the rest of the chain if all commands in `try` fail', () => {
     const command1: Command<never, 'commandData1'> = vi.fn((_ctx, _next) => {});
     const command2: Command = vi.fn((_ctx, _next) => {});

--- a/packages/framework/block-std/src/command/manager.ts
+++ b/packages/framework/block-std/src/command/manager.ts
@@ -162,9 +162,19 @@ export class CommandManager {
   exec<K extends keyof BlockSuite.Commands>(
     command: K,
     ...args: IfAllKeysOptional<
-      InDataOfCommand<BlockSuite.Commands[K]>,
-      [inData: void],
-      [inData: InDataOfCommand<BlockSuite.Commands[K]>]
+      Omit<InDataOfCommand<BlockSuite.Commands[K]>, keyof InitCommandCtx>,
+      [
+        inData: void | Omit<
+          InDataOfCommand<BlockSuite.Commands[K]>,
+          keyof InitCommandCtx
+        >,
+      ],
+      [
+        inData: Omit<
+          InDataOfCommand<BlockSuite.Commands[K]>,
+          keyof InitCommandCtx
+        >,
+      ]
     >
   ): ExecCommandResult<K> {
     const cmdFunc = this._commands.get(command);
@@ -183,7 +193,7 @@ export class CommandManager {
 
     cmdFunc(ctx, result => {
       // @ts-ignore
-      execResult = result;
+      execResult = result ?? {};
     });
 
     return execResult;

--- a/packages/framework/block-std/src/command/manager.ts
+++ b/packages/framework/block-std/src/command/manager.ts
@@ -1,5 +1,12 @@
 import { cmdSymbol } from './consts.js';
-import type { Chain, Command, InitCommandCtx } from './types.js';
+import type {
+  Chain,
+  Command,
+  ExecCommandResult,
+  IfAllKeysOptional,
+  InDataOfCommand,
+  InitCommandCtx,
+} from './types.js';
 
 export class CommandManager {
   private _commands = new Map<string, Command>();
@@ -151,6 +158,36 @@ export class CommandManager {
 
     return createChain(methods, []) as never;
   };
+
+  exec<K extends keyof BlockSuite.Commands>(
+    command: K,
+    ...args: IfAllKeysOptional<
+      InDataOfCommand<BlockSuite.Commands[K]>,
+      [inData: void],
+      [inData: InDataOfCommand<BlockSuite.Commands[K]>]
+    >
+  ): ExecCommandResult<K> {
+    const cmdFunc = this._commands.get(command);
+
+    if (!cmdFunc) {
+      throw new Error(`The command "${command}" not found`);
+    }
+
+    const inData = args[0];
+    const ctx = {
+      ...this._getCommandCtx(),
+      ...inData,
+    };
+
+    let execResult: ExecCommandResult<K> = {} as ExecCommandResult<K>;
+
+    cmdFunc(ctx, result => {
+      // @ts-ignore
+      execResult = result;
+    });
+
+    return execResult;
+  }
 }
 
 function runCmds(ctx: BlockSuite.CommandContext, [cmd, ...rest]: Command[]) {

--- a/packages/framework/block-std/src/command/types.ts
+++ b/packages/framework/block-std/src/command/types.ts
@@ -6,7 +6,7 @@
 // type TestC = MakeOptionalIfEmpty<C>;  // { prop: string }
 import type { cmdSymbol } from './consts.js';
 
-type IfAllKeysOptional<T, Yes, No> =
+export type IfAllKeysOptional<T, Yes, No> =
   Partial<T> extends T ? (T extends Partial<T> ? Yes : No) : No;
 type MakeOptionalIfEmpty<T> = IfAllKeysOptional<T, void | T, T>;
 
@@ -30,7 +30,7 @@ export type Command<
 type Omit1<A, B> = [keyof Omit<A, keyof B>] extends [never]
   ? void
   : Omit<A, keyof B>;
-type InDataOfCommand<C> =
+export type InDataOfCommand<C> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends Command<infer K, any, infer R> ? CommandKeyToData<K> & R : never;
 type OutDataOfCommand<C> =
@@ -67,6 +67,9 @@ export type Chain<In extends object = {}> = CommonMethods<In> & {
     >
   ) => Chain<In & OutDataOfCommand<BlockSuite.Commands[K]>>;
 } & Cmds;
+
+export type ExecCommandResult<K extends keyof BlockSuite.Commands> =
+  OutDataOfCommand<BlockSuite.Commands[K]>;
 
 declare global {
   namespace BlockSuite {


### PR DESCRIPTION
Add `exec` to allow executing a single command without calling `chain`.  Usage is shown below.

```TypeScript
const result = this.std.command.exec('getBlockIndex');

console.log(result.blockIndex);
```