### PR TITLE
fix(blocks): toolbar should not be displayed in synced doc block

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -174,16 +174,16 @@ export class RichText extends WithDisposable(ShadowlessElement) {
       );
     }
 
-    // lazy
-    const verticalScrollContainer =
-      this.#verticalScrollContainer ||
-      (this.#verticalScrollContainer =
-        this.verticalScrollContainerGetter?.() || null);
-
     // init auto scroll
     inlineEditor.disposables.add(
       inlineEditor.slots.inlineRangeUpdate.on(([inlineRange, sync]) => {
         if (!inlineRange || !sync) return;
+
+        // lazy
+        const verticalScrollContainer =
+          this.#verticalScrollContainer ||
+          (this.#verticalScrollContainer =
+            this.verticalScrollContainerGetter?.() || null);
 
         inlineEditor
           .waitForUpdate()

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -203,7 +203,7 @@ async function renderNoteContent(
       : BlockViewType.Hidden;
   };
   const previewDoc = doc.blockCollection.getDoc(selector);
-  const previewSpec = SpecProvider.getInstance().getSpec('preview');
+  const previewSpec = SpecProvider.getInstance().getSpec('page:preview');
   const previewTemplate = card.host.renderSpecPortal(
     previewDoc,
     previewSpec.value

--- a/packages/blocks/src/embed-synced-doc-block/styles.ts
+++ b/packages/blocks/src/embed-synced-doc-block/styles.ts
@@ -37,11 +37,9 @@ export const blockStyles = css`
     border: 1px solid var(--affine-border-color);
   }
 
-  affine-embed-synced-doc-block[data-nested-editor] {
-    position: relative;
-    display: block;
-    left: -24px;
-    width: calc(100% + 48px);
+  affine-embed-synced-doc-block[data-nested-editor]
+    .affine-embed-synced-doc-container.page {
+    padding: 0 24px;
   }
 
   .affine-embed-synced-doc-container {
@@ -131,6 +129,11 @@ export const blockStyles = css`
   .affine-embed-synced-doc-container
     > .affine-embed-synced-doc-editor.affine-page-viewport {
     background: transparent;
+  }
+
+  .affine-embed-synced-doc-container > .affine-embed-synced-doc-editor {
+    width: 100%;
+    height: 100%;
   }
 
   .affine-embed-synced-doc-editor .affine-page-root-block-container {

--- a/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
@@ -357,7 +357,7 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
       doc.blockCollection.clearSelector(selector);
     });
     const doc = model.doc.blockCollection.getDoc(selector);
-    const previewSpec = SpecProvider.getInstance().getSpec('preview');
+    const previewSpec = SpecProvider.getInstance().getSpec('page:preview');
     return this.host.renderSpecPortal(doc, previewSpec.value);
   }
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -127,6 +127,13 @@ export class EdgelessRootBlockComponent extends BlockElement<
   `;
 
   /**
+   * Disable components
+   *
+   * Toolbar is not allowed to display in `syncd doc block`.
+   */
+  disableComponents = false;
+
+  /**
    * Shared components
    */
   components = {
@@ -672,6 +679,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
       this.tools.setEdgelessTool({ type: 'pan', panning: true });
     }
 
+    if (this.disableComponents) return;
     requestConnectedFrame(() => {
       this._handleToolbarFlag();
       this.requestUpdate();

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -1,4 +1,9 @@
-import type { BlockSpec } from '@blocksuite/block-std';
+import type {
+  BlockElement,
+  BlockService,
+  BlockSpec,
+  BlockSpecSlots,
+} from '@blocksuite/block-std';
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
 import { RootBlockSchema } from '../root-model.js';
@@ -14,6 +19,7 @@ import { AFFINE_MODAL_WIDGET } from '../widgets/modal/modal.js';
 import { AFFINE_PIE_MENU_WIDGET } from '../widgets/pie-menu/index.js';
 import { AFFINE_SLASH_MENU_WIDGET } from '../widgets/slash-menu/index.js';
 import { AFFINE_VIEWPORT_OVERLAY_WIDGET } from '../widgets/viewport-overlay/viewport-overlay.js';
+import type { EdgelessRootBlockComponent } from './edgeless-root-block.js';
 import { EdgelessRootService } from './edgeless-root-service.js';
 
 export type EdgelessRootBlockWidgetName =
@@ -69,5 +75,29 @@ export const EdgelessRootBlockSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
         AFFINE_VIEWPORT_OVERLAY_WIDGET
       )}`,
     },
+  },
+};
+
+export const PreviewEdgelessRootBlockSpec: BlockSpec = {
+  schema: RootBlockSchema,
+  service: EdgelessRootService,
+  view: {
+    component: literal`affine-edgeless-root`,
+  },
+  setup(slots: BlockSpecSlots) {
+    slots.viewConnected.on(
+      ({
+        component,
+        service,
+      }: {
+        component: BlockElement;
+        service: BlockService;
+      }) => {
+        // Does not allow the edgeless to display toolbar.
+        (component as EdgelessRootBlockComponent).disableComponents = true;
+        // Does not allow the user to move and zoom.
+        (service as EdgelessRootService).locked = true;
+      }
+    );
   },
 };

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -422,7 +422,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
       const doc = this.doc.blockCollection.getDoc(selector);
 
