### PR TITLE
fix(std): hot key should not be case sensitive

### DIFF
--- a/packages/framework/block-std/src/event/keymap.ts
+++ b/packages/framework/block-std/src/event/keymap.ts
@@ -50,6 +50,7 @@ function normalizeKeyName(name: string) {
 }
 
 function modifiers(name: string, event: KeyboardEvent, shift = true) {
+  if (name.length === 1) name = name.toLocaleLowerCase();
   if (event.altKey) name = 'Alt-' + name;
   if (event.ctrlKey) name = 'Ctrl-' + name;
   if (event.metaKey) name = 'Meta-' + name;


### PR DESCRIPTION
The current editor, when caps lock is on, exhibits unexpected behavior for some shortcuts, such as:

- redo (Ctrl+Y), not work
- select all (Ctrl+A), which selects all the text directly, rather than all the text in the line.