### PR TITLE
feat(blocks): add caption for code block

### DIFF
--- a/packages/blocks/src/_common/components/block-caption.ts
+++ b/packages/blocks/src/_common/components/block-caption.ts
@@ -1,21 +1,23 @@
+import type { BlockElement } from '@blocksuite/block-std';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import type { BlockModel } from '@blocksuite/store';
 import { Text } from '@blocksuite/store';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
-import type { AttachmentBlockComponent } from '../../../attachment-block/attachment-block.js';
-import type { EmbedHtmlBlockComponent } from '../../../embed-html-block/embed-html-block.js';
-import type { EmbedSyncedDocBlockComponent } from '../../../embed-synced-doc-block/embed-synced-doc-block.js';
-import type { ImageBlockComponent } from '../../../image-block/image-block.js';
-import type { SurfaceRefBlockComponent } from '../../../surface-ref-block/surface-ref-block.js';
-import { stopPropagation } from '../../utils/event.js';
-import { asyncFocusRichText } from '../../utils/selection.js';
-import type { EmbedToolbarBlockElement } from './type.js';
+import { stopPropagation } from '../utils/event.js';
+import { asyncFocusRichText } from '../utils/selection.js';
 
-@customElement('embed-card-caption')
-export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
+export interface BlockCaptionProps {
+  caption: string | null | undefined;
+}
+
+@customElement('block-caption-editor')
+export class BlockCaptionEditor<
+  Model extends BlockModel<BlockCaptionProps> = BlockModel<BlockCaptionProps>,
+> extends WithDisposable(ShadowlessElement) {
   static override styles = css`
-    .affine-embed-card-caption {
+    .block-caption-editor {
       display: inline-table;
       resize: none;
       width: 100%;
@@ -27,19 +29,13 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
       font-family: inherit;
       text-align: center;
     }
-    .affine-embed-card-caption::placeholder {
+    .block-caption-editor::placeholder {
       color: var(--affine-placeholder-color);
     }
   `;
 
   @property({ attribute: false })
-  accessor block!:
-    | EmbedToolbarBlockElement
-    | AttachmentBlockComponent
-    | ImageBlockComponent
-    | EmbedHtmlBlockComponent
-    | SurfaceRefBlockComponent
-    | EmbedSyncedDocBlockComponent;
+  accessor block!: BlockElement<Model> & { isInSurface?: boolean };
 
   @state()
   accessor display = false;
@@ -47,7 +43,7 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
   @state()
   accessor caption: string | null | undefined = undefined;
 
-  @query('.affine-embed-card-caption')
+  @query('.block-caption-editor')
   accessor input!: HTMLInputElement;
 
   private _focus = false;
@@ -138,7 +134,7 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
     return html`<textarea
       .disabled=${this.block.doc.readonly}
       placeholder="Write a caption"
-      class="affine-embed-card-caption"
+      class="block-caption-editor"
       .value=${this.caption ?? ''}
       @input=${this._onInputChange}
       @focus=${this._onInputFocus}
@@ -157,6 +153,6 @@ export class EmbedCardCaption extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'embed-card-caption': EmbedCardCaption;
+    'block-caption-editor': BlockCaptionEditor;
   }
 }

--- a/packages/blocks/src/_common/components/index.ts
+++ b/packages/blocks/src/_common/components/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-item/index.js';
+export * from './block-caption.js';
 export * from './block-selection.js';
 export * from './drag-indicator.js';
 export * from './file-drop-manager.js';
@@ -9,6 +10,7 @@ export * from './notification-service.js';
 export * from './rich-text/rich-text.js';
 export * from './toast.js';
 export * from './tooltip/index.js';
+
 import './portal.js';
 
 export { scrollbarStyle } from './utils.js';

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -1,5 +1,4 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { BlockElement } from '@blocksuite/block-std';
 import { flip, offset } from '@floating-ui/dom';
@@ -9,7 +8,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ref } from 'lit/directives/ref.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/index.js';
 import { HoverController } from '../_common/components/index.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import {
@@ -52,8 +51,8 @@ export class AttachmentBlockComponent extends BlockElement<
   @property({ attribute: false })
   accessor allowEmbed = false;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   @state()
   private accessor _showOverlay = true;
@@ -317,7 +316,7 @@ export class AttachmentBlockComponent extends BlockElement<
               <div class="affine-attachment-banner">${FileTypeIcon}</div>
             </div>`}
 
