### PR TITLE
refactor: add docsService for doc mode get, set, toogle and observe change

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/types.ts
+++ b/packages/blocks/src/_common/components/ai-item/types.ts
@@ -1,7 +1,7 @@
 import type { Chain, EditorHost, InitCommandCtx } from '@blocksuite/block-std';
 import type { TemplateResult } from 'lit';
 
-import type { EditorMode } from '../../utils/index.js';
+import type { DocMode } from '../../utils/index.js';
 
 export interface AIItemGroupConfig {
   name?: string;
@@ -13,7 +13,7 @@ export interface AIItemConfig {
   icon: TemplateResult | (() => HTMLElement);
   showWhen?: (
     chain: Chain<InitCommandCtx>,
-    editorMode: EditorMode,
+    editorMode: DocMode,
     host: EditorHost
   ) => boolean;
   subItem?: AISubItemConfig[];

--- a/packages/blocks/src/_common/components/biz-services.ts
+++ b/packages/blocks/src/_common/components/biz-services.ts
@@ -1,4 +1,9 @@
+import type { BlockElement } from '@blocksuite/block-std';
+import type { Disposable } from '@blocksuite/global/utils';
 import type { TemplateResult } from 'lit';
+
+import type { QuickSearchResult } from '../../root-block/root-service.js';
+import type { DocMode } from '../types.js';
 
 export interface NotificationService {
   toast(
@@ -36,4 +41,28 @@ export interface NotificationService {
     };
     onClose: () => void;
   }): void;
+}
+
+export interface QuickSearchService {
+  searchDoc: (options: {
+    action?: 'insert';
+    userInput?: string;
+    skipSelection?: boolean;
+  }) => Promise<QuickSearchResult>;
+}
+
+export interface PeekViewService {
+  peek(pageRef: { docId: string; blockId?: string }): void;
+  peek(target: HTMLElement): void;
+  peek<Element extends BlockElement>(target: Element): void;
+}
+
+export interface DocModeService {
+  setMode: (mode: DocMode, docId?: string) => void;
+  getMode: (docId?: string) => DocMode | null;
+  toggleMode: (docId?: string) => DocMode | null;
+  onModeChange: (
+    handler: (mode: DocMode | null) => void,
+    docId?: string
+  ) => Disposable;
 }

--- a/packages/blocks/src/_common/components/index.ts
+++ b/packages/blocks/src/_common/components/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-item/index.js';
+export * from './biz-services.js';
 export * from './block-caption.js';
 export * from './block-component.js';
 export * from './block-selection.js';
@@ -7,7 +8,6 @@ export * from './file-drop-manager.js';
 export * from './hover/index.js';
 export * from './menu/index.js';
 export * from './menu-divider.js';
-export * from './notification-service.js';
 export * from './peekable.js';
 export * from './portal.js';
 export * from './rich-text/rich-text.js';

--- a/packages/blocks/src/_common/components/peekable.ts
+++ b/packages/blocks/src/_common/components/peekable.ts
@@ -28,12 +28,6 @@ export class PeekableController {
   };
 }
 
