### PR TITLE
feat(edgeless): support edgeless mode create linked doc

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -17,6 +17,7 @@ import {
   OpenIcon,
   RefreshIcon,
 } from '../../icons/text.js';
+import { getBlockProps } from '../../utils/block-props.js';
 import { isPeekable, peek } from '../peekable.js';
 import { toast } from '../toast.js';
 import type { EmbedToolbarBlockElement } from './type.js';
@@ -99,11 +100,7 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
 
   private _duplicateBlock() {
     const model = this._model;
-    const keys = model.keys as (keyof typeof model)[];
-    const values = keys.map(key => model[key]);
-    const blockProps = Object.fromEntries(
-      keys.map((key, i) => [key, values[i]])
-    );
+    const blockProps = getBlockProps(model);
     const { width, height, xywh, rotate, zIndex, ...duplicateProps } =
       blockProps;
 

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -12,7 +12,7 @@ import {
   DatabaseTableViewIcon20,
   FontLinkedDocIcon,
 } from '../../icons/index.js';
-import { createLinkedDocFromSelectedBlocks } from '../../utils/render-linked-doc.js';
+import { convertSelectedBlocksToLinkedDoc } from '../../utils/render-linked-doc.js';
 import { DATABASE_CONVERT_WHITE_LIST } from './database-convert-view.js';
 
 export interface QuickActionConfig {
@@ -134,7 +134,7 @@ export const quickActionConfig: QuickActionConfig[] = [
       host.selection.clear();
 
       const doc = host.doc;
-      const linkedDoc = createLinkedDocFromSelectedBlocks(doc, selectedModels);
+      const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
       const linkedDocService = host.spec.getService('affine:embed-linked-doc');
       linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
     },

--- a/packages/blocks/src/_common/utils/block-props.ts
+++ b/packages/blocks/src/_common/utils/block-props.ts
@@ -1,0 +1,8 @@
+import type { BlockModel } from '@blocksuite/store';
+
+export function getBlockProps(model: BlockModel): { [index: string]: unknown } {
+  const keys = model.keys as (keyof typeof model)[];
+  const values = keys.map(key => model[key]);
+  const blockProps = Object.fromEntries(keys.map((key, i) => [key, values[i]]));
+  return blockProps;
+}

--- a/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
@@ -1,8 +1,18 @@
 import type { BlockStdScope } from '@blocksuite/block-std';
 import { Job } from '@blocksuite/store';
 
-import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
-import { ConnectorElementModel } from '../../../surface-block/index.js';
+import { groupBy } from '../../../_common/utils/iterable.js';
+import {
+  type SerializedElement,
+  SurfaceGroupLikeModel,
+} from '../../../surface-block/element-model/base.js';
+import type { SerializedConnectorElement } from '../../../surface-block/element-model/connector.js';
+import type { SerializedGroupElement } from '../../../surface-block/element-model/group.js';
+import {
+  ConnectorElementModel,
+  GroupElementModel,
+  MindmapElementModel,
+} from '../../../surface-block/index.js';
 import type { EdgelessFrameManager } from '../frame-manager.js';
 import { EdgelessBlockModel } from '../type.js';
 import { isFrameBlock } from '../utils/query.js';
@@ -73,4 +83,119 @@ export function serializeConnector(
     };
   }
   return serialized;
+}
+
+/**
+ * There are interdependencies between elements,
+ * so they must be added in a certain order
+ * @param elements edgeless model list
+ * @returns sorted edgeless model list
+ */
+export function sortEdgelessElements(elements: BlockSuite.EdgelessModelType[]) {
+  const result = groupBy(elements, element => {
+    if (element instanceof ConnectorElementModel) {
+      return 'connector';
+    }
+    if (element instanceof GroupElementModel) {
+      return 'group';
+    }
+    if (element instanceof MindmapElementModel) {
+      return 'mindmap';
+    }
+    return 'default';
+  });
+  return [
+    ...(result.default ?? []),
+    ...(result.connector ?? []),
+    ...(result.group ?? []),
+    ...(result.mindmap ?? []),
+  ];
+}
+
+/**
+ * map connector source & target ids
+ * @param props serialized element props
+ * @param ids old element id to new element id map
+ * @returns updated element props
+ */
+export function mapConnectorIds(
+  props: SerializedConnectorElement,
+  ids: Map<string, string>
+) {
+  if (props.source.id) {
+    props.source.id = ids.get(props.source.id);
+  }
+  if (props.target.id) {
+    props.target.id = ids.get(props.target.id);
+  }
+  return props;
+}
+
+/**
+ * map group children ids
+ * @param props serialized element props
+ * @param ids old element id to new element id map
+ * @returns updated element props
+ */
+export function mapGroupIds(
+  props: SerializedGroupElement,
+  ids: Map<string, string>
+) {
+  if (props.children) {
+    const newMap: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(props.children)) {
+      const newKey = ids.get(key);
+      if (newKey) {
+        newMap[newKey] = value;
+      }
+    }
+    props.children = newMap;
+  }
+  return props;
+}
+
+/**
+ * map mindmap children & parent ids
+ * @param props serialized element props
+ * @param ids old element id to new element id map
+ * @returns updated element props
+ */
+export function mapMindmapIds(
+  props: SerializedElement,
+  ids: Map<string, string>
+) {
+  if (props.children) {
+    const newMap: Record<string, boolean> = {};
+    for (const [key, value] of Object.entries(props.children)) {
+      const newKey = ids.get(key);
+      if (value.parent) {
+        const newParent = ids.get(value.parent);
+        value.parent = newParent;
+      }
+      if (newKey) {
+        newMap[newKey] = value;
+      }
+    }
+    props.children = newMap;
+  }
+  return props;
+}
+
+export function getElementProps(
+  element: BlockSuite.SurfaceModelType,
+  ids: Map<string, string>
+) {
+  if (element instanceof ConnectorElementModel) {
+    const props = element.serialize();
+    return mapConnectorIds(props, ids);
+  }
+  if (element instanceof GroupElementModel) {
+    const props = element.serialize();
+    return mapGroupIds(props, ids);
+  }
+  if (element instanceof MindmapElementModel) {
+    const props = element.serialize();
+    return mapMindmapIds(props, ids);
+  }
+  return element.serialize();
 }