-        <embed-card-caption .block=${this}></embed-card-caption>
+        <block-caption-editor .block=${this}></block-caption-editor>
 
         <affine-block-selection .block=${this}></affine-block-selection>
       </div>

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -1,13 +1,12 @@
 import './components/bookmark-card.js';
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { BlockElement } from '@blocksuite/block-std';
 import { html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import { type BookmarkBlockModel } from './bookmark-model.js';
@@ -28,8 +27,8 @@ export class BookmarkBlockComponent extends BlockElement<
   @query('bookmark-card')
   accessor bookmarkCard!: HTMLElement;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isInSurface = false;
 
@@ -110,7 +109,7 @@ export class BookmarkBlockComponent extends BlockElement<
           .error=${this.error}
         ></bookmark-card>
 
-        <embed-card-caption .block=${this}></embed-card-caption>
+        <block-caption-editor .block=${this}></block-caption-editor>
 
         <affine-block-selection .block=${this}></affine-block-selection>
       </div>

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -17,6 +17,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { type BundledLanguage, type Highlighter } from 'shiki';
 import { z } from 'zod';
 
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { toast } from '../_common/components/toast.js';
@@ -46,6 +47,9 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
   @query('.lang-button')
   private accessor _langButton!: HTMLButtonElement;
+
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   @state()
   private accessor _langListAbortController: AbortController | undefined =
@@ -446,33 +450,37 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
   override renderBlock(): TemplateResult<1> {
     return html`
-      <div
-        class=${classMap({
-          'affine-code-block-container': true,
-          wrap: this.model.wrap,
-        })}
-      >
-        ${this._curLanguageButtonTemplate()}
+      <div class="affine-code-block-wrapper">
+        <div
+          class=${classMap({
+            'affine-code-block-container': true,
+            wrap: this.model.wrap,
+          })}
+        >
+          ${this._curLanguageButtonTemplate()}
 
-        <div class="rich-text-container">
-          <div contenteditable="false" id="line-numbers"></div>
-          <rich-text
-            .yText=${this.model.text.yText}
-            .inlineEventSource=${this.topContenteditableElement ?? nothing}
-            .undoManager=${this.doc.history}
-            .attributesSchema=${this.attributesSchema}
-            .attributeRenderer=${this.getAttributeRenderer()}
-            .readonly=${this.doc.readonly}
-            .inlineRangeProvider=${this._inlineRangeProvider}
-            .enableClipboard=${false}
-            .enableUndoRedo=${false}
-            .wrapText=${this.model.wrap}
-            .verticalScrollContainer=${getViewportElement(this.host)}
-          >
-          </rich-text>
+          <div class="rich-text-container">
+            <div contenteditable="false" id="line-numbers"></div>
+            <rich-text
+              .yText=${this.model.text.yText}
+              .inlineEventSource=${this.topContenteditableElement ?? nothing}
+              .undoManager=${this.doc.history}
+              .attributesSchema=${this.attributesSchema}
+              .attributeRenderer=${this.getAttributeRenderer()}
+              .readonly=${this.doc.readonly}
+              .inlineRangeProvider=${this._inlineRangeProvider}
+              .enableClipboard=${false}
+              .enableUndoRedo=${false}
+              .wrapText=${this.model.wrap}
+              .verticalScrollContainer=${getViewportElement(this.host)}
+            >
+            </rich-text>
+          </div>
+
+          ${this.renderChildren(this.model)} ${Object.values(this.widgets)}
         </div>
 
-        ${this.renderChildren(this.model)} ${Object.values(this.widgets)}
+        <block-caption-editor .block=${this}></block-caption-editor>
         <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;

--- a/packages/blocks/src/code-block/code-model.ts
+++ b/packages/blocks/src/code-block/code-model.ts
@@ -9,6 +9,7 @@ export const CodeBlockSchema = defineBlockSchema({
     text: internal.Text(),
     language: FALLBACK_LANG,
     wrap: false,
+    caption: '',
   }),
   metadata: {
     version: 1,

--- a/packages/blocks/src/code-block/styles.ts
+++ b/packages/blocks/src/code-block/styles.ts
@@ -5,15 +5,19 @@ export const codeBlockStyles = css`
     position: relative;
     z-index: 1;
   }
+  .affine-code-block-wrapper {
+    position: relative;
+    margin: 24px 0px;
+  }
 
   .affine-code-block-container {
     font-size: var(--affine-font-sm);
     line-height: var(--affine-line-height);
     position: relative;
     padding: 32px 24px;
+    margin-bottom: 4px;
     background: var(--affine-background-code-block);
     border-radius: 10px;
-    margin: 24px 0px;
     box-sizing: border-box;
   }
 

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -1,12 +1,11 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -30,8 +29,8 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
   @state()
   private accessor _showOverlay = true;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -187,7 +186,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
             </div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
 
           <affine-block-selection .block=${this}></affine-block-selection>
         </div>

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -1,5 +1,4 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
@@ -8,7 +7,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -38,8 +37,8 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
   @property({ attribute: false })
   accessor loading = false;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _selectBlock() {
     const selectionManager = this.host.selection;
@@ -288,7 +287,7 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
             <div class="affine-embed-github-banner">${bannerImage}</div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
 
           <affine-block-selection .block=${this}></affine-block-selection>
         </div>

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -1,5 +1,4 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 import './components/fullscreen-toolbar.js';
 
 import { assertExists } from '@blocksuite/global/utils';
@@ -8,7 +7,7 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
 import { Bound } from '../surface-block/utils/bound.js';
@@ -34,8 +33,8 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
   @query('.embed-html-block-iframe-wrapper')
   accessor iframeWrapper!: HTMLDivElement;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -180,7 +179,7 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
           </div>
         </div>
 
-        <embed-card-caption .block=${this}></embed-card-caption>
+        <block-caption-editor .block=${this}></block-caption-editor>
 
         <affine-block-selection .block=${this}></affine-block-selection>
       `;

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -1,5 +1,4 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
@@ -13,7 +12,7 @@ import {
 } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
@@ -65,8 +64,8 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
   @state()
   private accessor _loading = false;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   @queryAsync('.affine-embed-linked-doc-banner.render')
   accessor bannerContainer!: Promise<HTMLDivElement>;
@@ -463,7 +462,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
             <div class="affine-embed-linked-doc-block-overlay"></div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
 
           <affine-block-selection .block=${this}></affine-block-selection>
         </div>

--- a/packages/blocks/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-block.ts
@@ -1,12 +1,11 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -35,8 +34,8 @@ export class EmbedLoomBlockComponent extends EmbedBlockElement<
   @state()
   private accessor _showOverlay = true;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -220,7 +219,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockElement<
             </div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
 
           <affine-block-selection .block=${this}></affine-block-selection>
         </div>

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -1,6 +1,5 @@
 import './components/embed-synced-doc-card.js';
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
@@ -11,7 +10,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
@@ -60,8 +59,8 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   @query(':scope > .embed-block-container > affine-embed-synced-doc-card')
   accessor syncedDocCard: EmbedSyncedDocCard | null = null;
 
-  @query(':scope > .embed-block-container > embed-card-caption')
-  accessor captionElement: EmbedCardCaption | null = null;
+  @query(':scope > .embed-block-container > block-caption-editor')
+  accessor captionElement: BlockCaptionEditor | null = null;
 
   @query(
     ':scope > .embed-block-container > .affine-embed-synced-doc-container > .affine-embed-synced-doc-editor > editor-host'
@@ -434,7 +433,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
             .block=${this}
           ></affine-embed-synced-doc-card>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
         `
       );
     }
