### PR TITLE
fix(presets): new image actions should display in chat panel

### DIFF
--- a/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
@@ -461,7 +461,8 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
       return (
         'role' in item ||
         item.messages?.length === 3 ||
-        (item.action === 'image' && item.messages?.length === 2)
+        (HISTORY_IMAGE_ACTIONS.includes(item.action) &&
+          item.messages?.length === 2)
       );
     });
 


### PR DESCRIPTION
[BS-470](https://linear.app/affine-design/issue/BS-470/新增的-image-actions-在-chat-panel-的显示)