-      const previewSpec = SpecProvider.getInstance().getSpec('preview');
+      const previewSpec = SpecProvider.getInstance().getSpec('page:preview');
       const previewTemplate = this.host.renderSpecPortal(
         doc,
         previewSpec.value

--- a/packages/blocks/src/specs/edgeless-specs.ts
+++ b/packages/blocks/src/specs/edgeless-specs.ts
@@ -1,13 +1,24 @@
 import type { BlockSpec } from '@blocksuite/block-std';
 
 import { FrameBlockSpec } from '../frame-block/frame-spec.js';
-import { EdgelessRootBlockSpec } from '../root-block/edgeless/edgeless-root-spec.js';
+import {
+  EdgelessRootBlockSpec,
+  PreviewEdgelessRootBlockSpec,
+} from '../root-block/edgeless/edgeless-root-spec.js';
 import { EdgelessSurfaceBlockSpec } from '../surface-block/surface-spec.js';
 import { EdgelessSurfaceRefBlockSpec } from '../surface-ref-block/surface-ref-spec.js';
 import { CommonFirstPartyBlockSpecs } from './common.js';
 
 export const EdgelessEditorBlockSpecs: BlockSpec[] = [
   EdgelessRootBlockSpec,
+  ...CommonFirstPartyBlockSpecs,
+  EdgelessSurfaceBlockSpec,
+  EdgelessSurfaceRefBlockSpec,
+  FrameBlockSpec,
+];
+
+export const PreviewEdgelessEditorBlockSpecs: BlockSpec[] = [
+  PreviewEdgelessRootBlockSpec,
   ...CommonFirstPartyBlockSpecs,
   EdgelessSurfaceBlockSpec,
   EdgelessSurfaceRefBlockSpec,

--- a/packages/blocks/src/specs/index.ts
+++ b/packages/blocks/src/specs/index.ts
@@ -22,14 +22,21 @@ import { EdgelessSurfaceBlockSpec } from '../surface-block/surface-spec.js';
 import { PageSurfaceBlockSpec } from '../surface-block/surface-spec.js';
 import { EdgelessSurfaceRefBlockSpec } from '../surface-ref-block/surface-ref-spec.js';
 import { PageSurfaceRefBlockSpec } from '../surface-ref-block/surface-ref-spec.js';
-import { EdgelessEditorBlockSpecs } from './edgeless-specs.js';
+import {
+  EdgelessEditorBlockSpecs,
+  PreviewEdgelessEditorBlockSpecs,
+} from './edgeless-specs.js';
 import { PageEditorBlockSpecs } from './page-specs.js';
 import { PreviewEditorBlockSpecs } from './preview-specs.js';
 import { SpecProvider } from './utils/spec-provider.js';
 
 SpecProvider.getInstance().addSpec('page', PageEditorBlockSpecs);
 SpecProvider.getInstance().addSpec('edgeless', EdgelessEditorBlockSpecs);
-SpecProvider.getInstance().addSpec('preview', PreviewEditorBlockSpecs);
+SpecProvider.getInstance().addSpec('page:preview', PreviewEditorBlockSpecs);
+SpecProvider.getInstance().addSpec(
+  'edgeless:preview',
+  PreviewEdgelessEditorBlockSpecs
+);
 
 // specs preset
 export * from './edgeless-specs.js';

--- a/packages/blocks/src/surface-ref-block/portal/note.ts
+++ b/packages/blocks/src/surface-ref-block/portal/note.ts
@@ -41,7 +41,7 @@ export class SurfaceRefNotePortal extends WithDisposable(ShadowlessElement) {
 
   renderPreview() {
     const doc = this.model.doc.blockCollection.getDoc();
-    const previewSpec = SpecProvider.getInstance().getSpec('preview');
+    const previewSpec = SpecProvider.getInstance().getSpec('page:preview');
     return this.host.renderSpecPortal(doc, previewSpec.value.slice());
   }
 

--- a/tests/embed-synced-doc.spec.ts
+++ b/tests/embed-synced-doc.spec.ts
@@ -113,7 +113,8 @@ test.describe('Embed synced doc', () => {
     expect(EmbedSyncedDocPortalBox.height).toBeCloseTo(height + border, 1);
   });
 
-  test('can jump to other docs when click linked doc inside embed synced doc block', async ({
+  // @TODO: if `center peek` feature is already landed in, we can delete it.
+  test.skip('can jump to other docs when click linked doc inside embed synced doc block', async ({
     page,
   }) => {
     await initEmptyParagraphState(page);


### PR DESCRIPTION
Closes: [BS-177](https://linear.app/affine-design/issue/BS-177/embedded-doc-in-edgeless-mode-should-be-under-readonly-mode-without)