-export interface PeekViewService {
-  peek(pageRef: { docId: string; blockId?: string }): void;
-  peek(target: HTMLElement): void;
-  peek<Element extends BlockElement>(target: Element): void;
-}
-
 type PeekableAction = 'double-click' | 'selected-click' | 'shift-click';
 
 type PeekableOptions = {

--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -32,15 +32,15 @@ export interface EditingState {
 
 export type CommonSlots = RefNodeSlots;
 
-export type EditorMode = 'page' | 'edgeless';
+export type DocMode = 'page' | 'edgeless';
+
 type EditorSlots = {
-  editorModeSwitched: Slot<EditorMode>;
   docUpdated: Slot<{ newDocId: string }>;
 };
 
 export type AbstractEditor = {
   doc: Doc;
-  mode: EditorMode;
+  mode: DocMode | null;
   readonly slots: CommonSlots & EditorSlots;
 } & HTMLElement;
 

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -159,7 +159,7 @@ export function notifyDocCreated(host: EditorHost, doc: Doc) {
     accent: 'info',
     duration: 10 * 1000,
     action: {
-      label: 'undo',
+      label: 'Undo',
       onClick: () => {
         doc.undo();
         clear();
@@ -518,14 +518,14 @@ export function createLinkedDocFromNote(
 }
 
 export function createLinkedDocFromEdgelessElements(
-  doc: Doc,
+  host: EditorHost,
   elements: BlockSuite.EdgelessModelType[],
   docTitle?: string
 ) {
-  const linkedDoc = doc.collection.createDoc({});
+  const linkedDoc = host.doc.collection.createDoc({});
   linkedDoc.load(() => {
     const rootId = linkedDoc.addBlock('affine:page', {
-      title: new doc.Text(docTitle),
+      title: new host.doc.Text(docTitle),
     });
     const surfaceId = linkedDoc.addBlock('affine:surface', {}, rootId);
     const surface = getSurfaceBlock(linkedDoc);
@@ -557,6 +557,7 @@ export function createLinkedDocFromEdgelessElements(
       ids.set(model.id, newId);
     });
   });
-
+  const pageService = host.spec.getService('affine:page');
+  pageService.docModeService?.setMode('edgeless', linkedDoc.id);
   return linkedDoc;
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -19,15 +19,21 @@ import { deserializeXYWH } from './surface-block/index.js';
 
 export * from './_common/adapters/index.js';
 export * from './_common/components/ai-item/index.js';
+export type {
+  DocModeService,
+  NotificationService,
+  PeekViewService,
+  QuickSearchService,
+} from './_common/components/index.js';
 export {
   createLitPortal,
   HoverController,
   PeekableController,
-  type PeekViewService,
+  RichText,
+  scrollbarStyle,
   toast,
   Tooltip,
 } from './_common/components/index.js';
-export { RichText, scrollbarStyle } from './_common/components/index.js';
 export { type NavigatorMode } from './_common/edgeless/frame/consts.js';
 export {
   createEmbedBlock,
@@ -65,7 +71,11 @@ export {
   ThemeObserver,
 } from './_common/theme/theme-observer.js';
 export * from './_common/transformers/index.js';
-export { type AbstractEditor, NoteDisplayMode } from './_common/types.js';
+export {
+  type AbstractEditor,
+  type DocMode,
+  NoteDisplayMode,
+} from './_common/types.js';
 export {
   createButtonPopper,
   matchFlavours,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -82,8 +82,6 @@ export class EdgelessRootService extends RootService {
       blockId?: string;
     }>(),
     tagClicked: new Slot<{ tagId: string }>(),
-    editorModeSwitch: new Slot<'edgeless' | 'page'>(),
-
     toolbarLocked: new Slot<boolean>(),
   };
 

--- a/packages/blocks/src/root-block/page/page-root-service.ts
+++ b/packages/blocks/src/root-block/page/page-root-service.ts
@@ -13,6 +13,5 @@ export class PageRootService extends RootService {
       tagId: string;
     }>(),
     viewportUpdated: new Slot<Viewport>(),
-    editorModeSwitch: new Slot<'edgeless' | 'page'>(),
   };
 }

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -8,10 +8,12 @@ import {
   type FileDropOptions,
 } from '../_common/components/file-drop-manager.js';
 import {
+  type DocModeService,
   getSelectedPeekableBlocksCommand,
   type NotificationService,
   peekSelectedBlockCommand,
   type PeekViewService,
+  type QuickSearchService,
 } from '../_common/components/index.js';
 import {
   DEFAULT_IMAGE_PROXY_ENDPOINT,
@@ -65,14 +67,6 @@ export type QuickSearchResult =
   | { userInput: string }
   | null;
 
-export interface QuickSearchService {
-  searchDoc: (options: {
-    action?: 'insert';
-    userInput?: string;
-    skipSelection?: boolean;
-  }) => Promise<QuickSearchResult>;
-}
-
 export class RootService extends BlockService<RootBlockModel> {
   readonly fontLoader = new FontLoader();
 
@@ -86,6 +80,8 @@ export class RootService extends BlockService<RootBlockModel> {
   notificationService: NotificationService | null = null;
 
   peekViewService: PeekViewService | null = null;
+
+  docModeService: DocModeService | null = null;
 
   transformers = {
     markdown: MarkdownTransformer,

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -401,7 +401,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       this.edgeless.surface.edgeless.service.frame
     );
     const linkedDoc = createLinkedDocFromEdgelessElements(
-      this.edgeless.host.doc,
+      this.edgeless.host,
       elements,
       title
     );

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -497,7 +497,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     const pageService = this.std.spec.getService('affine:page');
 
     pageService.editPropsStore.setItem('viewport', viewport);
-    pageService.slots.editorModeSwitch.emit('edgeless');
+    pageService.docModeService?.setMode('edgeless');
   }
 
   private _renderMask(referencedModel: RefElementModel, flavourOrType: string) {

--- a/packages/playground/apps/_common/components/custom-chat-panel.ts
+++ b/packages/playground/apps/_common/components/custom-chat-panel.ts
@@ -37,15 +37,15 @@ export class CustomChatPanel extends WithDisposable(ShadowlessElement) {
   override connectedCallback(): void {
     super.connectedCallback();
     const { editor } = this;
+    const { docModeService } = editor.host.spec.getService('affine:page');
+    if (!docModeService) return;
 
     this.disposables.add(
-      editor.host.spec
-        .getService('affine:page')
-        .slots.editorModeSwitch.on(() => {
-          this.editor.updateComplete
-            .then(() => this.requestUpdate())
-            .catch(console.error);
-        })
+      docModeService.onModeChange(() => {
+        this.editor.updateComplete
+          .then(() => this.requestUpdate())
+          .catch(console.error);
+      })
     );
   }
 

--- a/packages/playground/apps/_common/components/custom-frame-panel.ts
+++ b/packages/playground/apps/_common/components/custom-frame-panel.ts
@@ -44,13 +44,16 @@ export class CustomFramePanel extends WithDisposable(ShadowlessElement) {
       });
     });
 
-    this.disposables.add(
-      this.editor.slots.editorModeSwitched.on(() => {
-        this.editor.updateComplete
-          .then(() => this.requestUpdate())
-          .catch(console.error);
-      })
-    );
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    if (docModeService) {
+      this.disposables.add(
+        docModeService.onModeChange(() => {
+          this.editor.updateComplete
+            .then(() => this.requestUpdate())
+            .catch(console.error);
+        })
+      );
+    }
   }
 
   override render() {

--- a/packages/playground/apps/_common/components/debug-menu.ts
+++ b/packages/playground/apps/_common/components/debug-menu.ts
@@ -23,6 +23,7 @@ import {
   BlocksUtils,
   ColorVariables,
   defaultImageProxyMiddleware,
+  type DocMode,
   extractCssVariables,
   FontFamilyVariables,
   HtmlTransformer,
@@ -239,7 +240,7 @@ export class DebugMenu extends ShadowlessElement {
     return this.editor.mode;
   }
 
-  set mode(value: 'page' | 'edgeless') {
+  set mode(value: DocMode | null) {
     this.editor.mode = value;
   }
 
@@ -304,7 +305,9 @@ export class DebugMenu extends ShadowlessElement {
   }
 
   private _switchEditorMode() {
-    this.mode = this.mode === 'page' ? 'edgeless' : 'page';
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    if (!docModeService) return;
+    this.mode = docModeService.toggleMode();
   }
 
   private _toggleOutlinePanel() {
@@ -573,7 +576,8 @@ export class DebugMenu extends ShadowlessElement {
       this._canRedo = this.doc.canRedo;
     });
 
-    this.editor.slots.editorModeSwitched.on(() => {
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    docModeService?.onModeChange(() => {
       this.requestUpdate();
     });
   }

--- a/packages/playground/apps/_common/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/_common/components/quick-edgeless-menu.ts
@@ -18,7 +18,11 @@ import '@shoelace-style/shoelace/dist/themes/dark.css';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
-import type { AffineTextAttributes, SerializedXYWH } from '@blocksuite/blocks';
+import type {
+  AffineTextAttributes,
+  DocMode,
+  SerializedXYWH,
+} from '@blocksuite/blocks';
 import { ColorVariables, extractCssVariables } from '@blocksuite/blocks';
 import type { DeltaInsert } from '@blocksuite/inline';
 import type { AffineEditorContainer } from '@blocksuite/presets';
@@ -86,7 +90,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   private accessor _canRedo = false;
 
   @property({ attribute: false })
-  accessor mode: 'page' | 'edgeless' = 'page';
+  accessor mode: DocMode | null = 'page';
 
   @property({ attribute: false })
   accessor readonly = false;
@@ -131,16 +135,15 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   };
 
   private _switchEditorMode() {
-    const mode = this.editor.mode === 'page' ? 'edgeless' : 'page';
-    localStorage.setItem('playground:editorMode', mode);
-    this.mode = mode;
+    const { docModeService } = this.rootService;
+    if (!docModeService) return;
+    this.mode = docModeService.toggleMode();
   }
 
   private _restoreMode() {
-    const mode = localStorage.getItem('playground:editorMode');
-    if (mode && (mode === 'edgeless' || mode === 'page')) {
-      this.mode = mode;
-    }
+    const { docModeService } = this.rootService;
+    if (!docModeService) return;
+    this.mode = docModeService.getMode();
   }
 
   private _addNote() {

--- a/packages/playground/apps/_common/mock-services.ts
+++ b/packages/playground/apps/_common/mock-services.ts
@@ -1,0 +1,83 @@
+import type { EditorHost } from '@blocksuite/block-std';
+import {
+  type DocMode,
+  type DocModeService,
+  type NotificationService,
+  type PageRootService,
+  type QuickSearchService,
+  toast,
+} from '@blocksuite/blocks';
+import { type DocCollection, Slot } from '@blocksuite/store';
+
+export function mockDocModeService() {
+  const modeChange = new Slot<DocMode>();
+  const docModeService: DocModeService = {
+    setMode: (mode: DocMode) => {
+      localStorage.setItem('playground:editorMode', mode);
+      modeChange.emit(mode);
+    },
+    getMode: () => {
+      return localStorage.getItem('playground:editorMode') as DocMode;
+    },
+    toggleMode: () => {
+      const mode = docModeService.getMode() === 'page' ? 'edgeless' : 'page';
+      docModeService.setMode(mode);
+      return mode;
+    },
+    onModeChange: (handler: (mode: DocMode | null) => void) => {
+      return modeChange.on(handler);
+    },
+  };
+  return docModeService;
+}
+
+export function mockNotificationService(service: PageRootService) {
+  const notificationService: NotificationService = {
+    toast: (message, options) => {
+      toast(service.host as EditorHost, message, options?.duration);
+    },
+    confirm: notification => {
+      return Promise.resolve(confirm(notification.title.toString()));
+    },
+    prompt: notification => {
+      return Promise.resolve(
+        prompt(notification.title.toString(), notification.autofill?.toString())
+      );
+    },
+    notify: notification => {
+      // todo: implement in playground
+      console.log(notification);
+    },
+  };
+  return notificationService;
+}
+
+export function mockQuickSearchService(collection: DocCollection) {
+  const quickSearchService: QuickSearchService = {
+    async searchDoc({ userInput }) {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      const docs = collection.search({
+        query: userInput,
+        limit: 1,
+      });
+      const doc = [...docs].at(0);
+      if (doc) {
+        return {
+          docId: doc[1],
+        };
+      } else if (userInput) {
+        return {
+          userInput: userInput,
+        };
+      } else {
+        // randomly pick a doc
+        return {
+          docId: [...collection.docs.values()][
+            Math.floor(Math.random() * collection.docs.size)
+          ].id,
+        };
+      }
+    },
+  };
+  return quickSearchService;
+}

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -1,5 +1,5 @@
 import type { BlockSpec, EditorHost } from '@blocksuite/block-std';
-import { type PageRootService, toast } from '@blocksuite/blocks';
+import type { DocMode, PageRootService } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import { AffineEditorContainer } from '@blocksuite/presets';
 import type { BlockCollection } from '@blocksuite/store';
@@ -8,6 +8,11 @@ import type { DocCollection } from '@blocksuite/store';
 import { DocsPanel } from '../../_common/components/docs-panel.js';
 import { LeftSidePanel } from '../../_common/components/left-side-panel.js';
 import { QuickEdgelessMenu } from '../../_common/components/quick-edgeless-menu.js';
+import {
+  mockDocModeService,
+  mockNotificationService,
+  mockQuickSearchService,
+} from '../../_common/mock-services.js';
 import { getExampleSpecs } from '../specs-examples/index.js';
 
 const params = new URLSearchParams(location.search);
@@ -68,7 +73,8 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   quickEdgelessMenu.leftSidePanel = leftSidePanel;
   quickEdgelessMenu.docsPanel = docsPanel;
 
-  function switchQuickEdgelessMenu(mode: typeof defaultMode) {
+  function switchQuickEdgelessMenu(mode: DocMode | null) {
+    if (!mode) return;
     quickEdgelessMenu.mode = mode;
   }
 
@@ -99,62 +105,23 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
         setup?.(slots, disposable);
         slots.mounted.once(({ service }) => {
           const pageRootService = service as PageRootService;
-          disposable.add(
-            pageRootService.slots.editorModeSwitch.on(switchQuickEdgelessMenu)
-          );
-          pageRootService.notificationService = {
-            toast: (message, options) => {
-              toast(service.host as EditorHost, message, options?.duration);
-            },
-            confirm: notification => {
-              return Promise.resolve(confirm(notification.title.toString()));
-            },
-            prompt: notification => {
-              return Promise.resolve(
-                prompt(
-                  notification.title.toString(),
-                  notification.autofill?.toString()
-                )
-              );
-            },
-            notify: notification => {
-              // todo: implement in playground
-              console.log(notification);
-            },
-          };
-          pageRootService.quickSearchService = {
-            async searchDoc({ userInput }) {
-              await new Promise(resolve => setTimeout(resolve, 500));
-              const docs = collection.search({
-                query: userInput,
-                limit: 1,
-              });
-              const doc = [...docs].at(0);
-              if (doc) {
-                return {
-                  docId: doc[1],
-                };
-              } else if (userInput) {
-                return {
-                  userInput: userInput,
-                };
-              } else {
-                // randomly pick a doc
-                return {
-                  docId: [...collection.docs.values()][
-                    Math.floor(Math.random() * collection.docs.size)
-                  ].id,
-                };
-              }
-            },
-          };
-
+          pageRootService.notificationService =
+            mockNotificationService(pageRootService);
+          pageRootService.quickSearchService =
+            mockQuickSearchService(collection);
           pageRootService.peekViewService = {
             peek(target: unknown) {
               alert('Peek view not implemented in playground');
               console.log('peek', target);
             },
           };
+          pageRootService.docModeService = mockDocModeService();
+          pageRootService.docModeService &&
+            disposable.add(
+              pageRootService.docModeService.onModeChange(
+                switchQuickEdgelessMenu
+              )
+            );
         });
       },
     };

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -4,7 +4,6 @@ import {
   AffineFormatBarWidget,
   EdgelessEditorBlockSpecs,
   PageEditorBlockSpecs,
-  toast,
   toolbarDefaultConfig,
 } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
@@ -24,6 +23,11 @@ import { DebugMenu } from '../../_common/components/debug-menu.js';
 import { DocsPanel } from '../../_common/components/docs-panel.js';
 import { LeftSidePanel } from '../../_common/components/left-side-panel.js';
 import { SidePanel } from '../../_common/components/side-panel.js';
+import {
+  mockDocModeService,
+  mockNotificationService,
+  mockQuickSearchService,
+} from '../../_common/mock-services.js';
 
 const params = new URLSearchParams(location.search);
 const defaultMode = params.get('mode') === 'edgeless' ? 'edgeless' : 'page';
@@ -151,51 +155,11 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
             }
           });
           disposable.add(onFormatBarConnected);
-          pageRootService.notificationService = {
-            toast: (message, options) => {
-              toast(service.host as EditorHost, message, options?.duration);
-            },
-            confirm: notification => {
-              return Promise.resolve(confirm(notification.title.toString()));
-            },
-            prompt: notification => {
-              return Promise.resolve(
-                prompt(
-                  notification.title.toString(),
-                  notification.autofill?.toString()
-                )
-              );
-            },
-            notify: notification => {
-              // todo: implement in playground
-              console.log(notification);
-            },
-          };
-          pageRootService.quickSearchService = {
-            async searchDoc({ userInput }) {
-              await new Promise(resolve => setTimeout(resolve, 500));
-              const docs = collection.search({
-                query: userInput,
-                limit: 1,
-              });
-              const doc = [...docs].at(0);
-              if (doc) {
-                return {
-                  docId: doc[1],
-                };
-              } else if (userInput) {
-                return {
-                  userInput: userInput,
-                };
-              } else {
-                // randomly create a doc
-                const newDoc = collection.createDoc();
-                return {
-                  docId: newDoc.id,
-                };
-              }
-            },
-          };
+          pageRootService.notificationService =
+            mockNotificationService(pageRootService);
+          pageRootService.quickSearchService =
+            mockQuickSearchService(collection);
+          pageRootService.docModeService = mockDocModeService();
         });
       },
     };

