### PR TITLE
feat(blocks): add new `onAbort` API to HoverController

### DIFF
--- a/packages/blocks/src/_common/components/filterable-list/index.ts
+++ b/packages/blocks/src/_common/components/filterable-list/index.ts
@@ -101,7 +101,7 @@ export class FilterableListComponent<Props = unknown> extends WithDisposable(
           })}
           @mouseover=${() => (this._curFocusIndex = idx)}
           @click=${() => this._select(item)}
-          hover=${focussed}
+          ?hover=${focussed}
           width="100%"
           height="32px"
         >
@@ -177,7 +177,7 @@ export class FilterableListComponent<Props = unknown> extends WithDisposable(
 export function showPopFilterableList({
   options,
   filter,
-  abortController,
+  abortController = new AbortController(),
   referenceElement,
   container,
   maxHeight = 440,
@@ -185,7 +185,7 @@ export function showPopFilterableList({
   options: FilterableListComponent['options'];
   referenceElement: Element;
   container?: Element;
-  abortController: AbortController;
+  abortController?: AbortController;
   filter?: FilterableListComponent['listFilter'];
   maxHeight?: number;
 }) {

--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -43,6 +43,9 @@ export type HoverOptions = {
    * @default true
    */
   setPortalAsFloating: boolean;
+  /**
+   * @deprecated TODO add new `exclusion` option
+   */
   allowMultiple?: boolean;
 } & WhenHoverOptions;
 
@@ -112,6 +115,12 @@ export class HoverController implements ReactiveController {
   private readonly _hoverOptions: HoverOptions;
 
   private _isHovering = false;
+
+  /**
+   * Whether the host is currently hovering.
+   *
+   * This property is unreliable when the floating element disconnect from the DOM suddenly.
+   */
   get isHovering() {
     return this._isHovering;
   }
@@ -127,6 +136,9 @@ export class HoverController implements ReactiveController {
     return this._portal;
   }
 
+  /**
+   * Callback when the portal needs to be aborted.
+   */
   public onAbort = () => {
     this.abort();
   };

--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -43,9 +43,6 @@ export type HoverOptions = {
    * @default true
    */
   setPortalAsFloating: boolean;
-  /**
-   * @deprecated TODO add new `exclusion` option
-   */
   allowMultiple?: boolean;
 } & WhenHoverOptions;
 

--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -16,9 +16,35 @@ type HoverPortalOptions = Omit<AdvancedPortalOptions, 'abortController'>;
 
 export type HoverOptions = {
   /**
+   * Callback when the portal is aborted.
+   *
+   * If not provided, the signal will be aborted after the transition ends.
+   */
+  onAbort?: (context: {
+    portal: HTMLDivElement | undefined;
+    hoverOptions: HoverOptions;
+    abortController: AbortController;
+  }) => void;
+  /**
    * Transition style when the portal is shown or hidden.
    */
   transition: {
+    /**
+     * Specifies the length of the transition in ms.
+     *
+     * You only need to specify the transition end duration actually.
+     *
+     * ---
+     *
+     * Why is the duration required?
+     *
+     * The transition event is not reliable, and it may not be triggered in some cases.
+     *
+     * See also https://github.com/w3c/csswg-drafts/issues/3043 https://github.com/toeverything/blocksuite/pull/7248/files#r1631375330
+     *
+     * Take a look at solutions from other projects: https://floating-ui.com/docs/useTransition#duration
+     */
+    duration: number;
     in: StyleInfo;
     out: StyleInfo;
   } | null;
@@ -32,6 +58,7 @@ export type HoverOptions = {
 
 const DEFAULT_HOVER_OPTIONS: HoverOptions = {
   transition: {
+    duration: 100,
     in: {
       opacity: '1',
       transition: 'opacity 0.1s ease-in-out',
@@ -43,6 +70,41 @@ const DEFAULT_HOVER_OPTIONS: HoverOptions = {
   },
   setPortalAsFloating: true,
   allowMultiple: false,
+};
+
+const abortHoverPortal = ({
+  portal,
+  hoverOptions,
+  abortController,
+}: {
+  portal: HTMLDivElement | undefined;
+  hoverOptions: HoverOptions;
+  abortController: AbortController;
+}) => {
+  if (!portal || !hoverOptions.transition) {
+    abortController.abort();
+    return;
+  }
+  // Transition out
+  Object.assign(portal.style, hoverOptions.transition.out);
+
+  portal.addEventListener(
+    'transitionend',
+    () => {
+      abortController.abort();
+    },
+    { signal: abortController.signal }
+  );
+  portal.addEventListener(
+    'transitioncancel',
+    () => {
+      abortController.abort();
+    },
+    { signal: abortController.signal }
+  );
+
+  // Make sure the portal is aborted after the transition ends
+  setTimeout(() => abortController.abort(), hoverOptions.transition.duration);
 };
 
 export class HoverController implements ReactiveController {
@@ -58,6 +120,11 @@ export class HoverController implements ReactiveController {
     options: OptionsParams
   ) => HoverPortalOptions | null;
   private readonly _hoverOptions: HoverOptions;
+
+  private _isHovering = false;
+  get isHovering() {
+    return this._isHovering;
+  }
 
   get setReference() {
     if (!this._setReference) {
@@ -86,39 +153,30 @@ export class HoverController implements ReactiveController {
     }
     // Start a timer when the host is connected
     const { setReference, setFloating, dispose } = whenHover(isHover => {
+      this._isHovering = isHover;
       if (!isHover) {
         const abortController = this._abortController;
         if (!abortController) return;
-        if (!this._portal || !this._hoverOptions.transition) {
-          abortController.abort();
+        if (!this._hoverOptions.onAbort) {
+          // Default abort action
+          abortHoverPortal({
+            portal: this._portal,
+            hoverOptions: this._hoverOptions,
+            abortController,
+          });
           return;
         }
-        // Transition out
-        Object.assign(this._portal.style, this._hoverOptions.transition.out);
-
-        // The transition event is not reliable,
-        // consider adding explicit duration to the transition options in the future
-        // See also https://github.com/w3c/csswg-drafts/issues/3043 https://github.com/toeverything/blocksuite/pull/7248/files#r1631375330
-        this._portal.addEventListener(
-          'transitionend',
-          () => {
-            abortController.abort();
-          },
-          { signal: abortController.signal }
-        );
-        this._portal.addEventListener(
-          'transitioncancel',
-          () => {
-            abortController.abort();
-          },
-          { signal: abortController.signal }
-        );
+        this._hoverOptions.onAbort({
+          portal: this._portal,
+          hoverOptions: this._hoverOptions,
+          abortController,
+        });
         return;
       }
 
-      // If some problems arise when aborting the previous hover,
-      // consider fixing the transition related issues and return void here
-      this._abortController?.abort();
+      if (this._abortController) {
+        return;
+      }
 
       this._abortController = new AbortController();
       this._abortController.signal.addEventListener('abort', () => {
@@ -135,6 +193,7 @@ export class HoverController implements ReactiveController {
         abortController: this._abortController,
       });
       if (!portalOptions) {
+        // Sometimes the portal is not ready to show
         this._abortController.abort();
         return;
       }
@@ -159,5 +218,14 @@ export class HoverController implements ReactiveController {
   hostDisconnected() {
     this._abortController?.abort();
     this._disposables.dispose();
+  }
+
+  abort() {
+    if (!this._abortController) return;
+    abortHoverPortal({
+      portal: this._portal,
+      hoverOptions: this._hoverOptions,
+      abortController: this._abortController,
+    });
   }
 }

--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -71,7 +71,8 @@ export class LanguageListButton extends LitElement {
     this._updateLanguage();
   }
 
-  private _clickLangBtn = () => {
+  private _clickLangBtn = (e: PointerEvent) => {
+    e.stopPropagation();
     if (this.blockElement.doc.readonly) return;
     if (this._abortController) {
       // Close the language list if it's already opened.

--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -1,3 +1,4 @@
+import { noop } from '@blocksuite/global/utils';
 import { css, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
@@ -55,7 +56,7 @@ export class LanguageListButton extends LitElement {
   private accessor _langButton!: HTMLElement;
 
   @property({ attribute: false })
-  accessor onChange: ((active: boolean) => void) | undefined = undefined;
+  accessor onActiveStatusChange: (active: boolean) => void = noop;
 
   private _abortController?: AbortController;
 
@@ -79,10 +80,10 @@ export class LanguageListButton extends LitElement {
     }
     this._abortController = new AbortController();
     this._abortController.signal.addEventListener('abort', () => {
-      this.onChange?.(false);
+      this.onActiveStatusChange(false);
       this._abortController = undefined;
     });
-    this.onChange?.(true);
+    this.onActiveStatusChange(true);
 
     const languages = (
       [...bundledLanguagesInfo, PLAIN_TEXT_LANG_INFO] as StrictLanguageInfo[]

--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -71,8 +71,7 @@ export class LanguageListButton extends LitElement {
     this._updateLanguage();
   }
 
-  private _clickLangBtn = (e: PointerEvent) => {
-    e.stopPropagation();
+  private _clickLangBtn = () => {
     if (this.blockElement.doc.readonly) return;
     if (this._abortController) {
       // Close the language list if it's already opened.

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -53,7 +53,7 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
             // This snippet is not perfect, it only checks the hover status at the moment.
             if (this._hoverController.isHovering) return;
             await sleep(1000);
-            if (this._hoverController.isHovering) return;
+            if (this._hoverController.isHovering || this._isActivated) return;
             this._hoverController.abort();
           }
         }}

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -20,53 +20,59 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
 > {
   private _isActivated = false;
 
-  private _hoverController = new HoverController(this, () => {
-    const codeBlock = this.blockElement;
-    const selection = this.host.selection;
+  private _hoverController = new HoverController(
+    this,
+    () => {
+      const codeBlock = this.blockElement;
+      const selection = this.host.selection;
 
-    const textSelection = selection.find('text');
-    if (
-      !!textSelection &&
-      (!!textSelection.to || !!textSelection.from.length)
-    ) {
-      return null;
+      const textSelection = selection.find('text');
+      if (
+        !!textSelection &&
+        (!!textSelection.to || !!textSelection.from.length)
+      ) {
+        return null;
+      }
+
+      const blockSelections = selection.filter('block');
+      if (
+        blockSelections.length > 1 ||
+        (blockSelections.length === 1 &&
+          blockSelections[0].blockId !== codeBlock.blockId)
+      ) {
+        return null;
+      }
+
+      return {
+        template: html`<language-list-button
+          .blockElement=${this.blockElement}
+          .onActiveStatusChange=${async (active: boolean) => {
+            this._isActivated = active;
+            if (!active) {
+              // Wait a moment for the user to see the result.
+              // This is to prevent the language list from closing immediately.
+              //
+              // This snippet is not perfect, it only checks the hover status at the moment.
+              if (this._hoverController.isHovering) return;
+              await sleep(1000);
+              if (this._hoverController.isHovering || this._isActivated) return;
+              this._hoverController.abort();
+            }
+          }}
+        >
+        </language-list-button>`,
+        computePosition: {
+          referenceElement: this.blockElement,
+          placement: 'left-start',
+          middleware: [offset({ mainAxis: -5, crossAxis: 5 })],
+          autoUpdate: true,
+        },
+      };
+    },
+    {
+      allowMultiple: true,
     }
-
-    const blockSelections = selection.filter('block');
-    if (
-      blockSelections.length > 1 ||
-      (blockSelections.length === 1 &&
-        blockSelections[0].blockId !== codeBlock.blockId)
-    ) {
-      return null;
-    }
-
-    return {
-      template: html`<language-list-button
-        .blockElement=${this.blockElement}
-        .onActiveStatusChange=${async (active: boolean) => {
-          this._isActivated = active;
-          if (!active) {
-            // Wait a moment for the user to see the result.
-            // This is to prevent the language list from closing immediately.
-            //
-            // This snippet is not perfect, it only checks the hover status at the moment.
-            if (this._hoverController.isHovering) return;
-            await sleep(1000);
-            if (this._hoverController.isHovering || this._isActivated) return;
-            this._hoverController.abort();
-          }
-        }}
-      >
-      </language-list-button>`,
-      computePosition: {
-        referenceElement: this.blockElement,
-        placement: 'left-start',
-        middleware: [offset({ mainAxis: -5, crossAxis: 5 })],
-        autoUpdate: true,
-      },
-    };
-  });
+  );
 
   override connectedCallback() {
     super.connectedCallback();

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -1,15 +1,12 @@
 import './components/lang-button.js';
 
 import { WidgetElement } from '@blocksuite/block-std';
+import { sleep } from '@blocksuite/global/utils';
 import { offset } from '@floating-ui/dom';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { ref } from 'lit/directives/ref.js';
 
-import {
-  createLitPortal,
-  whenHover,
-} from '../../../_common/components/index.js';
+import { HoverController } from '../../../_common/components/index.js';
 import type { CodeBlockModel } from '../../../code-block/code-model.js';
 import type { CodeBlockComponent } from '../../../code-block/index.js';
 
@@ -21,44 +18,65 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
   CodeBlockModel,
   CodeBlockComponent
 > {
+  private _isActivated = false;
+
+  private _hoverController = new HoverController(this, () => {
+    const codeBlock = this.blockElement;
+    const selection = this.host.selection;
+
+    const textSelection = selection.find('text');
+    if (
+      !!textSelection &&
+      (!!textSelection.to || !!textSelection.from.length)
+    ) {
+      return null;
+    }
+
+    const blockSelections = selection.filter('block');
+    if (
+      blockSelections.length > 1 ||
+      (blockSelections.length === 1 &&
+        blockSelections[0].blockId !== codeBlock.blockId)
+    ) {
+      return null;
+    }
+
+    return {
+      template: html`<language-list-button
+        .blockElement=${this.blockElement}
+        .onActiveStatusChange=${async (active: boolean) => {
+          this._isActivated = active;
+          if (!active) {
+            // Wait a moment for the user to see the result.
+            // This is to prevent the language list from closing immediately.
+            //
+            // This snippet is not perfect, it only checks the hover status at the moment.
+            if (this._hoverController.isHovering) return;
+            await sleep(1000);
+            if (this._hoverController.isHovering) return;
+            this._hoverController.abort();
+          }
+        }}
+      >
+      </language-list-button>`,
+      computePosition: {
+        referenceElement: this.blockElement,
+        placement: 'left-start',
+        middleware: [offset({ mainAxis: -5, crossAxis: 5 })],
+        autoUpdate: true,
+      },
+    };
+  });
+
   override connectedCallback() {
     super.connectedCallback();
-
-    let isActivated = false;
-    let abortController: AbortController | null = null;
-    const { setFloating, setReference } = whenHover(isHover => {
-      if (!isHover) {
-        // If the language list is opened, don't close it.
-        if (isActivated) return;
-        abortController?.abort();
-        return;
-      }
-      if (abortController) return;
-      abortController = new AbortController();
-      abortController.signal.addEventListener('abort', () => {
-        abortController = null;
-      });
-
-      createLitPortal({
-        closeOnClickAway: true,
-        abortController,
-        template: html`<language-list-button
-          ${ref(setFloating)}
-          .blockElement=${this.blockElement}
-          .onChange=${(active: boolean) => {
-            isActivated = active;
-          }}
-        >
-        </language-list-button>`,
-        computePosition: {
-          referenceElement: this.blockElement,
-          placement: 'left-start',
-          middleware: [offset({ mainAxis: -5, crossAxis: 5 })],
-          autoUpdate: true,
-        },
-      });
-    });
-    setReference(this.blockElement);
+    this._hoverController.setReference(this.blockElement);
+    this._hoverController.onAbort = () => {
+      // If the language list is opened, don't close it.
+      if (this._isActivated) return;
+      this._hoverController.abort();
+      return;
+    };
   }
 }
 

--- a/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
@@ -1,5 +1,5 @@
 import { WithDisposable } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
+import { assertExists, noop } from '@blocksuite/global/utils';
 import { flip, offset } from '@floating-ui/dom';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -53,6 +53,9 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
   @property({ attribute: false })
   accessor moreItems!: CodeToolbarMoreItem[];
 
+  @property({ attribute: false })
+  accessor onActiveStatusChange: (active: boolean) => void = noop;
+
   @state()
   private accessor _moreMenuOpen = false;
 
@@ -82,10 +85,11 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
 
     this.closeCurrentMenu();
     this._popMenuAbortController = new AbortController();
-    this._popMenuAbortController.signal.addEventListener(
-      'abort',
-      () => (this._moreMenuOpen = false)
-    );
+    this._popMenuAbortController.signal.addEventListener('abort', () => {
+      this._moreMenuOpen = false;
+      this.onActiveStatusChange(false);
+    });
+    this.onActiveStatusChange(true);
 
     this._currentOpenMenu = this._popMenuAbortController;
 

--- a/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
@@ -87,7 +87,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
             .moreItems=${this.moreItems}
             .onActiveStatusChange=${(active: boolean) => {
               this._isActivated = active;
-              if (!active) {
+              if (!active && !this._hoverController?.isHovering) {
                 this._hoverController?.abort();
               }
             }}

--- a/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
@@ -52,6 +52,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
   }
 
   private _hoverController: HoverController | null = null;
+  private _isActivated = false;
 
   private _setHoverController = () => {
     this._hoverController = null;
@@ -84,6 +85,12 @@ export class AffineCodeToolbarWidget extends WidgetElement<
             .abortController=${abortController}
             .items=${this.items}
             .moreItems=${this.moreItems}
+            .onActiveStatusChange=${(active: boolean) => {
+              this._isActivated = active;
+              if (!active) {
+                this._hoverController?.abort();
+              }
+            }}
           ></affine-code-toolbar>`,
           computePosition: {
             referenceElement: codeBlock,
@@ -108,6 +115,12 @@ export class AffineCodeToolbarWidget extends WidgetElement<
 
     const codeBlock = this.blockElement;
     this._hoverController.setReference(codeBlock);
+    this._hoverController.onAbort = () => {
+      // If the more menu is opened, don't close it.
+      if (this._isActivated) return;
+      this._hoverController?.abort();
+      return;
+    };
   };
 
   override firstUpdated() {

--- a/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
@@ -1,4 +1,4 @@
-import { assertExists } from '@blocksuite/global/utils';
+import { assertExists, noop } from '@blocksuite/global/utils';
 import { flip, offset } from '@floating-ui/dom';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
@@ -27,6 +27,9 @@ export class AffineImageToolbar extends LitElement {
 
   @property({ attribute: false })
   accessor moreMenuConfig!: MoreMenuConfigItem[];
+
+  @property({ attribute: false })
+  accessor onActiveStatusChange: (active: boolean) => void = noop;
 
   @query('.image-toolbar-button.more')
   private accessor _moreButton!: HTMLElement;
@@ -74,10 +77,12 @@ export class AffineImageToolbar extends LitElement {
 
     this.closeCurrentMenu();
     this._popMenuAbortController = new AbortController();
-    this._popMenuAbortController.signal.addEventListener(
-      'abort',
-      () => (this._moreMenuOpen = false)
-    );
+    this._popMenuAbortController.signal.addEventListener('abort', () => {
+      this._moreMenuOpen = false;
+      this.onActiveStatusChange(false);
+    });
+    this.onActiveStatusChange(true);
+
     this._currentOpenMenu = this._popMenuAbortController;
 
     const moreMenu = new MorePopupMenu();

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -97,7 +97,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
             .moreMenuConfig=${this.moreMenuConfig}
             .onActiveStatusChange=${(active: boolean) => {
               this._isActivated = active;
-              if (!active) {
+              if (!active && !this._hoverController?.isHovering) {
                 this._hoverController?.abort();
               }
             }}

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -57,6 +57,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
   };
 
   private _hoverController: HoverController | null = null;
+  private _isActivated = false;
 
   private _setHoverController = () => {
     this._hoverController = null;
@@ -94,6 +95,12 @@ export class AffineImageToolbarWidget extends WidgetElement<
             .abortController=${abortController}
             .config=${this.config}
             .moreMenuConfig=${this.moreMenuConfig}
+            .onActiveStatusChange=${(active: boolean) => {
+              this._isActivated = active;
+              if (!active) {
+                this._hoverController?.abort();
+              }
+            }}
           ></affine-image-toolbar>`,
           computePosition: {
             referenceElement: imageContainer,
@@ -118,6 +125,12 @@ export class AffineImageToolbarWidget extends WidgetElement<
 
     const imageBlock = this.blockElement;
     this._hoverController.setReference(imageBlock);
+    this._hoverController.onAbort = () => {
+      // If the more menu is opened, don't close it.
+      if (this._isActivated) return;
+      this._hoverController?.abort();
+      return;
+    };
   };
 
   override firstUpdated() {

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -479,7 +479,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
       text=${customTemplate ?? name}
       subText=${ifDefined(description)}
       data-testid="${name}"
-      hover=${hover}
+      ?hover=${hover}
       @mouseenter=${() => {
         this._activeItem = item;
         this._closeSubMenu();
@@ -515,7 +515,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
       text=${name}
       subText=${ifDefined(description)}
       data-testid="${name}"
-      hover=${hover}
+      ?hover=${hover}
       @mouseenter=${() => {
         this._activeItem = item;
         this._openSubMenu(item);

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -170,25 +170,25 @@ test.describe('slash menu should show and hide correctly', () => {
 
     await pressArrowDown(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.nth(1)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(1)).toHaveAttribute('hover');
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Heading 1']);
     await assertRichTexts(page, ['/']);
 
     await pressArrowUp(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
 
     await pressArrowUp(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.last()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.last()).toHaveAttribute('hover');
     await expect(slashItems.last().locator('.text')).toHaveText(['Delete']);
     await assertRichTexts(page, ['/']);
 
     await pressArrowDown(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
   });
@@ -204,25 +204,25 @@ test.describe('slash menu should show and hide correctly', () => {
 
     await pressTab(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.nth(1)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(1)).toHaveAttribute('hover');
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Heading 1']);
     await assertRichTexts(page, ['/']);
 
     await pressShiftTab(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
 
     await pressShiftTab(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.last()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.last()).toHaveAttribute('hover');
     await expect(slashItems.last().locator('.text')).toHaveText(['Delete']);
     await assertRichTexts(page, ['/']);
 
     await pressTab(page);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
   });
@@ -240,25 +240,25 @@ test.describe('slash menu should show and hide correctly', () => {
 
     await page.keyboard.press(`${SHORT_KEY}+n`);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.nth(1)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(1)).toHaveAttribute('hover');
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Heading 1']);
     await assertRichTexts(page, ['/']);
 
     await page.keyboard.press(`${SHORT_KEY}+p`);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
 
     await page.keyboard.press(`${SHORT_KEY}+p`);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.last()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.last()).toHaveAttribute('hover');
     await expect(slashItems.last().locator('.text')).toHaveText(['Delete']);
     await assertRichTexts(page, ['/']);
 
     await page.keyboard.press(`${SHORT_KEY}+n`);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.first()).toHaveAttribute('hover', 'true');
+    await expect(slashItems.first()).toHaveAttribute('hover');
     await expect(slashItems.first().locator('.text')).toHaveText(['Text']);
     await assertRichTexts(page, ['/']);
   });
@@ -279,7 +279,7 @@ test.describe('slash menu should show and hide correctly', () => {
     assertExists(rect);
     await page.mouse.move(rect.x + 10, rect.y + 10);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.nth(4)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(4)).toHaveAttribute('hover');
     await expect(slashItems.nth(4).locator('.text')).toHaveText([
       'Other Headings',
     ]);
@@ -289,7 +289,7 @@ test.describe('slash menu should show and hide correctly', () => {
     assertExists(rect);
     await page.mouse.move(rect.x + 10, rect.y + 10);
     await expect(slashMenu).toBeVisible();
-    await expect(slashItems.nth(3)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(3)).toHaveAttribute('hover');
     await expect(slashItems.nth(3).locator('.text')).toHaveText(['Heading 3']);
     await expect(subMenu).toBeHidden();
   });
@@ -317,7 +317,7 @@ test.describe('slash menu should show and hide correctly', () => {
 
     await type(page, '/');
     await pressArrowDown(page, 4);
-    await expect(slashItems.nth(4)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(4)).toHaveAttribute('hover');
     await expect(slashItems.nth(4).locator('.text')).toHaveText([
       'Other Headings',
     ]);
@@ -352,7 +352,7 @@ test.describe('slash menu should show and hide correctly', () => {
     await type(page, '/');
     await expect(slashMenu).toBeVisible();
     await pressArrowDown(page, 4);
-    await expect(slashItems.nth(4)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(4)).toHaveAttribute('hover');
     await expect(slashItems.nth(4).locator('.text')).toHaveText([
       'Other Headings',
     ]);
@@ -469,7 +469,7 @@ test.describe('slash search', () => {
     await expect(slashItems).toHaveCount(2);
     await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Copy']);
-    await expect(slashItems.nth(0)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(0)).toHaveAttribute('hover');
 
     await type(page, 'p');
     await expect(slashItems).toHaveCount(1);
@@ -480,7 +480,7 @@ test.describe('slash search', () => {
     await expect(slashItems).toHaveCount(2);
     await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Copy']);
-    await expect(slashItems.nth(0)).toHaveAttribute('hover', 'true');
+    await expect(slashItems.nth(0)).toHaveAttribute('hover');
   });
 
   test('slash menu supports fuzzy search', async ({ page }) => {


### PR DESCRIPTION
This pull request adds the HoverController functionality to toolbar widgets.

The HoverController improves the user experience by preventing the widgets from disappearing when they are active.

## API Changes

### HoverController.onAbort

```ts
class {
  private _hoverController = new HoverController(this, () => {})

  override connectedCallback() {
    super.connectedCallback();
    this._hoverController.setReference(this.blockElement);

    // ⬇️ Prevent abort in some condition
    this._hoverController.onAbort = () => {
      // If activated, don't close it.
      if (this._isActivated) return;
      this._hoverController.abort(); // default abort action
      return;
    };
  }
}
```

### Explicitly `transition.duration`

You need to specify the length of the transition explicitly.

```ts
class {
  private _hoverController = new HoverController(this, () => {}, {
    transition: { duration: 100, in: {}, out: {} },
    //                      ⬆️ ms
  });
}

```
