### PR TITLE
fix(blocks): refine tooltip visual effect

### DIFF
--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -1,4 +1,4 @@
-import { assertExists, DisposableGroup } from '@blocksuite/global/utils';
+import { DisposableGroup } from '@blocksuite/global/utils';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import type { StyleInfo } from 'lit/directives/style-map.js';
 
@@ -14,7 +14,7 @@ type OptionsParams = Omit<
 };
 type HoverPortalOptions = Omit<AdvancedPortalOptions, 'abortController'>;
 
-type HoverOptions = {
+export type HoverOptions = {
   /**
    * Transition style when the portal is shown or hidden.
    */
@@ -75,9 +75,9 @@ export class HoverController implements ReactiveController {
     onHover: (options: OptionsParams) => HoverPortalOptions | null,
     hoverOptions?: Partial<HoverOptions>
   ) {
+    this._hoverOptions = { ...DEFAULT_HOVER_OPTIONS, ...hoverOptions };
     (this.host = host).addController(this);
     this._onHover = onHover;
-    this._hoverOptions = { ...DEFAULT_HOVER_OPTIONS, ...hoverOptions };
   }
 
   hostConnected() {
@@ -104,10 +104,8 @@ export class HoverController implements ReactiveController {
         );
         return;
       }
-      if (this._abortController) {
-        return;
-      }
 
+      this._abortController?.abort();
       this._abortController = new AbortController();
       this._abortController.signal.addEventListener('abort', () => {
         this._abortController = undefined;
@@ -133,11 +131,7 @@ export class HoverController implements ReactiveController {
 
       const transition = this._hoverOptions.transition;
       if (transition) {
-        Object.assign(this._portal.style, transition.out);
-        setTimeout(() => {
-          assertExists(this._portal);
-          Object.assign(this._portal.style, transition.in);
-        });
+        Object.assign(this._portal.style, transition.in);
       }
 
       if (this._hoverOptions.setPortalAsFloating) {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/default/default-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/default/default-tool-button.ts
@@ -18,6 +18,9 @@ export class EdgelessDefaultToolButton extends WithDisposable(LitElement) {
     .current-icon {
       transition: 100ms;
     }
+    .current-icon > svg {
+      display: block;
+    }
     .arrow-up-icon {
       position: absolute;
       top: 4px;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/lasso/lasso-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/lasso/lasso-tool-button.ts
@@ -18,6 +18,9 @@ export class EdgelessDefaultToolButton extends WithDisposable(LitElement) {
     .current-icon {
       transition: 100ms;
     }
+    .current-icon > svg {
+      display: block;
+    }
     .arrow-up-icon {
       position: absolute;
       top: 4px;

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -492,6 +492,10 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
         tip-position="right"
         .offset=${22}
         .tooltipStyle=${slashItemToolTipStyle}
+        .hoverOptions=${{
+          enterDelay: 1500,
+          allowMultiple: false,
+        }}
       >
         <div class="tooltip-figure">${tooltip.figure}</div>
         <div class="tooltip-caption">${tooltip.caption}</div>


### PR DESCRIPTION
Close BS-327

- Refine tooltip visual effect


https://github.com/toeverything/blocksuite/assets/20479050/dc078ea2-475b-4560-9935-4dbec57f5b2f

https://github.com/toeverything/blocksuite/assets/20479050/6dd62885-b28b-4b64-95c3-a3e4dd301827

- Fix edgeless tool bar button size (40x43.33 -> 40x40)
![image](https://github.com/toeverything/blocksuite/assets/20479050/70590d08-8310-4786-ae73-b2f437f6a3cb)
![image](https://github.com/toeverything/blocksuite/assets/20479050/0c327918-79e3-4ff9-afce-2d7e95c3fa01)