--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -178,8 +178,7 @@ describe('basic', () => {
 
     const switchEditor = vi.fn(() => {});
     const pageService = editor.host.std.spec.getService('affine:page');
-
-    pageService.slots.editorModeSwitch.once(switchEditor);
+    pageService.docModeService?.onModeChange(switchEditor);
 
     expect(surfaceRef).instanceOf(Element);
     (surfaceRef as SurfaceRefBlockComponent).viewInEdgeless();

--- a/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
@@ -205,13 +205,10 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
           this.requestUpdate();
         })
       );
-      disposables.add(
-        this.host.spec
-          .getService('affine:page')
-          .slots.editorModeSwitch.on(() => {
-            this.requestUpdate();
-          })
-      );
+
+      const { docModeService } = this.host.spec.getService('affine:page');
+      if (!docModeService) return;
+      disposables.add(docModeService.onModeChange(() => this.requestUpdate()));
     }
   }
 

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -256,7 +256,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
 
       const rootService = this.editorHost.spec.getService('affine:page');
       rootService.editPropsStore.setItem('viewport', viewport);
-      rootService.slots.editorModeSwitch.emit('edgeless');
+      rootService.docModeService?.setMode('edgeless');
     } else {
       this.edgeless.service.viewport.setViewportByBound(
         bound,

--- a/packages/presets/src/fragments/frame-panel/frame-panel.ts
+++ b/packages/presets/src/fragments/frame-panel/frame-panel.ts
@@ -99,13 +99,16 @@ export class FramePanel extends WithDisposable(ShadowlessElement) {
   private _setEditorDisposables() {
     this._clearEditorDisposables();
     this._editorDisposables = new DisposableGroup();
-    this._editorDisposables.add(
-      this.editor.slots.editorModeSwitched.on(() => {
-        this.editor.updateComplete
-          .then(() => this.requestUpdate())
-          .catch(console.error);
-      })
-    );
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    if (docModeService) {
+      this._editorDisposables.add(
+        docModeService.onModeChange(() => {
+          this.editor.updateComplete
+            .then(() => this.requestUpdate())
+            .catch(console.error);
+        })
+      );
+    }
     this._editorDisposables.add(
       this.editor.slots.docUpdated.on(() => {
         this.editor.updateComplete

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -130,8 +130,9 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
   }
 
   private _enterPresentationMode = () => {
-    if (!this.edgeless)
-      this.rootService.slots.editorModeSwitch.emit('edgeless');
+    if (!this.edgeless) {
+      this.rootService.docModeService?.setMode('edgeless');
+    }
 
     setTimeout(() => {
       this.edgeless?.updateComplete

--- a/packages/presets/src/fragments/outline-panel/outline-panel.ts
+++ b/packages/presets/src/fragments/outline-panel/outline-panel.ts
@@ -139,15 +139,18 @@ export class OutlinePanel extends WithDisposable(LitElement) {
   private _setEditorDisposables() {
     this._clearEditorDisposables();
     this._editorDisposables = new DisposableGroup();
-    this._editorDisposables.add(
-      this.editor.slots.editorModeSwitched.on(() => {
-        this.editor.updateComplete
-          .then(() => {
-            this.requestUpdate();
-          })
-          .catch(console.error);
-      })
-    );
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    if (docModeService) {
+      this._editorDisposables.add(
+        docModeService.onModeChange(() => {
+          this.editor.updateComplete
+            .then(() => {
+              this.requestUpdate();
+            })
+            .catch(console.error);
+        })
+      );
+    }
     this._editorDisposables.add(
       this.editor.slots.docUpdated.on(() => {
         this.editor.updateComplete

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -23,6 +23,7 @@ import {
   enterPlaygroundRoom,
   getEditorLocator,
   initEmptyEdgelessState,
+  mockDocMode,
   waitNextFrame,
 } from './misc.js';
 
@@ -110,6 +111,7 @@ export async function toggleFramePanel(page: Page) {
 }
 
 export async function switchEditorMode(page: Page) {
+  await mockDocMode(page);
   await page.click('sl-tooltip[content="Switch Editor"]');
   // FIXME: listen to editor loaded event
   await waitNextFrame(page);

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -5,6 +5,7 @@ import type { EditorHost } from '@block-std/view/element/lit-host.js';
 import type { CssVariableName } from '@blocks/_common/theme/css-variables.js';
 import type {
   DatabaseBlockModel,
+  DocMode,
   ListType,
   RichText,
   ThemeObserver,
@@ -278,6 +279,7 @@ export async function enterPlaygroundRoom(
   url.searchParams.set('room', room);
   url.searchParams.set('blobSource', blobSource?.join(',') || 'idb');
   await page.goto(url.toString());
+
   // const readyPromise = waitForPageReady(page);
 
   // See https://github.com/microsoft/playwright/issues/5546
@@ -1438,4 +1440,28 @@ export async function mockQuickSearch(
       },
     };
   }, mapping);
+}
+
+export async function mockDocMode(page: Page) {
+  await page.evaluate(() => {
+    let docMode: DocMode = 'page';
+    const docModeService = {
+      setMode: (mode: DocMode) => {
+        docMode = mode;
+      },
+      getMode: () => {
+        return docMode;
+      },
+      toggleMode: () => {
+        const mode = docMode === 'page' ? 'edgeless' : 'page';
+        docModeService.setMode(mode);
+        return mode;
+      },
+      onModeChange: () => {
+        return { dispose: () => null };
+      },
+    };
+    window.host.std.spec.getService('affine:page').docModeService =
+      docModeService;
+  });
 }


### PR DESCRIPTION
### What changed?
- add docsService for doc mode get, set, toogle and observe change
- set doc mode to edgeless after linked doc created

[Related PR in AFFiNE](https://github.com/toeverything/AFFiNE/pull/7174)


---

