### PR TITLE
perf: reduce the edgeless rendering overhead

### DIFF
--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,11 +1,8 @@
-import type { EditorHost } from '@blocksuite/block-std';
 import type { Text } from '@blocksuite/store';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
 import type { HitTestOptions } from '../root-block/edgeless/type.js';
-import type { EdgelessRootService } from '../root-block/index.js';
-import { getTextRect } from '../surface-block/elements/text/utils.js';
 import { Bound, type SerializedXYWH } from '../surface-block/index.js';
 
 type FrameBlockProps = {
@@ -37,32 +34,13 @@ export const FrameBlockSchema = defineBlockSchema({
 export class FrameBlockModel extends selectable<FrameBlockProps>(BlockModel) {
   static PADDING = [8, 10];
 
-  override hitTest(
-    x: number,
-    y: number,
-    _: HitTestOptions,
-    host: EditorHost
-  ): boolean {
+  override hitTest(x: number, y: number, _: HitTestOptions): boolean {
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointNearBound([x, y], 5);
-    const zoom = _.zoom ?? 1;
 
     if (hit) return true;
 
-    const rootService =
-      host.std.spec.getService<EdgelessRootService>('affine:page');
-    const isInner = rootService.frame.getFrameInner(this);
-
-    const titleRect = getTextRect(this.title.toString(), 'Inter', 14);
-
-    titleRect.w = (titleRect.w + FrameBlockModel.PADDING[1] * 2) / zoom;
-    titleRect.h = (titleRect.h + FrameBlockModel.PADDING[0] * 2) / zoom;
-
-    bound.y = isInner ? bound.y : bound.y - titleRect.h;
-    bound.w = titleRect.w;
-    bound.h = titleRect.h;
-
-    return bound.isPointInBound([x, y]);
+    return this.externalBound?.isPointInBound([x, y]) ?? false;
   }
 
   override boxSelect(selectedBound: Bound): boolean {

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/note/edgeless-note.ts
@@ -54,7 +54,8 @@ export class EdgelessNoteMask extends WithDisposable(ShadowlessElement) {
           const bound = Bound.deserialize(this.model.xywh);
           const scale = this.model.edgeless.scale ?? 1;
           const height = entry.contentRect.height * scale;
-          if (almostEqual(bound.h, height)) {
+
+          if (!height || almostEqual(bound.h, height)) {
             return;
           }
 

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-frame-title-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-frame-title-editor.ts
@@ -118,7 +118,12 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
     const viewport = this.edgeless.service.viewport;
     const bound = Bound.deserialize(this.frameModel.xywh);
     const [x, y] = viewport.toViewCoord(bound.x, bound.y);
-    const isInner = this.edgeless.service.frame.getFrameInner(this.frameModel);
+    const isInner = this.edgeless.service.layer.framesGrid.has(
+      this.frameModel.elementBound,
+      true,
+      true,
+      new Set([this.frameModel])
+    );
 
     const inlineEditorStyle = styleMap({
       transformOrigin: 'top left',

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -826,13 +826,6 @@ export class EdgelessRootBlockComponent extends BlockElement<
     return html`${this.host.renderModel(this.surfaceBlockModel)}
       <edgeless-block-portal-container .edgeless=${this}>
       </edgeless-block-portal-container>
-      <edgeless-frames-container
-        .surface=${this.surface}
-        .edgeless=${this}
-        .frames=${this.service.frames}
-        .onlyTitle=${true}
-      >
-      </edgeless-frames-container>
       <div class="widgets-container">${widgets}</div> `;
   }
 }

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -353,23 +353,25 @@ export class EdgelessRootService extends RootService {
     const pickFrames = () => {
       return this._layer.frames.filter(
         frame =>
-          frame.hitTest(x, y, options, this.host) ||
+          frame.hitTest(x, y, options) ||
           frame.externalBound?.isPointInBound([x, y])
       ) as EdgelessModel[];
     };
 
-    let results = pickCanvasElement().concat(pickBlock());
+    const frames = pickFrames();
 
-    // FIXME: optimazation on ordered element
-    results.sort(this._layer.compare);
+    if (frames.length === 0 || options.all) {
+      let results = pickCanvasElement().concat(pickBlock());
 
-    if (options.all || results.length === 0) {
-      const frames = pickFrames();
+      // FIXME: optimazation on ordered element
+      results.sort(this._layer.compare);
 
-      results = frames.concat(results);
+      results = results.concat(frames);
+
+      return options.all ? results : last(results) ?? null;
+    } else {
+      return last(frames) ?? null;
     }
-
-    return options.all ? results : last(results) ?? null;
   }
 
   /**
@@ -413,13 +415,13 @@ export class EdgelessRootService extends RootService {
       case 'canvas':
         return pickCanvasElement();
       case 'blocks':
-        return pickFrames().concat(pickBlock());
+        return pickBlock().concat(pickFrames());
       case 'frame':
         return pickFrames();
       case 'all': {
         const results = pickCanvasElement().concat(pickBlock());
         results.sort(this._layer.compare);
-        return pickFrames().concat(results);
+        return results.concat(pickFrames());
       }
     }
   }

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -66,37 +66,9 @@ export function isFrameInner(
 }
 
 export class EdgelessFrameManager {
-  private _innerMap = new Map<string, boolean>();
   private _disposable = new DisposableGroup();
 
-  constructor(private _rootService: EdgelessRootService) {
-    this._disposable.add(
-      this._rootService.doc.slots.blockUpdated.on(e => {
-        const { id, type } = e;
-        const element = this._rootService.getElementById(id);
-        if (!isFrameBlock(element)) return;
-        if (type === 'add') {
-          this._innerMap.set(
-            id,
-            isFrameInner(element, this._rootService.frames)
-          );
-        } else if (type === 'update' && e.props.key === 'xywh') {
-          this._innerMap.set(
-            id,
-            isFrameInner(element, this._rootService.frames)
-          );
-        }
-      })
-    );
-  }
-
-  getFrameInner(frame: FrameBlockModel) {
-    return this._innerMap.get(frame.id);
-  }
-
-  setFrameInner(frame: FrameBlockModel, isInner: boolean) {
-    this._innerMap.set(frame.id, isInner);
-  }
+  constructor(private _rootService: EdgelessRootService) {}
 
   selectFrame(eles: Selectable[]) {
     const frames = this._rootService.frames;

--- a/packages/blocks/src/surface-block/grid.ts
+++ b/packages/blocks/src/surface-block/grid.ts
@@ -232,4 +232,42 @@ export class GridManager<T extends EdgelessModel> {
 
     return results;
   }
+
+  /**
+   *
+   * @param bound
+   * @param strict
+   * @param reverseChecking If true, check if the bound is inside the elements instead of checking if the elements are inside the bound
+   * @returns
+   */
+  has(
+    bound: IBound,
+    strict: boolean = false,
+    reverseChecking: boolean = false,
+    exclude?: Set<T>
+  ) {
+    const [minRow, maxRow, minCol, maxCol] = rangeFromBound(bound);
+    const b = Bound.from(bound);
+    const check = reverseChecking
+      ? (target: Bound) => {
+          return strict ? target.contains(b) : intersects(b, target);
+        }
+      : (target: Bound) => {
+          return strict ? b.contains(target) : intersects(target, b);
+        };
+
+    for (let i = minRow; i <= maxRow; i++) {
+      for (let j = minCol; j <= maxCol; j++) {
+        const gridElements = this._getGrid(i, j);
+        if (!gridElements) continue;
+        for (const element of gridElements) {
+          if (!exclude?.has(element) && check(element.elementBound)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
 }

--- a/packages/blocks/src/surface-block/managers/layer-manager.ts
+++ b/packages/blocks/src/surface-block/managers/layer-manager.ts
@@ -89,7 +89,10 @@ export class LayerManager {
   private _disposables = new DisposableGroup();
 
   slots = {
-    layerUpdated: new Slot(),
+    layerUpdated: new Slot<{
+      type: 'delete' | 'add' | 'update';
+      initiatingElement: EdgelessModel;
+    }>(),
   };
 
   canvasElements!: ElementModel[];
@@ -622,7 +625,10 @@ export class LayerManager {
     if (insertType) {
       this._insertIntoLayer(element as EdgelessModel, insertType);
       this._buildCanvasLayers();
-      this.slots.layerUpdated.emit();
+      this.slots.layerUpdated.emit({
+        type: 'add',
+        initiatingElement: element,
+      });
     }
   }
 
@@ -645,14 +651,20 @@ export class LayerManager {
     if (deleteType) {
       this._removeFromLayer(element, deleteType);
       this._buildCanvasLayers();
-      this.slots.layerUpdated.emit();
+      this.slots.layerUpdated.emit({
+        type: 'delete',
+        initiatingElement: element,
+      });
     }
   }
 
   update(element: EdgelessModel, props?: Record<string, unknown>) {
     if (this._updateLayer(element, props)) {
       this._buildCanvasLayers();
-      this.slots.layerUpdated.emit();
+      this.slots.layerUpdated.emit({
+        type: 'update',
+        initiatingElement: element,
+      });
     }
   }
 

--- a/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.spec.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest';
+
+import { markdownToMindmap } from './mindmap-preview.js';
+
+describe('markdownToMindmap: convert markdown list to a mind map tree', () => {
+  test('basic case', () => {
+    const markdown = `
+- Text A
+  - Text B
+    - Text C
+  - Text D
+    - Text E
+`;
+    const nodes = markdownToMindmap(markdown);
+
+    expect(nodes).toEqual({
+      text: 'Text A',
+      children: [
+        {
+          text: 'Text B',
+          children: [
+            {
+              text: 'Text C',
+              children: [],
+            },
+          ],
+        },
+        {
+          text: 'Text D',
+          children: [
+            {
+              text: 'Text E',
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('basic case with different indent', () => {
+    const markdown = `
+- Text A
+    - Text B
+        - Text C
+    - Text D
+        - Text E
+`;
+    const nodes = markdownToMindmap(markdown);
+
+    expect(nodes).toEqual({
+      text: 'Text A',
+      children: [
+        {
+          text: 'Text B',
+          children: [
+            {
+              text: 'Text C',
+              children: [],
+            },
+          ],
+        },
+        {
+          text: 'Text D',
+          children: [
+            {
+              text: 'Text E',
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('empty case', () => {
+    const markdown = '';
+    const nodes = markdownToMindmap(markdown);
+
+    expect(nodes).toEqual(null);
+  });
+});

--- a/packages/framework/block-std/src/view/utils/range-binding.ts
+++ b/packages/framework/block-std/src/view/utils/range-binding.ts
@@ -58,14 +58,18 @@ export class RangeBinding {
     path: string[];
   } | null = null;
   private _onStdSelectionChanged = (selections: BaseSelection[]) => {
+    const text =
+      selections.find((selection): selection is TextSelection =>
+        selection.is('text')
+      ) ?? null;
+
+    if (text === this._prevTextSelection) {
+      return;
+    }
+
     // wait for lit updated
     this.host.updateComplete
       .then(() => {
-        const text =
-          selections.find((selection): selection is TextSelection =>
-            selection.is('text')
-          ) ?? null;
-
         const model = text && this.host.doc.getBlockById(text.blockId);
         const path = model && this.host.view.calculatePath(model);
 
@@ -73,7 +77,8 @@ export class RangeBinding {
           text && this._prevTextSelection && path
             ? text.equals(this._prevTextSelection.selection) &&
               path.join('') === this._prevTextSelection.path.join('')
-            : text === this._prevTextSelection;
+            : false;
+
         if (eq) {
           return;
         }

--- a/tests/edgeless/frame.spec.ts
+++ b/tests/edgeless/frame.spec.ts
@@ -9,6 +9,7 @@ import {
   setEdgelessTool,
   Shape,
   triggerComponentToolbarAction,
+  zoomOutByKeyboard,
 } from '../utils/actions/edgeless.js';
 import {
   pressEnter,
@@ -66,10 +67,10 @@ test.describe('frame', () => {
   test('drag frame to move', async ({ page }) => {
     await addFrame(page);
     await autoFit(page);
-    await dragBetweenViewCoords(page, [100, 50], [105, 50]);
+    await dragBetweenViewCoords(page, [100, 50], [120, 70]);
     await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [5, 0, 100, 100], 0);
-    await assertSelectedBound(page, [105, 0, 100, 100], 1);
+    await assertSelectedBound(page, [20, 20, 100, 100], 0);
+    await assertSelectedBound(page, [120, 20, 100, 100], 1);
   });
 
   test('edit frame title', async ({ page }) => {
@@ -77,6 +78,45 @@ test.describe('frame', () => {
     await autoFit(page);
     expect(await page.locator('edgeless-frame-title-editor').count()).toBe(0);
     await dblclickView(page, [-300 + 5, -270 - 20]);
+    await page.locator('edgeless-frame-title-editor').waitFor({
+      state: 'attached',
+    });
+    await type(page, 'ABC');
+    await assertEdgelessCanvasText(page, 'ABC');
+  });
+
+  test('edit frame after zoom', async ({ page }) => {
+    await addFrame(page);
+    await autoFit(page);
+    await zoomOutByKeyboard(page);
+    expect(await page.locator('edgeless-frame-title-editor').count()).toBe(0);
+    await dblclickView(page, [-300 + 5, -270 - 20]);
+    await page.locator('edgeless-frame-title-editor').waitFor({
+      state: 'attached',
+    });
+    await type(page, 'ABC');
+    await assertEdgelessCanvasText(page, 'ABC');
+  });
+
+  test('edit frame title after drag', async ({ page }) => {
+    await addFrame(page);
+    await autoFit(page);
+    await dragBetweenViewCoords(page, [100, 50], [120, 70]);
+    await selectAllByKeyboard(page);
+    await dblclickView(page, [-300 + 5 + 20, -270 - 20 + 20]);
+    await page.locator('edgeless-frame-title-editor').waitFor({
+      state: 'attached',
+    });
+    await type(page, 'ABC');
+    await assertEdgelessCanvasText(page, 'ABC');
+  });
+
+  test('edit title of the frame that created by tool ', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await setEdgelessTool(page, 'frame');
+
+    await dragBetweenViewCoords(page, [0, 0], [200, 100]);
+    await dblclickView(page, [65, -20]);
     await page.locator('edgeless-frame-title-editor').waitFor({
       state: 'attached',
     });


### PR DESCRIPTION
### Change
- set `display: none` on the blocks outside the viewport
- remove `will-change` cause' it brings additional layerizing overhead
- reduce unnecessary selection update

After landing this, we should have a good enough performance baseline. The next step is to build a performance metrics tool.