### PR TITLE
feat(page): add notify toast after linked doc created

### DIFF
--- a/packages/blocks/src/_common/components/notification-service.ts
+++ b/packages/blocks/src/_common/components/notification-service.ts
@@ -28,11 +28,12 @@ export interface NotificationService {
     title: string | TemplateResult;
     message?: string | TemplateResult;
     accent?: 'info' | 'success' | 'warning' | 'error';
-    duration?: number; // give 0 to disable auto dismiss
+    duration?: number; // unit ms, give 0 to disable auto dismiss
     abort?: AbortSignal;
     action?: {
       label: string | TemplateResult;
       onClick: () => void;
     };
+    onClose: () => void;
   }): void;
 }

--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -15,6 +15,7 @@ import {
 import {
   convertSelectedBlocksToLinkedDoc,
   getTitleFromSelectedModels,
+  notifyDocCreated,
   promptDocTitle,
 } from '../../utils/render-linked-doc.js';
 import { DATABASE_CONVERT_WHITE_LIST } from './database-convert-view.js';
@@ -150,6 +151,7 @@ export const quickActionConfig: QuickActionConfig[] = [
           'affine:embed-linked-doc'
         );
         linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+        notifyDocCreated(host, doc);
       });
     },
   },

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -7,6 +7,7 @@ import { matchFlavours } from '../../_common/utils/model.js';
 import {
   convertSelectedBlocksToLinkedDoc,
   getTitleFromSelectedModels,
+  notifyDocCreated,
   promptDocTitle,
 } from '../../_common/utils/render-linked-doc.js';
 
@@ -166,6 +167,7 @@ export class PageKeyboardManager {
         'affine:embed-linked-doc'
       );
       linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+      notifyDocCreated(rootElement.host, doc);
     });
   }
 }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -29,6 +29,7 @@ import { type ReorderingType } from '../../../_common/utils/index.js';
 import {
   createLinkedDocFromEdgelessElements,
   createLinkedDocFromNote,
+  notifyDocCreated,
   promptDocTitle,
 } from '../../../_common/utils/render-linked-doc.js';
 import type {
@@ -419,12 +420,14 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         const title = await promptDocTitle(this.edgeless.host);
         if (title === null) return;
         this._turnIntoLinkedDoc(title);
+        notifyDocCreated(this.edgeless.host, this.edgeless.doc);
         break;
       }
       case 'create-linked-doc': {
         const title = await promptDocTitle(this.edgeless.host);
         if (title === null) return;
         this._createLinkedDoc(title);
+        notifyDocCreated(this.edgeless.host, this.edgeless.doc);
         break;
       }
       case 'create-frame': {

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -30,6 +30,7 @@ import {
 import {
   convertSelectedBlocksToLinkedDoc,
   getTitleFromSelectedModels,
+  notifyDocCreated,
   promptDocTitle,
 } from '../../../_common/utils/render-linked-doc.js';
 import type { AffineFormatBarWidget } from './format-bar.js';
@@ -200,6 +201,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
             'affine:embed-linked-doc'
           );
           linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+          notifyDocCreated(host, doc);
         });
       },
       showWhen: chain => {

--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lit/binding-positions, lit/no-invalid-html */
 
 import { handleError } from '@blocksuite/global/exceptions';
-import { assertExists } from '@blocksuite/global/utils';
+import { assertExists, Slot } from '@blocksuite/global/utils';
 import type { BlockModel, Doc } from '@blocksuite/store';
 import { css } from 'lit';
 import {
@@ -48,6 +48,10 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
   std!: BlockSuite.Std;
 
   rangeManager: RangeManager | null = null;
+
+  readonly slots = {
+    unmounted: new Slot(),
+  };
 
   get command(): CommandManager {
     return this.std.command;
@@ -129,6 +133,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
     super.disconnectedCallback();
     this.std.unmount();
     this.rangeManager = null;
+    this.slots.unmounted.emit();
   }
 
   override render() {


### PR DESCRIPTION
This pull request adds a notify toast after linked doc created. Users can click the `undo` button on the toast to revert the change that created the linked document.

### What changed?
- Add the notify toast both in page mode and edgeless mode
- When user edit or undo or switch doc, close the notify toast
- Clear all observers when toast closed

[Related PR in AFFiNE](https://github.com/toeverything/AFFiNE/pull/7162)

https://github.com/toeverything/blocksuite/assets/12724894/3a9c21d7-4d40-408a-978e-455c6370ef68

---

