### PR TITLE
fix(blocks): connectors resize and rotate

### DIFF
--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -8,18 +8,18 @@ import {
   type DropResult,
   getClosestBlockElementByPoint,
   getModelByBlockComponent,
-  type IPoint,
   isInsidePageEditor,
   matchFlavours,
   Point,
 } from '../../_common/utils/index.js';
+import type { IVec2 } from '../../surface-block/index.js';
 import type { DragIndicator } from './drag-indicator.js';
 
 export type onDropProps = {
   files: File[];
   targetModel: BlockModel | null;
   place: 'before' | 'after';
-  point: IPoint;
+  point: IVec2;
 };
 
 export type FileDropOptions = {
@@ -165,16 +165,13 @@ export class FileDropManager {
     event.preventDefault();
 
     const { targetModel, type: place } = this;
-    const { clientX, clientY } = event;
+    const { x, y } = event;
 
     onDrop({
       files: [...droppedFiles],
       targetModel,
       place,
-      point: {
-        x: clientX,
-        y: clientY,
-      },
+      point: [x, y],
     })?.catch(console.error);
   };
 }

--- a/packages/blocks/src/attachment-block/attachment-service.ts
+++ b/packages/blocks/src/attachment-block/attachment-service.ts
@@ -68,7 +68,7 @@ export class AttachmentBlockService extends BlockService<AttachmentBlockModel> {
         );
       } else if (isInsideEdgelessEditor(this.host as EditorHost)) {
         const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
-        point = edgelessRoot.service.viewport.toViewPointFromClientPoint(point);
+        point = edgelessRoot.service.viewport.toViewCoordFromClientCoord(point);
         await edgelessRoot.addAttachments(attachmentFiles, point);
       }
 