@@ -520,7 +519,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
 
           ${
             isInSurface
-              ? html`<embed-card-caption .block=${this}></embed-card-caption>`
+              ? html`<block-caption-editor
+                  .block=${this}
+                ></block-caption-editor>`
               : nothing
           }
 

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -1,12 +1,11 @@
 import '../_common/components/block-selection.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -41,8 +40,8 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
   @state()
   private accessor _showImage = false;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -266,7 +265,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
             </div>
           </div>
 
-          <embed-card-caption .block=${this}></embed-card-caption>
+          <block-caption-editor .block=${this}></block-caption-editor>
 
           <affine-block-selection .block=${this}></affine-block-selection>
         </div>

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -1,7 +1,6 @@
 import './components/image-card.js';
 import './components/page-image-block.js';
 import './components/edgeless-image-block.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 import '../_common/components/block-selection.js';
 
 import { BlockElement } from '@blocksuite/block-std';
@@ -9,7 +8,7 @@ import { html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import type { ImageBlockEdgelessComponent } from './components/edgeless-image-block.js';
 import type { AffineImageCard } from './components/image-card.js';
@@ -59,8 +58,8 @@ export class ImageBlockComponent extends BlockElement<
   @query('affine-edgeless-image')
   private accessor _edgelessImage: ImageBlockEdgelessComponent | null = null;
 
-  @query('embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isInSurface = false;
 
@@ -201,7 +200,7 @@ export class ImageBlockComponent extends BlockElement<
               ></affine-edgeless-image>`
             : html`<affine-page-image .block=${this}></affine-page-image>`}
 
-        <embed-card-caption .block=${this}></embed-card-caption>
+        <block-caption-editor .block=${this}></block-caption-editor>
 
         <affine-block-selection .block=${this}></affine-block-selection>
       </div>

--- a/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
@@ -1,5 +1,6 @@
 import {
   CancelWrapIcon,
+  CaptionIcon,
   CopyIcon,
   DeleteIcon,
   DuplicateIcon,
@@ -17,6 +18,16 @@ export const defaultItems: CodeToolbarItem[] = [
     showWhen: () => true,
     action: codeBlock => {
       codeBlock.copyCode();
+    },
+  },
+  {
+    type: 'action',
+    name: 'caption',
+    icon: CaptionIcon,
+    tooltip: 'Caption',
+    showWhen: blockElement => !blockElement.doc.readonly,
+    action: codeBlock => {
+      codeBlock.captionElement.show();
     },
   },
 ];

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -1,5 +1,4 @@
 import './surface-ref-portal.js';
-import '../_common/components/embed-card/embed-card-caption.js';
 
 import { PathFinder } from '@blocksuite/block-std';
 import { BlockElement } from '@blocksuite/block-std';
@@ -8,7 +7,7 @@ import { css, html, nothing, type TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EmbedCardCaption } from '../_common/components/embed-card/embed-card-caption.js';
+import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import {
   EdgelessModeIcon,
   FrameIcon,
@@ -232,8 +231,8 @@ export class SurfaceRefBlockComponent extends BlockElement<
   @query('surface-ref-portal')
   accessor portal!: SurfaceRefPortal;
 
-  @query('affine-surface-ref > embed-card-caption')
-  accessor captionElement!: EmbedCardCaption;
+  @query('affine-surface-ref > block-caption-editor')
+  accessor captionElement!: BlockCaptionEditor;
 
   private _isInSurface = false;
 
@@ -602,7 +601,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
         ${content}
       </div>
 
-      <embed-card-caption .block=${this}></embed-card-caption>
+      <block-caption-editor .block=${this}></block-caption-editor>
 
       ${Object.values(this.widgets)}
     `;

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -27,6 +27,7 @@ import {
   type,
   undoByKeyboard,
   updateBlockType,
+  waitNextFrame,
 } from './utils/actions/index.js';
 import {
   assertBlockCount,
@@ -60,6 +61,7 @@ function getCodeBlock(page: Page) {
 
   const copyButton = codeToolbar.getByTestId('copy-code');
   const moreButton = codeToolbar.getByTestId('more-button');
+  const captionButton = codeToolbar.getByTestId('caption');
 
   const moreMenu = page.locator('affine-menu');
 
@@ -85,14 +87,16 @@ function getCodeBlock(page: Page) {
   return {
     codeBlock,
     codeToolbar,
+    captionButton,
     languageButton,
-    clickLanguageButton,
     langList,
     copyButton,
     moreButton,
-    openMore,
     langFilterInput,
     moreMenu,
+
+    openMore,
+    clickLanguageButton,
   };
 }
 
@@ -184,6 +188,7 @@ test('use markdown syntax can create code block', async ({ page }) => {
   prop:index="a0"
 >
   <affine:code
+    prop:caption=""
     prop:language="Plain Text"
     prop:wrap={false}
   />
@@ -300,6 +305,7 @@ test('change code language can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="rust"
   prop:wrap={false}
 />`,
@@ -310,6 +316,7 @@ test('change code language can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={false}
 />`,
@@ -442,11 +449,13 @@ test.skip('use keyboard copy inside code block copy', async ({ page }) => {
     prop:index="a0"
   >
     <affine:code
+      prop:caption=""
       prop:language="Plain Text"
       prop:text="use"
       prop:wrap={false}
     />
     <affine:code
+      prop:caption=""
       prop:language="Plain Text"
       prop:text="use"
       prop:wrap={false}
@@ -494,11 +503,13 @@ test('code block has content, click code block copy menu, copy whole code block'
     prop:index="a0"
   >
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:text="use"
       prop:wrap={false}
     />
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:text="use"
       prop:wrap={false}
@@ -545,10 +556,12 @@ test('code block is empty, click code block copy menu, copy the empty code block
     prop:index="a0"
   >
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:wrap={false}
     />
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:wrap={false}
     />
@@ -589,10 +602,12 @@ test('duplicate code block in more menu', async ({ page }) => {
     prop:index="a0"
   >
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:wrap={false}
     />
     <affine:code
+      prop:caption=""
       prop:language="javascript"
       prop:wrap={false}
     />
@@ -841,6 +856,29 @@ test('should tab works in code block', async ({ page }) => {
   await assertRichTexts(page, ['const a = 10;\n  \nconst b = "NothingToSay"']);
 });
 
+test('add caption works', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  const { codeBlockId } = await initEmptyCodeBlockState(page);
+
+  const codeBlockController = getCodeBlock(page);
+  await codeBlockController.codeBlock.hover();
+  await codeBlockController.captionButton.click();
+  await type(page, 'BlockSuite');
+  await pressEnter(page);
+  await waitNextFrame(page, 100);
+
+  await assertStoreMatchJSX(
+    page,
+    /*xml*/ `
+<affine:code
+  prop:caption="BlockSuite"
+  prop:language="Plain Text"
+  prop:wrap={false}
+/>`,
+    codeBlockId
+  );
+});
+
 test('toggle code block wrap can work', async ({ page }) => {
   await enterPlaygroundRoom(page);
   const { codeBlockId } = await initEmptyCodeBlockState(page);
@@ -851,6 +889,7 @@ test('toggle code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={false}
 />`,
@@ -868,6 +907,7 @@ test('toggle code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={true}
 />`,
@@ -879,6 +919,7 @@ test('toggle code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={false}
 />`,
@@ -896,6 +937,7 @@ test('undo code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={false}
 />`,
@@ -908,6 +950,7 @@ test('undo code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={true}
 />`,
@@ -920,6 +963,7 @@ test('undo code block wrap can work', async ({ page }) => {
     page,
     /*xml*/ `
 <affine:code
+  prop:caption=""
   prop:language="Plain Text"
   prop:wrap={false}
 />`,

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -1316,6 +1316,7 @@ test('should format quick bar show after convert to code block', async ({
   prop:index="a0"
 >
   <affine:code
+    prop:caption=""
     prop:language="Plain Text"
     prop:text="123\n456\n789"
     prop:wrap={false}

--- a/tests/image.spec.ts
+++ b/tests/image.spec.ts
@@ -140,7 +140,7 @@ test('enter shortcut on focusing embed block and its caption', async ({
   await moveToImage(page);
   await assertImageOption(page);
 
-  const caption = page.locator('affine-image embed-card-caption textarea');
+  const caption = page.locator('affine-image block-caption-editor textarea');
   await focusCaption(page);
   await type(page, '123');
 
@@ -164,7 +164,7 @@ test('should support the enter key of image caption', async ({ page }) => {
   await moveToImage(page);
   await assertImageOption(page);
 
-  const caption = page.locator('affine-image embed-card-caption textarea');
+  const caption = page.locator('affine-image block-caption-editor textarea');
   await focusCaption(page);
   await type(page, 'abc123');
   await pressArrowLeft(page, 3);


### PR DESCRIPTION
This PR
- Adds caption for code block
- Moves the `embed-card-caption` component to `block-caption-editor` which can be used with any block with a `caption` prop

Closes: [AFF-1138](https://linear.app/affine-design/issue/AFF-1138/add-caption-function-for-code-block)