--- a/packages/blocks/src/root-block/edgeless/utils/connector.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/connector.ts
@@ -1,0 +1,27 @@
+import type { EdgelessRootService } from '../edgeless-root-service.js';
+
+/**
+ * move connectors from origin to target
+ * @param originId origin element id
+ * @param targetId target element id
+ * @param service edgeless root service
+ */
+export function moveConnectors(
+  originId: string,
+  targetId: string,
+  service: EdgelessRootService
+) {
+  const connectors = service.surface.getConnectors(originId);
+  connectors.forEach(connector => {
+    if (connector.source.id === originId) {
+      service.updateElement(connector.id, {
+        source: { ...connector.source, id: targetId },
+      });
+    }
+    if (connector.target.id === originId) {
+      service.updateElement(connector.id, {
+        target: { ...connector.target, id: targetId },
+      });
+    }
+  });
+}

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -4,7 +4,7 @@ import { IS_MAC, IS_WINDOWS } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
 
 import { matchFlavours } from '../../_common/utils/model.js';
-import { createLinkedDocFromSelectedBlocks } from '../../_common/utils/render-linked-doc.js';
+import { convertSelectedBlocksToLinkedDoc } from '../../_common/utils/render-linked-doc.js';
 
 export class PageKeyboardManager {
   constructor(public rootElement: BlockElement) {
@@ -150,7 +150,7 @@ export class PageKeyboardManager {
     }
 
     const doc = rootElement.host.doc;
-    const linkedDoc = createLinkedDocFromSelectedBlocks(doc, selectedModels);
+    const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
     const linkedDocService = rootElement.host.spec.getService(
       'affine:embed-linked-doc'
     );

--- a/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
@@ -7,6 +7,7 @@ import {
 import { assertExists } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
+import { getBlockProps } from '../../../_common/utils/block-props.js';
 import {
   type BlockComponent,
   type EmbedCardStyle,
@@ -359,13 +360,6 @@ export function updateDragHandleClassName(blockElements: BlockElement[] = []) {
   previousEle.forEach(blockElement => blockElement.classList.remove(className));
   previousEle = blockElements;
   blockElements.forEach(blockElement => blockElement.classList.add(className));
-}
-
-function getBlockProps(model: BlockModel): { [index: string]: unknown } {
-  const keys = model.keys as (keyof typeof model)[];
-  const values = keys.map(key => model[key]);
-  const blockProps = Object.fromEntries(keys.map((key, i) => [key, values[i]]));
-  return blockProps;
 }
 
 export function getDuplicateBlocks(blocks: BlockModel[]) {

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -27,7 +27,7 @@ import {
   TextIcon,
   UnderlineIcon,
 } from '../../../_common/icons/index.js';
-import { createLinkedDocFromSelectedBlocks } from '../../../_common/utils/render-linked-doc.js';
+import { convertSelectedBlocksToLinkedDoc } from '../../../_common/utils/render-linked-doc.js';
 import type { AffineFormatBarWidget } from './format-bar.js';
 
 export type DividerConfigItem = {
@@ -184,10 +184,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
         host.selection.clear();
 
         const doc = host.doc;
-        const linkedDoc = createLinkedDocFromSelectedBlocks(
-          doc,
-          selectedModels
-        );
+        const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
         const linkedDocService = host.spec.getService(
           'affine:embed-linked-doc'
         );

--- a/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
@@ -4,6 +4,7 @@ import '../../../_common/components/tooltip/tooltip.js';
 import { assertExists } from '@blocksuite/global/utils';
 import { html, type TemplateResult } from 'lit';
 
+import { getBlockProps } from '../../../_common/utils/block-props.js';
 import { isInsidePageEditor } from '../../../_common/utils/query.js';
 import type { ImageBlockComponent } from '../../../image-block/image-block.js';
 import type {
@@ -101,9 +102,7 @@ export function duplicate(
   abortController?: AbortController
 ) {
   const model = blockElement.model;
-  const keys = model.keys as (keyof typeof model)[];
-  const values = keys.map(key => model[key]);
-  const blockProps = Object.fromEntries(keys.map((key, i) => [key, values[i]]));
+  const blockProps = getBlockProps(model);
   const { width, height, xywh, rotate, zIndex, ...duplicateProps } = blockProps;
 
   const { doc } = model;

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -96,6 +96,14 @@ export interface IEdgelessElement {
   boxSelect(bound: Bound): boolean;
 }
 
+export type SerializedElement = Record<string, unknown> & {
+  type: string;
+  xywh: SerializedXYWH;
+  id: string;
+  index: string;
+  props: Record<string, unknown>;
+};
+
 export abstract class SurfaceElementModel<Props extends IBaseProps = IBaseProps>
   implements IEdgelessElement
 {
@@ -353,7 +361,7 @@ export abstract class SurfaceElementModel<Props extends IBaseProps = IBaseProps>
   }
 
   serialize() {
-    return this.yMap.toJSON();
+    return this.yMap.toJSON() as SerializedElement;
   }
 
   /**

--- a/packages/blocks/src/surface-block/element-model/connector.ts
+++ b/packages/blocks/src/surface-block/element-model/connector.ts
@@ -27,6 +27,7 @@ import type { SerializedXYWH, XYWH } from '../utils/xywh.js';
 import {
   type IBaseProps,
   type IHitTestOptions,
+  type SerializedElement,
   SurfaceElementModel,
   SurfaceLocalModel,
 } from './base.js';
@@ -42,6 +43,11 @@ export type PointStyle = 'None' | 'Arrow' | 'Triangle' | 'Circle' | 'Diamond';
 export const DEFAULT_FRONT_END_POINT_STYLE = 'None' as const;
 export const DEFAULT_REAR_END_POINT_STYLE = 'Arrow' as const;
 export const CONNECTOR_LABEL_MAX_WIDTH = 280;
+
+export type SerializedConnection = {
+  id?: string;
+  position?: `[${number},${number}]` | PointLocation;
+};
 
 // at least one of id and position is not null
 // both exists means the position is relative to the element
@@ -83,6 +89,11 @@ export type ConnectorLabelProps = {
   labelOffset?: ConnectorLabelOffsetProps;
   labelStyle?: TextStyleProps;
   labelConstraints?: ConnectorLabelConstraintsProps;
+};
+
+export type SerializedConnectorElement = SerializedElement & {
+  source: SerializedConnection;
+  target: SerializedConnection;
 };
 
 type ConnectorElementProps = IBaseProps & {
@@ -328,7 +339,7 @@ export class ConnectorElementModel extends SurfaceElementModel<ConnectorElementP
   override serialize() {
     const result = super.serialize();
     result.xywh = this.xywh;
-    return result;
+    return result as SerializedConnectorElement;
   }
 
   /**

--- a/packages/blocks/src/surface-block/element-model/group.ts
+++ b/packages/blocks/src/surface-block/element-model/group.ts
@@ -6,13 +6,17 @@ import { Bound } from '../utils/bound.js';
 import { linePolygonIntersects } from '../utils/math-utils.js';
 import type { PointLocation } from '../utils/point-location.js';
 import type { IVec2 } from '../utils/vec.js';
-import type { IBaseProps } from './base.js';
+import type { IBaseProps, SerializedElement } from './base.js';
 import { SurfaceGroupLikeModel } from './base.js';
 import { local, observe, yfield } from './decorators.js';
 
 type GroupElementProps = IBaseProps & {
   children: Y.Map<boolean>;
   title: Y.Text;
+};
+
+export type SerializedGroupElement = SerializedElement & {
+  children: Record<string, boolean>;
 };
 
 export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> {
@@ -59,9 +63,16 @@ export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> 
     return 'group';
   }
 
+  override serialize() {
+    const result = super.serialize();
+    return result as SerializedGroupElement;
+  }
+
   addChild(element: BlockSuite.EdgelessModelType | string) {
     const id = typeof element === 'string' ? element : element.id;
-
+    if (!this.children) {
+      return;
+    }
     this.surface.doc.transact(() => {
       this.children.set(id, true);
     });
@@ -69,7 +80,9 @@ export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> 
 
   removeDescendant(element: BlockSuite.EdgelessModelType | string) {
     const id = typeof element === 'string' ? element : element.id;
-
+    if (!this.children) {
+      return;
+    }
     this.surface.doc.transact(() => {
       this.children.delete(id);
     });

--- a/tests/edgeless/linked-doc.spec.ts
+++ b/tests/edgeless/linked-doc.spec.ts
@@ -1,0 +1,313 @@
+import { assertNotExists } from '@global/utils.js';
+import { expect } from '@playwright/test';
+
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import {
+  activeNoteInEdgeless,
+  createConnectorElement,
+  createNote,
+  createShapeElement,
+  edgelessCommonSetup,
+  getConnectorPath,
+  locatorComponentToolbarMoreButton,
+  selectNoteInEdgeless,
+  Shape,
+  triggerComponentToolbarAction,
+} from '../utils/actions/edgeless.js';
+import {
+  addBasicBrushElement,
+  pressEnter,
+  selectAllByKeyboard,
+  type,
+  waitNextFrame,
+} from '../utils/actions/index.js';
+import { assertConnectorPath } from '../utils/asserts.js';
+import { assertExists } from '../utils/asserts.js';
+import { test } from '../utils/playwright.js';
+
+test.describe('note to linked doc', () => {
+  test('select a note and turn it into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    const noteId = await createNote(page, [100, 0]);
+    await activeNoteInEdgeless(page, noteId);
+    await waitNextFrame(page, 200);
+    await type(page, 'Hello');
+    await pressEnter(page);
+    await type(page, 'World');
+
+    await page.mouse.click(10, 50);
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'turnIntoLinkedDoc');
+
+    await waitNextFrame(page, 200);
+    const embedSyncedBlock = page.locator('affine-embed-synced-doc-block');
+    assertExists(embedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'linkedDocInfo');
+    await waitNextFrame(page, 200);
+    const noteBlock = page.locator('affine-note');
+    assertExists(noteBlock);
+    const noteContent = await noteBlock.innerText();
+    expect(noteContent).toBe('Hello\nWorld');
+  });
+
+  test('turn note into a linked doc, connector keeps', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    const noteId = await createNote(page, [100, 0]);
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+    await createConnectorElement(page, [100, 150], [100, 10]);
+    const connectorPath = await getConnectorPath(page);
+
+    await page.mouse.click(10, 50);
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'turnIntoLinkedDoc');
+
+    await waitNextFrame(page, 200);
+    const embedSyncedBlock = page.locator('affine-embed-synced-doc-block');
+    assertExists(embedSyncedBlock);
+
+    await assertConnectorPath(page, [connectorPath[0], connectorPath[1]], 0);
+  });
+
+  // TODO FIX ME
+  test.skip('embed-synced-doc card can not turn into linked doc', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    const noteId = await createNote(page, [100, 0]);
+    await activeNoteInEdgeless(page, noteId);
+    await waitNextFrame(page, 200);
+    await type(page, 'Hello World');
+
+    await page.mouse.click(10, 50);
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'turnIntoLinkedDoc');
+
+    const moreButton = locatorComponentToolbarMoreButton(page);
+    await moreButton.click();
+    const turnButton = page.locator('.turn-into-linked-doc');
+    assertNotExists(turnButton);
+  });
+
+  // TODO FIX ME
+  test.skip('embed-linked-doc card can not turn into linked doc', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    const noteId = await createNote(page, [100, 0]);
+    await activeNoteInEdgeless(page, noteId);
+    await waitNextFrame(page, 200);
+    await type(page, 'Hello World');
+
+    await page.mouse.click(10, 50);
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'turnIntoLinkedDoc');
+
+    await triggerComponentToolbarAction(page, 'toCardView');
+    const moreButton = locatorComponentToolbarMoreButton(page);
+    await moreButton.click();
+    const turnButton = page.locator('.turn-into-linked-doc');
+    assertNotExists(turnButton);
+  });
+});
+
+test.describe('single edgeless element to linked doc', () => {
+  test('select a shape, turn into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+
+    const shapes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      return container!.service
+        .getElementsByType('shape')
+        .map(s => ({ type: s.type, xywh: s.xywh }));
+    });
+    expect(shapes.length).toBe(1);
+    expect(shapes[0]).toEqual({ type: 'shape', xywh: '[100,100,100,100]' });
+  });
+
+  test('select a connector, turn into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createConnectorElement(page, [100, 150], [100, 10]);
+    const connectorPath = await getConnectorPath(page);
+
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    await assertConnectorPath(page, [connectorPath[0], connectorPath[1]], 0);
+  });
+
+  test('select a brush, turn into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    const start = { x: 400, y: 400 };
+    const end = { x: 500, y: 500 };
+    await addBasicBrushElement(page, start, end);
+    await page.mouse.click(start.x + 5, start.y + 5);
+
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const brushes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      return container!.service
+        .getElementsByType('brush')
+        .map(s => ({ type: s.type, xywh: s.xywh }));
+    });
+    expect(brushes.length).toBe(1);
+    expect(brushes[0]).toEqual({ type: 'brush', xywh: '[318,-4.5,104,104]' });
+  });
+
+  test('select a group, turn into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createNote(page, [100, 0]);
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+    await createConnectorElement(page, [100, 150], [100, 10]);
+    const start = { x: 400, y: 400 };
+    const end = { x: 500, y: 500 };
+    await addBasicBrushElement(page, start, end);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const groups = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      return container!.service.getElementsByType('group').map(s => ({
+        type: s.type,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        children: s.childElements.map((c: any) => c.type || c.flavour),
+      }));
+    });
+    expect(groups.length).toBe(1);
+    expect(groups[0]).toEqual({
+      type: 'group',
+      children: ['affine:note', 'shape', 'connector', 'brush'],
+    });
+  });
+
+  test('select a frame, turn into a linked doc', async ({ page }) => {
+    await edgelessCommonSetup(page);
+    await createNote(page, [100, 0]);
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+    await createConnectorElement(page, [100, 150], [100, 10]);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addGroup');
+
+    const start = { x: 400, y: 400 };
+    const end = { x: 500, y: 500 };
+    await addBasicBrushElement(page, start, end);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const nodes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      const elements = container!.service.elements.map(s => s.type);
+      const blocks = container!.service.blocks.map(b => b.flavour);
+      return { blocks, elements };
+    });
+    expect(nodes).toEqual({
+      blocks: ['affine:frame', 'affine:note'],
+      elements: ['group', 'shape', 'connector', 'brush'],
+    });
+  });
+});
+
+test.describe('multiple edgeless elements to linked doc', () => {
+  test('multi-select note, frame, shape, connector, brush and group, turn it into a linked doc', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    await createNote(page, [100, 0], 'Hello World');
+    await page.mouse.click(10, 50);
+
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'addFrame');
+
+    await createConnectorElement(page, [100, 150], [100, 10]);
+    const start = { x: 400, y: 400 };
+    const end = { x: 500, y: 500 };
+    await addBasicBrushElement(page, start, end);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const nodes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      const elements = container!.service.elements.map(s => s.type);
+      const blocks = container!.service.blocks.map(b => b.flavour);
+      return { blocks, elements };
+    });
+    expect(nodes).toEqual({
+      blocks: ['affine:frame', 'affine:note'],
+      elements: ['shape', 'connector', 'brush'],
+    });
+  });
+
+  test('multi-select with embed doc card inside, turn it into a linked doc', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    const noteId = await createNote(page, [100, 0], 'Hello World');
+    await page.mouse.click(10, 50);
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'turnIntoLinkedDoc');
+
+    await createShapeElement(page, [100, 100], [100, 100], Shape.Square);
+    await createConnectorElement(page, [100, 150], [100, 10]);
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const nodes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      const elements = container!.service.elements.map(s => s.type);
+      const blocks = container!.service.blocks.map(b => b.flavour);
+      return { blocks, elements };
+    });
+    expect(nodes).toEqual({
+      blocks: ['affine:embed-synced-doc'],
+      elements: ['shape', 'connector'],
+    });
+  });
+});

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -1612,7 +1612,41 @@ test('create linked doc from block selection with format bar', async ({
   );
   await waitNextFrame(page, 200);
 
-  await assertRichTexts(page, ['123', '456', '789']);
-  await assertBlockChildrenIds(page, '8', ['10', '12']);
-  await assertBlockChildrenIds(page, '10', ['11']);
+  await assertStoreMatchJSX(
+    page,
+    `
+<affine:page>
+  <affine:surface />
+  <affine:note
+    prop:background="--affine-background-secondary-color"
+    prop:displayMode="both"
+    prop:edgeless={
+      Object {
+        "style": Object {
+          "borderRadius": 8,
+          "borderSize": 4,
+          "borderStyle": "solid",
+          "shadowType": "--affine-note-shadow-box",
+        },
+      }
+    }
+    prop:hidden={false}
+    prop:index="a0"
+  >
+    <affine:paragraph
+      prop:text="123"
+      prop:type="text"
+    >
+      <affine:paragraph
+        prop:text="456"
+        prop:type="text"
+      />
+    </affine:paragraph>
+    <affine:paragraph
+      prop:text="789"
+      prop:type="text"
+    />
+  </affine:note>
+</affine:page>`
+  );
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -777,7 +777,7 @@ export function locatorComponentToolbar(page: Page) {
   return page.locator('edgeless-element-toolbar-widget');
 }
 
-function locatorComponentToolbarMoreButton(page: Page) {
+export function locatorComponentToolbarMoreButton(page: Page) {
   const moreButton = locatorComponentToolbar(page).locator(
     'edgeless-more-button'
   );
@@ -809,7 +809,13 @@ type Action =
   | 'changeNoteDisplayMode'
   | 'changeNoteSlicerSetting'
   | 'addText'
-  | 'quickConnect';
+  | 'quickConnect'
+  | 'turnIntoLinkedDoc'
+  | 'createLinkedDoc'
+  | 'linkedDocInfo'
+  | 'openLinkedDoc'
+  | 'toCardView'
+  | 'toEmbedView';
 
 export async function triggerComponentToolbarAction(
   page: Page,
@@ -1035,6 +1041,58 @@ export async function triggerComponentToolbarAction(
       const button = locatorComponentToolbar(page).getByRole('button', {
         name: 'Draw connector',
       });
+      await button.click();
+      break;
+    }
+    case 'turnIntoLinkedDoc': {
+      const moreButton = locatorComponentToolbarMoreButton(page);
+      await moreButton.click();
+
+      const actionButton = moreButton
+        .locator('.more-actions-container .action-item')
+        .filter({
+          hasText: 'Turn into linked doc',
+        });
+      await actionButton.click();
+      break;
+    }
+    case 'createLinkedDoc': {
+      const moreButton = locatorComponentToolbarMoreButton(page);
+      await moreButton.click();
+
+      const actionButton = moreButton
+        .locator('.more-actions-container .action-item')
+        .filter({
+          hasText: 'Create linked doc',
+        });
+      await actionButton.click();
+      break;
+    }
+    case 'linkedDocInfo': {
+      const button = locatorComponentToolbar(page).locator('.doc-info');
+      await button.click();
+      break;
+    }
+    case 'openLinkedDoc': {
+      const button = locatorComponentToolbar(page).locator('.open');
+      await button.click();
+      break;
+    }
+    case 'toCardView': {
+      const button = locatorComponentToolbar(page)
+        .locator('edgeless-tool-icon-button')
+        .filter({
+          hasText: 'Card view',
+        });
+      await button.click();
+      break;
+    }
+    case 'toEmbedView': {
+      const button = locatorComponentToolbar(page)
+        .locator('edgeless-tool-icon-button')
+        .filter({
+          hasText: 'Embed view',
+        });
       await button.click();
       break;
     }
@@ -1443,9 +1501,13 @@ export async function createConnectorElement(
   );
 }
 
-export async function createNote(page: Page, coord1: number[]) {
+export async function createNote(
+  page: Page,
+  coord1: number[],
+  content?: string
+) {
   const start = await toViewCoord(page, coord1);
-  return addNote(page, 'note', start[0], start[1]);
+  return addNote(page, content || 'note', start[0], start[1]);
 }
 
 export async function hoverOnNote(page: Page, id: string, offset = [0, 0]) {


### PR DESCRIPTION
### TL;DR
This pull request support edgeless mode to create linked doc. Find more details in [THIS RFC](https://app.affine.pro/workspace/af3478a2-9c9c-4d16-864d-bffa1eb10eb6/XUmNieqGMKDs525xNqY8G).

There are two way to create a linked doc in edgeless editor:
- The first way, select a single note and click the `Turn into linked doc` menu item. The content of the selected note will become a independant document.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/029fa907-26a5-4063-9fb2-0409931ab291.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/029fa907-26a5-4063-9fb2-0409931ab291.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/029fa907-26a5-4063-9fb2-0409931ab291.mov">录屏2024-06-03 18.52.41.mov</video>

- The second way, select multiple edgeless elements and click the `create linked doc` menu item. All the selected elements will be moved to the linked document.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/06852f1b-7b16-4745-a8d8-24f1770ee306.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/06852f1b-7b16-4745-a8d8-24f1770ee306.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/06852f1b-7b16-4745-a8d8-24f1770ee306.mov">录屏2024-06-03 18.50.04.mov</video>


### What changed?
Features:
- Add `Turn into linked doc` and `Create linked doc` item in more menu, as well as handlers for the menu items.
- Add three kind of linked doc create method:
  - createLinkedDocFromBlocks
  - createLinkedDocFromNote
  - createLinkedDocFromEdgelessElements
- Add `sortEdgelessElements` to sort elements before added to edgeless root element.
- Add`mapConnectorIds` to maintain interdependencies between nodes. 
Since the id of the element in linked doc will be regenerated，using `mapConnectorIds` to complete the mapping of old and new element ids. Three kind of interdependencies:
  - source and target of connector
  - children of groups
  - parent and children of mindmaps
- Add e2e tests for edgeless mode create linked doc scenes.
- Add `SerializedElement` typescript type for better type inference.

Refactor:
- Move `getBlockProps` function from embed card popover to `common/utils/block-props.ts`, thus it can be easily reused.
- Extract side effects of `createLinkedDocFromSelectedBlocks`, using the first heading block content as doc title only works in page mode.
- Split the move blocks into two parts: add blocks and delete blocks, so they can be easily reused.

### How to test?

As shown in the screen recording video before, select any elements on the edgeless board and convert it in to linked doc. Get more inspiration based on scenarios from e2e testing.

---

