### PR TITLE
fix(presets): clear selection after ai panel close in edgeless mode

### DIFF
--- a/packages/presets/src/ai/actions/doc-handler.ts
+++ b/packages/presets/src/ai/actions/doc-handler.ts
@@ -166,7 +166,6 @@ function updateAIPanelConfig<T extends keyof BlockSuitePresets.AIActions>(
   config.errorStateConfig = buildErrorConfig(aiPanel);
   config.copy = buildCopyConfig(aiPanel);
   config.discardCallback = () => {
-    aiPanel.hide();
     reportResponse('result:discard');
   };
 }

--- a/packages/presets/src/ai/actions/edgeless-handler.ts
+++ b/packages/presets/src/ai/actions/edgeless-handler.ts
@@ -318,7 +318,6 @@ function updateEdgelessAIPanelConfig<
     },
   };
   config.discardCallback = () => {
-    aiPanel.hide();
     reportResponse('result:discard');
   };
   config.hideCallback = () => {
@@ -328,6 +327,7 @@ function updateEdgelessAIPanelConfig<
           elements: [],
           editing: false,
         });
+        host.selection.clear();
         edgelessCopilot.lockToolbar(false);
       })
       .catch(console.error);


### PR DESCRIPTION
Close [BS-310](https://linear.app/affine-design/issue/BS-310/edgeless%E4%B8%8B%EF%BC%8C%E9%87%8D%E6%96%B0%E5%AF%B9doc%E6%96%87%E6%9C%AC%E4%BD%BF%E7%94%A8ai-aciton%E4%BC%9A%E4%BD%BF%E5%BE%97%E9%80%89%E5%8C%BA%E4%B8%A2%E5%A4%B1)

Clear selection after discarding the edgeless AI action, which is consistent with the AI action behaviors of other edgeless elements.

- Edgeless element selection behavior with edgeless ai action:

https://github.com/toeverything/blocksuite/assets/20479050/375bd4a7-38ed-4462-bf17-78e22c7ed67c

- Doc text selection behavior with edgeless  ai action (**Before**):

https://github.com/toeverything/blocksuite/assets/20479050/3a6de2a7-c670-4980-b65e-f4aeacd04d83

- Doc text selection behavior with edgeless  ai action (**After**):

https://github.com/toeverything/blocksuite/assets/20479050/38850211-bc19-470c-875e-907471cdbb89

