### PR TITLE
chore: remove package manager in package json since its wont support range

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: ${{ inputs.repo || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: latest
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: latest
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: latest
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -22,7 +22,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: latest
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: latest
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: latest
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
       - uses: actions/setup-node@v3

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
+        with:
+          version: latest
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: latest
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: latest
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -24,7 +24,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: latest
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
         with:
-          version: latest
+          version: 9
 
       - name: Download Previous Size Data
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: latest
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -44,6 +46,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+        with:
+          version: latest
 
       - name: Download Previous Size Data
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,9 +63,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -135,7 +137,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -165,7 +169,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -185,9 +191,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
+        with:
+          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "engines": {
     "node": ">=18.19.0 <21.0.0"
   },
-  "packageManager": "pnpm@9.1.1",
   "scripts": {
     "preview": "pnpm --filter @blocksuite/playground preview",
     "dev": "pnpm --filter @blocksuite/playground dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18.19.0 <21.0.0"
+    "node": ">=18.19.0 <21.0.0",
+    "pnpm": ">=9"
   },
   "scripts": {
     "preview": "pnpm --filter @blocksuite/playground preview",


### PR DESCRIPTION
You'll even get an error if you have pnpm 9.1.2 but the field is set to 9.1.1. We really don't need this field.

https://github.com/nodejs/corepack/issues/95#issuecomment-1889553265