### PR TITLE
fix(store): dead loop on set default props

### DIFF
--- a/packages/framework/store/src/store/doc/block.ts
+++ b/packages/framework/store/src/store/doc/block.ts
@@ -223,7 +223,7 @@ export class Block {
     // Set default props if not exists
     if (defaultProps) {
       Object.entries(defaultProps).forEach(([key, value]) => {
-        if (props[key] !== undefined) return;
+        if (key in props) return;
 
         const yValue = native2Y(value);
         this.yBlock.set(`prop:${key}`, yValue);


### PR DESCRIPTION
https://github.com/toeverything/blocksuite/blob/master/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-spec.ts#L16

Some blocks have undefined default props, causing the default values ​​to be set over and over again, creating an dead loop.