### PR TITLE
fix(edgeless): note blocks not ordered because of missing images

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -1385,7 +1385,8 @@ export function getCopyElements(
         set.add(ele)
       );
       set.add(element);
-    } else {
+    } else if (!isImageBlock(element)) {
+      // TODO: add support for image block
       set.add(element);
     }
   });


### PR DESCRIPTION
https://linear.app/affine-design/issue/BS-323