### PR TITLE
fix(edgeless): use minimum note width and height

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
@@ -10,7 +10,7 @@ import {
 import type { SelectionArea } from '../../services/tools-manager.js';
 import {
   EXCLUDING_MOUSE_OUT_CLASS_LIST,
-  NOTE_MIN_HEIGHT,
+  NOTE_INIT_HEIGHT,
   NOTE_MIN_WIDTH,
 } from '../../utils/consts.js';
 import { addNote } from '../../utils/note.js';
@@ -131,25 +131,30 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     this._draggingArea = null;
 
     const { x, y, width, height } = this._draggingNoteOverlay;
+
     this._disposeOverlay(this._draggingNoteOverlay);
 
-    if (width < NOTE_MIN_WIDTH || height < NOTE_MIN_HEIGHT) {
-      //TODO: add toast to notify user
-      this._edgeless.tools.setEdgelessTool({ type: 'default' });
-      return;
-    }
-
     const { childFlavour, childType } = this.tool;
+
     const options = {
       childFlavour,
       childType,
       collapse: true,
     };
+
     const [viewX, viewY] = this._edgeless.service.viewport.toViewCoord(x, y);
+
     const point = new Point(viewX, viewY);
 
     this._doc.captureSync();
-    addNote(this._edgeless, point, options, width, height);
+
+    addNote(
+      this._edgeless,
+      point,
+      options,
+      Math.max(width, NOTE_MIN_WIDTH),
+      Math.max(height, NOTE_INIT_HEIGHT)
+    );
   }
 
   private _updateOverlayPosition(x: number, y: number) {

--- a/tests/edgeless/note.spec.ts
+++ b/tests/edgeless/note.spec.ts
@@ -1,4 +1,8 @@
 import { NoteDisplayMode } from '@blocks/_common/types.js';
+import {
+  NOTE_INIT_HEIGHT,
+  NOTE_MIN_WIDTH,
+} from '@blocks/root-block/edgeless/utils/consts.js';
 import { expect } from '@playwright/test';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
@@ -881,7 +885,7 @@ test('drag to add customized size note', async ({ page }) => {
   await assertEdgelessSelectedRect(page, [270, 260, 600, 300]);
 });
 
-test('drag to add customized size note: should wider than minimum width and higher than minimum height ', async ({
+test('drag to add customized size note: should clamp to min width and min height', async ({
   page,
 }) => {
   await enterPlaygroundRoom(page);
@@ -890,6 +894,7 @@ test('drag to add customized size note: should wider than minimum width and high
   await switchEditorMode(page);
   await zoomResetByKeyboard(page);
   await setEdgelessTool(page, 'note');
+
   // add note at 300,300
   await page.mouse.move(300, 300);
   await page.mouse.down();
@@ -897,17 +902,7 @@ test('drag to add customized size note: should wider than minimum width and high
   await page.mouse.up();
   await waitNextFrame(page);
 
-  // assert add note unsuccessful, note should be wider than minimum width and higher than minimum height
-  await assertBlockCount(page, 'note', 1);
-
-  await setEdgelessTool(page, 'note');
   await waitNextFrame(page);
-
-  // add note at 300,300
-  await page.mouse.move(300, 300);
-  await page.mouse.down();
-  await page.mouse.move(900, 600, { steps: 10 });
-  await page.mouse.up();
 
   // should wait for inline editor update and resizeObserver callback
   await waitForInlineEditorStateUpdated(page);
@@ -917,10 +912,15 @@ test('drag to add customized size note: should wider than minimum width and high
   // click out of note
   await page.mouse.click(250, 200);
   // click on note to select it
-  await page.mouse.click(600, 500);
+  await page.mouse.click(320, 300);
   // assert selected note
   // note add on edgeless mode will have a offsetX of 30 and offsetY of 40
-  await assertEdgelessSelectedRect(page, [270, 260, 600, 300]);
+  await assertEdgelessSelectedRect(page, [
+    270,
+    260,
+    NOTE_MIN_WIDTH,
+    NOTE_INIT_HEIGHT,
+  ]);
 });
 
 test('Note added on doc mode should display on both modes by default', async ({


### PR DESCRIPTION
Close [AFF-778](https://linear.app/affine-design/issue/AFF-778/incorrect-minimal-width-limit-when-creating-note-block-on-edgeless)