### PR TITLE
fix: code-language-list widget disappear

### DIFF
--- a/packages/blocks/src/_common/components/filterable-list/index.ts
+++ b/packages/blocks/src/_common/components/filterable-list/index.ts
@@ -172,7 +172,7 @@ export class FilterableListComponent<Props = unknown> extends WithDisposable(
   }
 }
 
-export function popFilterableList({
+export function showPopFilterableList({
   options,
   filter,
   abortController,
@@ -236,7 +236,10 @@ export function popFilterableList({
           },
         }),
       ],
-      autoUpdate: true,
+      autoUpdate: {
+        // fix the lang list position incorrectly when scrolling
+        animationFrame: true,
+      },
     },
     abortController,
   });

--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -95,8 +95,19 @@ export class HoverController implements ReactiveController {
         }
         // Transition out
         Object.assign(this._portal.style, this._hoverOptions.transition.out);
+
+        // The transition event is not reliable,
+        // consider adding explicit duration to the transition options in the future
+        // See also https://github.com/w3c/csswg-drafts/issues/3043 https://github.com/toeverything/blocksuite/pull/7248/files#r1631375330
         this._portal.addEventListener(
           'transitionend',
+          () => {
+            abortController.abort();
+          },
+          { signal: abortController.signal }
+        );
+        this._portal.addEventListener(
+          'transitioncancel',
           () => {
             abortController.abort();
           },
@@ -105,6 +116,8 @@ export class HoverController implements ReactiveController {
         return;
       }
 
+      // If some problems arise when aborting the previous hover,
+      // consider fixing the transition related issues and return void here
       this._abortController?.abort();
       this._abortController = new AbortController();
       this._abortController.signal.addEventListener('abort', () => {


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/pull/7245 https://github.com/toeverything/blocksuite/pull/7246

The `HoverController` is unsuitable here since the lang list should not disappear when the user hovers out.