### PR TITLE
feat(blocks): support connecting different linked doc formats

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -197,7 +197,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
   };
 
   convertToEmbed = () => {
-    const { doc, pageId, caption, xywh } = this.model;
+    const { id, doc, pageId, caption, xywh } = this.model;
 
     // synced doc entry controlled by awareness flag
     const isSyncedDocEnabled = doc.awarenessStore.getFlag(
@@ -215,14 +215,21 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
 
       const edgeless = this.edgeless;
       assertExists(edgeless);
-      const blockId = edgeless.service.addBlock(
+
+      const newId = edgeless.service.addBlock(
         'affine:embed-synced-doc',
         { pageId, xywh: bound.serialize(), caption },
         edgeless.surface.model
       );
+
+      this.std.command.exec('reassociateConnectors', {
+        oldId: id,
+        newId,
+      });
+
       edgeless.service.selection.set({
         editing: false,
-        elements: [blockId],
+        elements: [newId],
       });
     } else {
       const parent = doc.getParent(this.model);

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -258,7 +258,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   };
 
   convertToCard = () => {
-    const { doc, pageId, caption, xywh } = this.model;
+    const { id, doc, pageId, caption, xywh } = this.model;
 
     if (this.isInSurface) {
       const style = 'vertical';
@@ -268,14 +268,20 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
 
       const edgeless = this.edgeless;
       assertExists(edgeless);
-      const blockId = edgeless.service.addBlock(
+      const newId = edgeless.service.addBlock(
         'affine:embed-linked-doc',
         { pageId, xywh: bound.serialize(), style, caption },
         edgeless.surface.model
       );
+
+      this.std.command.exec('reassociateConnectors', {
+        oldId: id,
+        newId,
+      });
+
       edgeless.service.selection.set({
         editing: false,
-        elements: [blockId],
+        elements: [newId],
       });
     } else {
       const parent = doc.getParent(this.model);

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -423,7 +423,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const { url, xywh, style, caption } = this.model;
+    const { id, url, xywh, style, caption } = this.model;
 
     let targetFlavour = 'affine:bookmark',
       targetStyle = style;
@@ -440,14 +440,20 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     bound.w = EMBED_CARD_WIDTH[targetStyle];
     bound.h = EMBED_CARD_HEIGHT[targetStyle];
 
-    const blockId = this.edgeless.service.addBlock(
+    const newId = this.edgeless.service.addBlock(
       targetFlavour as EdgelessBlockType,
       { url, xywh: bound.serialize(), style: targetStyle, caption },
       this.edgeless.surface.model
     );
+
+    this.std.command.exec('reassociateConnectors', {
+      oldId: id,
+      newId,
+    });
+
     this.edgeless.service.selection.set({
       editing: false,
-      elements: [blockId],
+      elements: [newId],
     });
     this._doc.deleteBlock(this.model);
   };
@@ -471,7 +477,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
     const { flavour, styles } = this._embedOptions;
 
-    const { url, xywh, style } = this.model;
+    const { id, url, xywh, style } = this.model;
 
     const targetStyle = styles.includes(style) ? style : styles[0];
 
@@ -479,7 +485,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     bound.w = EMBED_CARD_WIDTH[targetStyle];
     bound.h = EMBED_CARD_HEIGHT[targetStyle];
 
-    const blockId = this.edgeless.service.addBlock(
+    const newId = this.edgeless.service.addBlock(
       flavour as EdgelessBlockType,
       {
         url,
@@ -489,9 +495,14 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       this.edgeless.surface.model
     );
 
+    this.std.command.exec('reassociateConnectors', {
+      oldId: id,
+      newId,
+    });
+
     this.edgeless.service.selection.set({
       editing: false,
-      elements: [blockId],
+      elements: [newId],
     });
     this._doc.deleteBlock(this.model);
   };
@@ -579,7 +590,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
           `
         : nothing,
 
-      isEmbedLinkedDocBlock(model) || isEmbedSyncedDocBlock(model)
+      isEmbedSyncedDocBlock(model) || isEmbedLinkedDocBlock(model)
         ? html`
             <edgeless-tool-icon-button
               arai-label="Open"

--- a/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
+++ b/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
@@ -1,0 +1,49 @@
+import type { Command } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
+
+/**
+ * Re-associate bindings for block that have been converted.
+ *
+ * @param oldId - the old block id
+ * @param newId - the new block id
+ */
+export const reassociateConnectorsCommand: Command<
+  never,
+  never,
+  { oldId: string; newId: string }
+> = (ctx, next) => {
+  const { oldId, newId } = ctx;
+  assertExists(oldId, 'The old block ID is required!');
+  assertExists(newId, 'The new block ID is required!');
+
+  const service = ctx.std.spec.getService('affine:surface');
+  assertExists(service);
+
+  const surface = service.surface;
+  const connectors = surface.getConnectors(oldId);
+  for (const connector of connectors) {
+    if (connector.source.id === oldId) {
+      connector.source.id = newId;
+      surface.updateElement(connector.id, {
+        source: connector.source,
+      });
+      continue;
+    }
+    if (connector.target.id === oldId) {
+      connector.target.id = newId;
+      surface.updateElement(connector.id, {
+        target: connector.target,
+      });
+    }
+  }
+
+  next();
+};
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      reassociateConnectors: typeof reassociateConnectorsCommand;
+    }
+  }
+}

--- a/packages/blocks/src/surface-block/surface-service.ts
+++ b/packages/blocks/src/surface-block/surface-service.ts
@@ -1,5 +1,6 @@
 import { BlockService } from '@blocksuite/block-std';
 
+import { reassociateConnectorsCommand } from './commands/reassociate-connectors.js';
 import { LayerManager } from './managers/layer-manager.js';
 import type { SurfaceBlockModel } from './surface-model.js';
 
@@ -9,6 +10,9 @@ export class SurfaceBlockService extends BlockService<SurfaceBlockModel> {
 
   override mounted(): void {
     super.mounted();
+
+    this.std.command.add('reassociateConnectors', reassociateConnectorsCommand);
+
     this.surface = this.doc.getBlockByFlavour(
       'affine:surface'
     )[0] as SurfaceBlockModel;


### PR DESCRIPTION
Closes: [BS-432](https://linear.app/affine-design/issue/BS-432/linked-doc切换形态时，connector要保持连接)

### What's changed?

* Support re-associate connectors when switch mode