### PR TITLE
fix(std): use promises for blobs when copying

### DIFF
--- a/packages/blocks/src/image-block/utils.ts
+++ b/packages/blocks/src/image-block/utils.ts
@@ -251,7 +251,7 @@ export async function copyImageBlob(blockElement: ImageBlockComponent) {
       }
 
       await navigator.clipboard.write([
-        new ClipboardItem({ [blob.type]: blob }),
+        new ClipboardItem({ [blob.type]: Promise.resolve(blob) }),
       ]);
     }
 

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
@@ -51,6 +51,8 @@ export const writeImageBlobToClipboard = async (blob: Blob) => {
     // @ts-ignore
     await window.apis.clipboard?.copyAsImageFromString(blob);
   } else {
-    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+    await navigator.clipboard.write([
+      new ClipboardItem({ [blob.type]: Promise.resolve(blob) }),
+    ]);
   }
 };


### PR DESCRIPTION
In safari, should use promises for blobs when copying.

Refs:
* https://bugs.webkit.org/show_bug.cgi?id=222262
* https://developer.apple.com/forums/thread/691873
