### PR TITLE
feat(blocks): add notify method to NotificationService

### DIFF
--- a/packages/blocks/src/_common/components/notification-service.ts
+++ b/packages/blocks/src/_common/components/notification-service.ts
@@ -15,4 +15,10 @@ export interface NotificationService {
     cancelText: string;
     abort?: AbortSignal;
   }): Promise<boolean>;
+  notify(notification: {
+    title: string | TemplateResult;
+    message?: string | TemplateResult;
+    accent?: 'info' | 'success' | 'warning' | 'error';
+    duration?: number; // give 0 to disable auto dismiss
+  }): void;
 }

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -109,6 +109,10 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
             confirm: notification => {
               return Promise.resolve(confirm(notification.title));
             },
+            notify: notification => {
+              // todo: implement in playground
+              console.log(notification);
+            },
           };
           pageRootService.quickSearchService = {
             async searchDoc({ userInput }) {

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -158,6 +158,10 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
             confirm: notification => {
               return Promise.resolve(confirm(notification.title));
             },
+            notify: notification => {
+              // todo: implement in playground
+              console.log(notification);
+            },
           };
           pageRootService.quickSearchService = {
             async searchDoc({ userInput }) {


### PR DESCRIPTION
```ts
  notify(notification: {
    title: string | TemplateResult;
    message?: string | TemplateResult;
    accent?: 'info' | 'success' | 'warning' | 'error';
    duration?: number; // give 0 to disable auto dismiss
  }): void;
```