### PR TITLE
refactor: add common clone elements logic for copy, clone, duplicate scenes

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -35,6 +35,7 @@ import {
 } from '../../../../surface-block/index.js';
 import { isConnectorAndBindingsAllSelected } from '../../../../surface-block/managers/connector-manager.js';
 import { edgelessElementsBound } from '../../utils/bound-utils.js';
+import { prepareCloneData } from '../../utils/clone-utils.js';
 import { calPanDelta } from '../../utils/panning-utils.js';
 import {
   isCanvasElement,
@@ -49,7 +50,6 @@ import {
   mountShapeTextEditor,
   mountTextElementEditor,
 } from '../../utils/text.js';
-import { prepareClipboardData } from '../clipboard.js';
 import { EdgelessToolController } from './index.js';
 
 export enum DefaultModeDragType {
@@ -468,10 +468,7 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     const { _edgeless } = this;
     const { clipboardController } = _edgeless;
 
-    const { snapshot } = await prepareClipboardData(
-      this._toBeMoved,
-      _edgeless.std
-    );
+    const snapshot = await prepareCloneData(this._toBeMoved, _edgeless.std);
 
     const bound = edgelessElementsBound(this._toBeMoved);
     const [elements, blocks] =

--- a/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
@@ -2,12 +2,9 @@ import { groupBy } from '../../../_common/utils/iterable.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
-import {
-  getCopyElements,
-  prepareClipboardData,
-} from '../controllers/clipboard.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 import { edgelessElementsBound } from './bound-utils.js';
+import { getCloneElements, prepareCloneData } from './clone-utils.js';
 import { getElementsWithoutGroup } from './group.js';
 import { isFrameBlock, isImageBlock, isNoteBlock } from './query.js';
 
@@ -18,12 +15,14 @@ export async function duplicate(
   select = true
 ) {
   const { clipboardController } = edgeless;
-  const copyElements = getCopyElements(edgeless.surface, elements);
+  const copyElements = getCloneElements(
+    elements,
+    edgeless.surface.edgeless.service.frame
+  );
   const totalBound = edgelessElementsBound(copyElements);
   totalBound.x += totalBound.w + offset;
 
-  const { snapshot } = await prepareClipboardData(copyElements, edgeless.std);
-
+  const snapshot = await prepareCloneData(copyElements, edgeless.std);
   const [canvasElements, blocks] =
     await clipboardController.createElementsFromClipboardData(
       snapshot as Record<string, unknown>[],

--- a/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
@@ -1,0 +1,76 @@
+import type { BlockStdScope } from '@blocksuite/block-std';
+import { Job } from '@blocksuite/store';
+
+import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
+import { ConnectorElementModel } from '../../../surface-block/index.js';
+import type { EdgelessFrameManager } from '../frame-manager.js';
+import { EdgelessBlockModel } from '../type.js';
+import { isFrameBlock } from '../utils/query.js';
+
+export function getCloneElements(
+  elements: BlockSuite.EdgelessModelType[],
+  frame: EdgelessFrameManager
+) {
+  const set = new Set<BlockSuite.EdgelessModelType>();
+  elements.forEach(element => {
+    set.add(element);
+    if (isFrameBlock(element)) {
+      frame.getElementsInFrame(element).forEach(ele => set.add(ele));
+    } else if (element instanceof SurfaceGroupLikeModel) {
+      const children = element.childElements;
+      getCloneElements(children, frame).forEach(ele => set.add(ele));
+    }
+  });
+  return Array.from(set);
+}
+
+export async function prepareCloneData(
+  elements: BlockSuite.EdgelessModelType[],
+  std: BlockStdScope
+) {
+  const job = new Job({
+    collection: std.collection,
+  });
+  const res = await Promise.all(
+    elements.map(async element => {
+      const data = await serializeElement(element, elements, job);
+      return data;
+    })
+  );
+  return res.filter(d => !!d);
+}
+
+export async function serializeElement(
+  element: BlockSuite.EdgelessModelType,
+  elements: BlockSuite.EdgelessModelType[],
+  job: Job
+) {
+  if (element instanceof EdgelessBlockModel) {
+    const snapshot = await job.blockToSnapshot(element);
+    return { ...snapshot };
+  } else if (element instanceof ConnectorElementModel) {
+    return serializeConnector(element, elements);
+  } else {
+    return element.serialize();
+  }
+}
+
+export function serializeConnector(
+  connector: ConnectorElementModel,
+  elements: BlockSuite.EdgelessModelType[]
+) {
+  const sourceId = connector.source?.id;
+  const targetId = connector.target?.id;
+  const serialized = connector.serialize();
+  // if the source or target element not to be cloned
+  // transfer connector position to absolute path
+  if (sourceId && elements.every(s => s.id !== sourceId)) {
+    serialized.source = { position: connector.absolutePath[0] };
+  }
+  if (targetId && elements.every(s => s.id !== targetId)) {
+    serialized.target = {
+      position: connector.absolutePath[connector.absolutePath.length - 1],
+    };
+  }
+  return serialized;
+}

--- a/tests/edgeless/clipboard.spec.ts
+++ b/tests/edgeless/clipboard.spec.ts
@@ -4,6 +4,8 @@ import {
   createConnectorElement,
   createNote,
   createShapeElement,
+  decreaseZoomLevel,
+  edgelessCommonSetup,
   getAllSortedIds,
   getTypeById,
   Shape,
@@ -189,5 +191,154 @@ test.describe('connector clipboard', () => {
     expect(await getTypeById(page, sortedIds[2])).toBe(
       await getTypeById(page, sortedIds[5])
     );
+  });
+});
+
+test.describe('group clipboard', () => {
+  test('copy and paste group with shape and note inside', async ({ page }) => {
+    await commonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(3);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(6);
+  });
+
+  // FIX ME: can not group a group inside
+  test.skip('copy and paste group with group inside', async ({ page }) => {
+    await commonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createShapeElement(page, [200, 0], [300, 100], Shape.Square);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'createGroupOnMoreOption');
+
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(5);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(10);
+  });
+
+  // FIX ME: paste position unexpected & redundant empty note
+  test.skip('copy and paste group with frame inside', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+
+    await decreaseZoomLevel(page);
+    await createShapeElement(page, [700, 0], [800, 100], Shape.Square);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(5);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(10);
+  });
+});
+
+test.describe('frame clipboard', () => {
+  test('copy and paste frame with shape elements inside', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(3);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(6);
+  });
+
+  test('copy and paste frame with group elements inside', async ({ page }) => {
+    await commonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    await createShapeElement(page, [200, 0], [300, 100], Shape.Square);
+    await triggerComponentToolbarAction(page, 'createFrameOnMoreOption');
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(5);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(10);
+  });
+
+  test('copy and paste frame with frame inside', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+    await createNote(page, [100, -100]);
+    await page.mouse.click(10, 50);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+
+    await decreaseZoomLevel(page);
+    await createShapeElement(page, [700, 0], [800, 100], Shape.Square);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+
+    const originIds = await getAllSortedIds(page);
+    expect(originIds.length).toBe(5);
+
+    await copyByKeyboard(page);
+    const move = await toViewCoord(page, [250, 250]);
+    await page.mouse.move(move[0], move[1]);
+    await page.mouse.click(move[0], move[1]);
+    await pasteByKeyboard(page, true);
+    await waitNextFrame(page, 500);
+    const sortedIds = await getAllSortedIds(page);
+    expect(sortedIds.length).toBe(10);
   });
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -798,6 +798,7 @@ type Action =
   | 'changeConnectorStrokeStyles'
   | 'addFrame'
   | 'addGroup'
+  | 'createGroupOnMoreOption'
   | 'ungroup'
   | 'releaseFromGroup'
   | 'createFrameOnMoreOption'
@@ -951,6 +952,18 @@ export async function triggerComponentToolbarAction(
         'edgeless-add-group-button'
       );
       await button.click();
+      break;
+    }
+    case 'createGroupOnMoreOption': {
+      const moreButton = locatorComponentToolbarMoreButton(page);
+      await moreButton.click();
+
+      const actionButton = moreButton
+        .locator('.more-actions-container .action-item')
+        .filter({
+          hasText: 'Group Section',
+        });
+      await actionButton.click();
       break;
     }
     case 'ungroup': {


### PR DESCRIPTION
- Refactor the logic of `getCopyElements` and `prepareClipboardData` in the clipboard, split into several atomic functions so they can be easily reused in copy, clone and duplicate scenarios
- Use `instanceof EdgelessBlockModel` assert instead of enum `isXXBlock` assert
- Add several e2e tests for copy group and frame cases