### PR TITLE
fix(blocks): reassociate connectors

### DIFF
--- a/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
+++ b/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
@@ -21,18 +21,22 @@ export const reassociateConnectorsCommand: Command<
 
   const surface = service.surface;
   const connectors = surface.getConnectors(oldId);
-  for (const connector of connectors) {
-    if (connector.source.id === oldId) {
-      connector.source.id = newId;
-      surface.updateElement(connector.id, {
-        source: connector.source,
+  for (const { id, source, target } of connectors) {
+    if (source.id === oldId) {
+      surface.updateElement(id, {
+        source: {
+          ...source,
+          id: newId,
+        },
       });
       continue;
     }
-    if (connector.target.id === oldId) {
-      connector.target.id = newId;
-      surface.updateElement(connector.id, {
-        target: connector.target,
+    if (target.id === oldId) {
+      surface.updateElement(id, {
+        target: {
+          ...target,
+          id: newId,
+        },
       });
     }
   }


### PR DESCRIPTION
Closes: [BS-465](https://linear.app/affine-design/issue/BS-465/linked-与-synced-频繁切换时，进行-undoredo-操作，connectors-会丢)