### PR TITLE
fix(blocks): lazy get viewport element on rich-text

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -121,7 +121,10 @@ export class RichText extends WithDisposable(ShadowlessElement) {
   accessor enableFormat = true;
 
   @property({ attribute: false })
-  accessor verticalScrollContainer: HTMLElement | undefined = undefined;
+  accessor verticalScrollContainerGetter:
+    | (() => HTMLElement | null)
+    | undefined = undefined;
+  #verticalScrollContainer: HTMLElement | null = null;
 
   private _inlineEditor: AffineInlineEditor | null = null;
   get inlineEditor() {
@@ -171,6 +174,12 @@ export class RichText extends WithDisposable(ShadowlessElement) {
       );
     }
 
+    // lazy
+    const verticalScrollContainer =
+      this.#verticalScrollContainer ||
+      (this.#verticalScrollContainer =
+        this.verticalScrollContainerGetter?.() || null);
+
     // init auto scroll
     inlineEditor.disposables.add(
       inlineEditor.slots.inlineRangeUpdate.on(([inlineRange, sync]) => {
@@ -184,9 +193,9 @@ export class RichText extends WithDisposable(ShadowlessElement) {
             const range = inlineEditor.toDomRange(inlineRange);
             if (!range) return;
 
-            if (this.verticalScrollContainer) {
+            if (verticalScrollContainer) {
               const containerRect =
-                this.verticalScrollContainer.getBoundingClientRect();
+                verticalScrollContainer.getBoundingClientRect();
               const rangeRect = range.getBoundingClientRect();
 
               if (rangeRect.top < containerRect.top) {

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -472,7 +472,8 @@ export class CodeBlockComponent extends BlockElement<CodeBlockModel> {
               .enableClipboard=${false}
               .enableUndoRedo=${false}
               .wrapText=${this.model.wrap}
-              .verticalScrollContainer=${getViewportElement(this.host)}
+              .verticalScrollContainerGetter=${() =>
+                getViewportElement(this.host)}
             >
             </rich-text>
           </div>

--- a/packages/blocks/src/data-view-block/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/data-view-block/columns/rich-text/cell-renderer.ts
@@ -355,9 +355,10 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
       .attributeRenderer=${this.attributeRenderer}
       .embedChecker=${this.inlineManager?.embedChecker}
       .markdownShortcutHandler=${this.inlineManager?.markdownShortcutHandler}
-      .verticalScrollContainer=${this.topContenteditableElement?.host
-        ? getViewportElement(this.topContenteditableElement.host)
-        : nothing}
+      .verticalScrollContainerGetter=${() =>
+        this.topContenteditableElement?.host
+          ? getViewportElement(this.topContenteditableElement.host)
+          : null}
       class="affine-data-view-rich-text inline-editor"
     ></rich-text>`;
   }

--- a/packages/blocks/src/database-block/columns/rich-text/cell-renderer.ts
+++ b/packages/blocks/src/database-block/columns/rich-text/cell-renderer.ts
@@ -349,9 +349,10 @@ export class RichTextCellEditing extends BaseCellRenderer<Text> {
       .attributeRenderer=${this.attributeRenderer}
       .embedChecker=${this.inlineManager?.embedChecker}
       .markdownShortcutHandler=${this.inlineManager?.markdownShortcutHandler}
-      .verticalScrollContainer=${this.topContenteditableElement?.host
-        ? getViewportElement(this.topContenteditableElement.host)
-        : nothing}
+      .verticalScrollContainerGetter=${() =>
+        this.topContenteditableElement?.host
+          ? getViewportElement(this.topContenteditableElement.host)
+          : null}
       class="affine-database-rich-text inline-editor"
     ></rich-text>`;
   }

--- a/packages/blocks/src/database-block/columns/title/text.ts
+++ b/packages/blocks/src/database-block/columns/title/text.ts
@@ -1,7 +1,7 @@
 import { IS_MAC } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
 import type { Text } from '@blocksuite/store';
-import { css, nothing } from 'lit';
+import { css } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
@@ -196,9 +196,10 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
         .embedChecker=${this.inlineManager?.embedChecker}
         .markdownShortcutHandler=${this.inlineManager?.markdownShortcutHandler}
         .readonly=${this.readonly}
-        .verticalScrollContainer=${this.topContenteditableElement?.host
-          ? getViewportElement(this.topContenteditableElement.host)
-          : nothing}
+        .verticalScrollContainerGetter=${() =>
+          this.topContenteditableElement?.host
+            ? getViewportElement(this.topContenteditableElement.host)
+            : null}
         class="data-view-header-area-rich-text"
       ></rich-text>`;
   }

--- a/packages/blocks/src/database-block/components/title/index.ts
+++ b/packages/blocks/src/database-block/components/title/index.ts
@@ -2,7 +2,7 @@ import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import type { InlineRange } from '@blocksuite/inline';
 import type { Text } from '@blocksuite/store';
-import { css, html, nothing } from 'lit';
+import { css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -151,9 +151,10 @@ export class DatabaseTitle extends WithDisposable(ShadowlessElement) {
         .undoManager=${this.topContenteditableElement?.doc.history}
         .enableFormat=${false}
         .readonly=${this.readonly}
-        .verticalScrollContainer=${this.topContenteditableElement?.host
-          ? getViewportElement(this.topContenteditableElement.host)
-          : nothing}
+        .verticalScrollContainerGetter=${() =>
+          this.topContenteditableElement?.host
+            ? getViewportElement(this.topContenteditableElement.host)
+            : null}
         class="${classList}"
         data-title-empty="${isEmpty}"
         data-title-focus="${this.isActive}"

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -205,7 +205,8 @@ export class ListBlockComponent extends BlockElement<
             .inlineRangeProvider=${this._inlineRangeProvider}
             .enableClipboard=${false}
             .enableUndoRedo=${false}
-            .verticalScrollContainer=${getViewportElement(this.host)}
+            .verticalScrollContainerGetter=${() =>
+              getViewportElement(this.host)}
           ></rich-text>
         </div>
 

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -172,7 +172,8 @@ export class ParagraphBlockComponent extends BlockElement<
             .inlineRangeProvider=${this._inlineRangeProvider}
             .enableClipboard=${false}
             .enableUndoRedo=${false}
-            .verticalScrollContainer=${getViewportElement(this.host)}
+            .verticalScrollContainerGetter=${() =>
+              getViewportElement(this.host)}
           ></rich-text>
           <div contenteditable="false" class="affine-paragraph-placeholder">
             ${this.service.placeholderGenerator(this.model)}

--- a/packages/presets/src/fragments/doc-title/doc-title.ts
+++ b/packages/presets/src/fragments/doc-title/doc-title.ts
@@ -171,7 +171,7 @@ export class DocTitle extends WithDisposable(ShadowlessElement) {
         <rich-text
           .yText=${this._rootModel.title.yText}
           .undoManager=${this.doc.history}
-          .verticalScrollContainer=${this._viewport}
+          .verticalScrollContainerGetter=${() => this._viewport}
           .readonly=${this.doc.readonly}
           .enableFormat=${false}
         ></rich-text>


### PR DESCRIPTION
When switching modes, if there is an embed syncd block in the page, the following occurs:

<img width="1424" alt="Screenshot 2024-05-31 at 23 26 32" src="https://github.com/toeverything/blocksuite/assets/27926/f776a09f-72cb-4dbf-acec-b4944b149961">

https://github.com/toeverything/blocksuite/assets/27926/e4b921e4-5182-4db9-a246-ee391d95a6a7

