### PR TITLE
refactor(blocks): extract common components from blocks

### DIFF
--- a/packages/blocks/src/_common/components/block-component.ts
+++ b/packages/blocks/src/_common/components/block-component.ts
@@ -1,0 +1,48 @@
+import { BlockElement, type BlockService } from '@blocksuite/block-std';
+import { type BlockModel } from '@blocksuite/store';
+import { html, nothing } from 'lit';
+import { query } from 'lit/decorators.js';
+import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
+
+import type { BlockCaptionEditor } from './block-caption.js';
+
+export class BlockComponent<
+  Model extends BlockModel = BlockModel,
+  Service extends BlockService = BlockService,
+  WidgetName extends string = string,
+> extends BlockElement<Model, Service, WidgetName> {
+  protected accessor useCaptionEditor = false;
+
+  protected accessor blockContainerStyles: StyleInfo | undefined = undefined;
+
+  @query('.affine-block-component > block-caption-editor')
+  private accessor _captionEditor!: BlockCaptionEditor | null;
+
+  constructor() {
+    super();
+    this.addRenderer(this._renderWithWidget);
+  }
+
+  get captionEditor() {
+    if (!this.useCaptionEditor || !this._captionEditor)
+      throw new Error(
+        'Oops! Please enable useCaptionEditor before accessing captionEditor'
+      );
+    return this._captionEditor;
+  }
+
+  private _renderWithWidget(content: unknown) {
+    const style = styleMap({
+      position: 'relative',
+      ...this.blockContainerStyles,
+    });
+
+    return html`<div style=${style} class="affine-block-component">
+      ${content}
+      ${this.useCaptionEditor
+        ? html`<block-caption-editor .block=${this}></block-caption-editor>`
+        : nothing}
+      <affine-block-selection .block=${this}></affine-block-selection>
+    </div>`;
+  }
+}

--- a/packages/blocks/src/_common/components/block-selection.ts
+++ b/packages/blocks/src/_common/components/block-selection.ts
@@ -12,11 +12,9 @@ import { customElement, property } from 'lit/decorators.js';
  *     :host {
  *       position: relative;
  *     }
