### PR TITLE
refactor: clean up edgeless types

### DIFF
--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -17,8 +17,11 @@ import { xywhArrayToObject } from '../../root-block/edgeless/utils/convert.js';
 import { getBackgroundGrid } from '../../root-block/edgeless/utils/query.js';
 import type { RootBlockModel } from '../../root-block/index.js';
 import type { IBound } from '../../surface-block/consts.js';
-import { ElementModel } from '../../surface-block/element-model/index.js';
-import type { GroupElementModel, Renderer } from '../../surface-block/index.js';
+import {
+  type GroupElementModel,
+  type Renderer,
+  SurfaceElementModel,
+} from '../../surface-block/index.js';
 import { Bound } from '../../surface-block/utils/bound.js';
 import { fetchImage } from '../adapters/utils.js';
 import { CANVAS_EXPORT_IGNORE_TAGS } from '../consts.js';
@@ -193,7 +196,7 @@ export class ExportManager {
     blockElementGetter: (model: BlockModel) => Element | null = () => null,
     edgeless?: EdgelessRootBlockComponent,
     nodes?: EdgelessBlockModel[],
-    surfaces?: ElementModel[],
+    surfaces?: BlockSuite.SurfaceElementModelType[],
     edgelessBackground?: {
       zoom: number;
     }
@@ -308,8 +311,8 @@ export class ExportManager {
       const surfaceElements = surfaces.flatMap(element =>
         element.type === 'group'
           ? ((element as GroupElementModel).childElements.filter(
-              el => el instanceof ElementModel
-            ) as ElementModel[])
+              el => el instanceof SurfaceElementModel
+            ) as BlockSuite.SurfaceElementModelType[])
           : element
       );
       const surfaceCanvas = surfaceRenderer.getCanvasByBound(

--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -1,23 +1,10 @@
 import { type Slot } from '@blocksuite/global/utils';
 import { type BlockModel, type Doc } from '@blocksuite/store';
 
-import type { BookmarkBlockModel } from '../bookmark-block/bookmark-model.js';
-import type { EmbedFigmaModel } from '../embed-figma-block/embed-figma-model.js';
-import type { EmbedGithubModel } from '../embed-github-block/embed-github-model.js';
-import type { EmbedHtmlModel } from '../embed-html-block/embed-html-model.js';
-import type { EmbedLinkedDocModel } from '../embed-linked-doc-block/embed-linked-doc-model.js';
-import type { EmbedLoomModel } from '../embed-loom-block/embed-loom-model.js';
-import type { EmbedSyncedDocModel } from '../embed-synced-doc-block/embed-synced-doc-model.js';
-import type { EmbedYoutubeModel } from '../embed-youtube-block/embed-youtube-model.js';
-import type { FrameBlockModel } from '../frame-block/frame-model.js';
-import type { ImageBlockModel } from '../image-block/image-model.js';
-import type { NoteBlockModel } from '../note-block/note-model.js';
-import type { EdgelessModel } from '../root-block/edgeless/type.js';
 import type {
   ConnectorElementModel,
   ConnectorMode,
 } from '../surface-block/element-model/connector.js';
-import { type CanvasElement } from '../surface-block/element-model/index.js';
 import type {
   BrushElementModel,
   GroupElementModel,
@@ -60,34 +47,10 @@ export type AbstractEditor = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ExtendedModel = BlockModel & Record<string, any>;
 
-// blocks that would only appear under the edgeless container root
-export type TopLevelBlockModel =
-  | NoteBlockModel
-  | FrameBlockModel
-  | ImageBlockModel
-  | BookmarkBlockModel
-  | EmbedGithubModel
-  | EmbedYoutubeModel
-  | EmbedFigmaModel
-  | EmbedLinkedDocModel
-  | EmbedSyncedDocModel
-  | EmbedHtmlModel
-  | EmbedLoomModel;
-
-export type { EdgelessModel as EdgelessModel };
-
-export type Alignable = EdgelessModel;
-
-export type Selectable = EdgelessModel;
-
-export type Erasable = EdgelessModel;
-
-export type Connectable =
-  | TopLevelBlockModel
-  | Exclude<
-      CanvasElement,
-      ConnectorElementModel | BrushElementModel | GroupElementModel
-    >;
+export type Connectable = Exclude<
+  BlockSuite.EdgelessModelType,
+  ConnectorElementModel | BrushElementModel | GroupElementModel
+>;
 
 export type DefaultTool = {
   type: 'default';

--- a/packages/blocks/src/bookmark-block/bookmark-model.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-model.ts
@@ -54,3 +54,11 @@ export const BookmarkBlockSchema = defineBlockSchema({
 export class BookmarkBlockModel extends selectable<BookmarkBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:bookmark': BookmarkBlockModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-figma-block/embed-figma-model.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-model.ts
@@ -22,3 +22,11 @@ export type EmbedFigmaBlockProps = {
 export class EmbedFigmaModel extends defineEmbedModel<EmbedFigmaBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-figma': EmbedFigmaModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-github-block/embed-github-model.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-model.ts
@@ -36,3 +36,11 @@ export type EmbedGithubBlockProps = {
 export class EmbedGithubModel extends defineEmbedModel<EmbedGithubBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-github': EmbedGithubModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-html-block/embed-html-model.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-model.ts
@@ -15,3 +15,11 @@ export type EmbedHtmlBlockProps = {
 export class EmbedHtmlModel extends defineEmbedModel<EmbedHtmlBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-html': EmbedHtmlModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-model.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-model.ts
@@ -20,3 +20,11 @@ export type EmbedLinkedDocBlockProps = {
 export class EmbedLinkedDocModel extends defineEmbedModel<EmbedLinkedDocBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-linked-doc': EmbedLinkedDocModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-loom-block/embed-loom-model.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-model.ts
@@ -24,3 +24,11 @@ export type EmbedLoomBlockProps = {
 export class EmbedLoomModel extends defineEmbedModel<EmbedLoomBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-loom': EmbedLoomModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-model.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-model.ts
@@ -15,3 +15,11 @@ export type EmbedSyncedDocBlockProps = {
 export class EmbedSyncedDocModel extends defineEmbedModel<EmbedSyncedDocBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-synced-doc': EmbedSyncedDocModel;
+    }
+  }
+}

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-model.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-model.ts
@@ -27,3 +27,11 @@ export type EmbedYoutubeBlockProps = {
 export class EmbedYoutubeModel extends defineEmbedModel<EmbedYoutubeBlockProps>(
   BlockModel
 ) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:embed-youtube': EmbedYoutubeModel;
+    }
+  }
+}

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -2,7 +2,7 @@ import type { Text } from '@blocksuite/store';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
-import type { HitTestOptions } from '../root-block/edgeless/type.js';
+import type { IHitTestOptions } from '../surface-block/element-model/base.js';
 import { Bound, type SerializedXYWH } from '../surface-block/index.js';
 
 type FrameBlockProps = {
@@ -34,7 +34,7 @@ export const FrameBlockSchema = defineBlockSchema({
 export class FrameBlockModel extends selectable<FrameBlockProps>(BlockModel) {
   static PADDING = [8, 10];
 
-  override hitTest(x: number, y: number, _: HitTestOptions): boolean {
+  override hitTest(x: number, y: number, _: IHitTestOptions): boolean {
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointNearBound([x, y], 5);
 
@@ -48,5 +48,13 @@ export class FrameBlockModel extends selectable<FrameBlockProps>(BlockModel) {
     return (
       bound.isIntersectWithBound(selectedBound) || selectedBound.contains(bound)
     );
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:frame': FrameBlockModel;
+    }
   }
 }

--- a/packages/blocks/src/image-block/image-model.ts
+++ b/packages/blocks/src/image-block/image-model.ts
@@ -38,3 +38,11 @@ export const ImageBlockSchema = defineBlockSchema({
 });
 
 export class ImageBlockModel extends selectable<ImageBlockProps>(BlockModel) {}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:image': ImageBlockModel;
+    }
+  }
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -101,7 +101,6 @@ export type {
   TemplateManager,
 } from './root-block/edgeless/components/toolbar/template/template-type.js';
 export { CopilotSelectionController } from './root-block/edgeless/controllers/tools/copilot-tool.js';
-export type { EdgelessModel } from './root-block/edgeless/type.js';
 export * from './root-block/index.js';
 export * from './schemas.js';
 export * from './specs/index.js';
@@ -113,7 +112,6 @@ export {
   CommunityCanvasTextFonts,
   ConnectorElementModel,
   ConnectorMode,
-  ElementModel,
   fitContent,
   generateKeyBetween,
   getElementsBound,

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -105,3 +105,11 @@ export class NoteBlockModel extends selectable<NoteProps>(BlockModel) {
     return super.boxSelect(bound);
   }
 }
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessBlockModelMap {
+      'affine:note': NoteBlockModel;
+    }
+  }
+}

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -19,7 +19,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { html, literal, unsafeStatic } from 'lit/static-html.js';
 
 import { requestThrottledConnectFrame } from '../../../../_common/utils/event.js';
-import { type TopLevelBlockModel } from '../../../../_common/utils/index.js';
 import { last } from '../../../../_common/utils/iterable.js';
 import type { FrameBlockModel } from '../../../../frame-block/frame-model.js';
 import type { NoteBlockModel } from '../../../../note-block/index.js';
@@ -65,7 +64,7 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
   `;
 
   static renderPortal(
-    block: TopLevelBlockModel,
+    block: BlockSuite.EdgelessBlockModelType,
     zIndex: number,
     surface: SurfaceBlockComponent,
     edgeless: EdgelessRootBlockComponent
@@ -325,7 +324,8 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
           ${layers
             .filter(layer => layer.type === 'block')
             .map(layer => {
-              const elements = layer.elements as TopLevelBlockModel[];
+              const elements =
+                layer.elements as BlockSuite.EdgelessBlockModelType[];
 
               return repeat(
                 elements,

--- a/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
@@ -11,7 +11,6 @@ import { css, html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EdgelessModel } from '../../../../_common/types.js';
 import type { FrameBlockModel } from '../../../../frame-block/frame-model.js';
 import type { NoteBlockModel } from '../../../../note-block/note-model.js';
 import type {
@@ -25,7 +24,7 @@ import type { SurfaceRefRenderer } from '../../../../surface-ref-block/surface-r
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import { isTopLevelBlock } from '../../utils/query.js';
 
-type RefElement = Exclude<EdgelessModel, NoteBlockModel>;
+type RefElement = Exclude<BlockSuite.EdgelessModelType, NoteBlockModel>;
 
 const DEFAULT_PREVIEW_CONTAINER_WIDTH = 280;
 const DEFAULT_PREVIEW_CONTAINER_HEIGHT = 166;

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -9,11 +9,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { EMBED_CARD_HEIGHT } from '../../../../_common/consts.js';
-import type {
-  EdgelessModel,
-  IPoint,
-  Selectable,
-} from '../../../../_common/types.js';
+import type { IPoint } from '../../../../_common/types.js';
 import {
   requestThrottledConnectFrame,
   stopPropagation,
@@ -36,7 +32,6 @@ import type {
 import { NoteBlockModel } from '../../../../note-block/note-model.js';
 import { normalizeTextBound } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { TextElementModel } from '../../../../surface-block/element-model/text.js';
-import type { ElementModel } from '../../../../surface-block/index.js';
 import {
   CanvasElementType,
   deserializeXYWH,
@@ -454,7 +449,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
   private _resizeManager: HandleResizeManager;
   private _cursorRotate = 0;
-  private _propDiposables: Disposable[] = [];
+  private _propDisposables: Disposable[] = [];
   private _dragEndCallback: (() => void)[] = [];
 
   constructor() {
@@ -516,7 +511,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         areAllShapes = false;
         areAllTexts = false;
       } else {
-        assertType<ElementModel>(element);
+        assertType<BlockSuite.SurfaceElementModelType>(element);
         if (element.type === CanvasElementType.CONNECTOR) {
           const connector = element as ConnectorElementModel;
           areAllIndependentConnectors &&= !(
@@ -548,7 +543,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     return 'corner';
   }
 
-  private _isProportionalElement(element: EdgelessModel) {
+  private _isProportionalElement(element: BlockSuite.EdgelessModelType) {
     return (
       isAttachmentBlock(element) ||
       isImageBlock(element) ||
@@ -561,7 +556,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     );
   }
 
-  private _shouldRenderSelection(elements?: Selectable[]) {
+  private _shouldRenderSelection(elements?: BlockSuite.EdgelessModelType[]) {
     elements = elements ?? this.selection.elements;
     return elements.length > 0 && !this.selection.editing;
   }
@@ -722,39 +717,39 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         edgeless.service.updateElement(element.id, {
           xywh: bound.serialize(),
         });
-      } else {
-        if (element instanceof TextElementModel) {
-          let p = 1;
-          if (
-            direction === HandleDirection.Left ||
-            direction === HandleDirection.Right
-          ) {
-            bound = normalizeTextBound(element, bound, true);
-            // If the width of the text element has been changed by dragging,
-            // We need to set hasMaxWidth to true for wrapping the text
-            edgeless.service.updateElement(id, {
-              xywh: bound.serialize(),
-              fontSize: element.fontSize * p,
-              hasMaxWidth: true,
-            });
-          } else {
-            p = bound.h / element.h;
-            // const newFontsize = element.fontSize * p;
-            // bound = normalizeTextBound(element, bound, false, newFontsize);
-
-            edgeless.service.updateElement(id, {
-              xywh: bound.serialize(),
-              fontSize: element.fontSize * p,
-            });
-          }
-        } else {
-          if (element instanceof ShapeElementModel) {
-            bound = normalizeShapeBound(element, bound);
-          }
+      } else if (element instanceof TextElementModel) {
+        let p = 1;
+        if (
+          direction === HandleDirection.Left ||
+          direction === HandleDirection.Right
+        ) {
+          bound = normalizeTextBound(element, bound, true);
+          // If the width of the text element has been changed by dragging,
+          // We need to set hasMaxWidth to true for wrapping the text
           edgeless.service.updateElement(id, {
             xywh: bound.serialize(),
+            fontSize: element.fontSize * p,
+            hasMaxWidth: true,
+          });
+        } else {
+          p = bound.h / element.h;
+          // const newFontsize = element.fontSize * p;
+          // bound = normalizeTextBound(element, bound, false, newFontsize);
+
+          edgeless.service.updateElement(id, {
+            xywh: bound.serialize(),
+            fontSize: element.fontSize * p,
           });
         }
+      } else if (element instanceof ShapeElementModel) {
+        bound = normalizeShapeBound(element, bound);
+        edgeless.service.updateElement(id, {
+          xywh: bound.serialize(),
+        });
+      } else {
+        edgeless.service.updateElement(id, {
+          xywh: bound.serialize(),
+        });
       }
     });
   };
@@ -771,7 +766,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
         isImageBlock(element) ||
         (isCanvasElement(element) &&
           element.type !== CanvasElementType.CONNECTOR)
-    ) as EdgelessModel[];
+    ) as BlockSuite.EdgelessModelType[];
 
     getElementsWithoutGroup(elements).forEach(element => {
       const { id, rotate } = element;
@@ -962,12 +957,12 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
   };
 
   private _initSelectedSlot = () => {
-    this._propDiposables.forEach(diposable => diposable.dispose());
-    this._propDiposables = [];
+    this._propDisposables.forEach(disposable => disposable.dispose());
+    this._propDisposables = [];
 
     this.selection.elements.forEach(element => {
       if ('flavour' in element) {
-        this._propDiposables.push(
+        this._propDisposables.push(
           element.propsUpdated.on(() => {
             this._updateOnElementChange(element.id);
           })
@@ -1043,7 +1038,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       edgeless.slots.elementResizeEnd.on(() => (this._isResizing = false))
     );
     _disposables.add(() => {
-      this._propDiposables.forEach(diposable => diposable.dispose());
+      this._propDisposables.forEach(disposable => disposable.dispose());
     });
   }
 

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/copilot-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/copilot-tool.ts
@@ -3,7 +3,6 @@ import { Slot } from '@blocksuite/store';
 
 import type {
   CopilotSelectionTool,
-  EdgelessModel,
   EdgelessTool,
 } from '../../../../_common/utils/index.js';
 import { Bound, getElementsBound } from '../../../../surface-block/index.js';
@@ -60,7 +59,10 @@ export class CopilotSelectionController extends EdgelessToolController<CopilotSe
     this._edgeless.tools.setEdgelessTool({ type: 'default' });
   }
 
-  updateDragPointsWith(selectedElements: EdgelessModel[], padding = 0) {
+  updateDragPointsWith(
+    selectedElements: BlockSuite.EdgelessModelType[],
+    padding = 0
+  ) {
     const bounds = getElementsBound(
       selectedElements.map(e => e.elementBound)
     ).expand(padding / this._edgeless.service.zoom);
@@ -69,7 +71,10 @@ export class CopilotSelectionController extends EdgelessToolController<CopilotSe
     this.dragLastPoint = bounds.br as [number, number];
   }
 
-  updateSelectionWith(selectedElements: EdgelessModel[], padding = 0) {
+  updateSelectionWith(
+    selectedElements: BlockSuite.EdgelessModelType[],
+    padding = 0
+  ) {
     const { selection } = this._edgeless.service;
 
     selection.clear();

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/eraser-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/eraser-tool.ts
@@ -1,7 +1,7 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
-import type { Erasable, IPoint } from '../../../../_common/utils/index.js';
+import type { IPoint } from '../../../../_common/utils/index.js';
 import { buildPath, type EraserTool } from '../../../../_common/utils/index.js';
 import {
   Bound,
@@ -11,6 +11,7 @@ import {
   linePolygonIntersects,
   Overlay,
 } from '../../../../surface-block/index.js';
+import type { IVec2 } from '../../../../surface-block/utils/vec.js';
 import { deleteElements } from '../../utils/crud.js';
 import { isTopLevelBlock } from '../../utils/query.js';
 import { EdgelessToolController } from './index.js';
@@ -36,8 +37,8 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
   private _eraserPoints: IVec[] = [];
   private _prevPoint: IVec = [];
   private _prevEraserPoint: IVec = [];
-  private _erasables: Set<Erasable> = new Set();
-  private _eraseTargets: Set<Erasable> = new Set();
+  private _erasables: Set<BlockSuite.EdgelessModelType> = new Set();
+  private _eraseTargets: Set<BlockSuite.EdgelessModelType> = new Set();
 
   private _loop = () => {
     const now = Date.now();
@@ -114,7 +115,12 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
           ele && ((<HTMLElement>ele).style.opacity = '0.3');
         }
       } else {
-        if (erasable.intersectWithLine(this._prevPoint, currentPoint)) {
+        if (
+          erasable.intersectWithLine(
+            this._prevPoint as IVec2,
+            currentPoint as IVec2
+          )
+        ) {
           this._eraseTargets.add(erasable);
           erasable.opacity = 0.3;
         }

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -4,10 +4,7 @@ import { type EdgelessTool, LassoMode } from '../../_common/types.js';
 import { matchFlavours } from '../../_common/utils/model.js';
 import { MindmapElementModel } from '../../surface-block/element-model/mindmap.js';
 import { LayoutType } from '../../surface-block/element-model/utils/mindmap/layout.js';
-import type {
-  ElementModel,
-  ShapeElementModel,
-} from '../../surface-block/index.js';
+import type { ShapeElementModel } from '../../surface-block/index.js';
 import {
   Bound,
   ConnectorElementModel,
@@ -493,7 +490,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
       const node = mindmapNodes[0];
       const mindmap = node.group as MindmapElementModel;
       const nodeDirection = mindmap.getLayoutDir(node.id);
-      let targetNode: ElementModel | null = null;
+      let targetNode: BlockSuite.SurfaceElementModelType | null = null;
 
       switch (key) {
         case 'ArrowUp':

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -2,14 +2,16 @@ import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlockModel, Slot } from '@blocksuite/store';
 
-import type { EdgelessTool, TopLevelBlockModel } from '../../_common/types.js';
+import type { EdgelessTool } from '../../_common/types.js';
 import { last } from '../../_common/utils/iterable.js';
 import { clamp } from '../../_common/utils/math.js';
 import type { FrameBlockModel } from '../../frame-block/index.js';
 import type { IBound } from '../../surface-block/consts.js';
-import { GroupLikeModel } from '../../surface-block/element-model/base.js';
 import {
-  type CanvasElement,
+  type IHitTestOptions,
+  SurfaceGroupLikeModel,
+} from '../../surface-block/element-model/base.js';
+import {
   type CanvasElementType,
   type ConnectorElementModel,
 } from '../../surface-block/element-model/index.js';
@@ -38,11 +40,7 @@ import {
 } from './services/template-middlewares.js';
 import type { EdgelessToolConstructor } from './services/tools-manager.js';
 import { EdgelessToolsManager } from './services/tools-manager.js';
-import {
-  EdgelessBlockModel,
-  type EdgelessModel,
-  type HitTestOptions,
-} from './type.js';
+import { EdgelessBlockModel } from './type.js';
 import { FIT_TO_SCREEN_PADDING } from './utils/consts.js';
 import { getCursorMode } from './utils/query.js';
 import { EdgelessSnapManager } from './utils/snap-manager.js';
@@ -63,8 +61,8 @@ export class EdgelessRootService extends RootService {
     pressShiftKeyUpdated: new Slot<boolean>(),
     cursorUpdated: new Slot<string>(),
     copyAsPng: new Slot<{
-      blocks: TopLevelBlockModel[];
-      shapes: CanvasElement[];
+      blocks: BlockSuite.EdgelessBlockModelType[];
+      shapes: BlockSuite.SurfaceModelType[];
     }>(),
     readonlyUpdated: new Slot<boolean>(),
     draggingAreaUpdated: new Slot(),
@@ -291,7 +289,7 @@ export class EdgelessRootService extends RootService {
     }
   }
 
-  removeElement(id: string | EdgelessModel) {
+  removeElement(id: string | BlockSuite.EdgelessModelType) {
     id = typeof id === 'string' ? id : id.id;
 
     if (this._surface.hasElementById(id)) {
@@ -312,17 +310,21 @@ export class EdgelessRootService extends RootService {
     );
   }
 
-  pickElement(x: number, y: number, options: { all: true }): EdgelessModel[];
+  pickElement(
+    x: number,
+    y: number,
+    options: { all: true }
+  ): BlockSuite.EdgelessModelType[];
   pickElement(
     x: number,
     y: number,
     options?: { all: false }
-  ): EdgelessModel | null;
+  ): BlockSuite.EdgelessModelType | null;
   pickElement(
     x: number,
     y: number,
-    options: HitTestOptions = { all: false, expand: 10 }
-  ): EdgelessModel[] | EdgelessModel | null {
+    options: IHitTestOptions = { all: false, expand: 10 }
+  ): BlockSuite.EdgelessModelType[] | BlockSuite.EdgelessModelType | null {
     options.expand ??= 10;
     options.zoom = this._viewport.zoom;
 
@@ -339,7 +341,7 @@ export class EdgelessRootService extends RootService {
           element.hitTest(x, y, options, this.host) ||
           element.externalBound?.isPointInBound([x, y])
       );
-      return picked as EdgelessModel[];
+      return picked as BlockSuite.EdgelessModelType[];
     };
     const pickBlock = () => {
       const candidates = this._layer.blocksGrid.search(hitTestBound);
@@ -348,14 +350,14 @@ export class EdgelessRootService extends RootService {
           element.hitTest(x, y, options, this.host) ||
           element.externalBound?.isPointInBound([x, y])
       );
-      return picked as EdgelessModel[];
+      return picked as BlockSuite.EdgelessModelType[];
     };
     const pickFrames = () => {
       return this._layer.frames.filter(
         frame =>
           frame.hitTest(x, y, options) ||
           frame.externalBound?.isPointInBound([x, y])
-      ) as EdgelessModel[];
+      ) as BlockSuite.EdgelessModelType[];
     };
 
     const frames = pickFrames();
@@ -379,7 +381,10 @@ export class EdgelessRootService extends RootService {
    * @param bound
    * @param type By default, it will pick all elements, but you can specify the type to pick only you need.
    */
-  pickElementsByBound(bound: IBound | Bound, type?: 'all'): EdgelessModel[];
+  pickElementsByBound(
+    bound: IBound | Bound,
+    type?: 'all'
+  ): BlockSuite.EdgelessModelType[];
   pickElementsByBound(
     bound: IBound | Bound,
     type: 'blocks'
@@ -387,7 +392,7 @@ export class EdgelessRootService extends RootService {
   pickElementsByBound(
     bound: IBound | Bound,
     type: 'frame' | 'blocks' | 'canvas' | 'all' = 'all'
-  ): EdgelessModel[] {
+  ): BlockSuite.EdgelessModelType[] {
     bound = new Bound(bound.x, bound.y, bound.w, bound.h);
 
     const pickCanvasElement = () => {
@@ -395,20 +400,20 @@ export class EdgelessRootService extends RootService {
       const picked = candidates.filter(element =>
         element.boxSelect(bound as Bound)
       );
-      return picked as EdgelessModel[];
+      return picked as BlockSuite.EdgelessModelType[];
     };
     const pickBlock = () => {
       const candidates = this._layer.blocksGrid.search(bound);
       const picked = candidates.filter(element =>
         element.boxSelect(bound as Bound)
       );
-      return picked as EdgelessModel[];
+      return picked as BlockSuite.EdgelessModelType[];
     };
     const pickFrames = () => {
       const candidates = this._layer.framesGrid.search(bound);
       return candidates.filter(frame =>
         frame.boxSelect(bound as Bound)
-      ) as EdgelessModel[];
+      ) as BlockSuite.EdgelessModelType[];
     };
 
     switch (type) {
@@ -434,13 +439,13 @@ export class EdgelessRootService extends RootService {
   pickElementInGroup(
     x: number,
     y: number,
-    options?: HitTestOptions
-  ): EdgelessModel | null {
+    options?: IHitTestOptions
+  ): BlockSuite.EdgelessModelType | null {
     const selectionManager = this._selection;
     const results = this.pickElement(x, y, {
       ...options,
       all: true,
-    }) as EdgelessModel[];
+    }) as BlockSuite.EdgelessModelType[];
 
     let picked = last(results) ?? null;
     const { activeGroup } = selectionManager;
@@ -451,7 +456,8 @@ export class EdgelessRootService extends RootService {
 
       while (
         picked === activeGroup ||
-        (picked instanceof GroupLikeModel && picked.hasDescendant(activeGroup))
+        (picked instanceof SurfaceGroupLikeModel &&
+          picked.hasDescendant(activeGroup))
       ) {
         picked = results[--index];
       }
@@ -467,10 +473,13 @@ export class EdgelessRootService extends RootService {
       }
     }
 
-    return (picked ?? first) as EdgelessModel | null;
+    return (picked ?? first) as BlockSuite.EdgelessModelType | null;
   }
 
-  reorderElement(element: EdgelessModel, direction: ReorderingDirection) {
+  reorderElement(
+    element: BlockSuite.EdgelessModelType,
+    direction: ReorderingDirection
+  ) {
     const index = this._layer.getReorderedIndex(element, direction);
 
     // block should be updated in transaction
@@ -483,7 +492,7 @@ export class EdgelessRootService extends RootService {
     }
   }
 
-  createGroup(elements: EdgelessModel[] | string[]) {
+  createGroup(elements: BlockSuite.EdgelessModelType[] | string[]) {
     const groups = this.elements.filter(
       el => el.type === 'group'
     ) as GroupElementModel[];
@@ -579,7 +588,7 @@ export class EdgelessRootService extends RootService {
     return this.tool.register(Tool);
   }
 
-  getConnectors(element: EdgelessModel | string) {
+  getConnectors(element: BlockSuite.EdgelessModelType | string) {
     const id = typeof element === 'string' ? element : element.id;
 
     return this.surface.getConnectors(id) as ConnectorElementModel[];

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -2,11 +2,6 @@ import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
 import type { Doc } from '@blocksuite/store';
 import { DocCollection } from '@blocksuite/store';
 
-import type {
-  EdgelessModel,
-  Selectable,
-  TopLevelBlockModel,
-} from '../../_common/types.js';
 import type { FrameBlockModel } from '../../frame-block/frame-model.js';
 import type { EdgelessRootService } from '../../index.js';
 import type { NoteBlockModel } from '../../note-block/note-model.js';
@@ -70,7 +65,7 @@ export class EdgelessFrameManager {
 
   constructor(private _rootService: EdgelessRootService) {}
 
-  selectFrame(eles: Selectable[]) {
+  selectFrame(eles: BlockSuite.EdgelessModelType[]) {
     const frames = this._rootService.frames;
     if (frames.length === 0) return null;
 
@@ -88,10 +83,8 @@ export class EdgelessFrameManager {
 
   getElementsInFrame(frame: FrameBlockModel, fullyContained = true) {
     const bound = Bound.deserialize(frame.xywh);
-    const elements: EdgelessModel[] = this._rootService.layer.canvasGrid.search(
-      bound,
-      true
-    );
+    const elements: BlockSuite.EdgelessModelType[] =
+      this._rootService.layer.canvasGrid.search(bound, true);
 
     return elements.concat(
       getBlocksInFrame(this._rootService.doc, frame, fullyContained)
@@ -167,7 +160,11 @@ export function getBlocksInFrame(
   ]) as SurfaceBlockModel[];
 
   return (
-    getNotesInFrame(doc, model, fullyContained) as TopLevelBlockModel[]
+    getNotesInFrame(
+      doc,
+      model,
+      fullyContained
+    ) as BlockSuite.EdgelessBlockModelType[]
   ).concat(
     surfaceModel[0].children.filter(ele => {
       if (ele.id === model.id) return;
@@ -179,6 +176,6 @@ export function getBlocksInFrame(
       }
 
       return false;
-    }) as TopLevelBlockModel[]
+    }) as BlockSuite.EdgelessBlockModelType[]
   );
 }

--- a/packages/blocks/src/root-block/edgeless/services/selection-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/services/selection-manager.ts
@@ -9,7 +9,6 @@ import {
   type SurfaceBlockModel,
 } from '../../../surface-block/index.js';
 import type { EdgelessRootService } from '../edgeless-root-service.js';
-import type { EdgelessModel } from '../type.js';
 import { edgelessElementsBound } from '../utils/bound-utils.js';
 
 export interface EdgelessSelectionState {
@@ -86,7 +85,7 @@ export class EdgelessSelectionManager {
    * models of the selected elements
    */
   get elements() {
-    const elements: EdgelessModel[] = [];
+    const elements: BlockSuite.EdgelessModelType[] = [];
 
     this._selectedIds.forEach(id => {
       const el = this.service.getElementById(id);

--- a/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
@@ -19,7 +19,6 @@ import { CopilotSelectionController } from '../controllers/tools/copilot-tool.js
 import type { EdgelessToolController } from '../controllers/tools/index.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 import type { EdgelessRootService } from '../edgeless-root-service.js';
-import type { EdgelessModel } from '../type.js';
 import { edgelessElementsBound } from '../utils/bound-utils.js';
 import { isNoteBlock } from '../utils/query.js';
 import type { EdgelessSelectionState } from './selection-manager.js';
@@ -35,7 +34,7 @@ export type EdgelessToolConstructor =
 
 export interface EdgelessHoverState {
   rect: Bound;
-  content: EdgelessModel;
+  content: BlockSuite.EdgelessModelType;
 }
 
 export interface SelectionArea {

--- a/packages/blocks/src/root-block/edgeless/utils/bound-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/bound-utils.ts
@@ -1,7 +1,8 @@
 import { Bound } from '../../../surface-block/index.js';
-import type { EdgelessModel } from '../../edgeless/type.js';
 
-export function edgelessElementsBound(elements: EdgelessModel[]) {
+export function edgelessElementsBound(
+  elements: BlockSuite.EdgelessModelType[]
+) {
   if (elements.length === 0) return new Bound();
   return elements.reduce((prev, element) => {
     return prev.unite(element.elementBound);

--- a/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
@@ -1,9 +1,7 @@
-import type { EdgelessModel } from '../../../_common/utils/index.js';
 import { groupBy } from '../../../_common/utils/iterable.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
-import { type CanvasElement } from '../../../surface-block/index.js';
 import {
   getCopyElements,
   prepareClipboardData,
@@ -16,7 +14,7 @@ import { isFrameBlock, isImageBlock, isNoteBlock } from './query.js';
 const offset = 10;
 export async function duplicate(
   edgeless: EdgelessRootBlockComponent,
-  elements: EdgelessModel[],
+  elements: BlockSuite.EdgelessModelType[],
   select = true
 ) {
   const { clipboardController } = edgeless;
@@ -43,7 +41,7 @@ export async function duplicate(
     });
   }
 }
-export const splitElements = (elements: EdgelessModel[]) => {
+export const splitElements = (elements: BlockSuite.EdgelessModelType[]) => {
   const { notes, frames, shapes, images } = groupBy(
     getElementsWithoutGroup(elements),
     element => {
@@ -58,7 +56,7 @@ export const splitElements = (elements: EdgelessModel[]) => {
     }
   ) as {
     notes: NoteBlockModel[];
-    shapes: CanvasElement[];
+    shapes: BlockSuite.SurfaceModelType[];
     frames: FrameBlockModel[];
     images: ImageBlockModel[];
   };

--- a/packages/blocks/src/root-block/edgeless/utils/crud.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/crud.ts
@@ -1,13 +1,10 @@
-import type {
-  Connectable,
-  EdgelessModel,
-} from '../../../_common/utils/index.js';
+import type { Connectable } from '../../../_common/utils/index.js';
 import type { SurfaceBlockComponent } from '../../../surface-block/surface-block.js';
 import { isConnectable, isNoteBlock } from './query.js';
 
 export function deleteElements(
   surface: SurfaceBlockComponent,
-  elements: EdgelessModel[]
+  elements: BlockSuite.EdgelessModelType[]
 ) {
   const set = new Set(elements);
   const service = surface.edgeless.service;

--- a/packages/blocks/src/root-block/edgeless/utils/group.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/group.ts
@@ -1,8 +1,8 @@
 import { GroupElementModel } from '../../../surface-block/index.js';
-import type { EdgelessModel } from '../type.js';
-
-export function getElementsWithoutGroup(elements: EdgelessModel[]) {
-  const set = new Set<EdgelessModel>();
+export function getElementsWithoutGroup(
+  elements: BlockSuite.EdgelessModelType[]
+) {
+  const set = new Set<BlockSuite.EdgelessModelType>();
 
   elements.forEach(element => {
     if (element instanceof GroupElementModel) {

--- a/packages/blocks/src/root-block/edgeless/utils/note.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/note.ts
@@ -3,7 +3,6 @@ import {
   handleNativeRangeAtPoint,
   type NoteChildrenFlavour,
   type Point,
-  type TopLevelBlockModel,
 } from '../../../_common/utils/index.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
@@ -52,7 +51,7 @@ export function addNote(
     const blocks =
       (doc.root?.children.filter(
         child => child.flavour === 'affine:note'
-      ) as TopLevelBlockModel[]) ?? [];
+      ) as BlockSuite.EdgelessBlockModelType[]) ?? [];
     const element = blocks.find(b => b.id === noteId);
     if (element) {
       edgeless.service.selection.set({

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -4,7 +4,6 @@ import type { EmbedBlockModel } from '../../../_common/embed-block-helper/embed-
 import {
   type Connectable,
   type EdgelessTool,
-  type Selectable,
 } from '../../../_common/utils/index.js';
 import type { AttachmentBlockModel } from '../../../attachment-block/index.js';
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
@@ -20,7 +19,6 @@ import type { ImageBlockModel } from '../../../image-block/index.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
 import {
   Bound,
-  type CanvasElement,
   type CanvasElementWithText,
   clamp,
   deserializeXYWH,
@@ -30,24 +28,24 @@ import {
   ShapeElementModel,
   TextElementModel,
 } from '../../../surface-block/index.js';
-import type { EdgelessBlockModel, EdgelessModel } from '../type.js';
+import type { EdgelessBlockModel } from '../type.js';
 import { getElementsWithoutGroup } from './group.js';
 import type { Viewport } from './viewport.js';
 
 export function isTopLevelBlock(
-  selectable: BlockModel | Selectable | BlockModel | null
+  selectable: BlockModel | BlockSuite.EdgelessModelType | BlockModel | null
 ): selectable is EdgelessBlockModel {
   return !!selectable && 'flavour' in selectable;
 }
 
 export function isNoteBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is NoteBlockModel {
   return !!element && 'flavour' in element && element.flavour === 'affine:note';
 }
 
 export function isFrameBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is FrameBlockModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:frame'
@@ -55,7 +53,7 @@ export function isFrameBlock(
 }
 
 export function isImageBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is ImageBlockModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:image'
@@ -63,7 +61,7 @@ export function isImageBlock(
 }
 
 export function isAttachmentBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is AttachmentBlockModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:attachment'
@@ -71,7 +69,7 @@ export function isAttachmentBlock(
 }
 
 export function isBookmarkBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is BookmarkBlockModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:bookmark'
@@ -79,7 +77,7 @@ export function isBookmarkBlock(
 }
 
 export function isEmbeddedBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedBlockModel {
   return (
     !!element && 'flavour' in element && /affine:embed-*/.test(element.flavour)
@@ -87,7 +85,7 @@ export function isEmbeddedBlock(
 }
 
 export function isEmbeddedLinkBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ) {
   return (
     isEmbeddedBlock(element) &&
@@ -97,7 +95,7 @@ export function isEmbeddedLinkBlock(
 }
 
 export function isEmbedGithubBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedGithubModel {
   return (
     !!element &&
@@ -107,7 +105,7 @@ export function isEmbedGithubBlock(
 }
 
 export function isEmbedYoutubeBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedYoutubeModel {
   return (
     !!element &&
@@ -117,7 +115,7 @@ export function isEmbedYoutubeBlock(
 }
 
 export function isEmbedLoomBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedLoomModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:embed-loom'
@@ -125,7 +123,7 @@ export function isEmbedLoomBlock(
 }
 
 export function isEmbedFigmaBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedFigmaModel {
   return (
     !!element &&
@@ -135,7 +133,7 @@ export function isEmbedFigmaBlock(
 }
 
 export function isEmbedLinkedDocBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedLinkedDocModel {
   return (
     !!element &&
@@ -145,7 +143,7 @@ export function isEmbedLinkedDocBlock(
 }
 
 export function isEmbedSyncedDocBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedSyncedDocModel {
   return (
     !!element &&
@@ -155,7 +153,7 @@ export function isEmbedSyncedDocBlock(
 }
 
 export function isEmbedHtmlBlock(
-  element: BlockModel | EdgelessModel | null
+  element: BlockModel | BlockSuite.EdgelessModelType | null
 ): element is EmbedHtmlModel {
   return (
     !!element && 'flavour' in element && element.flavour === 'affine:embed-html'
@@ -163,13 +161,13 @@ export function isEmbedHtmlBlock(
 }
 
 export function isCanvasElement(
-  selectable: Selectable | null
-): selectable is CanvasElement {
+  selectable: BlockSuite.EdgelessModelType | null
+): selectable is BlockSuite.SurfaceModelType {
   return !isTopLevelBlock(selectable);
 }
 
 export function isCanvasElementWithText(
-  element: Selectable
+  element: BlockSuite.EdgelessModelType
 ): element is CanvasElementWithText {
   return (
     element instanceof TextElementModel || element instanceof ShapeElementModel
@@ -177,7 +175,7 @@ export function isCanvasElementWithText(
 }
 
 export function isConnectable(
-  element: EdgelessModel | null
+  element: BlockSuite.EdgelessModelType | null
 ): element is Connectable {
   return !!element && element.connectable;
 }
@@ -221,7 +219,9 @@ export function getBackgroundGrid(zoom: number, showGrid: boolean) {
   };
 }
 
-export function getSelectedRect(selected: Selectable[]): DOMRect {
+export function getSelectedRect(
+  selected: BlockSuite.EdgelessModelType[]
+): DOMRect {
   if (selected.length === 0) {
     return new DOMRect();
   }
@@ -261,7 +261,9 @@ export function getSelectedRect(selected: Selectable[]): DOMRect {
   );
 }
 
-export function getSelectableBounds(selected: Selectable[]): Map<
+export function getSelectableBounds(
+  selected: BlockSuite.EdgelessModelType[]
+): Map<
   string,
   {
     bound: Bound;

--- a/packages/blocks/src/root-block/edgeless/utils/snap-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/snap-manager.ts
@@ -1,4 +1,3 @@
-import type { Alignable } from '../../../_common/types.js';
 import { buildPath } from '../../../_common/utils/query.js';
 import { Point } from '../../../_common/utils/rect.js';
 import type { SurfaceBlockComponent } from '../../../index.js';
@@ -49,7 +48,9 @@ export class EdgelessSnapManager extends Overlay {
    */
   private _distributedAlignLines: [Point, Point][] = [];
 
-  private _getBoundsWithRotationByAlignable(alignable: Alignable) {
+  private _getBoundsWithRotationByAlignable(
+    alignable: BlockSuite.EdgelessModelType
+  ) {
     const rotate = isTopLevelBlock(alignable) ? 0 : alignable.rotate;
     const [x, y, w, h] = deserializeXYWH(alignable.xywh);
     return Bound.from(getBoundsWithRotation({ x, y, w, h, rotate }));
@@ -66,7 +67,7 @@ export class EdgelessSnapManager extends Overlay {
     ) as SurfaceBlockComponent;
   }
 
-  setupAlignables(alignables: Alignable[]): Bound {
+  setupAlignables(alignables: BlockSuite.EdgelessModelType[]): Bound {
     if (alignables.length === 0) return new Bound();
 
     const connectors = alignables.filter(isConnectable).reduce((prev, el) => {
@@ -85,17 +86,18 @@ export class EdgelessSnapManager extends Overlay {
     const canvasElements = this._rootService.elements;
     const excludes = [...alignables, ...connectors];
     this._alignableBounds = [];
-    (<Alignable[]>[...this._rootService.blocks, ...canvasElements]).forEach(
-      alignable => {
-        const bounds = this._getBoundsWithRotationByAlignable(alignable);
-        if (
-          viewportBounds.isOverlapWithBound(bounds) &&
-          !excludes.includes(alignable)
-        ) {
-          this._alignableBounds.push(bounds);
-        }
+    (<BlockSuite.EdgelessModelType[]>[
+      ...this._rootService.blocks,
+      ...canvasElements,
+    ]).forEach(alignable => {
+      const bounds = this._getBoundsWithRotationByAlignable(alignable);
+      if (
+        viewportBounds.isOverlapWithBound(bounds) &&
+        !excludes.includes(alignable)
+      ) {
+        this._alignableBounds.push(bounds);
       }
-    );
+    });
 
     return alignables.reduce((prev, element) => {
       const bounds = this._getBoundsWithRotationByAlignable(element);

--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/toolbar-entry.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/toolbar-entry.ts
@@ -4,7 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import type { AIItemGroupConfig } from '../../../_common/components/ai-item/types.js';
 import { AIStarIcon } from '../../../_common/icons/ai.js';
-import { GroupLikeModel } from '../../../surface-block/element-model/base.js';
+import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
 import type { CopilotSelectionController } from '../../edgeless/controllers/tools/copilot-tool.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 import { isFrameBlock } from '../../edgeless/utils/query.js';
@@ -38,7 +38,7 @@ export class EdgelessCopilotToolbarEntry extends WithDisposable(LitElement) {
         this.edgeless.service.frame
           .getElementsInFrame(element)
           .forEach(ele => toBeSelected.add(ele));
-      } else if (element instanceof GroupLikeModel) {
+      } else if (element instanceof SurfaceGroupLikeModel) {
         element.decendants().forEach(ele => toBeSelected.add(ele));
       }
     });

--- a/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
@@ -7,7 +7,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { RemoteCursor } from '../../../_common/icons/edgeless.js';
-import type { Selectable } from '../../../_common/types.js';
 import { requestThrottledConnectFrame } from '../../../_common/utils/event.js';
 import { pickValues } from '../../../_common/utils/iterable.js';
 import type { EdgelessRootBlockComponent } from '../../../root-block/edgeless/edgeless-root-block.js';
@@ -130,7 +129,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<
 
       const elements = selection.elements
         .map(id => blockElement.service.getElementById(id))
-        .filter(element => element) as Selectable[];
+        .filter(element => element) as BlockSuite.EdgelessModelType[];
       const rect = getSelectedRect(elements);
 
       if (rect.width === 0 || rect.height === 0) return;

--- a/packages/blocks/src/root-block/widgets/element-toolbar/add-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/add-frame-button.ts
@@ -7,7 +7,6 @@ import { customElement, property } from 'lit/decorators.js';
 import { FrameIcon } from '../../../_common/icons/index.js';
 import { Bound, MindmapElementModel } from '../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
-import type { EdgelessModel } from '../../edgeless/type.js';
 
 @customElement('edgeless-add-frame-button')
 export class EdgelessAddFrameButton extends WithDisposable(LitElement) {
@@ -43,7 +42,7 @@ declare global {
 
 export function renderAddFrameButton(
   edgeless: EdgelessRootBlockComponent,
-  elements: EdgelessModel[]
+  elements: BlockSuite.EdgelessModelType[]
 ) {
   if (elements.length < 2) return nothing;
   if (elements.some(e => e.group instanceof MindmapElementModel))

--- a/packages/blocks/src/root-block/widgets/element-toolbar/add-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/add-group-button.ts
@@ -10,7 +10,6 @@ import {
   MindmapElementModel,
 } from '../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
-import type { EdgelessModel } from '../../edgeless/type.js';
 
 @customElement('edgeless-add-group-button')
 export class EdgelessAddGroupButton extends WithDisposable(LitElement) {
@@ -43,7 +42,7 @@ declare global {
 
 export function renderAddGroupButton(
   edgeless: EdgelessRootBlockComponent,
-  elements: EdgelessModel[]
+  elements: BlockSuite.EdgelessModelType[]
 ) {
   if (elements.length < 2) return nothing;
   if (elements[0] instanceof GroupElementModel) return nothing;

--- a/packages/blocks/src/root-block/widgets/element-toolbar/align-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/align-button.ts
@@ -16,7 +16,6 @@ import {
   AlignVerticallyIcon,
   SmallArrowDownIcon,
 } from '../../../_common/icons/index.js';
-import type { EdgelessModel } from '../../../_common/utils/index.js';
 import {
   Bound,
   ConnectorElementModel,
@@ -42,7 +41,7 @@ export class EdgelessAlignButton extends WithDisposable(LitElement) {
     );
   }
 
-  private _updateXYWH(ele: EdgelessModel, bound: Bound) {
+  private _updateXYWH(ele: BlockSuite.EdgelessModelType, bound: Bound) {
     if (ele instanceof ConnectorElementModel) {
       ele.moveTo(bound);
     } else if (ele instanceof GroupElementModel) {
@@ -265,7 +264,7 @@ declare global {
 
 export function renderAlignButton(
   edgeless: EdgelessRootBlockComponent,
-  elements: EdgelessModel[]
+  elements: BlockSuite.EdgelessModelType[]
 ) {
   if (elements.length < 2) return nothing;
   if (elements.some(e => e.group instanceof MindmapElementModel))

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -27,10 +27,7 @@ import type { FrameBlockModel } from '../../../frame-block/frame-model.js';
 import type { ImageBlockModel } from '../../../image-block/image-model.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { MindmapElementModel } from '../../../surface-block/element-model/mindmap.js';
-import {
-  type ElementModel,
-  GroupElementModel,
-} from '../../../surface-block/index.js';
+import { GroupElementModel } from '../../../surface-block/index.js';
 import {
   type BrushElementModel,
   clamp,
@@ -40,7 +37,6 @@ import {
 } from '../../../surface-block/index.js';
 import { renderMenuDivider } from '../../edgeless/components/buttons/menu-button.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
-import type { EdgelessModel } from '../../edgeless/type.js';
 import { edgelessElementsBound } from '../../edgeless/utils/bound-utils.js';
 import {
   isAttachmentBlock,
@@ -90,7 +86,7 @@ type CategorizedElements = {
 
 type CustomEntry = {
   render: (edgeless: EdgelessRootBlockComponent) => TemplateResult | null;
-  when: (model: EdgelessModel[]) => boolean;
+  when: (model: BlockSuite.EdgelessModelType[]) => boolean;
 };
 
 export const EDGELESS_ELEMENT_TOOLBAR_WIDGET =
@@ -168,7 +164,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
   @state()
   private accessor _registeredEntries: {
     render: (edgeless: EdgelessRootBlockComponent) => TemplateResult | null;
-    when: (model: EdgelessModel[]) => boolean;
+    when: (model: BlockSuite.EdgelessModelType[]) => boolean;
   }[] = [];
 
   @state({
@@ -212,7 +208,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
         return 'embedCard';
       }
 
-      return (model as ElementModel).type;
+      return (model as BlockSuite.SurfaceElementModelType).type;
     });
     return result as CategorizedElements;
   }

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -14,7 +14,6 @@ import {
   DeleteIcon,
   DownloadIcon,
 } from '../../../_common/icons/text.js';
-import type { EdgelessModel } from '../../../_common/types.js';
 import { downloadBlob } from '../../../_common/utils/filesys.js';
 import {
   type SurfaceRefBlockComponent,
@@ -213,7 +212,8 @@ function SurfaceRefToolbarOptions(options: {
           edgelessToBlob(blockElement.host, {
             surfaceRefBlock: blockElement,
             surfaceRenderer: blockElement.surfaceRenderer,
-            edgelessElement: blockElement.referenceModel as EdgelessModel,
+            edgelessElement:
+              blockElement.referenceModel as BlockSuite.EdgelessModelType,
             blockContainer: blockElement.portal,
           })
             .then(blob => {

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
@@ -1,7 +1,6 @@
 import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 
-import { type EdgelessModel } from '../../../_common/types.js';
 import { isTopLevelBlock } from '../../../root-block/edgeless/utils/query.js';
 import type { Renderer } from '../../../surface-block/canvas-renderer/renderer.js';
 import { Bound } from '../../../surface-block/utils/bound.js';
@@ -12,7 +11,7 @@ export const edgelessToBlob = async (
   options: {
     surfaceRefBlock: SurfaceRefBlockComponent;
     surfaceRenderer: Renderer;
-    edgelessElement: EdgelessModel;
+    edgelessElement: BlockSuite.EdgelessModelType;
     blockContainer: HTMLElement;
   }
 ): Promise<Blob> => {

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/index.ts
@@ -1,4 +1,4 @@
-import type { ElementModel, IBound } from '../../index.js';
+import type { IBound, SurfaceElementModel } from '../../index.js';
 import type { Renderer } from '../renderer.js';
 import { brush } from './brush/index.js';
 import { connector } from './connector/index.js';
@@ -8,7 +8,9 @@ import { shape } from './shape/index.js';
 import { text } from './text/index.js';
 export { normalizeShapeBound } from './shape/utils.js';
 
-export type ElementRenderer<T extends ElementModel = ElementModel> = (
+export type ElementRenderer<
+  T extends BlockSuite.SurfaceElementModelType = SurfaceElementModel,
+> = (
   model: T,
   ctx: CanvasRenderingContext2D,
   matrix: DOMMatrix,

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/type.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/type.ts
@@ -1,8 +1,8 @@
-import type { ElementModel } from '../../element-model/base.js';
+import type { SurfaceElementModel } from '../../element-model/base.js';
 import type { Renderer } from '../renderer.js';
 
 export type ElementRenderer = (
-  model: ElementModel,
+  model: SurfaceElementModel,
   ctx: CanvasRenderingContext2D,
   matrix: DOMMatrix,
   renderer: Renderer

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -3,7 +3,7 @@ import { DisposableGroup, Slot } from '@blocksuite/global/utils';
 import { requestConnectedFrame } from '../../_common/utils/event.js';
 import { Viewport } from '../../root-block/edgeless/utils/viewport.js';
 import { type IBound } from '../consts.js';
-import type { ElementModel } from '../element-model/base.js';
+import type { SurfaceElementModel } from '../element-model/base.js';
 import type { LayerManager } from '../managers/layer-manager.js';
 import { RoughCanvas } from '../rough/canvas.js';
 import { intersects } from '../utils/math-utils.js';
@@ -219,7 +219,7 @@ export class Renderer extends Viewport {
      * its element will be add to this array and drawing on the
      * main canvas
      */
-    let fallbackElement: ElementModel[] = [];
+    let fallbackElement: SurfaceElementModel[] = [];
 
     this.layerManager.getCanvasLayers().forEach((layer, idx) => {
       if (!this._stackingCanvas[idx]) {
@@ -250,7 +250,7 @@ export class Renderer extends Viewport {
     matrix: DOMMatrix,
     rc: RoughCanvas,
     bound: IBound,
-    surfaceElements?: ElementModel[],
+    surfaceElements?: SurfaceElementModel[],
     overLay: boolean = false
   ) {
     if (!ctx) return;
@@ -296,7 +296,7 @@ export class Renderer extends Viewport {
 
   public getCanvasByBound(
     bound: IBound = this.viewportBounds,
-    surfaceElements?: ElementModel[],
+    surfaceElements?: SurfaceElementModel[],
     canvas?: HTMLCanvasElement,
     clearBeforeDrawing?: boolean,
     withZoom?: boolean

--- a/packages/blocks/src/surface-block/element-model/brush.ts
+++ b/packages/blocks/src/surface-block/element-model/brush.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../root-block/edgeless/type.js';
 import { getSolidStrokePoints } from '../canvas-renderer/element-renderer/brush/utils.js';
 import {
   Bound,
@@ -18,10 +17,14 @@ import { PointLocation } from '../utils/point-location.js';
 import type { IVec2 } from '../utils/vec.js';
 import { Vec } from '../utils/vec.js';
 import { type SerializedXYWH } from '../utils/xywh.js';
-import { type BaseProps, ElementModel } from './base.js';
+import {
+  type IBaseProps,
+  type IHitTestOptions,
+  SurfaceElementModel,
+} from './base.js';
 import { convert, derive, watch, yfield } from './decorators.js';
 
-export type BrushProps = BaseProps & {
+export type BrushProps = IBaseProps & {
   /**
    * [[x0,y0,pressure0?],[x1,y1,pressure1?]...]
    * pressure is optional and exsits when pressure sensitivity is supported, otherwise not.
@@ -31,7 +34,7 @@ export type BrushProps = BaseProps & {
   lineWidth: number;
 };
 
-export class BrushElementModel extends ElementModel<BrushProps> {
+export class BrushElementModel extends SurfaceElementModel<BrushProps> {
   static override propsToY(props: BrushProps) {
     return props;
   }
@@ -144,7 +147,7 @@ export class BrushElementModel extends ElementModel<BrushProps> {
     return 'brush';
   }
 
-  override hitTest(px: number, py: number, options?: HitTestOptions): boolean {
+  override hitTest(px: number, py: number, options?: IHitTestOptions): boolean {
     const hit = isPointOnlines(
       Bound.deserialize(this.xywh),
       this.points as [number, number][],
@@ -201,5 +204,13 @@ export class BrushElementModel extends ElementModel<BrushProps> {
   override getRelativePointLocation(position: IVec2): PointLocation {
     const point = Bound.deserialize(this.xywh).getRelativePoint(position);
     return new PointLocation(point);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceElementModelMap {
+      brush: BrushElementModel;
+    }
   }
 }

--- a/packages/blocks/src/surface-block/element-model/connector.ts
+++ b/packages/blocks/src/surface-block/element-model/connector.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../root-block/edgeless/type.js';
 import { DEFAULT_ROUGHNESS } from '../consts.js';
 import { Bound } from '../utils/bound.js';
 import { getBezierNearestPoint } from '../utils/curve.js';
@@ -10,7 +9,12 @@ import {
 import { PointLocation } from '../utils/point-location.js';
 import { type IVec2, Vec } from '../utils/vec.js';
 import { type SerializedXYWH } from '../utils/xywh.js';
-import { type BaseProps, ElementModel, LocalModel } from './base.js';
+import {
+  type IBaseProps,
+  type IHitTestOptions,
+  SurfaceElementModel,
+  SurfaceLocalModel,
+} from './base.js';
 import type { StrokeStyle } from './common.js';
 import { derive, local, yfield } from './decorators.js';
 
@@ -37,7 +41,7 @@ export enum ConnectorMode {
   Curve,
 }
 
-type ConnectorElementProps = BaseProps & {
+type ConnectorElementProps = IBaseProps & {
   mode: ConnectorMode;
   stroke: string;
   strokeWidth: number;
@@ -51,7 +55,7 @@ type ConnectorElementProps = BaseProps & {
   rearEndpointStyle?: PointStyle;
 };
 
-export class ConnectorElementModel extends ElementModel<ConnectorElementProps> {
+export class ConnectorElementModel extends SurfaceElementModel<ConnectorElementProps> {
   updatingPath = false;
 
   get type() {
@@ -137,7 +141,7 @@ export class ConnectorElementModel extends ElementModel<ConnectorElementProps> {
   override hitTest(
     x: number,
     y: number,
-    options?: HitTestOptions | undefined
+    options?: IHitTestOptions | undefined
   ): boolean {
     const point =
       this.mode === ConnectorMode.Curve
@@ -174,7 +178,7 @@ export class ConnectorElementModel extends ElementModel<ConnectorElementProps> {
   }
 }
 
-export class LocalConnectorElementModel extends LocalModel {
+export class LocalConnectorElementModel extends SurfaceLocalModel {
   get type() {
     return 'connector';
   }
@@ -227,4 +231,15 @@ export class LocalConnectorElementModel extends LocalModel {
   frontEndpointStyle!: PointStyle;
 
   rearEndpointStyle!: PointStyle;
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceElementModelMap {
+      connector: ConnectorElementModel;
+    }
+    interface SurfaceLocalModelMap {
+      connector: LocalConnectorElementModel;
+    }
+  }
 }

--- a/packages/blocks/src/surface-block/element-model/decorators/convert.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/convert.ts
@@ -1,4 +1,4 @@
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import { getObjectPropMeta, setObjectPropMeta } from './common.js';
 
 const convertSymbol = Symbol('convert');
@@ -12,7 +12,7 @@ const convertSymbol = Symbol('convert');
  * @param fn
  * @returns
  */
-export function convert<V, T extends ElementModel>(
+export function convert<V, T extends SurfaceElementModel>(
   fn: (propValue: V, instance: T) => unknown
 ) {
   return function convertDecorator(

--- a/packages/blocks/src/surface-block/element-model/decorators/derive.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/derive.ts
@@ -1,5 +1,5 @@
 import { keys } from '../../../_common/utils/iterable.js';
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import {
   getDecoratorState,
   getObjectPropMeta,
@@ -20,7 +20,7 @@ function getDerivedMeta(
 export function getDeriveProperties(
   prop: string | symbol,
   propValue: unknown,
-  receiver: ElementModel
+  receiver: SurfaceElementModel
 ) {
   const prototype = Object.getPrototypeOf(receiver);
   const decoratorState = getDecoratorState();
@@ -49,7 +49,7 @@ export function getDeriveProperties(
 
 export function updateDerivedProp(
   derivedProps: Record<string, unknown> | null,
-  receiver: ElementModel
+  receiver: SurfaceElementModel
 ) {
   if (derivedProps) {
     const decoratorState = getDecoratorState();
@@ -76,7 +76,7 @@ export function updateDerivedProp(
  * @param fn
  * @returns
  */
-export function derive<V, T extends ElementModel>(
+export function derive<V, T extends SurfaceElementModel>(
   fn: (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     propValue: any,
@@ -89,7 +89,7 @@ export function derive<V, T extends ElementModel>(
   ) {
     const prop = String(context.name);
     return {
-      init(this: ElementModel, v: V) {
+      init(this: SurfaceElementModel, v: V) {
         const proto = Object.getPrototypeOf(this);
         const derived = getDerivedMeta(proto, prop);
 
@@ -101,6 +101,6 @@ export function derive<V, T extends ElementModel>(
 
         return v;
       },
-    } as ClassAccessorDecoratorResult<ElementModel, V>;
+    } as ClassAccessorDecoratorResult<SurfaceElementModel, V>;
   };
 }

--- a/packages/blocks/src/surface-block/element-model/decorators/local.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/local.ts
@@ -1,4 +1,4 @@
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import { getDecoratorState } from './common.js';
 import { convertProps } from './convert.js';
 import { getDeriveProperties, updateDerivedProp } from './derive.js';
@@ -9,7 +9,7 @@ import { getDeriveProperties, updateDerivedProp } from './derive.js';
  * The local property act like it is a yfield property, but it's not synced to the Y map.
  * Updating local property will also trigger the `elementUpdated` slot of the surface model
  */
-export function local<V, T extends ElementModel>() {
+export function local<V, T extends SurfaceElementModel>() {
   return function localDecorator(
     _target: ClassAccessorDecoratorTarget<T, V>,
     context: ClassAccessorDecoratorContext

--- a/packages/blocks/src/surface-block/element-model/decorators/observer.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/observer.ts
@@ -1,6 +1,6 @@
 import type { Y } from '@blocksuite/store';
 
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import { getObjectPropMeta, setObjectPropMeta } from './common.js';
 
 const observeSymbol = Symbol('observe');
@@ -9,7 +9,7 @@ const observerDisposableSymbol = Symbol('observerDisposable');
 type ObserveFn<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   E extends Y.YEvent<any> = Y.YEvent<any>,
-  T extends ElementModel = ElementModel,
+  T extends SurfaceElementModel = SurfaceElementModel,
 > = (
   /**
    * The event object of the Y.Map or Y.Array, the `null` value means the observer is initializing.
@@ -31,8 +31,12 @@ type ObserveFn<
  * @param fn
  * @returns
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function observe<V, E extends Y.YEvent<any>, T extends ElementModel>(
+export function observe<
+  V,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  E extends Y.YEvent<any>,
+  T extends SurfaceElementModel,
+>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: ObserveFn<E, T>
 ) {
@@ -46,7 +50,7 @@ export function observe<V, E extends Y.YEvent<any>, T extends ElementModel>(
         setObjectPropMeta(observeSymbol, Object.getPrototypeOf(this), prop, fn);
         return v;
       },
-    } as ClassAccessorDecoratorResult<ElementModel, V>;
+    } as ClassAccessorDecoratorResult<SurfaceElementModel, V>;
   };
 }
 
@@ -58,7 +62,10 @@ function getObserveMeta(
   return getObjectPropMeta(proto, observeSymbol, prop);
 }
 
-export function startObserve(prop: string | symbol, receiver: ElementModel) {
+export function startObserve(
+  prop: string | symbol,
+  receiver: SurfaceElementModel
+) {
   const proto = Object.getPrototypeOf(receiver);
   const observeFn = getObserveMeta(proto, prop as string)!;
   // @ts-ignore
@@ -76,7 +83,7 @@ export function startObserve(prop: string | symbol, receiver: ElementModel) {
     return;
   }
 
-  const value = receiver[prop as keyof ElementModel] as
+  const value = receiver[prop as keyof SurfaceElementModel] as
     | Y.Map<unknown>
     | Y.Array<unknown>
     | null;
@@ -103,7 +110,10 @@ export function startObserve(prop: string | symbol, receiver: ElementModel) {
   }
 }
 
-export function initializedObservers(proto: unknown, receiver: ElementModel) {
+export function initializedObservers(
+  proto: unknown,
+  receiver: SurfaceElementModel
+) {
   const observers = getObjectPropMeta(proto, observeSymbol);
 
   Object.keys(observers).forEach(prop => {

--- a/packages/blocks/src/surface-block/element-model/decorators/watch.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/watch.ts
@@ -1,7 +1,7 @@
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import { getObjectPropMeta, setObjectPropMeta } from './common.js';
 
-type WatchFn<T extends ElementModel = ElementModel> = (
+type WatchFn<T extends SurfaceElementModel = SurfaceElementModel> = (
   oldValue: unknown,
   instance: T,
   local: boolean
@@ -13,7 +13,7 @@ const watchSymbol = Symbol('watch');
  * The watch decorator is used to watch the property change of the element.
  * You can thinks of it as a decorator version of `elementUpdated` slot of the surface model.
  */
-export function watch<V, T extends ElementModel>(
+export function watch<V, T extends SurfaceElementModel>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: WatchFn<T>
 ) {
@@ -23,11 +23,11 @@ export function watch<V, T extends ElementModel>(
   ) {
     const prop = context.name;
     return {
-      init(this: ElementModel, v: V) {
+      init(this: SurfaceElementModel, v: V) {
         setObjectPropMeta(watchSymbol, Object.getPrototypeOf(this), prop, fn);
         return v;
       },
-    } as ClassAccessorDecoratorResult<ElementModel, V>;
+    } as ClassAccessorDecoratorResult<SurfaceElementModel, V>;
   };
 }
 
@@ -35,7 +35,7 @@ function getWatchMeta(proto: unknown, prop: string | symbol): null | WatchFn {
   return getObjectPropMeta(proto, watchSymbol, prop);
 }
 
-function startWatch(prop: string | symbol, receiver: ElementModel) {
+function startWatch(prop: string | symbol, receiver: SurfaceElementModel) {
   const proto = Object.getPrototypeOf(receiver);
   const watchFn = getWatchMeta(proto, prop as string)!;
 
@@ -50,7 +50,10 @@ function startWatch(prop: string | symbol, receiver: ElementModel) {
   );
 }
 
-export function initializeWatchers(prototype: unknown, receiver: ElementModel) {
+export function initializeWatchers(
+  prototype: unknown,
+  receiver: SurfaceElementModel
+) {
   const watchers = getObjectPropMeta(prototype, watchSymbol);
 
   Object.keys(watchers).forEach(prop => {

--- a/packages/blocks/src/surface-block/element-model/decorators/yfield.ts
+++ b/packages/blocks/src/surface-block/element-model/decorators/yfield.ts
@@ -1,4 +1,4 @@
-import type { ElementModel } from '../base.js';
+import type { SurfaceElementModel } from '../base.js';
 import { getDecoratorState } from './common.js';
 import { convertProps } from './convert.js';
 import { getDeriveProperties, updateDerivedProp } from './derive.js';
@@ -18,7 +18,7 @@ export function getYFieldPropsSet(target: unknown): Set<string | symbol> {
   return proto[yPropsSetSymbol] as Set<string | symbol>;
 }
 
-export function yfield<V, T extends ElementModel>(fallback?: V) {
+export function yfield<V, T extends SurfaceElementModel>(fallback?: V) {
   // return function yDecorator(prototype: unknown, prop: string | symbol) {
   return function yDecorator(
     target: ClassAccessorDecoratorTarget<T, V>,
@@ -27,7 +27,7 @@ export function yfield<V, T extends ElementModel>(fallback?: V) {
     const prop = context.name;
 
     return {
-      init(this: ElementModel, v: V) {
+      init(this: SurfaceElementModel, v: V) {
         const yProps = getYFieldPropsSet(this);
 
         yProps.add(prop);
@@ -48,7 +48,7 @@ export function yfield<V, T extends ElementModel>(fallback?: V) {
         }
         return v;
       },
-      get(this: ElementModel) {
+      get(this: SurfaceElementModel) {
         return (
           this.yMap.get(prop as string) ??
           this._preserved.get(prop as string) ??

--- a/packages/blocks/src/surface-block/element-model/group.ts
+++ b/packages/blocks/src/surface-block/element-model/group.ts
@@ -2,21 +2,20 @@ import type { Y } from '@blocksuite/store';
 import { DocCollection } from '@blocksuite/store';
 
 import { keys } from '../../_common/utils/iterable.js';
-import type { EdgelessModel } from '../../root-block/edgeless/type.js';
 import { Bound } from '../utils/bound.js';
 import { linePolygonIntersects } from '../utils/math-utils.js';
 import type { PointLocation } from '../utils/point-location.js';
 import type { IVec2 } from '../utils/vec.js';
-import type { BaseProps } from './base.js';
-import { GroupLikeModel } from './base.js';
+import type { IBaseProps } from './base.js';
+import { SurfaceGroupLikeModel } from './base.js';
 import { local, observe, yfield } from './decorators.js';
 
-type GroupElementProps = BaseProps & {
+type GroupElementProps = IBaseProps & {
   children: Y.Map<boolean>;
   title: Y.Text;
 };
 
-export class GroupElementModel extends GroupLikeModel<GroupElementProps> {
+export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> {
   static override propsToY(props: GroupElementProps) {
     if (props.title && !(props.title instanceof DocCollection.Y.Text)) {
       props.title = new DocCollection.Y.Text(props.title);
@@ -64,7 +63,7 @@ export class GroupElementModel extends GroupLikeModel<GroupElementProps> {
     return 'group';
   }
 
-  addChild(element: EdgelessModel | string) {
+  addChild(element: BlockSuite.EdgelessModelType | string) {
     const id = typeof element === 'string' ? element : element.id;
 
     this.surface.doc.transact(() => {
@@ -72,7 +71,7 @@ export class GroupElementModel extends GroupLikeModel<GroupElementProps> {
     });
   }
 
-  removeDescendant(element: EdgelessModel | string) {
+  removeDescendant(element: BlockSuite.EdgelessModelType | string) {
     const id = typeof element === 'string' ? element : element.id;
 
     this.surface.doc.transact(() => {
@@ -87,5 +86,13 @@ export class GroupElementModel extends GroupLikeModel<GroupElementProps> {
   override intersectWithLine(start: IVec2, end: IVec2): PointLocation[] | null {
     const bound = Bound.deserialize(this.xywh);
     return linePolygonIntersects(start, end, bound.points);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceGroupLikeModelMap {
+      group: GroupElementModel;
+    }
   }
 }

--- a/packages/blocks/src/surface-block/element-model/index.ts
+++ b/packages/blocks/src/surface-block/element-model/index.ts
@@ -1,7 +1,7 @@
 import { DocCollection, type Y } from '@blocksuite/store';
 
 import type { SurfaceBlockModel } from '../surface-model.js';
-import { ElementModel } from './base.js';
+import { SurfaceElementModel } from './base.js';
 import { BrushElementModel } from './brush.js';
 import { ConnectorElementModel } from './connector.js';
 import { initializedObservers, initializeWatchers } from './decorators.js';
@@ -36,7 +36,7 @@ export function createElementModel(
     newCreate?: boolean;
   }
 ): {
-  model: ElementModel;
+  model: SurfaceElementModel;
   unmount: () => void;
   mount: () => void;
 } {
@@ -58,7 +58,7 @@ export function createElementModel(
     model,
     stashedStore: stashed,
     onChange: payload => mounted && options.onChange({ id, ...payload }),
-  }) as ElementModel;
+  }) as SurfaceElementModel;
 
   state.creating = false;
   state.skipYfield = false;
@@ -143,7 +143,7 @@ export function propsToY(type: string, props: Record<string, unknown>) {
   }
 
   // @ts-ignore
-  return (ctor.propsToY ?? ElementModel.propsToY)(props);
+  return (ctor.propsToY ?? SurfaceElementModel.propsToY)(props);
 }
 
 export function createModelFromProps(
@@ -194,20 +194,12 @@ export function createModelFromProps(
 export {
   BrushElementModel,
   ConnectorElementModel,
-  ElementModel,
   GroupElementModel,
   MindmapElementModel,
   ShapeElementModel,
+  SurfaceElementModel,
   TextElementModel,
 };
-
-export type CanvasElement =
-  | BrushElementModel
-  | ConnectorElementModel
-  | ShapeElementModel
-  | TextElementModel
-  | GroupElementModel
-  | MindmapElementModel;
 
 export enum CanvasElementType {
   SHAPE = 'shape',

--- a/packages/blocks/src/surface-block/element-model/mindmap.ts
+++ b/packages/blocks/src/surface-block/element-model/mindmap.ts
@@ -3,7 +3,6 @@ import { DocCollection, type Y } from '@blocksuite/store';
 import { generateKeyBetween } from 'fractional-indexing';
 import { z } from 'zod';
 
-import type { EdgelessModel } from '../../_common/types.js';
 import { last } from '../../_common/utils/iterable.js';
 import { ConnectorPathGenerator } from '../managers/connector-manager.js';
 import {
@@ -11,7 +10,7 @@ import {
   type SerializedXYWH,
   type XYWH,
 } from '../utils/xywh.js';
-import { type BaseProps, GroupLikeModel } from './base.js';
+import { type IBaseProps, SurfaceGroupLikeModel } from './base.js';
 import { TextResizing } from './common.js';
 import { LocalConnectorElementModel } from './connector.js';
 import { convert, observe, watch, yfield } from './decorators.js';
@@ -49,11 +48,11 @@ const nodeSchema: z.ZodType<Node> = baseNodeSchema.extend({
 
 type NodeType = z.infer<typeof nodeSchema>;
 
-type MindmapElementProps = BaseProps & {
+type MindmapElementProps = IBaseProps & {
   nodes: Y.Map<NodeDetail>;
 };
 
-export class MindmapElementModel extends GroupLikeModel<MindmapElementProps> {
+export class MindmapElementModel extends SurfaceGroupLikeModel<MindmapElementProps> {
   get type() {
     return 'mindmap';
   }
@@ -66,7 +65,7 @@ export class MindmapElementModel extends GroupLikeModel<MindmapElementProps> {
   pathGenerator: ConnectorPathGenerator = new ConnectorPathGenerator({
     getElementById: (id: string) =>
       this.surface.getElementById(id) ??
-      (this.surface.doc.getBlockById(id) as EdgelessModel),
+      (this.surface.doc.getBlockById(id) as BlockSuite.EdgelessModelType),
   });
 
   @convert((initalValue, instance) => {
@@ -520,7 +519,9 @@ export class MindmapElementModel extends GroupLikeModel<MindmapElementProps> {
     this.pathGenerator.updatePath(connector);
   }
 
-  getLayoutDir(element: string | EdgelessModel): LayoutType | null {
+  getLayoutDir(
+    element: string | BlockSuite.EdgelessModelType
+  ): LayoutType | null {
     if (this.layoutType !== LayoutType.BALANCE) {
       return this.layoutType;
     }
@@ -646,5 +647,13 @@ export class MindmapElementModel extends GroupLikeModel<MindmapElementProps> {
     }
 
     return node.children.map(child => child.element);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceGroupLikeModelMap {
+      mindmap: MindmapElementModel;
+    }
   }
 }

--- a/packages/blocks/src/surface-block/element-model/shape.ts
+++ b/packages/blocks/src/surface-block/element-model/shape.ts
@@ -1,12 +1,15 @@
 import { DocCollection, type Y } from '@blocksuite/store';
 
-import type { HitTestOptions } from '../../root-block/edgeless/type.js';
 import { DEFAULT_ROUGHNESS } from '../consts.js';
 import type { IBound, SerializedXYWH } from '../index.js';
 import type { Bound } from '../utils/bound.js';
 import type { PointLocation } from '../utils/point-location.js';
 import { type IVec2 } from '../utils/vec.js';
-import { type BaseProps, ElementModel } from './base.js';
+import {
+  type IBaseProps,
+  type IHitTestOptions,
+  SurfaceElementModel,
+} from './base.js';
 import { FontFamily, FontWeight, TextResizing } from './common.js';
 import {
   type FontStyle,
@@ -39,7 +42,7 @@ export enum ShapeTextFontSize {
   XLARGE = 36,
 }
 
-export type ShapeProps = BaseProps & {
+export type ShapeProps = IBaseProps & {
   shapeType: ShapeType;
   radius: number;
   filled: boolean;
@@ -64,7 +67,7 @@ export type ShapeProps = BaseProps & {
   maxWidth?: false | number;
 };
 
-export class ShapeElementModel extends ElementModel<ShapeProps> {
+export class ShapeElementModel extends SurfaceElementModel<ShapeProps> {
   static override propsToY(props: ShapeProps) {
     if (props.text && !(props.text instanceof DocCollection.Y.Text)) {
       props.text = new DocCollection.Y.Text(props.text);
@@ -148,7 +151,7 @@ export class ShapeElementModel extends ElementModel<ShapeProps> {
 
   textBound: IBound | null = null;
 
-  override hitTest(x: number, y: number, options: HitTestOptions) {
+  override hitTest(x: number, y: number, options: IHitTestOptions) {
     return shapeMethods[this.shapeType].hitTest.call(this, x, y, {
       ...options,
       ignoreTransparent: options.ignoreTransparent ?? true,
@@ -169,5 +172,13 @@ export class ShapeElementModel extends ElementModel<ShapeProps> {
 
   override getRelativePointLocation(point: IVec2): PointLocation {
     return shapeMethods[this.shapeType].getRelativePointLocation(point, this);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceElementModelMap {
+      shape: ShapeElementModel;
+    }
   }
 }

--- a/packages/blocks/src/surface-block/element-model/text.ts
+++ b/packages/blocks/src/surface-block/element-model/text.ts
@@ -9,7 +9,7 @@ import {
   polygonNearestPoint,
 } from '../utils/math-utils.js';
 import type { IVec2 } from '../utils/vec.js';
-import { type BaseProps, ElementModel } from './base.js';
+import { type IBaseProps, SurfaceElementModel } from './base.js';
 import {
   FontFamily,
   type FontStyle,
@@ -18,7 +18,7 @@ import {
 } from './common.js';
 import { yfield } from './decorators.js';
 
-export type TextElementProps = BaseProps & {
+export type TextElementProps = IBaseProps & {
   text: Y.Text;
   color: string;
   fontSize: number;
@@ -29,7 +29,7 @@ export type TextElementProps = BaseProps & {
   hasMaxWidth?: boolean;
 };
 
-export class TextElementModel extends ElementModel<TextElementProps> {
+export class TextElementModel extends SurfaceElementModel<TextElementProps> {
   static override propsToY(props: Record<string, unknown>) {
     if (props.text && !(props.text instanceof DocCollection.Y.Text)) {
       props.text = new DocCollection.Y.Text(props.text as string);
@@ -92,5 +92,13 @@ export class TextElementModel extends ElementModel<TextElementProps> {
   override hitTest(x: number, y: number): boolean {
     const points = getPointsFromBoundsWithRotation(this);
     return pointInPolygon([x, y], points);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface SurfaceElementModelMap {
+      text: TextElementModel;
+    }
   }
 }

--- a/packages/blocks/src/surface-block/element-model/utils/mindmap/layout.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/mindmap/layout.ts
@@ -1,4 +1,4 @@
-import type { ElementModel, SerializedXYWH } from '../../../index.js';
+import type { SerializedXYWH } from '../../../index.js';
 import { Bound } from '../../../utils/bound.js';
 import type { MindmapElementModel } from '../../mindmap.js';
 import { applyNodeStyle } from './style.js';
@@ -24,7 +24,7 @@ export type MindmapNode = {
   id: string;
   detail: NodeDetail;
 
-  element: ElementModel;
+  element: BlockSuite.SurfaceElementModelType;
   children: MindmapNode[];
 };
 

--- a/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../../../root-block/edgeless/type.js';
 import type { IBound } from '../../../consts.js';
 import { Bound } from '../../../utils/bound.js';
 import {
@@ -13,6 +12,7 @@ import {
 } from '../../../utils/math-utils.js';
 import { PointLocation } from '../../../utils/point-location.js';
 import { type IVec2 } from '../../../utils/vec.js';
+import type { IHitTestOptions } from '../../base.js';
 import { DEFAULT_CENTRAL_AREA_RATIO } from '../../common.js';
 import type { ShapeElementModel } from '../../shape.js';
 
@@ -48,7 +48,7 @@ export const diamond = {
     this: ShapeElementModel,
     x: number,
     y: number,
-    options: HitTestOptions
+    options: IHitTestOptions
   ) {
     const points = getPointsFromBoundsWithRotation(this, diamond.points);
 

--- a/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../../../root-block/edgeless/type.js';
 import type { IBound } from '../../../consts.js';
 import { Bound } from '../../../utils/bound.js';
 import {
@@ -11,6 +10,7 @@ import {
 } from '../../../utils/math-utils.js';
 import { PointLocation } from '../../../utils/point-location.js';
 import type { IVec2 } from '../../../utils/vec.js';
+import type { IHitTestOptions } from '../../base.js';
 import { DEFAULT_CENTRAL_AREA_RATIO } from '../../common.js';
 import type { ShapeElementModel } from '../../shape.js';
 
@@ -41,7 +41,7 @@ export const ellipse = {
     this: ShapeElementModel,
     x: number,
     y: number,
-    options: HitTestOptions
+    options: IHitTestOptions
   ) {
     const point = [x, y];
     const expand = (options?.expand ?? 1) / (options?.zoom ?? 1);

--- a/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../../../root-block/edgeless/type.js';
 import { type IBound } from '../../../consts.js';
 import { Bound } from '../../../utils/bound.js';
 import {
@@ -13,6 +12,7 @@ import {
 } from '../../../utils/math-utils.js';
 import { PointLocation } from '../../../utils/point-location.js';
 import type { IVec2 } from '../../../utils/vec.js';
+import type { IHitTestOptions } from '../../base.js';
 import { DEFAULT_CENTRAL_AREA_RATIO } from '../../common.js';
 import type { ShapeElementModel } from '../../shape.js';
 
@@ -37,7 +37,7 @@ export const rect = {
     this: ShapeElementModel,
     x: number,
     y: number,
-    options: HitTestOptions
+    options: IHitTestOptions
   ) {
     const points = getPointsFromBoundsWithRotation(this);
 

--- a/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
@@ -1,4 +1,3 @@
-import type { HitTestOptions } from '../../../../root-block/edgeless/type.js';
 import { DEFAULT_CENTRAL_AREA_RATIO, type IBound } from '../../../consts.js';
 import { Bound } from '../../../utils/bound.js';
 import {
@@ -13,6 +12,7 @@ import {
 } from '../../../utils/math-utils.js';
 import { PointLocation } from '../../../utils/point-location.js';
 import type { IVec2 } from '../../../utils/vec.js';
+import type { IHitTestOptions } from '../../base.js';
 import type { ShapeElementModel } from '../../shape.js';
 
 export const triangle = {
@@ -44,7 +44,7 @@ export const triangle = {
     this: ShapeElementModel,
     x: number,
     y: number,
-    options: HitTestOptions
+    options: IHitTestOptions
   ) {
     const points = getPointsFromBoundsWithRotation(this, triangle.points);
 

--- a/packages/blocks/src/surface-block/elements/index.ts
+++ b/packages/blocks/src/surface-block/elements/index.ts
@@ -3,12 +3,9 @@ import type { IShape } from './shape/types.js';
 export { getFontString, getLineHeight, getLineWidth } from './text/utils.js';
 
 import type {
-  CanvasElement,
   ShapeElementModel,
   TextElementModel,
 } from '../element-model/index.js';
-
-export type { CanvasElement };
 
 export type CanvasElementWithText = ShapeElementModel | TextElementModel;
 

--- a/packages/blocks/src/surface-block/grid.ts
+++ b/packages/blocks/src/surface-block/grid.ts
@@ -1,4 +1,3 @@
-import type { EdgelessModel } from '../root-block/edgeless/type.js';
 import { GRID_SIZE, type IBound } from './consts.js';
 import { compare } from './managers/layer-utils.js';
 import { Bound } from './utils/bound.js';
@@ -21,7 +20,9 @@ function rangeFromBound(a: IBound): number[] {
   return [minRow, maxRow, minCol, maxCol];
 }
 
-function rangeFromElement<T extends EdgelessModel>(ele: T): number[] {
+function rangeFromElement<T extends BlockSuite.EdgelessModelType>(
+  ele: T
+): number[] {
   const bound = ele.elementBound;
   const minRow = getGridIndex(bound.x);
   const maxRow = getGridIndex(bound.maxX);
@@ -30,7 +31,7 @@ function rangeFromElement<T extends EdgelessModel>(ele: T): number[] {
   return [minRow, maxRow, minCol, maxCol];
 }
 
-function rangeFromElementExternal<T extends EdgelessModel>(
+function rangeFromElementExternal<T extends BlockSuite.EdgelessModelType>(
   ele: T
 ): number[] | null {
   if (!ele.externalXYWH) return null;
@@ -43,7 +44,7 @@ function rangeFromElementExternal<T extends EdgelessModel>(
   return [minRow, maxRow, minCol, maxCol];
 }
 
-export class GridManager<T extends EdgelessModel> {
+export class GridManager<T extends BlockSuite.EdgelessModelType> {
   private _grids: Map<string, Set<T>> = new Map();
   private _elementToGrids: Map<T, Set<Set<T>>> = new Map();
 

--- a/packages/blocks/src/surface-block/index.ts
+++ b/packages/blocks/src/surface-block/index.ts
@@ -19,7 +19,7 @@ export {
   GRID_GAP_MAX,
   GRID_GAP_MIN,
 } from './consts.js';
-export { ElementModel } from './element-model/base.js';
+export { SurfaceElementModel } from './element-model/base.js';
 export { BrushElementModel } from './element-model/brush.js';
 export {
   type Connection,

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -1,10 +1,6 @@
 import { assertEquals, assertExists } from '@blocksuite/global/utils';
 
-import type {
-  Connectable,
-  EdgelessModel,
-  Selectable,
-} from '../../_common/types.js';
+import type { Connectable } from '../../_common/types.js';
 import type { EdgelessRootService } from '../../root-block/edgeless/edgeless-root-service.js';
 import { Overlay } from '../canvas-renderer/renderer.js';
 import type { IBound } from '../consts.js';
@@ -43,14 +39,14 @@ export type OrthogonalConnectorInput = {
   endPoint: PointLocation;
 };
 
-function rBound(ele: EdgelessModel, anti = false): IBound {
+function rBound(ele: BlockSuite.EdgelessModelType, anti = false): IBound {
   const bound = Bound.deserialize(ele.xywh);
   return { ...bound, rotate: anti ? -ele.rotate : ele.rotate };
 }
 
 export function isConnectorAndBindingsAllSelected(
   connector: ConnectorElementModel | LocalConnectorElementModel,
-  selected: Selectable[]
+  selected: BlockSuite.EdgelessModelType[]
 ) {
   const connectorSelected = selected.find(s => s.id === connector.id);
   if (!connectorSelected) {
@@ -74,7 +70,7 @@ export function isConnectorAndBindingsAllSelected(
   return false;
 }
 
-export function getAnchors(ele: EdgelessModel) {
+export function getAnchors(ele: BlockSuite.EdgelessModelType) {
   const bound = Bound.deserialize(ele.xywh);
   const offset = 10;
   const anchors: { point: PointLocation; coord: IVec }[] = [];
@@ -88,7 +84,7 @@ export function getAnchors(ele: EdgelessModel) {
   ]
     .map(vec => getPointFromBoundsWithRotation({ ...bound, rotate }, vec))
     .forEach(vec => {
-      const rst = ele.intersectWithLine(bound.center, vec);
+      const rst = ele.intersectWithLine(bound.center as IVec2, vec as IVec2);
       assertExists(rst);
       const originPoint = getPointFromBoundsWithRotation(
         { ...bound, rotate: -rotate },
@@ -100,10 +96,10 @@ export function getAnchors(ele: EdgelessModel) {
 }
 
 function getConnectableRelativePosition(
-  connectable: EdgelessModel,
+  connectable: BlockSuite.EdgelessModelType,
   position: IVec
 ) {
-  const location = connectable.getRelativePointLocation(position);
+  const location = connectable.getRelativePointLocation(position as IVec2);
   if (isVecZero(Vec.sub(position, [0, 0.5])))
     location.tangent = Vec.rot([0, -1], toRadian(connectable.rotate));
   else if (isVecZero(Vec.sub(position, [1, 0.5])))
@@ -826,7 +822,7 @@ export class ConnectionOverlay extends Overlay {
       if (result) break;
 
       // if not, check if closes to bound
-      const nearestPoint = connectable.getNearestPoint(point);
+      const nearestPoint = connectable.getNearestPoint(point as IVec2);
 
       if (Vec.dist(nearestPoint, point) < 8) {
         this.highlightPoint = nearestPoint;
@@ -886,7 +882,7 @@ export class ConnectorPathGenerator {
 
   constructor(
     private options: {
-      getElementById: (id: string) => EdgelessModel | Connectable | null;
+      getElementById: (id: string) => BlockSuite.EdgelessModelType | null;
     }
   ) {}
 

--- a/packages/blocks/src/surface-block/managers/layer-manager.ts
+++ b/packages/blocks/src/surface-block/managers/layer-manager.ts
@@ -6,12 +6,9 @@ import { generateKeyBetween } from 'fractional-indexing';
 import { last, nToLast } from '../../_common/utils/iterable.js';
 import { matchFlavours } from '../../_common/utils/model.js';
 import type { FrameBlockModel } from '../../frame-block/frame-model.js';
-import {
-  EdgelessBlockModel,
-  type EdgelessModel,
-} from '../../root-block/edgeless/type.js';
+import { EdgelessBlockModel } from '../../root-block/edgeless/type.js';
 import { Bound } from '../../surface-block/utils/bound.js';
-import { ElementModel } from '../element-model/base.js';
+import { SurfaceElementModel } from '../element-model/base.js';
 import type { GroupElementModel } from '../element-model/group.js';
 import { GridManager } from '../grid.js';
 import type { SurfaceBlockModel } from '../surface-model.js';
@@ -52,7 +49,7 @@ export type BlockLayer = BaseLayer<EdgelessBlockModel> & {
   zIndex: number;
 };
 
-export type CanvasLayer = BaseLayer<ElementModel> & {
+export type CanvasLayer = BaseLayer<SurfaceElementModel> & {
   type: 'canvas';
 
   /**
@@ -77,7 +74,7 @@ export class LayerManager {
             model =>
               model instanceof EdgelessBlockModel &&
               renderableInEdgeless(doc, surface, model)
-          ) as EdgelessModel[]
+          ) as BlockSuite.EdgelessModelType[]
       ).concat(surface.elementModels)
     );
 
@@ -91,18 +88,18 @@ export class LayerManager {
   slots = {
     layerUpdated: new Slot<{
       type: 'delete' | 'add' | 'update';
-      initiatingElement: EdgelessModel;
+      initiatingElement: BlockSuite.EdgelessModelType;
     }>(),
   };
 
-  canvasElements!: ElementModel[];
+  canvasElements!: SurfaceElementModel[];
   blocks!: EdgelessBlockModel[];
   frames!: FrameBlockModel[];
 
   layers!: Layer[];
 
   canvasLayers!: {
-    set: Set<ElementModel>;
+    set: Set<SurfaceElementModel>;
     /**
      * fractional index
      */
@@ -111,14 +108,14 @@ export class LayerManager {
      * z-index, used for actual rendering
      */
     zIndex: number;
-    elements: Array<ElementModel>;
+    elements: Array<SurfaceElementModel>;
   }[];
 
   blocksGrid = new GridManager<EdgelessBlockModel>();
   framesGrid = new GridManager<FrameBlockModel>();
-  canvasGrid = new GridManager<ElementModel>();
+  canvasGrid = new GridManager<SurfaceElementModel>();
 
-  constructor(elements?: EdgelessModel[]) {
+  constructor(elements?: BlockSuite.EdgelessModelType[]) {
     if (elements) {
       this._init(elements);
     }
@@ -183,13 +180,13 @@ export class LayerManager {
     );
   }
 
-  private _init(elements: EdgelessModel[]) {
+  private _init(elements: BlockSuite.EdgelessModelType[]) {
     this.canvasElements = [];
     this.blocks = [];
     this.frames = [];
 
     elements.forEach(element => {
-      if (element instanceof ElementModel) {
+      if (element instanceof SurfaceElementModel) {
         this.canvasElements.push(element);
         this.canvasGrid.add(element);
       } else if (matchFlavours(element, ['affine:frame'])) {
@@ -346,7 +343,10 @@ export class LayerManager {
     this.layers = layers;
   }
 
-  private _insertIntoLayer(target: EdgelessModel, type: 'block' | 'canvas') {
+  private _insertIntoLayer(
+    target: BlockSuite.EdgelessModelType,
+    type: 'block' | 'canvas'
+  ) {
     if (this.layers.length === 0) {
       this._initLayers();
       return;
@@ -357,11 +357,11 @@ export class LayerManager {
 
     const addToLayer = (
       layer: Layer,
-      element: EdgelessModel,
+      element: BlockSuite.EdgelessModelType,
       position: number | 'tail'
     ) => {
       assertType<CanvasLayer>(layer);
-      assertType<ElementModel>(element);
+      assertType<SurfaceElementModel>(element);
 
       if (position === 'tail') {
         layer.elements.push(element);
@@ -384,7 +384,7 @@ export class LayerManager {
     };
     const createLayer = (
       type: 'block' | 'canvas',
-      targets: EdgelessModel[],
+      targets: BlockSuite.EdgelessModelType[],
       curZIndex: number
     ): Layer => {
       const newLayer = {
@@ -435,7 +435,7 @@ export class LayerManager {
             updateLayersZIndex(layers, cur);
           } else {
             const splicedElements = layer.elements.splice(insertIdx);
-            layer.set = new Set(layer.elements as ElementModel[]);
+            layer.set = new Set(layer.elements as SurfaceElementModel[]);
 
             layers.splice(
               cur + 1,
@@ -472,13 +472,16 @@ export class LayerManager {
     }
   }
 
-  private _removeFromLayer(target: EdgelessModel, type: 'block' | 'canvas') {
+  private _removeFromLayer(
+    target: BlockSuite.EdgelessModelType,
+    type: 'block' | 'canvas'
+  ) {
     const layers = this.layers;
     const index = layers.findIndex(layer => {
       if (layer.type !== type) return false;
 
       assertType<CanvasLayer>(layer);
-      assertType<ElementModel>(target);
+      assertType<SurfaceElementModel>(target);
 
       if (layer.set.has(target)) {
         layer.set.delete(target);
@@ -557,14 +560,17 @@ export class LayerManager {
    * @returns a boolean value to indicate whether the layers have been updated
    */
   private _updateLayer(
-    element: EdgelessModel,
+    element: BlockSuite.EdgelessModelType,
     props?: Record<string, unknown>
   ) {
     let updateType: 'block' | 'canvas' | undefined = undefined;
     const type = 'flavour' in element ? element.flavour : element.type;
 
     const indexChanged = !props || 'index' in props;
-    const updateArray = (array: EdgelessModel[], element: EdgelessModel) => {
+    const updateArray = (
+      array: BlockSuite.EdgelessModelType[],
+      element: BlockSuite.EdgelessModelType
+    ) => {
       if (!indexChanged) return;
       removeFromOrderedArray(array, element);
       insertToOrderedArray(array, element);
@@ -573,7 +579,7 @@ export class LayerManager {
     if (!type.startsWith('affine:')) {
       updateType = 'canvas';
       updateArray(this.canvasElements, element);
-      this.canvasGrid.update(element as ElementModel);
+      this.canvasGrid.update(element as SurfaceElementModel);
 
       if (type === 'group' && indexChanged) {
         (element as GroupElementModel).childElements.forEach(
@@ -590,8 +596,14 @@ export class LayerManager {
     }
 
     if (updateType && indexChanged) {
-      this._removeFromLayer(element as EdgelessModel, updateType);
-      this._insertIntoLayer(element as EdgelessModel, updateType);
+      this._removeFromLayer(
+        element as BlockSuite.EdgelessModelType,
+        updateType
+      );
+      this._insertIntoLayer(
+        element as BlockSuite.EdgelessModelType,
+        updateType
+      );
 
       return true;
     }
@@ -599,14 +611,14 @@ export class LayerManager {
     return false;
   }
 
-  add(element: EdgelessModel) {
+  add(element: BlockSuite.EdgelessModelType) {
     let insertType: 'block' | 'canvas' | undefined = undefined;
     const type = 'flavour' in element ? element.flavour : element.type;
 
     if (!type.startsWith('affine:')) {
       insertType = 'canvas';
       insertToOrderedArray(this.canvasElements, element);
-      this.canvasGrid.add(element as ElementModel);
+      this.canvasGrid.add(element as SurfaceElementModel);
 
       if (type === 'group') {
         (element as GroupElementModel).childElements.forEach(
@@ -623,7 +635,10 @@ export class LayerManager {
     }
 
     if (insertType) {
-      this._insertIntoLayer(element as EdgelessModel, insertType);
+      this._insertIntoLayer(
+        element as BlockSuite.EdgelessModelType,
+        insertType
+      );
       this._buildCanvasLayers();
       this.slots.layerUpdated.emit({
         type: 'add',
@@ -632,10 +647,10 @@ export class LayerManager {
     }
   }
 
-  delete(element: EdgelessModel) {
+  delete(element: BlockSuite.EdgelessModelType) {
     let deleteType: 'canvas' | 'block' | undefined = undefined;
 
-    if (element instanceof ElementModel) {
+    if (element instanceof SurfaceElementModel) {
       deleteType = 'canvas';
       removeFromOrderedArray(this.canvasElements, element);
       this.canvasGrid.remove(element);
@@ -658,7 +673,10 @@ export class LayerManager {
     }
   }
 
-  update(element: EdgelessModel, props?: Record<string, unknown>) {
+  update(
+    element: BlockSuite.EdgelessModelType,
+    props?: Record<string, unknown>
+  ) {
     if (this._updateLayer(element, props)) {
       this._buildCanvasLayers();
       this.slots.layerUpdated.emit({
@@ -767,21 +785,21 @@ export class LayerManager {
         groups: () => [],
       };
 
-      manager.add(mockedFakeElement as unknown as EdgelessModel);
+      manager.add(mockedFakeElement as unknown as BlockSuite.EdgelessModelType);
 
       return idx;
     };
   }
 
   getReorderedIndex(
-    element: EdgelessModel,
+    element: BlockSuite.EdgelessModelType,
     direction: ReorderingDirection
   ): string {
     const group = element.group;
     const isFrameBlock =
       (element as FrameBlockModel).flavour === 'affine:frame';
 
-    let elements: EdgelessModel[];
+    let elements: BlockSuite.EdgelessModelType[];
 
     if (group !== null) {
       elements = group.childElements.filter(
@@ -795,7 +813,7 @@ export class LayerManager {
       elements = this.frames;
     } else {
       elements = this.layers.reduce(
-        (pre: EdgelessModel[], current) =>
+        (pre: BlockSuite.EdgelessModelType[], current) =>
           pre.concat(current.elements.filter(element => element.group == null)),
         []
       );
@@ -844,7 +862,7 @@ export class LayerManager {
   /**
    * Pass to the `Array.sort` to  sort the elements by their index
    */
-  compare(a: EdgelessModel, b: EdgelessModel) {
+  compare(a: BlockSuite.EdgelessModelType, b: BlockSuite.EdgelessModelType) {
     return compare(a, b);
   }
 

--- a/packages/blocks/src/surface-block/managers/layer-utils.ts
+++ b/packages/blocks/src/surface-block/managers/layer-utils.ts
@@ -1,10 +1,6 @@
 import type { Doc } from '@blocksuite/store';
 
-import type {
-  EdgelessBlockModel,
-  EdgelessModel,
-} from '../../root-block/edgeless/type.js';
-import { GroupLikeModel } from '../element-model/base.js';
+import { SurfaceGroupLikeModel } from '../element-model/base.js';
 import type { SurfaceBlockModel } from '../surface-model.js';
 import type { Layer } from './layer-manager.js';
 
@@ -29,7 +25,7 @@ export function updateLayersZIndex(layers: Layer[], startIdx: number) {
   }
 }
 
-export function getElementIndex(indexable: EdgelessModel) {
+export function getElementIndex(indexable: BlockSuite.EdgelessModelType) {
   const groups = indexable.groups;
 
   if (groups.length > 1) {
@@ -50,8 +46,8 @@ export function ungroupIndex(index: string) {
 }
 
 export function insertToOrderedArray(
-  array: EdgelessModel[],
-  element: EdgelessModel
+  array: BlockSuite.EdgelessModelType[],
+  element: BlockSuite.EdgelessModelType
 ) {
   let idx = 0;
   while (idx < array.length && compare(array[idx], element) < 0) {
@@ -62,8 +58,8 @@ export function insertToOrderedArray(
 }
 
 export function removeFromOrderedArray(
-  array: EdgelessModel[],
-  element: EdgelessModel
+  array: BlockSuite.EdgelessModelType[],
+  element: BlockSuite.EdgelessModelType
 ) {
   const idx = array.indexOf(element);
 
@@ -73,8 +69,8 @@ export function removeFromOrderedArray(
 }
 
 export function isInRange(
-  edges: [EdgelessModel, EdgelessModel],
-  target: EdgelessModel
+  edges: [BlockSuite.EdgelessModelType, BlockSuite.EdgelessModelType],
+  target: BlockSuite.EdgelessModelType
 ) {
   return compare(target, edges[0]) >= 0 && compare(target, edges[1]) < 0;
 }
@@ -82,17 +78,20 @@ export function isInRange(
 export function renderableInEdgeless(
   doc: Doc,
   surface: SurfaceBlockModel,
-  block: EdgelessBlockModel
+  block: BlockSuite.EdgelessBlockModelType
 ) {
   const parent = doc.getParent(block);
 
   return parent === doc.root || parent === surface;
 }
 
-export function compare(a: EdgelessModel, b: EdgelessModel) {
-  if (a instanceof GroupLikeModel && a.hasDescendant(b)) {
+export function compare(
+  a: BlockSuite.EdgelessModelType,
+  b: BlockSuite.EdgelessModelType
+) {
+  if (a instanceof SurfaceGroupLikeModel && a.hasDescendant(b)) {
     return -1;
-  } else if (b instanceof GroupLikeModel && b.hasDescendant(a)) {
+  } else if (b instanceof SurfaceGroupLikeModel && b.hasDescendant(a)) {
     return 1;
   } else {
     const aGroups = a.groups;

--- a/packages/blocks/src/surface-block/middlewares/connector.ts
+++ b/packages/blocks/src/surface-block/middlewares/connector.ts
@@ -1,4 +1,3 @@
-import type { EdgelessModel } from '../../root-block/edgeless/type.js';
 import type { ConnectorElementModel } from '../index.js';
 import { ConnectorPathGenerator } from '../managers/connector-manager.js';
 import type { SurfaceBlockModel, SurfaceMiddleware } from '../surface-model.js';
@@ -8,7 +7,7 @@ export const connectorMiddleware: SurfaceMiddleware = (
 ) => {
   const getElementById = (id: string) =>
     surface.getElementById(id) ??
-    (surface.doc.getBlockById(id) as EdgelessModel);
+    (surface.doc.getBlockById(id) as BlockSuite.EdgelessModelType);
   const pathGenerator = new ConnectorPathGenerator({
     getElementById: getElementById,
   });

--- a/packages/blocks/src/surface-block/middlewares/group.ts
+++ b/packages/blocks/src/surface-block/middlewares/group.ts
@@ -1,5 +1,4 @@
-import type { EdgelessModel } from '../../root-block/edgeless/type.js';
-import { GroupLikeModel } from '../element-model/base.js';
+import { SurfaceGroupLikeModel } from '../element-model/base.js';
 import type { SurfaceBlockModel, SurfaceMiddleware } from '../surface-model.js';
 import type { Bound } from '../utils/bound.js';
 
@@ -8,10 +7,10 @@ export const groupSizeMiddleware: SurfaceMiddleware = (
 ) => {
   const getElementById = (id: string) =>
     surface.getElementById(id) ??
-    (surface.doc.getBlockById(id) as EdgelessModel);
+    (surface.doc.getBlockById(id) as BlockSuite.EdgelessModelType);
   let pending = false;
-  const groupSet = new Set<GroupLikeModel>();
-  const calculateGroupSize = (group: GroupLikeModel) => {
+  const groupSet = new Set<SurfaceGroupLikeModel>();
+  const calculateGroupSize = (group: SurfaceGroupLikeModel) => {
     let bound: Bound | undefined;
     group.childIds.forEach(childId => {
       const elementBound = getElementById(childId)?.elementBound;
@@ -23,7 +22,7 @@ export const groupSizeMiddleware: SurfaceMiddleware = (
 
     group.xywh = bound?.serialize() ?? '[0,0,0,0]';
   };
-  const addGroupSizeUpdateList = (group: GroupLikeModel) => {
+  const addGroupSizeUpdateList = (group: SurfaceGroupLikeModel) => {
     groupSet.add(group);
 
     if (!pending) {
@@ -43,7 +42,10 @@ export const groupSizeMiddleware: SurfaceMiddleware = (
       if (payload.type === 'update') {
         const group = surface.getGroup(payload.id);
 
-        if (group instanceof GroupLikeModel && payload.props.key === 'xywh') {
+        if (
+          group instanceof SurfaceGroupLikeModel &&
+          payload.props.key === 'xywh'
+        ) {
           addGroupSizeUpdateList(group);
         }
       }
@@ -51,12 +53,12 @@ export const groupSizeMiddleware: SurfaceMiddleware = (
     surface.elementUpdated.on(({ id, props }) => {
       // update the group's xywh when children's xywh updated
       const group = surface.getGroup(id);
-      if (group instanceof GroupLikeModel && props['xywh']) {
+      if (group instanceof SurfaceGroupLikeModel && props['xywh']) {
         addGroupSizeUpdateList(group);
       }
 
       const element = surface.getElementById(id);
-      if (element instanceof GroupLikeModel && props['childIds']) {
+      if (element instanceof SurfaceGroupLikeModel && props['childIds']) {
         addGroupSizeUpdateList(element);
       }
     }),
@@ -64,14 +66,14 @@ export const groupSizeMiddleware: SurfaceMiddleware = (
       // update the group's xywh when added
       const group = surface.getElementById(id);
 
-      if (group instanceof GroupLikeModel) {
+      if (group instanceof SurfaceGroupLikeModel) {
         addGroupSizeUpdateList(group);
       }
     }),
   ];
 
   surface.elementModels.forEach(model => {
-    if (model instanceof GroupLikeModel) {
+    if (model instanceof SurfaceGroupLikeModel) {
       addGroupSizeUpdateList(model);
     }
   });
@@ -91,7 +93,7 @@ export const groupRelationMiddleware: SurfaceMiddleware = (
         const element = surface.getElementById(id)!;
 
         // remove the group if it has no children
-        if (element instanceof GroupLikeModel && props['childIds']) {
+        if (element instanceof SurfaceGroupLikeModel && props['childIds']) {
           if (element.childIds.length === 0) {
             surface.removeElement(id);
           }

--- a/packages/blocks/src/surface-block/middlewares/mindmap.ts
+++ b/packages/blocks/src/surface-block/middlewares/mindmap.ts
@@ -1,4 +1,3 @@
-import type { EdgelessModel } from '../../root-block/edgeless/type.js';
 import { MindmapElementModel } from '../element-model/mindmap.js';
 import type { SurfaceBlockModel, SurfaceMiddleware } from '../surface-model.js';
 
@@ -8,7 +7,7 @@ export const mindmapMiddleware: SurfaceMiddleware = (
 ) => {
   const getElementById = (id: string) =>
     surface.getElementById(id) ??
-    (surface.doc.getBlockById(id) as EdgelessModel);
+    (surface.doc.getBlockById(id) as BlockSuite.EdgelessModelType);
   let layoutUpdPending = false;
   const layoutUpdList = new Set<MindmapElementModel>();
   const updateLayout = (mindmap: MindmapElementModel) => {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -18,7 +18,6 @@ import { requestConnectedFrame } from '../_common/utils/event.js';
 import type { FrameBlockModel } from '../frame-block/index.js';
 import { getBackgroundGrid } from '../root-block/edgeless/utils/query.js';
 import type { Renderer } from '../surface-block/canvas-renderer/renderer.js';
-import type { ElementModel } from '../surface-block/element-model/base.js';
 import type { SurfaceBlockModel } from '../surface-block/index.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import { deserializeXYWH } from '../surface-block/utils/xywh.js';
@@ -46,7 +45,7 @@ const NO_CONTENT_REASON = {
   DEFAULT: 'This content was deleted on edgeless mode',
 } as Record<string, string>;
 
-type RefElement = ElementModel | FrameBlockModel;
+type RefElementModel = BlockSuite.SurfaceElementModelType | FrameBlockModel;
 
 @customElement('affine-surface-ref')
 export class SurfaceRefBlockComponent extends BlockElement<
@@ -225,7 +224,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
 
   private _surfaceRefRenderer!: SurfaceRefRenderer;
 
-  private _referencedModel: RefElement | null = null;
+  private _referencedModel: RefElementModel | null = null;
 
   @query('.ref-canvas-container')
   accessor container!: HTMLDivElement;
@@ -394,7 +393,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
 
       const referencedModel = this._surfaceRefRenderer.getModel(
         this.model.reference
-      ) as RefElement;
+      ) as RefElementModel;
       this._referencedModel =
         referencedModel && 'xywh' in referencedModel ? referencedModel : null;
 
@@ -499,7 +498,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     pageService.slots.editorModeSwitch.emit('edgeless');
   }
 
-  private _renderMask(referencedModel: RefElement, flavourOrType: string) {
+  private _renderMask(referencedModel: RefElementModel, flavourOrType: string) {
     const title = 'title' in referencedModel ? referencedModel.title : '';
 
     return html`
@@ -537,7 +536,10 @@ export class SurfaceRefBlockComponent extends BlockElement<
     </div>`;
   }
 
-  private _renderRefContent(referencedModel: RefElement, renderer: Renderer) {
+  private _renderRefContent(
+    referencedModel: RefElementModel,
+    renderer: Renderer
+  ) {
     const [, , w, h] = deserializeXYWH(referencedModel.xywh);
     const { zoom } = renderer;
     const { gap } = getBackgroundGrid(zoom, true);

--- a/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
@@ -3,7 +3,6 @@ import { DisposableGroup, Slot } from '@blocksuite/global/utils';
 import type { Doc } from '@blocksuite/store';
 
 import { ThemeObserver } from '../_common/theme/theme-observer.js';
-import type { EdgelessModel, TopLevelBlockModel } from '../_common/types.js';
 import type { NoteBlockModel } from '../note-block/index.js';
 import { Renderer } from '../surface-block/index.js';
 import type { SurfaceBlockModel } from '../surface-block/surface-model.js';
@@ -77,10 +76,10 @@ export class SurfaceRefRenderer {
     this.slots.unmounted.emit();
   }
 
-  getModel(id: string): EdgelessModel | null {
+  getModel(id: string): BlockSuite.EdgelessModelType | null {
     return (
       (this.doc.getBlockById(id) as Exclude<
-        TopLevelBlockModel,
+        BlockSuite.EdgelessBlockModelType,
         NoteBlockModel
       >) ??
       this._surfaceModel?.getElementById(id) ??

--- a/packages/presets/src/__tests__/edgeless/layer.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/layer.spec.ts
@@ -3,7 +3,6 @@
 import type { BlockElement } from '@blocksuite/block-std';
 import type {
   EdgelessRootBlockComponent,
-  ElementModel,
   NoteBlockModel,
 } from '@blocksuite/blocks';
 import { beforeEach, describe, expect, test } from 'vitest';
@@ -497,7 +496,7 @@ test('the actual rendering order of blocks should satisfy the logic order of the
 });
 
 describe('index generator', () => {
-  let preinsertedShape: ElementModel;
+  let preinsertedShape: BlockSuite.SurfaceElementModelType;
   let preinsertedNote: NoteBlockModel;
 
   beforeEach(() => {
@@ -508,7 +507,9 @@ describe('index generator', () => {
       index: service.layer.generateIndex('affine:block'),
     });
 
-    preinsertedShape = service.getElementById(shapeId)! as ElementModel;
+    preinsertedShape = service.getElementById(
+      shapeId
+    )! as BlockSuite.SurfaceElementModelType;
     preinsertedNote = service.getElementById(noteId)! as NoteBlockModel;
   });
 

--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -3,7 +3,6 @@ import type {
   AffineAIPanelWidget,
   AIError,
   EdgelessCopilotWidget,
-  EdgelessModel,
   MindmapElementModel,
 } from '@blocksuite/blocks';
 import {
@@ -62,7 +61,9 @@ function actionToRenderer<T extends keyof BlockSuitePresets.AIActions>(
   ctx: CtxRecord
 ): AnswerRenderer {
   if (id === 'brainstormMindmap') {
-    const selectedElements = ctx.get()['selectedElements'] as EdgelessModel[];
+    const selectedElements = ctx.get()[
+      'selectedElements'
+    ] as BlockSuite.EdgelessModelType[];
 
     if (
       isMindMapRoot(selectedElements[0] || isMindmapChild(selectedElements[0]))
@@ -98,7 +99,7 @@ function actionToRenderer<T extends keyof BlockSuitePresets.AIActions>(
 
 export async function getContentFromSelected(
   host: EditorHost,
-  selected: EdgelessModel[]
+  selected: BlockSuite.EdgelessModelType[]
 ) {
   const { notes, texts, shapes, images } = selected.reduce<{
     notes: NoteBlockModel[];

--- a/packages/presets/src/ai/actions/edgeless-response.ts
+++ b/packages/presets/src/ai/actions/edgeless-response.ts
@@ -4,7 +4,6 @@ import type {
   AIItemConfig,
   EdgelessCopilotWidget,
   EdgelessElementToolbarWidget,
-  EdgelessModel,
   EdgelessRootService,
   MindmapElementModel,
   ShapeElementModel,
@@ -224,7 +223,9 @@ export const responses: {
       'affine:surface'
     ) as SurfaceBlockModel[];
 
-    const elements = ctx.get()['selectedElements'] as EdgelessModel[];
+    const elements = ctx.get()[
+      'selectedElements'
+    ] as BlockSuite.EdgelessModelType[];
     const data = ctx.get() as {
       node: MindMapNode;
     };
@@ -276,7 +277,9 @@ export const responses: {
     const [surface] = host.doc.getBlockByFlavour(
       'affine:surface'
     ) as SurfaceBlockModel[];
-    const elements = ctx.get()['selectedElements'] as EdgelessModel[];
+    const elements = ctx.get()[
+      'selectedElements'
+    ] as BlockSuite.EdgelessModelType[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = ctx.get() as any;
     let newGenerated = true;

--- a/packages/presets/src/ai/actions/types.ts
+++ b/packages/presets/src/ai/actions/types.ts
@@ -1,5 +1,4 @@
 import type { EditorHost } from '@blocksuite/block-std';
-import type { ElementModel } from '@blocksuite/blocks';
 import type { BlockModel } from '@blocksuite/store';
 
 export const translateLangs = [
@@ -56,7 +55,7 @@ declare global {
 
       // internal context
       host: EditorHost;
-      models?: (BlockModel | ElementModel)[];
+      models?: (BlockModel | BlockSuite.SurfaceElementModelType)[];
       control: 'format-bar' | 'slash-menu' | 'chat-send';
       where: 'chat-panel' | 'inline-chat-panel' | 'ai-panel';
     }

--- a/packages/presets/src/ai/utils/edgeless.ts
+++ b/packages/presets/src/ai/utils/edgeless.ts
@@ -5,7 +5,6 @@ import type {
 } from '@blocksuite/blocks';
 import {
   AFFINE_EDGELESS_COPILOT_WIDGET,
-  type EdgelessModel,
   MindmapElementModel,
   type ShapeElementModel,
 } from '@blocksuite/blocks';
@@ -31,13 +30,13 @@ export function mindMapToMarkdown(mindmap: MindmapElementModel) {
   return markdownStr;
 }
 
-export function isMindMapRoot(ele: EdgelessModel) {
+export function isMindMapRoot(ele: BlockSuite.EdgelessModelType) {
   const group = ele?.group;
 
   return group instanceof MindmapElementModel && group.tree.element === ele;
 }
 
-export function isMindmapChild(ele: EdgelessModel) {
+export function isMindmapChild(ele: BlockSuite.EdgelessModelType) {
   return ele?.group instanceof MindmapElementModel && !isMindMapRoot(ele);
 }
 

--- a/packages/presets/src/ai/utils/selection-utils.ts
+++ b/packages/presets/src/ai/utils/selection-utils.ts
@@ -2,7 +2,6 @@ import type { EditorHost } from '@blocksuite/block-std';
 import type {
   CopilotSelectionController,
   EdgelessBlock,
-  EdgelessModel,
   FrameBlockModel,
   ImageBlockModel,
   SurfaceBlockComponent,
@@ -199,7 +198,9 @@ export const getSelectedNoteAnchor = (host: EditorHost, id: string) => {
   return host.querySelector(`[data-portal-block-id="${id}"] .note-background`);
 };
 
-export function getCopilotSelectedElems(host: EditorHost): EdgelessModel[] {
+export function getCopilotSelectedElems(
+  host: EditorHost
+): BlockSuite.EdgelessModelType[] {
   const service = getService(host);
   const copilotWidget = getEdgelessCopilotWidget(host);
 


### PR DESCRIPTION
In Edgeless, there are two types of elements: block elements and surface(canvas) elements. The current codebase uses a large number of types to distinguish and represent these different types of elements. However, these types are scattered across root-block/edgeless and surface-block, lacking consistency and intuitive naming.

This PR mainly makes two changes:

1. Determine the storage location of the related types based on the type of whiteboard elements: block elements (such as note, frame, embed-*) are placed under root-block/edgeless, while surface elements (such as text, shape, connector) are placed under surface-block.

2. Add types through a global type space.

```ts
// surface element
declare global {
  namespace BlockSuite {
    interface SurfaceElementModelMap {}
    type SurfaceElementModelType =
      | SurfaceElementModelMap[keyof SurfaceElementModelMap]
      | SurfaceElementModel;

    interface SurfaceGroupLikeModelMap {}
    type SurfaceGroupLikeModelType =
      | SurfaceGroupLikeModelMap[keyof SurfaceGroupLikeModelMap]
      | SurfaceGroupLikeModel;

    interface SurfaceLocalModelMap {}
    type SurfaceLocalModelType =
      | SurfaceLocalModelMap[keyof SurfaceLocalModelMap]
      | SurfaceLocalModel;

    // not include local model
    type SurfaceModelType = SurfaceElementModelType | SurfaceGroupLikeModelType;
  }
}

// add type for `shape`
declare global {
  namespace BlockSuite {
    interface SurfaceElementModelMap {
      shape: ShapeElementModel;
    }
  }
}
// add type for `connector`
declare global {
  namespace BlockSuite {
    interface SurfaceElementModelMap {
      connector: ConnectorElementModel;
    }
    interface SurfaceLocalModelMap {
      connector: LocalConnectorElementModel;
    }
  }
}
```

```ts
// edgeless element
declare global {
  namespace BlockSuite {
    interface EdgelessBlockModelMap {}
    type EdgelessBlockModelType =
      | EdgelessBlockModelMap[keyof EdgelessBlockModelMap]
      | EdgelessBlockModel;

    type EdgelessModelType = EdgelessBlockModelType | SurfaceModelType;
  }
}

// add type for `note`
declare global {
  namespace BlockSuite {
    interface EdgelessBlockModelMap {
      'affine:note': NoteBlockModel;
    }
  }
}
```

![15c0c03eb8ab7d574dd6d562a1a2a157](https://github.com/toeverything/blocksuite/assets/50035259/629a30cd-952b-4566-b714-1d220c0af48f)
