### PR TITLE
feat(blocks): support connections between groups

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
@@ -7,6 +7,7 @@ import {
   CanvasElementType,
   type Connection,
   type ConnectorElementModel,
+  GroupElementModel,
   type IBound,
   type IVec,
 } from '../../../../surface-block/index.js';
@@ -52,18 +53,21 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
   quickConnect(point: IVec, element: BlockSuite.EdgelessModelType) {
     this._startPoint = this._service.viewport.toModelCoord(point[0], point[1]);
     this._mode = ConnectorToolMode.Quick;
-    this._sourceBounds =
-      element.externalBound || Bound.deserialize(element.xywh);
+    this._sourceBounds = Bound.deserialize(element.xywh);
     this._sourceBounds.rotate = element.rotate;
     this._source = {
       id: element.id,
-      position: calculateNearestLocation(
-        this._startPoint,
-        Bound.deserialize(element.xywh)
-      ),
+      position: calculateNearestLocation(this._startPoint, this._sourceBounds),
     };
+    this._allowCancel = true;
 
     this._createConnector();
+
+    if (element instanceof GroupElementModel) {
+      this._surface.overlays.connector.sourceBounds = this._sourceBounds;
+    }
+
+    this.findTargetByPoint(point);
   }
 
   findTargetByPoint(point: IVec) {

--- a/packages/blocks/src/surface-block/element-model/group.ts
+++ b/packages/blocks/src/surface-block/element-model/group.ts
@@ -55,10 +55,6 @@ export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> 
 
   set rotate(_: number) {}
 
-  override get connectable() {
-    return false;
-  }
-
   get type() {
     return 'group';
   }


### PR DESCRIPTION
Closes: [BS-431](https://linear.app/affine-design/issue/BS-431/group-connect-group), [AFF-1184](https://linear.app/affine-design/issue/AFF-1184/connector-可以连接-group-和-group-内的yuan素)

### What's changed?

* Allow groups connect other groups 
* Allow groups connect elements within other groups
* Allow elements within groups connect other groups
* Highlight groups