### PR TITLE
refactor(blocks): update code font

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -24,7 +24,7 @@
     "@floating-ui/dom": "^1.6.5",
     "@lit/context": "^1.1.1",
     "@sgtpooki/file-type": "1.0.1",
-    "@toeverything/theme": "^0.7.30",
+    "@toeverything/theme": "^0.7.32",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/sortablejs": "^1.15.8",

--- a/packages/blocks/src/_common/inline/presets/nodes/affine-text.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/affine-text.ts
@@ -23,11 +23,12 @@ export function affineTextStyles(
     inlineCodeStyle = {
       'font-family': 'var(--affine-font-code-family)',
       background: 'var(--affine-background-code-block)',
-      color: 'var(--affine-text-primary-color)',
+      border: '1px solid var(--affine-border-color)',
       'border-radius': '2px',
+      color: 'var(--affine-text-primary-color)',
       padding: '3px 6px 4px',
       'font-variant-ligatures': 'none',
-      'line-height': 'var(--affine-font-base)',
+      'line-height': 'auto',
     };
   }
 

--- a/packages/blocks/src/paragraph-block/styles.ts
+++ b/packages/blocks/src/paragraph-block/styles.ts
@@ -24,7 +24,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h1 code {
-    font-size: calc(var(--affine-font-base) + 8px);
+    font-size: calc(var(--affine-font-base) + 10px);
   }
   .h2 {
     font-size: var(--affine-font-h-2);
@@ -34,7 +34,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h2 code {
-    font-size: calc(var(--affine-font-base) + 6px);
+    font-size: calc(var(--affine-font-base) + 8px);
   }
   .h3 {
     font-size: var(--affine-font-h-3);
@@ -44,7 +44,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h3 code {
-    font-size: calc(var(--affine-font-base) + 4px);
+    font-size: calc(var(--affine-font-base) + 6px);
   }
   .h4 {
     font-size: var(--affine-font-h-4);
@@ -54,7 +54,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h4 code {
-    font-size: calc(var(--affine-font-base) + 2px);
+    font-size: calc(var(--affine-font-base) + 4px);
   }
   .h5 {
     font-size: var(--affine-font-h-5);
@@ -64,7 +64,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h5 code {
-    font-size: calc(var(--affine-font-base));
+    font-size: calc(var(--affine-font-base) + 2px);
   }
   .h6 {
     font-size: var(--affine-font-h-6);
@@ -74,7 +74,7 @@ export const paragraphBlockStyles = css`
     margin-bottom: 10px;
   }
   .h6 code {
-    font-size: calc(var(--affine-font-base) - 2px);
+    font-size: var(--affine-font-base);
   }
   .quote {
     line-height: 26px;

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -21,7 +21,7 @@
     "@dotlottie/player-component": "^2.7.12",
     "@fal-ai/serverless-client": "^0.10.0",
     "@floating-ui/dom": "^1.6.5",
-    "@toeverything/theme": "^0.7.30",
+    "@toeverything/theme": "^0.7.32",
     "lit": "^3.1.3",
     "openai": "^4.47.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       '@toeverything/theme':
-        specifier: ^0.7.30
-        version: 0.7.30
+        specifier: ^0.7.32
+        version: 0.7.32
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -569,8 +569,8 @@ importers:
         specifier: ^1.6.5
         version: 1.6.5
       '@toeverything/theme':
-        specifier: ^0.7.30
-        version: 0.7.30
+        specifier: ^0.7.32
+        version: 0.7.32
       lit:
         specifier: ^3.1.3
         version: 3.1.3
@@ -1530,8 +1530,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@toeverything/theme@0.7.30':
-    resolution: {integrity: sha512-2qYUNQ5KvHdmZcHhd1nO+XdKy3NHhHx7fFtj5s8fmgdiBRKyNXhQ3nfiO4pWUB5oYr1jD/IYy/uuxzeby47OpQ==}
+  '@toeverything/theme@0.7.32':
+    resolution: {integrity: sha512-Fb5WCKdA6247OQVmaFewIxQXDR0z4VWgSSEaU2pdtupsT7W6nNcWBJ656gZLODHKhI1meQXJqn5HDMgFJ1MZAQ==}
 
   '@toeverything/y-indexeddb@0.10.0-canary.9':
     resolution: {integrity: sha512-3hzktNuOaXut/RgRjKNeqQura1zeYF+tSLSlWDc0rDBOrEpwD/1EOpKVCbgtl8ke7f4oinLfgBNk4HcwqaQUYQ==}
@@ -6065,7 +6065,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@toeverything/theme@0.7.30': {}
+  '@toeverything/theme@0.7.32': {}
 
   '@toeverything/y-indexeddb@0.10.0-canary.9(yjs@13.6.15)':
     dependencies:


### PR DESCRIPTION
Close https://github.com/toeverything/blocksuite/issues/7099, Close https://github.com/toeverything/blocksuite/issues/6086,  [BS-322](https://linear.app/affine-design/issue/BS-322/update-mono-fonts), [BS-108](https://linear.app/affine-design/issue/BS-108/inline-code-block-update)

- Bump theme to update font to `IBM Plex Mono`