### PR TITLE
feat(page): add prompt pop-up for users to input linked doc title

### DIFF
--- a/packages/blocks/src/_common/components/notification-service.ts
+++ b/packages/blocks/src/_common/components/notification-service.ts
@@ -18,6 +18,7 @@ export interface NotificationService {
   prompt(options: {
     title: string | TemplateResult;
     message: string | TemplateResult;
+    autofill?: string;
     placeholder?: string;
     confirmText?: string;
     cancelText?: string;

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -12,7 +12,11 @@ import {
   DatabaseTableViewIcon20,
   FontLinkedDocIcon,
 } from '../../icons/index.js';
-import { convertSelectedBlocksToLinkedDoc } from '../../utils/render-linked-doc.js';
+import {
+  convertSelectedBlocksToLinkedDoc,
+  getTitleFromSelectedModels,
+  promptDocTitle,
+} from '../../utils/render-linked-doc.js';
 import { DATABASE_CONVERT_WHITE_LIST } from './database-convert-view.js';
 
 export interface QuickActionConfig {
@@ -134,9 +138,19 @@ export const quickActionConfig: QuickActionConfig[] = [
       host.selection.clear();
 
       const doc = host.doc;
-      const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
-      const linkedDocService = host.spec.getService('affine:embed-linked-doc');
-      linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+      const autofill = getTitleFromSelectedModels(selectedModels);
+      void promptDocTitle(host, autofill).then(title => {
+        if (title === null) return;
+        const linkedDoc = convertSelectedBlocksToLinkedDoc(
+          doc,
+          selectedModels,
+          title
+        );
+        const linkedDocService = host.spec.getService(
+          'affine:embed-linked-doc'
+        );
+        linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+      });
     },
   },
 ];

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -4,7 +4,11 @@ import { IS_MAC, IS_WINDOWS } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
 
 import { matchFlavours } from '../../_common/utils/model.js';
-import { convertSelectedBlocksToLinkedDoc } from '../../_common/utils/render-linked-doc.js';
+import {
+  convertSelectedBlocksToLinkedDoc,
+  getTitleFromSelectedModels,
+  promptDocTitle,
+} from '../../_common/utils/render-linked-doc.js';
 
 export class PageKeyboardManager {
   constructor(public rootElement: BlockElement) {
@@ -150,10 +154,18 @@ export class PageKeyboardManager {
     }
 
     const doc = rootElement.host.doc;
-    const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
-    const linkedDocService = rootElement.host.spec.getService(
-      'affine:embed-linked-doc'
-    );
-    linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+    const autofill = getTitleFromSelectedModels(selectedModels);
+    void promptDocTitle(rootElement.host, autofill).then(title => {
+      if (title === null) return;
+      const linkedDoc = convertSelectedBlocksToLinkedDoc(
+        doc,
+        selectedModels,
+        title
+      );
+      const linkedDocService = rootElement.host.spec.getService(
+        'affine:embed-linked-doc'
+      );
+      linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+    });
   }
 }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -29,6 +29,7 @@ import { type ReorderingType } from '../../../_common/utils/index.js';
 import {
   createLinkedDocFromEdgelessElements,
   createLinkedDocFromNote,
+  promptDocTitle,
 } from '../../../_common/utils/render-linked-doc.js';
 import type {
   AttachmentBlockComponent,
@@ -292,14 +293,15 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     return [ACTION_DIVIDER, CREATE_LINKED_DOC_ACTION];
   }
 
-  private _turnIntoLinkedDoc = () => {
+  private _turnIntoLinkedDoc = (title?: string) => {
     const isSingleSelect = this.selection.selectedElements.length === 1;
     const { firstElement: element } = this.selection;
 
     if (isSingleSelect && isNoteBlock(element)) {
       const linkedDoc = createLinkedDocFromNote(
         this.edgeless.host.doc,
-        element
+        element,
+        title
       );
       // insert linked doc card
       const cardId = this.edgeless.service.addBlock(
@@ -322,11 +324,11 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         editing: false,
       });
     } else {
-      this._createLinkedDoc();
+      this._createLinkedDoc(title);
     }
   };
 
-  private _createLinkedDoc = () => {
+  private _createLinkedDoc = (title?: string) => {
     const selection = this.edgeless.service.selection;
     const elements = getCloneElements(
       selection.selectedElements,
@@ -334,7 +336,8 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     );
     const linkedDoc = createLinkedDocFromEdgelessElements(
       this.edgeless.host.doc,
-      elements
+      elements,
+      title
     );
     // insert linked doc card
     const width = 364;
@@ -413,11 +416,15 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         break;
       }
       case 'turn-into-linked-doc': {
-        this._turnIntoLinkedDoc();
+        const title = await promptDocTitle(this.edgeless.host);
+        if (title === null) return;
+        this._turnIntoLinkedDoc(title);
         break;
       }
       case 'create-linked-doc': {
-        this._createLinkedDoc();
+        const title = await promptDocTitle(this.edgeless.host);
+        if (title === null) return;
+        this._createLinkedDoc(title);
         break;
       }
       case 'create-frame': {

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -27,7 +27,11 @@ import {
   TextIcon,
   UnderlineIcon,
 } from '../../../_common/icons/index.js';
-import { convertSelectedBlocksToLinkedDoc } from '../../../_common/utils/render-linked-doc.js';
+import {
+  convertSelectedBlocksToLinkedDoc,
+  getTitleFromSelectedModels,
+  promptDocTitle,
+} from '../../../_common/utils/render-linked-doc.js';
 import type { AffineFormatBarWidget } from './format-bar.js';
 
 export type DividerConfigItem = {
@@ -184,11 +188,19 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
         host.selection.clear();
 
         const doc = host.doc;
-        const linkedDoc = convertSelectedBlocksToLinkedDoc(doc, selectedModels);
-        const linkedDocService = host.spec.getService(
-          'affine:embed-linked-doc'
-        );
-        linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+        const autofill = getTitleFromSelectedModels(selectedModels);
+        void promptDocTitle(host, autofill).then(title => {
+          if (title === null) return;
+          const linkedDoc = convertSelectedBlocksToLinkedDoc(
+            doc,
+            selectedModels,
+            title
+          );
+          const linkedDocService = host.spec.getService(
+            'affine:embed-linked-doc'
+          );
+          linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+        });
       },
       showWhen: chain => {
         const [_, ctx] = chain

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -110,7 +110,12 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
               return Promise.resolve(confirm(notification.title.toString()));
             },
             prompt: notification => {
-              return Promise.resolve(prompt(notification.title.toString()));
+              return Promise.resolve(
+                prompt(
+                  notification.title.toString(),
+                  notification.autofill?.toString()
+                )
+              );
             },
             notify: notification => {
               // todo: implement in playground

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -159,7 +159,12 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
               return Promise.resolve(confirm(notification.title.toString()));
             },
             prompt: notification => {
-              return Promise.resolve(prompt(notification.title.toString()));
+              return Promise.resolve(
+                prompt(
+                  notification.title.toString(),
+                  notification.autofill?.toString()
+                )
+              );
             },
             notify: notification => {
               // todo: implement in playground


### PR DESCRIPTION
This pull request adds support for page and edgeless mode to create a linked documents using a specific doc title entered by the user. 

https://github.com/toeverything/blocksuite/assets/12724894/68e7ee42-1c0f-449d-9832-2a80134589dd

### What Changed?
- Add a prompt pop-up window for users to enter the title of the linked document.
- In page mode, use the first heading block content as pop-up input autofill value and default document title.

