### PR TITLE
ci: enable corepack again

### DIFF
--- a/.github/workflows/browser-compatibility.yml
+++ b/.github/workflows/browser-compatibility.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -46,8 +44,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-        with:
-          version: 9
 
       - name: Download Previous Size Data
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -68,8 +66,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:
@@ -127,8 +123,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -159,8 +153,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -183,8 +175,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
-        with:
-          version: 9
       - name: Use Node.js LTS
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18.19.0 <21.0.0",
-    "pnpm": ">=9"
+    "node": ">=18.19.0 <21.0.0"
   },
+  "packageManager": "pnpm@9.2.0",
   "scripts": {
     "preview": "pnpm --filter @blocksuite/playground preview",
     "dev": "pnpm --filter @blocksuite/playground dev",


### PR DESCRIPTION
Enable corepack again since pnpm finally won't throw error when version mismatch.

https://github.com/pnpm/pnpm/releases/tag/v9.2.0