--- a/packages/blocks/src/image-block/image-service.ts
+++ b/packages/blocks/src/image-block/image-service.ts
@@ -60,7 +60,7 @@ export class ImageBlockService extends BlockService<ImageBlockModel> {
         );
       } else if (isInsideEdgelessEditor(this.host as EditorHost)) {
         const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
-        point = edgelessRoot.service.viewport.toViewPointFromClientPoint(point);
+        point = edgelessRoot.service.viewport.toViewCoordFromClientCoord(point);
         await edgelessRoot.addImages(imageFiles, point);
       }
 

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-block-portal.ts
@@ -393,12 +393,12 @@ export class EdgelessBlockPortalContainer extends WithDisposable(
         .autoCompleteOff=${this._enableNoteSlicer}
       ></edgeless-selected-rect>
 
-      ${!readonly
-        ? html`<edgeless-index-label
+      ${readonly
+        ? nothing
+        : html`<edgeless-index-label
             .surface=${surface}
             .edgeless=${edgeless}
-          ></edgeless-index-label>`
-        : nothing}
+          ></edgeless-index-label>`}
 
       <edgeless-navigator-black-background
         .edgeless=${edgeless}

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -18,6 +18,7 @@ import {
 import { pickValues } from '../../../../_common/utils/iterable.js';
 import { clamp } from '../../../../_common/utils/math.js';
 import { EDGELESS_TEXT_BLOCK_MIN_WIDTH } from '../../../../edgeless-text/edgeless-text-block.js';
+import type { EdgelessTextBlockModel } from '../../../../edgeless-text/edgeless-text-model.js';
 import {
   EMBED_HTML_MIN_HEIGHT,
   EMBED_HTML_MIN_WIDTH,
@@ -38,6 +39,7 @@ import {
   CanvasElementType,
   deserializeXYWH,
   GroupElementModel,
+  type PointLocation,
   ShapeElementModel,
 } from '../../../../surface-block/index.js';
 import {
@@ -46,7 +48,6 @@ import {
   type IVec,
   normalizeDegAngle,
   normalizeShapeBound,
-  serializeXYWH,
 } from '../../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import { NOTE_MIN_HEIGHT, NOTE_MIN_WIDTH } from '../../utils/consts.js';
@@ -588,6 +589,256 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     return elements.length > 0 && !this.selection.editing;
   }
 
+  #adjustNote(
+    element: NoteBlockModel,
+    bound: Bound,
+    direction: HandleDirection
+  ) {
+    const curBound = Bound.deserialize(element.xywh);
+
+    let scale = element.edgeless.scale ?? 1;
+    let width = curBound.w / scale;
+    let height = curBound.h / scale;
+
+    if (this._shiftKey) {
+      scale = bound.w / width;
+      this._scalePercent = `${Math.round(scale * 100)}%`;
+      this._scaleDirection = direction;
+    } else if (curBound.h !== bound.h) {
+      this.edgeless.doc.updateBlock(element, () => {
+        element.edgeless.collapse = true;
+        element.edgeless.collapsedHeight = bound.h / scale;
+      });
+    }
+
+    width = bound.w / scale;
+    width = clamp(width, NOTE_MIN_WIDTH, Infinity);
+    bound.w = width * scale;
+
+    height = bound.h / scale;
+    height = clamp(height, NOTE_MIN_HEIGHT, Infinity);
+    bound.h = height * scale;
+
+    this._isWidthLimit = width === NOTE_MIN_WIDTH;
+    this._isHeightLimit = height === NOTE_MIN_HEIGHT;
+
+    this.edgeless.service.updateElement(element.id, {
+      edgeless: {
+        ...element.edgeless,
+        scale,
+      },
+      xywh: bound.serialize(),
+    });
+  }
+
+  #adjustEdgelessText(
+    element: EdgelessTextBlockModel,
+    bounds: Bound,
+    direction: HandleDirection
+  ) {
+    const oldXYWH = Bound.deserialize(element.xywh);
+    if (
+      direction === HandleDirection.TopLeft ||
+      direction === HandleDirection.TopRight ||
+      direction === HandleDirection.BottomRight ||
+      direction === HandleDirection.BottomLeft
+    ) {
+      const newScale = element.scale * (bounds.w / oldXYWH.w);
+      this._scalePercent = `${Math.round(newScale * 100)}%`;
+      this._scaleDirection = direction;
+
+      bounds.h = bounds.w * (oldXYWH.h / oldXYWH.w);
+      this.edgeless.service.updateElement(element.id, {
+        scale: newScale,
+        xywh: bounds.serialize(),
+      });
+    } else if (
+      direction === HandleDirection.Left ||
+      direction === HandleDirection.Right
+    ) {
+      const newRealWidth = clamp(
+        bounds.w / element.scale,
+        EDGELESS_TEXT_BLOCK_MIN_WIDTH,
+        Infinity
+      );
+      bounds.w = newRealWidth * element.scale;
+      this.edgeless.service.updateElement(element.id, {
+        xywh: Bound.serialize({
+          ...bounds,
+          h: oldXYWH.h,
+        }),
+        hasMaxWidth: true,
+      });
+    }
+  }
+
+  #adjustEmbedSyncedDoc(
+    element: EmbedSyncedDocModel,
+    bound: Bound,
+    direction: HandleDirection
+  ) {
+    const curBound = Bound.deserialize(element.xywh);
+
+    let scale = element.scale ?? 1;
+    let width = curBound.w / scale;
+    let height = curBound.h / scale;
+    if (this._shiftKey) {
+      scale = bound.w / width;
+      this._scalePercent = `${Math.round(scale * 100)}%`;
+      this._scaleDirection = direction;
+    }
+
+    width = bound.w / scale;
+    width = clamp(width, SYNCED_MIN_WIDTH, Infinity);
+    bound.w = width * scale;
+
+    height = bound.h / scale;
+    height = clamp(height, SYNCED_MIN_HEIGHT, Infinity);
+    bound.h = height * scale;
+
+    this._isWidthLimit = width === SYNCED_MIN_WIDTH;
+    this._isHeightLimit = height === SYNCED_MIN_HEIGHT;
+
+    this.edgeless.service.updateElement(element.id, {
+      scale,
+      xywh: bound.serialize(),
+    });
+  }
+
+  #adjustEmbedHtml(
+    element: EmbedHtmlModel,
+    bound: Bound,
+    _direction: HandleDirection
+  ) {
+    bound.w = clamp(bound.w, EMBED_HTML_MIN_WIDTH, Infinity);
+    bound.h = clamp(bound.h, EMBED_HTML_MIN_HEIGHT, Infinity);
+
+    this._isWidthLimit = bound.w === EMBED_HTML_MIN_WIDTH;
+    this._isHeightLimit = bound.h === EMBED_HTML_MIN_HEIGHT;
+
+    this.edgeless.service.updateElement(element.id, {
+      xywh: bound.serialize(),
+    });
+  }
+
+  #adjustProportional(
+    element: BlockSuite.EdgelessModelType,
+    bound: Bound,
+    direction: HandleDirection
+  ) {
+    const curBound = Bound.deserialize(element.xywh);
+
+    if (isImageBlock(element)) {
+      const { height } = element;
+      if (height) {
+        this._scalePercent = `${Math.round((bound.h / height) * 100)}%`;
+        this._scaleDirection = direction;
+      }
+    } else {
+      const cardStyle = (element as BookmarkBlockModel).style;
+      const height = EMBED_CARD_HEIGHT[cardStyle];
+      this._scalePercent = `${Math.round((bound.h / height) * 100)}%`;
+      this._scaleDirection = direction;
+    }
+    if (
+      direction === HandleDirection.Left ||
+      direction === HandleDirection.Right
+    ) {
+      bound.h = (curBound.h / curBound.w) * bound.w;
+    } else if (
+      direction === HandleDirection.Top ||
+      direction === HandleDirection.Bottom
+    ) {
+      bound.w = (curBound.w / curBound.h) * bound.h;
+    }
+
+    this.edgeless.service.updateElement(element.id, {
+      xywh: bound.serialize(),
+    });
+  }
+
+  #adjustText(
+    element: TextElementModel,
+    bound: Bound,
+    direction: HandleDirection
+  ) {
+    let p = 1;
+    if (
+      direction === HandleDirection.Left ||
+      direction === HandleDirection.Right
+    ) {
+      const {
+        text: yText,
+        fontFamily,
+        fontSize,
+        fontStyle,
+        fontWeight,
+        hasMaxWidth,
+      } = element;
+      // If the width of the text element has been changed by dragging,
+      // We need to set hasMaxWidth to true for wrapping the text
+      bound = normalizeTextBound(
+        {
+          yText,
+          fontFamily,
+          fontSize,
+          fontStyle,
+          fontWeight,
+          hasMaxWidth,
+        },
+        bound,
+        true
+      );
+      // If the width of the text element has been changed by dragging,
+      // We need to set hasMaxWidth to true for wrapping the text
+      this.edgeless.service.updateElement(element.id, {
+        xywh: bound.serialize(),
+        fontSize: element.fontSize * p,
+        hasMaxWidth: true,
+      });
+    } else {
+      p = bound.h / element.h;
+      // const newFontsize = element.fontSize * p;
+      // bound = normalizeTextBound(element, bound, false, newFontsize);
+
+      this.edgeless.service.updateElement(element.id, {
+        xywh: bound.serialize(),
+        fontSize: element.fontSize * p,
+      });
+    }
+  }
+
+  #adjustShape(
+    element: ShapeElementModel,
+    bound: Bound,
+    _direction: HandleDirection
+  ) {
+    bound = normalizeShapeBound(element, bound);
+    this.edgeless.service.updateElement(element.id, {
+      xywh: bound.serialize(),
+    });
+  }
+
+  #adjustConnector(
+    element: ConnectorElementModel,
+    bounds: Bound,
+    matrix: DOMMatrix,
+    originalPath: PointLocation[]
+  ) {
+    const props = element.resize(bounds, originalPath, matrix);
+    this.edgeless.service.updateElement(element.id, props);
+  }
+
+  #adjustUseFallback(
+    element: BlockSuite.EdgelessModelType,
+    bound: Bound,
+    _direction: HandleDirection
+  ) {
+    this.edgeless.service.updateElement(element.id, {
+      xywh: bound.serialize(),
+    });
+  }
+
   private _onDragStart = () => {
     this.slots.dragStart.emit();
 
@@ -636,6 +887,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       string,
       {
         bound: Bound;
+        path?: PointLocation[];
+        matrix?: DOMMatrix;
       }
     >,
     direction: HandleDirection
@@ -644,200 +897,51 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
     const { edgeless } = this;
 
-    newBounds.forEach(({ bound }, id) => {
+    newBounds.forEach(({ bound, matrix, path }, id) => {
       const element = edgeless.service.getElementById(id);
       if (!element) return;
 
       if (isNoteBlock(element)) {
-        const curBound = Bound.deserialize(element.xywh);
-        const props: Partial<NoteBlockModel> = {};
-
-        let scale = element.edgeless.scale ?? 1;
-        let width = curBound.w / scale;
-        let height = curBound.h / scale;
-
-        if (this._shiftKey) {
-          scale = bound.w / width;
-          this._scalePercent = `${Math.round(scale * 100)}%`;
-          this._scaleDirection = direction;
-        } else if (curBound.h !== bound.h) {
-          edgeless.doc.updateBlock(element, () => {
-            element.edgeless.collapse = true;
-            element.edgeless.collapsedHeight = bound.h / scale;
-          });
-        }
-
-        width = bound.w / scale;
-        width = clamp(width, NOTE_MIN_WIDTH, Infinity);
-        bound.w = width * scale;
-
-        height = bound.h / scale;
-        height = clamp(height, NOTE_MIN_HEIGHT, Infinity);
-        bound.h = height * scale;
-
-        this._isWidthLimit = width === NOTE_MIN_WIDTH;
-        this._isHeightLimit = height === NOTE_MIN_HEIGHT;
-
-        props.edgeless = { ...element.edgeless, scale };
-        props.xywh = bound.serialize();
-        edgeless.service.updateElement(element.id, props);
-      } else if (isEdgelessTextBlock(element)) {
-        const oldXYWH = Bound.deserialize(element.xywh);
-        if (
-          direction === HandleDirection.TopLeft ||
-          direction === HandleDirection.TopRight ||
-          direction === HandleDirection.BottomRight ||
-          direction === HandleDirection.BottomLeft
-        ) {
-          const newScale = element.scale * (bound.w / oldXYWH.w);
-          this._scalePercent = `${Math.round(newScale * 100)}%`;
-          this._scaleDirection = direction;
-
-          bound.h = bound.w * (oldXYWH.h / oldXYWH.w);
-          edgeless.service.updateElement(element.id, {
-            scale: newScale,
-            xywh: bound.serialize(),
-          });
-        } else if (
-          direction === HandleDirection.Left ||
-          direction === HandleDirection.Right
-        ) {
-          const newRealWidth = clamp(
-            bound.w / element.scale,
-            EDGELESS_TEXT_BLOCK_MIN_WIDTH,
-            Infinity
-          );
-          bound.w = newRealWidth * element.scale;
-          edgeless.service.updateElement(element.id, {
-            xywh: Bound.serialize({
-              ...bound,
-              h: oldXYWH.h,
-            }),
-            hasMaxWidth: true,
-          });
-        }
-      } else if (isEmbedSyncedDocBlock(element)) {
-        const curBound = Bound.deserialize(element.xywh);
-        const props: Partial<EmbedSyncedDocModel> = {};
-
-        let scale = element.scale ?? 1;
-        let width = curBound.w / scale;
-        let height = curBound.h / scale;
-        if (this._shiftKey) {
-          scale = bound.w / width;
-          this._scalePercent = `${Math.round(scale * 100)}%`;
-          this._scaleDirection = direction;
-        }
-
-        width = bound.w / scale;
-        width = clamp(width, SYNCED_MIN_WIDTH, Infinity);
-        bound.w = width * scale;
-
-        height = bound.h / scale;
-        height = clamp(height, SYNCED_MIN_HEIGHT, Infinity);
-        bound.h = height * scale;
-
-        this._isWidthLimit = width === SYNCED_MIN_WIDTH;
-        this._isHeightLimit = height === SYNCED_MIN_HEIGHT;
-
-        props.scale = scale;
-        props.xywh = bound.serialize();
-        edgeless.service.updateElement(element.id, props);
-      } else if (isEmbedHtmlBlock(element)) {
-        bound.w = clamp(bound.w, EMBED_HTML_MIN_WIDTH, Infinity);
-        bound.h = clamp(bound.h, EMBED_HTML_MIN_HEIGHT, Infinity);
-
-        this._isWidthLimit = bound.w === EMBED_HTML_MIN_WIDTH;
-        this._isHeightLimit = bound.h === EMBED_HTML_MIN_HEIGHT;
-
-        const props: Partial<EmbedHtmlModel> = {};
-        props.xywh = bound.serialize();
-        edgeless.service.updateElement(element.id, props);
-      } else if (this._isProportionalElement(element)) {
-        const curBound = Bound.deserialize(element.xywh);
-
-        if (isImageBlock(element)) {
-          const { height } = element;
-          if (height) {
-            this._scalePercent = `${Math.round((bound.h / height) * 100)}%`;
-            this._scaleDirection = direction;
-          }
-        } else {
-          const cardStyle = (element as BookmarkBlockModel).style;
-          const height = EMBED_CARD_HEIGHT[cardStyle];
-          this._scalePercent = `${Math.round((bound.h / height) * 100)}%`;
-          this._scaleDirection = direction;
-        }
-        if (
-          direction === HandleDirection.Left ||
-          direction === HandleDirection.Right
-        ) {
-          bound.h = (curBound.h / curBound.w) * bound.w;
-        } else if (
-          direction === HandleDirection.Top ||
-          direction === HandleDirection.Bottom
-        ) {
-          bound.w = (curBound.w / curBound.h) * bound.h;
-        }
-
-        edgeless.service.updateElement(element.id, {
-          xywh: bound.serialize(),
-        });
-      } else if (element instanceof TextElementModel) {
-        let p = 1;
-        if (
-          direction === HandleDirection.Left ||
-          direction === HandleDirection.Right
-        ) {
-          const {
-            text: yText,
-            fontFamily,
-            fontSize,
-            fontStyle,
-            fontWeight,
-            hasMaxWidth,
-          } = element;
-          // If the width of the text element has been changed by dragging,
-          // We need to set hasMaxWidth to true for wrapping the text
-          bound = normalizeTextBound(
-            {
-              yText,
-              fontFamily,
-              fontSize,
-              fontStyle,
-              fontWeight,
-              hasMaxWidth,
-            },
-            bound,
-            true
-          );
-          // If the width of the text element has been changed by dragging,
-          // We need to set hasMaxWidth to true for wrapping the text
-          edgeless.service.updateElement(id, {
-            xywh: bound.serialize(),
-            fontSize: element.fontSize * p,
-            hasMaxWidth: true,
-          });
-        } else {
-          p = bound.h / element.h;
-          // const newFontsize = element.fontSize * p;
-          // bound = normalizeTextBound(element, bound, false, newFontsize);
-
-          edgeless.service.updateElement(id, {
-            xywh: bound.serialize(),
-            fontSize: element.fontSize * p,
-          });
-        }
-      } else if (element instanceof ShapeElementModel) {
-        bound = normalizeShapeBound(element, bound);
-        edgeless.service.updateElement(id, {
-          xywh: bound.serialize(),
-        });
-      } else {
-        edgeless.service.updateElement(id, {
-          xywh: bound.serialize(),
-        });
+        this.#adjustNote(element, bound, direction);
+        return;
       }
+
+      if (isEdgelessTextBlock(element)) {
+        this.#adjustEdgelessText(element, bound, direction);
+        return;
+      }
+
+      if (isEmbedSyncedDocBlock(element)) {
+        this.#adjustEmbedSyncedDoc(element, bound, direction);
+        return;
+      }
+
+      if (isEmbedHtmlBlock(element)) {
+        this.#adjustEmbedHtml(element, bound, direction);
+        return;
+      }
+
+      if (this._isProportionalElement(element)) {
+        this.#adjustProportional(element, bound, direction);
+        return;
+      }
+
+      if (element instanceof TextElementModel) {
+        this.#adjustText(element, bound, direction);
+        return;
+      }
+
+      if (element instanceof ShapeElementModel) {
+        this.#adjustShape(element, bound, direction);
+        return;
+      }
+
+      if (element instanceof ConnectorElementModel && matrix && path) {
+        this.#adjustConnector(element, bound, matrix, path);
+        return;
+      }
+
+      this.#adjustUseFallback(element, bound, direction);
     });
   };
 
@@ -854,19 +958,32 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       element =>
         isImageBlock(element) ||
         isEdgelessTextBlock(element) ||
-        (isCanvasElement(element) &&
-          element.type !== CanvasElementType.CONNECTOR)
-    ) as BlockSuite.EdgelessModelType[];
+        isCanvasElement(element)
+    );
 
     getElementsWithoutGroup(elements).forEach(element => {
       const { id, rotate } = element;
-      const { x, y, w, h } = Bound.deserialize(element.xywh);
-      const center = new DOMPoint(x + w / 2, y + h / 2).matrixTransform(m);
+      const bounds = Bound.deserialize(element.xywh);
+      const originalCenter = bounds.center;
+      const point = new DOMPoint(...originalCenter).matrixTransform(m);
+      bounds.center = [point.x, point.y];
 
-      this.edgeless.service.updateElement(id, {
-        xywh: serializeXYWH(center.x - w / 2, center.y - h / 2, w, h),
-        rotate: normalizeDegAngle(rotate + delta),
-      });
+      if (
+        isCanvasElement(element) &&
+        element instanceof ConnectorElementModel
+      ) {
+        this.#adjustConnector(
+          element,
+          bounds,
+          m,
+          element.absolutePath.map(p => p.clone())
+        );
+      } else {
+        this.edgeless.service.updateElement(id, {
+          xywh: bounds.serialize(),
+          rotate: normalizeDegAngle(rotate + delta),
+        });
+      }
     });
 
     this._updateCursor(true, { type: 'rotate', angle: delta });