- *   `
+ *
  *   render() {
- *     return html`${this.selected?.is('block')
- *       ? html`<affine-block-selection></affine-block-selection>`
- *       : null}`;
+ *      return html`<affine-block-selection></affine-block-selection>
  *   };
  * }
  * ```
@@ -26,6 +24,7 @@ export class BlockSelection extends LitElement {
   static override styles = css`
     :host {
       position: absolute;
+      z-index: 1;
       left: 0;
       top: 0;
       width: 100%;

--- a/packages/blocks/src/_common/components/index.ts
+++ b/packages/blocks/src/_common/components/index.ts
@@ -1,5 +1,6 @@
 export * from './ai-item/index.js';
 export * from './block-caption.js';
+export * from './block-component.js';
 export * from './block-selection.js';
 export * from './drag-indicator.js';
 export * from './file-drop-manager.js';

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -1,5 +1,4 @@
 import type { BlockService } from '@blocksuite/block-std';
-import { BlockElement } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
@@ -17,6 +16,7 @@ import {
   convertDragPreviewEdgelessToDoc,
 } from '../../root-block/widgets/drag-handle/utils.js';
 import { Bound } from '../../surface-block/index.js';
+import { BlockComponent } from '../components/block-component.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../consts.js';
 import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
 import { type EmbedCardStyle, matchFlavours } from '../utils/index.js';
@@ -26,7 +26,8 @@ export class EmbedBlockElement<
     BlockModel<EdgelessSelectableProps> = BlockModel<EdgelessSelectableProps>,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
-> extends BlockElement<Model, Service, WidgetName> {
+> extends BlockComponent<Model, Service, WidgetName> {
+  override accessor useCaptionEditor = true;
   protected _cardStyle: EmbedCardStyle = 'horizontal';
   protected _width = EMBED_CARD_WIDTH.horizontal;
   protected _height = EMBED_CARD_HEIGHT.horizontal;
@@ -155,6 +156,10 @@ export class EmbedBlockElement<
     const parent = this.host.doc.getParent(this.model);
     this._isInSurface = parent?.flavour === 'affine:surface';
 
+    this.blockContainerStyles = this.isInSurface
+      ? undefined
+      : { margin: '18px 0' };
+
     this.disposables.add(
       AffineDragHandleWidget.registerOption(this._dragHandleOption)
     );
@@ -168,7 +173,6 @@ export class EmbedBlockElement<
           style=${styleMap({
             position: 'relative',
             width: '100%',
-            margin: '18px 0px',
           })}
         >
           ${children()}

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -1,15 +1,14 @@
-import '../_common/components/block-selection.js';
-
-import { BlockElement } from '@blocksuite/block-std';
 import { flip, offset } from '@floating-ui/dom';
 import { html, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ref } from 'lit/directives/ref.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/index.js';
-import { HoverController } from '../_common/components/index.js';
+import {
+  BlockComponent,
+  HoverController,
+} from '../_common/components/index.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import {
   AttachmentIcon16,
@@ -30,10 +29,11 @@ import { styles } from './styles.js';
 import { checkAttachmentBlob, downloadAttachmentBlob } from './utils.js';
 
 @customElement('affine-attachment')
-export class AttachmentBlockComponent extends BlockElement<
+export class AttachmentBlockComponent extends BlockComponent<
   AttachmentBlockModel,
   AttachmentBlockService
 > {
+  override accessor useCaptionEditor = true;
   static override styles = styles;
 
   @property({ attribute: false })
@@ -50,9 +50,6 @@ export class AttachmentBlockComponent extends BlockElement<
 
   @property({ attribute: false })
   accessor allowEmbed = false;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   @state()
   private accessor _showOverlay = true;
@@ -106,7 +103,7 @@ export class AttachmentBlockComponent extends BlockElement<
       template: AttachmentOptionsTemplate({
         anchor: this,
         model: this.model,
-        showCaption: () => this.captionElement.show(),
+        showCaption: () => this.captionEditor.show(),
         downloadAttachment: this.download,
         abortController,
       }),
@@ -315,10 +312,6 @@ export class AttachmentBlockComponent extends BlockElement<
 
               <div class="affine-attachment-banner">${FileTypeIcon}</div>
             </div>`}
-
-        <block-caption-editor .block=${this}></block-caption-editor>
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -1,12 +1,10 @@
 import './components/bookmark-card.js';
-import '../_common/components/block-selection.js';
 
-import { BlockElement } from '@blocksuite/block-std';
 import { html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
+import { BlockComponent } from '../_common/components/block-component.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import { type BookmarkBlockModel } from './bookmark-model.js';
@@ -14,10 +12,12 @@ import type { BookmarkBlockService } from './bookmark-service.js';
 import { refreshBookmarkUrlData } from './utils.js';
 
 @customElement('affine-bookmark')
-export class BookmarkBlockComponent extends BlockElement<
+export class BookmarkBlockComponent extends BlockComponent<
   BookmarkBlockModel,
   BookmarkBlockService
 > {
+  override accessor useCaptionEditor = true;
+
   @property({ attribute: false })
   accessor loading = false;
 
@@ -26,9 +26,6 @@ export class BookmarkBlockComponent extends BlockElement<
 
   @query('bookmark-card')
   accessor bookmarkCard!: HTMLElement;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isInSurface = false;
 
@@ -63,6 +60,10 @@ export class BookmarkBlockComponent extends BlockElement<
     const parent = this.host.doc.getParent(this.model);
     this._isInSurface = parent?.flavour === 'affine:surface';
 
+    this.blockContainerStyles = this._isInSurface
+      ? undefined
+      : { margin: '18px 0' };
+
     if (!this.model.description && !this.model.title) {
       this.refreshData();
     }
@@ -82,8 +83,8 @@ export class BookmarkBlockComponent extends BlockElement<
     let containerStyleMap = styleMap({
       position: 'relative',
       width: '100%',
-      margin: '18px 0px',
     });
+
     if (this.isInSurface) {
       const width = EMBED_CARD_WIDTH[style];
       const height = EMBED_CARD_HEIGHT[style];
@@ -108,10 +109,6 @@ export class BookmarkBlockComponent extends BlockElement<
           .loading=${this.loading}
           .error=${this.error}
         ></bookmark-card>
-
-        <block-caption-editor .block=${this}></block-caption-editor>
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
 
       ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -1,7 +1,7 @@
 import '../_common/components/rich-text/rich-text.js';
 import './components/lang-list.js';
 
-import { BlockElement, getInlineRangeProvider } from '@blocksuite/block-std';
+import { getInlineRangeProvider } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import {
   INLINE_ROOT_ATTR,
@@ -17,7 +17,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { type BundledLanguage, type Highlighter } from 'shiki';
 import { z } from 'zod';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { toast } from '../_common/components/toast.js';
@@ -26,6 +25,7 @@ import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { getViewportElement } from '../_common/utils/query.js';
 import type { NoteBlockComponent } from '../note-block/note-block.js';
 import { EdgelessRootBlockComponent } from '../root-block/edgeless/edgeless-root-block.js';
+import { BlockComponent } from './../_common/components/block-component.js';
 import { CodeClipboardController } from './clipboard/index.js';
 import type { CodeBlockModel, HighlightOptionsGetter } from './code-model.js';
 import { createLangList } from './components/lang-list.js';
@@ -42,14 +42,17 @@ import {
 import { getHighLighter } from './utils/high-lighter.js';
 
 @customElement('affine-code')
-export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
+export class CodeBlockComponent extends BlockComponent<CodeBlockModel> {
   static override styles = codeBlockStyles;
+
+  override accessor useCaptionEditor = true;
+
+  override accessor blockContainerStyles = {
+    margin: '24px 0',
+  };
 
   @query('.lang-button')
   private accessor _langButton!: HTMLButtonElement;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   @state()
   private accessor _langListAbortController: AbortController | undefined =
@@ -450,39 +453,34 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
 
   override renderBlock(): TemplateResult<1> {
     return html`
-      <div class="affine-code-block-wrapper">
-        <div
-          class=${classMap({
-            'affine-code-block-container': true,
-            wrap: this.model.wrap,
-          })}
-        >
-          ${this._curLanguageButtonTemplate()}
+      <div
+        class=${classMap({
+          'affine-code-block-container': true,
+          wrap: this.model.wrap,
+        })}
+      >
+        ${this._curLanguageButtonTemplate()}
 
-          <div class="rich-text-container">
-            <div contenteditable="false" id="line-numbers"></div>
-            <rich-text
-              .yText=${this.model.text.yText}
-              .inlineEventSource=${this.topContenteditableElement ?? nothing}
-              .undoManager=${this.doc.history}
-              .attributesSchema=${this.attributesSchema}
-              .attributeRenderer=${this.getAttributeRenderer()}
-              .readonly=${this.doc.readonly}
-              .inlineRangeProvider=${this._inlineRangeProvider}
-              .enableClipboard=${false}
-              .enableUndoRedo=${false}
-              .wrapText=${this.model.wrap}
-              .verticalScrollContainerGetter=${() =>
-                getViewportElement(this.host)}
-            >
-            </rich-text>
-          </div>
-
-          ${this.renderChildren(this.model)} ${Object.values(this.widgets)}
+        <div class="rich-text-container">
+          <div contenteditable="false" id="line-numbers"></div>
+          <rich-text
+            .yText=${this.model.text.yText}
+            .inlineEventSource=${this.topContenteditableElement ?? nothing}
+            .undoManager=${this.doc.history}
+            .attributesSchema=${this.attributesSchema}
+            .attributeRenderer=${this.getAttributeRenderer()}
+            .readonly=${this.doc.readonly}
+            .inlineRangeProvider=${this._inlineRangeProvider}
+            .enableClipboard=${false}
+            .enableUndoRedo=${false}
+            .wrapText=${this.model.wrap}
+            .verticalScrollContainerGetter=${() =>
+              getViewportElement(this.host)}
+          >
+          </rich-text>
         </div>
 
-        <block-caption-editor .block=${this}></block-caption-editor>
-        <affine-block-selection .block=${this}></affine-block-selection>
+        ${this.renderChildren(this.model)} ${Object.values(this.widgets)}
       </div>
     `;
   }

--- a/packages/blocks/src/code-block/styles.ts
+++ b/packages/blocks/src/code-block/styles.ts
@@ -1,13 +1,9 @@
 import { css } from 'lit';
 
 export const codeBlockStyles = css`
-  code-block {
+  affine-code {
     position: relative;
     z-index: 1;
-  }
-  .affine-code-block-wrapper {
-    position: relative;
-    margin: 24px 0px;
   }
 
   .affine-code-block-container {

--- a/packages/blocks/src/data-view-block/data-view-block.ts
+++ b/packages/blocks/src/data-view-block/data-view-block.ts
@@ -1,10 +1,10 @@
-import { BlockElement, RangeManager } from '@blocksuite/block-std';
+import { RangeManager } from '@blocksuite/block-std';
 import { Slice, Slot } from '@blocksuite/store';
 import { css, nothing, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
-import { popMenu } from '../_common/components/index.js';
+import { BlockComponent, popMenu } from '../_common/components/index.js';
 import {
   CopyIcon,
   DeleteIcon,
@@ -35,7 +35,7 @@ import type { DataViewBlockModel } from './data-view-model.js';
 import { BlockQueryViewSource } from './view-source.js';
 
 @customElement('affine-data-view')
-export class DataViewBlockComponent extends BlockElement<DataViewBlockModel> {
+export class DataViewBlockComponent extends BlockComponent<DataViewBlockModel> {
   static override styles = css`
     ${unsafeCSS(dataViewCommonStyle('affine-database'))}
     affine-database {
@@ -282,11 +282,6 @@ export class DataViewBlockComponent extends BlockElement<DataViewBlockModel> {
             target: () => this.innerModalWidget.target,
           },
         })}
-
-        <affine-block-selection
-          .block="${this}"
-          style="z-index: 1"
-        ></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -1,13 +1,17 @@
 import './components/title/index.js';
 
-import { BlockElement, RangeManager } from '@blocksuite/block-std';
+import { RangeManager } from '@blocksuite/block-std';
 import { Slot } from '@blocksuite/global/utils';
 import { Slice } from '@blocksuite/store';
 import { css, nothing, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
-import { DragIndicator, popMenu } from '../_common/components/index.js';
+import {
+  BlockComponent,
+  DragIndicator,
+  popMenu,
+} from '../_common/components/index.js';
 import {
   CopyIcon,
   DeleteIcon,
@@ -46,7 +50,7 @@ import type { DatabaseBlockService } from './database-service.js';
 import { DatabaseBlockViewSource } from './view-source.js';
 
 @customElement('affine-database')
-export class DatabaseBlockComponent extends BlockElement<
+export class DatabaseBlockComponent extends BlockComponent<
   DatabaseBlockModel,
   DatabaseBlockService
 > {
@@ -387,11 +391,6 @@ export class DatabaseBlockComponent extends BlockElement<
             target: () => this.innerModalWidget.target,
           },
         })}
-
-        <affine-block-selection
-          .block="${this}"
-          style="z-index: 1"
-        ></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/divider-block/divider-block.ts
+++ b/packages/blocks/src/divider-block/divider-block.ts
@@ -1,16 +1,15 @@
 /// <reference types="vite/client" />
-import '../_common/components/block-selection.js';
 
-import { BlockElement } from '@blocksuite/block-std';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import { BlockComponent } from '../_common/components/block-component.js';
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../_common/consts.js';
 import type { DividerBlockModel } from './divider-model.js';
 import { dividerBlockStyles } from './styles.js';
 
 @customElement('affine-divider')
-export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
+export class DividerBlockComponent extends BlockComponent<DividerBlockModel> {
   static override styles = dividerBlockStyles;
 
   override connectedCallback() {
@@ -40,8 +39,6 @@ export class DividerBlockComponent extends BlockElement<DividerBlockModel> {
         <hr />
 
         ${children}
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -1,11 +1,8 @@
-import '../_common/components/block-selection.js';
-
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -28,9 +25,6 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
 
   @state()
   private accessor _showOverlay = true;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -185,10 +179,6 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
               </div>
             </div>
           </div>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -1,13 +1,10 @@
-import '../_common/components/block-selection.js';
-
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -36,9 +33,6 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
 
   @property({ attribute: false })
   accessor loading = false;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _selectBlock() {
     const selectionManager = this.host.selection;
@@ -286,10 +280,6 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
 
             <div class="affine-embed-github-banner">${bannerImage}</div>
           </div>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -1,4 +1,3 @@
-import '../_common/components/block-selection.js';
 import './components/fullscreen-toolbar.js';
 
 import { assertExists } from '@blocksuite/global/utils';
@@ -7,7 +6,6 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
 import { Bound } from '../surface-block/utils/bound.js';
@@ -32,9 +30,6 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
 
   @query('.embed-html-block-iframe-wrapper')
   accessor iframeWrapper!: HTMLDivElement;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -178,10 +173,6 @@ export class EmbedHtmlBlockComponent extends EmbedBlockElement<
             <div class="affine-embed-html-title-text">${titleText}</div>
           </div>
         </div>
-
-        <block-caption-editor .block=${this}></block-caption-editor>
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       `;
     });
   }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -1,18 +1,9 @@
-import '../_common/components/block-selection.js';
-
 import { assertExists } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
 import { html, nothing } from 'lit';
-import {
-  customElement,
-  property,
-  query,
-  queryAsync,
-  state,
-} from 'lit/decorators.js';
+import { customElement, property, queryAsync, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { isPeekable, Peekable } from '../_common/components/peekable.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
@@ -65,9 +56,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
 
   @state()
   private accessor _loading = false;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   @queryAsync('.affine-embed-linked-doc-banner.render')
   accessor bannerContainer!: Promise<HTMLDivElement>;
@@ -465,10 +453,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
               : nothing}
             <div class="affine-embed-linked-doc-block-overlay"></div>
           </div>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-block.ts
@@ -1,11 +1,8 @@
-import '../_common/components/block-selection.js';
-
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -33,9 +30,6 @@ export class EmbedLoomBlockComponent extends EmbedBlockElement<
 
   @state()
   private accessor _showOverlay = true;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -218,10 +212,6 @@ export class EmbedLoomBlockComponent extends EmbedBlockElement<
               </div>
             </div>
           </div>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/embed-synced-doc-block/components/embed-synced-doc-card.ts
+++ b/packages/blocks/src/embed-synced-doc-block/components/embed-synced-doc-card.ts
@@ -1,5 +1,3 @@
-import '../../_common/components/block-selection.js';
-
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import { html, nothing } from 'lit';
 import { customElement, property, queryAsync } from 'lit/decorators.js';
@@ -260,8 +258,6 @@ export class EmbedSyncedDocCard extends WithDisposable(ShadowlessElement) {
             `
           : nothing}
       </div>
-
-      <affine-block-selection .block=${this.block}></affine-block-selection>
     `;
   }
 }

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -1,5 +1,4 @@
 import './components/embed-synced-doc-card.js';
-import '../_common/components/block-selection.js';
 
 import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
@@ -10,7 +9,6 @@ import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { Peekable } from '../_common/components/peekable.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
@@ -32,6 +30,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   EmbedSyncedDocModel,
   EmbedSyncedDocBlockService
 > {
+  override accessor useCaptionEditor = false;
   static override styles = blockStyles;
 
   @state()
@@ -58,14 +57,13 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   @state()
   private accessor _empty = false;
 
-  @query(':scope > .embed-block-container > affine-embed-synced-doc-card')
+  @query(
+    ':scope > .affine-block-component > .embed-block-container > affine-embed-synced-doc-card'
+  )
   accessor syncedDocCard: EmbedSyncedDocCard | null = null;
 
-  @query(':scope > .embed-block-container > block-caption-editor')
-  accessor captionElement: BlockCaptionEditor | null = null;
-
   @query(
-    ':scope > .embed-block-container > .affine-embed-synced-doc-container > .affine-embed-synced-doc-editor > div > editor-host'
+    ':scope > .affine-block-component > .embed-block-container > .affine-embed-synced-doc-container > .affine-embed-synced-doc-editor > div > editor-host'
   )
   accessor syncedDocEditorHost: EditorHost | null = null;
 
@@ -387,7 +385,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     this.syncedDocCard?.requestUpdate();
   }
 
-  override render() {
+  override renderBlock() {
     delete this.dataset.nestedEditor;
 
     const { style, xywh } = this.model;
@@ -429,8 +427,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
             style=${cardStyleMap}
             .block=${this}
           ></affine-embed-synced-doc-card>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
         `
       );
     }
@@ -522,13 +518,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
                 ></div>
               `
             : nothing}
-          ${isInSurface
-            ? html`
-                <block-caption-editor .block=${this}></block-caption-editor>
-              `
-            : nothing}
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -1,11 +1,8 @@
-import '../_common/components/block-selection.js';
-
 import { assertExists } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
-import { customElement, property, query, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
@@ -39,9 +36,6 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
 
   @state()
   private accessor _showImage = false;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isDragging = false;
 
@@ -264,10 +258,6 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
               </div>
             </div>
           </div>
-
-          <block-caption-editor .block=${this}></block-caption-editor>
-
-          <affine-block-selection .block=${this}></affine-block-selection>
         </div>
 
         ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -1,14 +1,12 @@
 import './components/image-card.js';
 import './components/page-image-block.js';
 import './components/edgeless-image-block.js';
-import '../_common/components/block-selection.js';
 
-import { BlockElement } from '@blocksuite/block-std';
 import { html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
+import { BlockComponent } from '../_common/components/block-component.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import type { ImageBlockEdgelessComponent } from './components/edgeless-image-block.js';
 import type { AffineImageCard } from './components/image-card.js';
@@ -24,10 +22,12 @@ import {
 } from './utils.js';
 
 @customElement('affine-image')
-export class ImageBlockComponent extends BlockElement<
+export class ImageBlockComponent extends BlockComponent<
   ImageBlockModel,
   ImageBlockService
 > {
+  override accessor useCaptionEditor = true;
+
   @property({ attribute: false })
   accessor loading = false;
 
@@ -57,9 +57,6 @@ export class ImageBlockComponent extends BlockElement<
 
   @query('affine-edgeless-image')
   private accessor _edgelessImage: ImageBlockEdgelessComponent | null = null;
-
-  @query('block-caption-editor')
-  accessor captionElement!: BlockCaptionEditor;
 
   private _isInSurface = false;
 
@@ -143,6 +140,10 @@ export class ImageBlockComponent extends BlockElement<
     const parent = this.host.doc.getParent(this.model);
     this._isInSurface = parent?.flavour === 'affine:surface';
 
+    this.blockContainerStyles = this._isInSurface
+      ? undefined
+      : { margin: '18px 0' };
+
     this.model.propsUpdated.on(({ key }) => {
       if (key === 'sourceId') {
         this.refreshData();
@@ -165,7 +166,6 @@ export class ImageBlockComponent extends BlockElement<
     let containerStyleMap = styleMap({
       position: 'relative',
       width: '100%',
-      margin: '18px 0px',
     });
 
     if (this.isInSurface) {
@@ -199,10 +199,6 @@ export class ImageBlockComponent extends BlockElement<
                 }}
               ></affine-edgeless-image>`
             : html`<affine-page-image .block=${this}></affine-page-image>`}
-
-        <block-caption-editor .block=${this}></block-caption-editor>
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
 
       ${this.isInSurface ? nothing : Object.values(this.widgets)}

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -1,13 +1,14 @@
 /// <reference types="vite/client" />
 import '../_common/components/rich-text/rich-text.js';
-import '../_common/components/block-selection.js';
 
-import { BlockElement, getInlineRangeProvider } from '@blocksuite/block-std';
+import type { BlockElement } from '@blocksuite/block-std';
+import { getInlineRangeProvider } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import type { InlineRangeProvider } from '@blocksuite/inline';
 import { html, nothing, type TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 
+import { BlockComponent } from '../_common/components/block-component.js';
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../_common/consts.js';
@@ -21,11 +22,16 @@ import { ListIcon } from './utils/get-list-icon.js';
 import { playCheckAnimation, toggleDown, toggleRight } from './utils/icons.js';
 
 @customElement('affine-list')
-export class ListBlockComponent extends BlockElement<
+export class ListBlockComponent extends BlockComponent<
   ListBlockModel,
   ListBlockService
 > {
   static override styles = listBlockStyles;
+
+  override accessor blockContainerStyles = {
+    margin: '10px 0',
+  };
+
   get inlineManager() {
     const inlineManager = this.service?.inlineManager;
     assertExists(inlineManager);
@@ -211,8 +217,6 @@ export class ListBlockComponent extends BlockElement<
         </div>
 
         ${collapsed ? nothing : children}
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -65,7 +65,6 @@ export const toggleStyles = css`
 export const listBlockStyles = css`
   affine-list {
     display: block;
-    margin: 10px 0;
     font-size: var(--affine-font-base);
   }
 

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -1,13 +1,13 @@
 import '../_common/components/rich-text/rich-text.js';
-import '../_common/components/block-selection.js';
 
 import type { TextSelection } from '@blocksuite/block-std';
-import { BlockElement, getInlineRangeProvider } from '@blocksuite/block-std';
+import { getInlineRangeProvider } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { type InlineRangeProvider } from '@blocksuite/inline';
 import { html, nothing, type TemplateResult } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 
+import { BlockComponent } from '../_common/components/block-component.js';
 import { bindContainerHotkey } from '../_common/components/rich-text/keymap/index.js';
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../_common/consts.js';
@@ -19,11 +19,13 @@ import type { ParagraphBlockService } from './paragraph-service.js';
 import { paragraphBlockStyles } from './styles.js';
 
 @customElement('affine-paragraph')
-export class ParagraphBlockComponent extends BlockElement<
+export class ParagraphBlockComponent extends BlockComponent<
   ParagraphBlockModel,
   ParagraphBlockService
 > {
   static override styles = paragraphBlockStyles;
+
+  override accessor blockContainerStyles = { margin: '10px 0' };
 
   get inlineManager() {
     const inlineManager = this.service?.inlineManager;
@@ -181,8 +183,6 @@ export class ParagraphBlockComponent extends BlockElement<
         </div>
 
         ${children}
-
-        <affine-block-selection .block=${this}></affine-block-selection>
       </div>
     `;
   }

--- a/packages/blocks/src/paragraph-block/styles.ts
+++ b/packages/blocks/src/paragraph-block/styles.ts
@@ -3,7 +3,6 @@ import { css } from 'lit';
 export const paragraphBlockStyles = css`
   affine-paragraph {
     display: block;
-    margin: 10px 0;
     font-size: var(--affine-font-base);
   }
 

--- a/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
@@ -28,7 +28,7 @@ export const defaultItems: CodeToolbarItem[] = [
     tooltip: 'Caption',
     showWhen: blockElement => !blockElement.doc.readonly,
     action: codeBlock => {
-      codeBlock.captionElement.show();
+      codeBlock.captionEditor.show();
     },
   },
 ];

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
@@ -74,7 +74,7 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
   }
 
   private _showCaption() {
-    this._blockElement?.captionElement.show();
+    this._blockElement?.captionEditor.show();
   }
 
   private _setCardStyle(style: EmbedCardStyle) {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -384,7 +384,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
   }
 
   private _showCaption() {
-    this._blockElement?.captionElement?.show();
+    this._blockElement?.captionEditor.show();
   }
 
   private _copyUrl() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
@@ -39,7 +39,7 @@ export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
   }
 
   private _showCaption() {
-    this._blockElement?.captionElement.show();
+    this._blockElement?.captionEditor.show();
   }
 
   override render() {

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -326,10 +326,9 @@ export class EmbedCardToolbar extends WidgetElement<
   }
 
   private _showCaption() {
-    const captionElement = this.blockElement.captionElement;
-    if (captionElement) {
-      captionElement.show();
-    } else {
+    try {
+      this.blockElement.captionEditor.show();
+    } catch (_) {
       toggleEmbedCardCaptionEditModal(this.blockElement);
     }
     this._resetAbortController();

--- a/packages/blocks/src/root-block/widgets/image-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/config.ts
@@ -35,7 +35,7 @@ export const commonConfig: ImageConfigItem[] = [
       abortController: AbortController
     ) => {
       abortController.abort();
-      blockElement.captionElement.show();
+      blockElement.captionEditor.show();
     },
     type: 'common',
   },

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -1339,7 +1339,7 @@ test(scoped`paste parent block`, async ({ page }) => {
   ]);
 });
 
-test(scoped`clipboard copy muti selection`, async ({ page }) => {
+test(scoped`clipboard copy multi selection`, async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await focusRichText(page);


### PR DESCRIPTION
Extracts common components
Extend from this class `block-selection` or `block-caption-editor` is needed.
```ts
export class BlockComponent<
  Model extends BlockModel = BlockModel,
  Service extends BlockService = BlockService,
  WidgetName extends string = string,
> extends BlockElement<Model, Service, WidgetName> {

  protected accessor useCaptionEditor = false;

  protected accessor blockContainerStyles: StyleInfo | undefined = undefined;
}

```

Closes: [BS-361](https://linear.app/affine-design/issue/BS-361/extract-common-logic-from-blocks)