### PR TITLE
fix: frame duplicate lost linked doc card

### DIFF
--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -7,12 +7,12 @@ import type {
   Selectable,
   TopLevelBlockModel,
 } from '../../_common/types.js';
-import { matchFlavours } from '../../_common/utils/model.js';
 import type { FrameBlockModel } from '../../frame-block/frame-model.js';
 import type { EdgelessRootService } from '../../index.js';
 import type { NoteBlockModel } from '../../note-block/note-model.js';
 import { Bound, Overlay, type RoughCanvas } from '../../surface-block/index.js';
 import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
+import { EdgelessBlockModel } from './type.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import { isFrameBlock } from './utils/query.js';
 
@@ -199,7 +199,7 @@ export function getBlocksInFrame(
   ).concat(
     surfaceModel[0].children.filter(ele => {
       if (ele.id === model.id) return;
-      if (matchFlavours(ele, ['affine:image', 'affine:frame'])) {
+      if (ele instanceof EdgelessBlockModel) {
         const blockBound = Bound.deserialize(ele.xywh);
         return fullyContained
           ? bound.contains(blockBound)


### PR DESCRIPTION
Duplicate a frame with linked doc card inside, only canvas shape cloned successfully and the linked doc card is lost. 

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/ae663813-7493-4503-99d8-9317d2601f15.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/ae663813-7493-4503-99d8-9317d2601f15.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/ae663813-7493-4503-99d8-9317d2601f15.mov">录屏2024-05-27 14.38.43.mov</video>


There is a whitelist in function `getBlocksInFrame` which only allow `affine:image` and `affine:frame` bypass causes this issue. Using `instanceof EdgelessBlockModel` instead of the enum whitelist will be a better solution.


---