@@ -1207,10 +1324,12 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
       const connectorHandle =
         elements.length === 1 && elements[0] instanceof ConnectorElementModel
-          ? html`<edgeless-connector-handle
-              .connector=${elements[0]}
-              .edgeless=${edgeless}
-            ></edgeless-connector-handle>`
+          ? html`
+              <edgeless-connector-handle
+                .connector=${elements[0]}
+                .edgeless=${edgeless}
+              ></edgeless-connector-handle>
+            `
           : nothing;
 
       const elementHandle =

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -19,7 +19,7 @@ import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
 } from '../../../_common/consts.js';
-import { matchFlavours, Point } from '../../../_common/utils/index.js';
+import { matchFlavours } from '../../../_common/utils/index.js';
 import { groupBy } from '../../../_common/utils/iterable.js';
 import {
   blockElementGetter,
@@ -53,7 +53,11 @@ import {
 import { ConnectorElementModel } from '../../../surface-block/index.js';
 import { compare } from '../../../surface-block/managers/layer-utils.js';
 import { Bound, getCommonBound } from '../../../surface-block/utils/bound.js';
-import { type IVec, Vec } from '../../../surface-block/utils/vec.js';
+import {
+  type IVec,
+  type IVec2,
+  Vec,
+} from '../../../surface-block/utils/vec.js';
 import { ClipboardAdapter } from '../../clipboard/adapter.js';
 import { PageClipboard } from '../../clipboard/index.js';
 import {
@@ -232,11 +236,12 @@ export class EdgelessClipboardController extends PageClipboard {
     const data = event.clipboardData;
     if (!data) return;
 
+    const { lastMousePos } = this.toolManager;
+    const point: IVec2 = [lastMousePos.x, lastMousePos.y];
+
     if (isPureFileInClipboard(data)) {
       const files = data.files;
       if (files.length === 0) return;
-
-      const { lastMousePos } = this.toolManager;
 
       const imageFiles: File[] = [],
         attachmentFiles: File[] = [];
@@ -251,9 +256,9 @@ export class EdgelessClipboardController extends PageClipboard {
 
       // when only images in clipboard, add image-blocks else add all files as attachments
       if (attachmentFiles.length === 0) {
-        await this.host.addImages(imageFiles, lastMousePos);
+        await this.host.addImages(imageFiles, point);
       } else {
-        await this.host.addAttachments([...files], lastMousePos);
+        await this.host.addAttachments([...files], point);
       }
 
       return;
@@ -324,8 +329,6 @@ export class EdgelessClipboardController extends PageClipboard {
 
     const svg = tryGetSvgFromClipboard(data);
     if (svg) {
-      const { lastMousePos } = this.toolManager;
-      const point = new Point(lastMousePos.x, lastMousePos.y);
       await this.host.addImages([svg], point);
       return;
     }

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -45,6 +45,7 @@ import type {
 import {
   Bound,
   type IBound,
+  type IVec2,
   normalizeWheelDeltaY,
   serializeXYWH,
   Vec,
@@ -378,7 +379,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
 
   async addImages(
     files: File[],
-    point?: IPoint,
+    point?: IVec2,
     inTopLeft?: boolean
   ): Promise<string[]> {
     const imageFiles = [...files].filter(file =>
@@ -402,7 +403,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
     }
 
     let { x, y } = this.service.viewport.center;
-    if (point) [x, y] = this.service.viewport.toModelCoord(point.x, point.y);
+    if (point) [x, y] = this.service.viewport.toModelCoord(...point);
 
     const dropInfos: { point: Point; blockId: string }[] = [];
 
@@ -460,7 +461,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
     return blockIds;
   }
 
-  async addAttachments(files: File[], point?: IPoint): Promise<string[]> {
+  async addAttachments(files: File[], point?: IVec2): Promise<string[]> {
     if (!files.length) return [];
 
     const attachmentService = this.host.spec.getService('affine:attachment');
@@ -479,7 +480,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
     }
 
     let { x, y } = this.service.viewport.center;
-    if (point) [x, y] = this.service.viewport.toModelCoord(point.x, point.y);
+    if (point) [x, y] = this.service.viewport.toModelCoord(...point);
 
     const CARD_STACK_GAP = 32;
 

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -18,10 +18,12 @@ import type { EmbedYoutubeModel } from '../../../embed-youtube-block/embed-youtu
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
+import type { PointLocation } from '../../../surface-block/index.js';
 import {
   Bound,
   type CanvasElementWithText,
   clamp,
+  ConnectorElementModel,
   deserializeXYWH,
   getQuadBoundsWithRotation,
   GRID_GAP_MAX,
@@ -279,29 +281,28 @@ export function getSelectedRect(
   );
 }
 
+export type SelectableProps = {
+  bound: Bound;
+  rotate: number;
+  path?: PointLocation[];
+};
+
 export function getSelectableBounds(
   selected: BlockSuite.EdgelessModelType[]
-): Map<
-  string,
-  {
-    bound: Bound;
-    rotate: number;
-  }
-> {
-  const bounds = new Map<
-    string,
-    {
-      bound: Bound;
-      rotate: number;
-    }
-  >();
+): Map<string, SelectableProps> {
+  const bounds = new Map();
   getElementsWithoutGroup(selected).forEach(ele => {
     const bound = Bound.deserialize(ele.xywh);
-
-    bounds.set(ele.id, {
+    const props: SelectableProps = {
       bound,
       rotate: ele.rotate,
-    });
+    };
+
+    if (isCanvasElement(ele) && ele instanceof ConnectorElementModel) {
+      props.path = ele.absolutePath.map(p => p.clone());
+    }
+
+    bounds.set(ele.id, props);
   });
 
   return bounds;

--- a/packages/blocks/src/root-block/edgeless/utils/viewport.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/viewport.ts
@@ -166,20 +166,22 @@ export class Viewport {
     this.setRect(rect.left, rect.top, rect.width, rect.height);
   }
 
-  toViewPointFromClientPoint({ x, y }: IPoint): IPoint {
+  toViewCoordFromClientCoord([x, y]: IVec2): IVec2 {
     const { left, top } = this;
-    return {
-      x: x - left,
-      y: y - top,
-    };
+    return [x - left, y - top];
   }
 
-  toModelCoord(viewX: number, viewY: number): [number, number] {
+  toModelCoordFromClientCoord([x, y]: IVec2): IVec2 {
+    const { left, top } = this;
+    return this.toModelCoord(x - left, y - top);
+  }
+
+  toModelCoord(viewX: number, viewY: number): IVec2 {
     const { viewportX, viewportY, zoom } = this;
     return [viewportX + viewX / zoom, viewportY + viewY / zoom];
   }
 
-  toViewCoord(modelX: number, modelY: number): [number, number] {
+  toViewCoord(modelX: number, modelY: number): IVec2 {
     const { viewportX, viewportY, zoom } = this;
     return [(modelX - viewportX) * zoom, (modelY - viewportY) * zoom];
   }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -326,12 +326,12 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
     this._registeredEntries.push(entry);
   }
 
-  private _quickConnect(e: MouseEvent) {
+  private _quickConnect = ({ x, y }: MouseEvent) => {
     const element = this.selection.selectedElements[0];
-    const point = this.edgeless.service.viewport.toViewPointFromClientPoint({
-      x: e.x,
-      y: e.y,
-    });
+    const point = this.edgeless.service.viewport.toViewCoordFromClientCoord([
+      x,
+      y,
+    ]);
     this.edgeless.doc.captureSync();
     this.edgeless.tools.setEdgelessTool({
       type: 'connector',
@@ -341,8 +341,8 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
     const ctc = this.edgeless.tools.controllers[
       'connector'
     ] as ConnectorToolController;
-    ctc.quickConnect([point.x, point.y], element);
-  }
+    ctc.quickConnect(point, element);
+  };
 
   private _renderQuickConnectButton() {
     return [
@@ -351,7 +351,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
           aria-label="Draw connector"
           .tooltip=${'Draw connector'}
           .activeMode=${'background'}
-          @click=${(e: MouseEvent) => this._quickConnect(e)}
+          @click=${this._quickConnect}
         >
           ${ConnectorCWithArrowIcon}
         </edgeless-tool-icon-button>

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
@@ -1,12 +1,14 @@
-import {
-  type ConnectorElementModel,
-  isConnectorWithLabel,
-  type LocalConnectorElementModel,
-  type PointStyle,
+import type {
+  ConnectorElementModel,
+  LocalConnectorElementModel,
+  PointStyle,
 } from '../../../element-model/connector.js';
-import { ConnectorMode } from '../../../element-model/connector.js';
-import type { PointLocation } from '../../../index.js';
+import {
+  ConnectorMode,
+  isConnectorWithLabel,
+} from '../../../element-model/connector.js';
 import { getBezierParameters } from '../../../utils/curve.js';
+import type { PointLocation } from '../../../utils/point-location.js';
 import type { Renderer } from '../../renderer.js';
 import {
   deltaInsertsToChunks,
@@ -65,7 +67,7 @@ export function connector(
     dy = ly - y;
 
     const path = new Path2D();
-    path.rect(0 - offset / 2, 0 - offset / 2, w + offset, h + offset);
+    path.rect(-offset / 2, -offset / 2, w + offset, h + offset);
     path.rect(dx - 3 - 0.5, dy - 3 - 0.5, lw + 6 + 1, lh + 6 + 1);
     ctx.clip(path, 'evenodd');
   }
@@ -213,8 +215,8 @@ function renderLabel(
     fontFamily,
   });
   const [, , w, h] = labelXYWH!;
-  const hw = w / 2;
-  const hh = h / 2;
+  const cx = w / 2;
+  const cy = h / 2;
   const deltas = wrapTextDeltas(text!, font, w);
   const lines = deltaInsertsToChunks(deltas);
   const lineHeight = getLineHeight(fontFamily, fontSize);
@@ -256,7 +258,7 @@ function renderLabel(
             : rtl
               ? 0.5
               : -0.5);
-      ctx.fillText(str, x + hw, index * lineHeight - textHeight + hh);
+      ctx.fillText(str, x + cx, index * lineHeight - textHeight + cy);
 
       if (shouldTemporarilyAttach) {
         ctx.canvas.remove();

--- a/packages/blocks/src/surface-block/element-model/connector.ts
+++ b/packages/blocks/src/surface-block/element-model/connector.ts
@@ -135,7 +135,7 @@ export class ConnectorElementModel extends SurfaceElementModel<ConnectorElementP
     const { x, y } = instance;
 
     return {
-      absolutePath: path.map(p => p.clone().setVec([p[0] + x, p[1] + y])),
+      absolutePath: path.map(p => p.clone().setVec(Vec.add(p, [x, y]))),
     };
   })
   @local()
@@ -240,6 +240,68 @@ export class ConnectorElementModel extends SurfaceElementModel<ConnectorElementP
   } as ConnectorLabelConstraintsProps)
   accessor labelConstraints!: ConnectorLabelConstraintsProps;
 
+  resizePath(originalPath: PointLocation[], matrix: DOMMatrix) {
+    if (this.mode === ConnectorMode.Curve) {
+      return originalPath.map(point => {
+        const [p, t, absIn, absOut] = [
+          point,
+          point.tangent,
+          point.absIn,
+          point.absOut,
+        ]
+          .map(p => new DOMPoint(...p).matrixTransform(matrix))
+          .map(p => [p.x, p.y]);
+        const ip = Vec.sub(absIn, p);
+        const op = Vec.sub(absOut, p);
+        return new PointLocation(p, t, ip, op);
+      });
+    }
+
+    return originalPath.map(point => {
+      const { x, y } = new DOMPoint(...point).matrixTransform(matrix);
+      const p = [x, y];
+      return PointLocation.fromVec(p);
+    });
+  }
+
+  resize(bounds: Bound, originalPath: PointLocation[], matrix: DOMMatrix) {
+    this.updatingPath = false;
+
+    const path = this.resizePath(originalPath, matrix);
+
+    // the property assignment order matters
+    this.xywh = bounds.serialize();
+    this.path = path.map(p => p.clone().setVec(Vec.sub(p, bounds.tl)));
+
+    const props: {
+      labelXYWH?: XYWH;
+      source?: Connection;
+      target?: Connection;
+    } = {};
+
+    // Updates Connector's Label position.
+    if (this.hasLabel()) {
+      const [cx, cy] = this.getPointByOffsetDistance(this.labelOffset.distance);
+      const [, , w, h] = this.labelXYWH!;
+      props.labelXYWH = [cx - w / 2, cy - h / 2, w, h];
+    }
+
+    if (!this.source.id) {
+      props.source = {
+        ...this.source,
+        position: path[0].toVec() as [number, number],
+      };
+    }
+    if (!this.target.id) {
+      props.target = {
+        ...this.target,
+        position: path[path.length - 1].toVec() as [number, number],
+      };
+    }
+
+    return props;
+  }
+
   moveTo(bound: Bound) {
     const oldBound = Bound.deserialize(this.xywh);
     const offset = Vec.sub([bound.x, bound.y], [oldBound.x, oldBound.y]);
@@ -262,6 +324,10 @@ export class ConnectorElementModel extends SurfaceElementModel<ConnectorElementP
       const [x, y, w, h] = this.labelXYWH!;
       this.labelXYWH = [x + offset[0], y + offset[1], w, h];
     }
+  }
+
+  get connected() {
+    return !!(this.source.id || this.target.id);
   }
 
   hasLabel() {

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -52,7 +52,7 @@ export const ConnectorEndpointLocations = [
   [0.5, 1],
   // At left
   [0, 0.5],
-] as const satisfies IVec2[];
+] as const;
 
 export function calculateNearestLocation(
   point: IVec,

--- a/packages/blocks/src/surface-block/utils/point-location.ts
+++ b/packages/blocks/src/surface-block/utils/point-location.ts
@@ -29,6 +29,10 @@ export class PointLocation extends Array<number> implements IVec {
     return point;
   }
 
+  toVec(): IVec {
+    return [this[0], this[1]];
+  }
+
   setVec(vec: IVec) {
     this[0] = vec[0];
     this[1] = vec[1];

--- a/packages/presets/src/ai/actions/edgeless-response.ts
+++ b/packages/presets/src/ai/actions/edgeless-response.ts
@@ -207,7 +207,7 @@ const imageHandler = (host: EditorHost) => {
       const [x, y] = edgelessRoot.service.viewport.toViewCoord(minX, minY);
 
       host.doc.transact(() => {
-        edgelessRoot.addImages([img], { x, y }, true).catch(console.error);
+        edgelessRoot.addImages([img], [x, y], true).catch(console.error);
       });
     })
     .catch(console.error);


### PR DESCRIPTION
Closes [BS-454](https://linear.app/affine-design/issue/BS-454/connector-resize-and-rotate)
Related to #6704

In the connectors scenario, just recalculate `source.position` and `target.position`.
Extract independent functions to resize elements.

> Maybe we can move these into their servies.

https://github.com/toeverything/blocksuite/assets/27926/ace30ee4-9b77-4962-8e49-8ada544ada63

