### PR TITLE
fix(blocks): should reset shape text when text is empty

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -4,6 +4,7 @@ import {
   WithDisposable,
 } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import { DocCollection } from '@blocksuite/store';
 import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -171,6 +172,17 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
   private _unmount() {
     this._resizeObserver?.disconnect();
     this._resizeObserver = null;
+
+    if (this.element.text) {
+      const text = this.element.text.toString();
+      const trimed = text.trim();
+      const len = trimed.length;
+      if (len === 0) {
+        this.element.text = undefined;
+      } else if (len < text.length) {
+        this.element.text = new DocCollection.Y.Text(trimed);
+      }
+    }
 
     this.element.textDisplay = true;
     this.element.group instanceof MindmapElementModel &&

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -9,6 +9,7 @@ import {
   changeShapeStyle,
   clickComponentToolbarMoreMenuButton,
   getEdgelessSelectedRect,
+  locatorComponentToolbar,
   locatorEdgelessToolButton,
   locatorShapeStrokeStyleButton,
   openComponentToolbarMoreMenu,
@@ -468,7 +469,7 @@ test('auto wrap text in shape', async ({ page }) => {
   await page.mouse.dblclick(250, 200);
   await waitNextFrame(page);
   // type long text
-  await type(page, 'cccccccc');
+  await type(page, '\ncccccccc');
   await assertEdgelessCanvasText(page, 'aaaa\nbbbb\ncccccccc');
 
   // blur to finish typing
@@ -527,6 +528,61 @@ test('change shape style', async ({ page }) => {
   const [picked] = await pickColorAtPoints(page, [[start.x + 1, start.y + 1]]);
 
   await assertEdgelessColorSameWithHexColor(page, color, picked);
+});
+
+test('shape adds text by button', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+
+  await setEdgelessTool(page, 'shape');
+  await waitNextFrame(page, 500);
+
+  await page.mouse.click(200, 150);
+  await waitNextFrame(page);
+
+  await triggerComponentToolbarAction(page, 'addText');
+  await type(page, 'hello');
+  await assertEdgelessCanvasText(page, 'hello');
+});
+
+test('should reset shape text when text is empty', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+
+  await setEdgelessTool(page, 'shape');
+  await waitNextFrame(page, 500);
+
+  await page.mouse.click(200, 150);
+  await waitNextFrame(page);
+
+  await triggerComponentToolbarAction(page, 'addText');
+  await type(page, ' a ');
+  await assertEdgelessCanvasText(page, ' a ');
+
+  await page.mouse.click(0, 0);
+  await waitNextFrame(page);
+  await page.mouse.click(200, 150);
+
+  const addTextBtn = locatorComponentToolbar(page).getByRole('button', {
+    name: 'Add text',
+  });
+  await expect(addTextBtn).toBeHidden();
+
+  await page.mouse.dblclick(250, 200);
+  await assertEdgelessCanvasText(page, 'a');
+
+  await page.keyboard.press('Backspace');
+  await assertEdgelessCanvasText(page, '');
+
+  await page.mouse.click(0, 0);
+  await waitNextFrame(page);
+  await page.mouse.click(200, 150);
+
+  await expect(addTextBtn).toBeVisible();
 });
 
 test.describe('shape hit test', () => {

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -805,7 +805,8 @@ type Action =
   | 'renameGroup'
   | 'autoSize'
   | 'changeNoteDisplayMode'
-  | 'changeNoteSlicerSetting';
+  | 'changeNoteSlicerSetting'
+  | 'addText';
 
 export async function triggerComponentToolbarAction(
   page: Page,
@@ -998,6 +999,13 @@ export async function triggerComponentToolbarAction(
       const button = locatorComponentToolbar(page)
         .locator('edgeless-change-note-button')
         .getByRole('button', { name: 'Size' });
+      await button.click();
+      break;
+    }
+    case 'addText': {
+      const button = locatorComponentToolbar(page).getByRole('button', {
+        name: 'Add text',
+      });
       await button.click();
       break;
     }


### PR DESCRIPTION
### Before

https://github.com/toeverything/blocksuite/assets/27926/6b594dc2-43db-48e4-9643-1e6e5fe02520


### After


https://github.com/toeverything/blocksuite/assets/27926/021d457f-dd3d-40c1-8b40-888eff18fd1b

