### PR TITLE
feat(edgeless): add default color and editing border for edgeless text

### DIFF
--- a/packages/blocks/src/edgeless-text/edgeless-text-model.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-model.ts
@@ -1,4 +1,3 @@
-import type { Text } from '@blocksuite/store';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
@@ -14,7 +13,6 @@ import type { SerializedXYWH } from '../surface-block/utils/xywh.js';
 type EdgelessTextProps = {
   xywh: SerializedXYWH;
   index: string;
-  text: Text;
   scale: number;
   rotate: number;
   hasMaxWidth: boolean;
@@ -22,10 +20,9 @@ type EdgelessTextProps = {
 
 export const EdgelessTextBlockSchema = defineBlockSchema({
   flavour: 'affine:edgeless-text',
-  props: (internal): EdgelessTextProps => ({
+  props: (): EdgelessTextProps => ({
     xywh: '[0,0,16,16]',
     index: 'a0',
-    text: internal.Text(),
     color: '#000000',
     fontFamily: FontFamily.Inter,
     fontStyle: FontStyle.Normal,

--- a/packages/blocks/src/edgeless-text/edgeless-text-service.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-service.ts
@@ -1,7 +1,9 @@
 import { BlockService } from '@blocksuite/block-std';
 
 import { asyncFocusRichText } from '../_common/utils/selection.js';
+import { GET_DEFAULT_TEXT_COLOR } from '../root-block/edgeless/components/panel/color-panel.js';
 import type { EdgelessRootBlockComponent } from '../root-block/index.js';
+import { FontFamily } from '../surface-block/consts.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import {
   EDGELESS_TEXT_BLOCK_MIN_HEIGHT,
@@ -28,6 +30,8 @@ export class EdgelessTextBlockService extends BlockService<EdgelessTextBlockMode
           EDGELESS_TEXT_BLOCK_MIN_WIDTH,
           EDGELESS_TEXT_BLOCK_MIN_HEIGHT
         ).serialize(),
+        color: GET_DEFAULT_TEXT_COLOR(),
+        fontFamily: FontFamily.Kalam,
       },
       edgeless.surface.blockId
     );

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -12,6 +12,7 @@ import { bindContainerHotkey } from '../_common/components/rich-text/keymap/inde
 import type { RichText } from '../_common/components/rich-text/rich-text.js';
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../_common/consts.js';
 import { getViewportElement } from '../_common/utils/query.js';
+import { EdgelessTextBlockComponent } from '../edgeless-text/edgeless-text-block.js';
 import { EdgelessRootBlockComponent } from '../root-block/edgeless/edgeless-root-block.js';
 import type { ParagraphBlockModel } from './paragraph-model.js';
 import type { ParagraphBlockService } from './paragraph-service.js';
@@ -66,6 +67,10 @@ export class ParagraphBlockComponent extends BlockComponent<
       return el;
     }
     return this.rootElement;
+  }
+
+  get inEdgelessText() {
+    return this.topContenteditableElement instanceof EdgelessTextBlockComponent;
   }
 
   get inlineEditor() {
@@ -182,9 +187,16 @@ export class ParagraphBlockComponent extends BlockComponent<
             .verticalScrollContainerGetter=${() =>
               getViewportElement(this.host)}
           ></rich-text>
-          <div contenteditable="false" class="affine-paragraph-placeholder">
-            ${this.service.placeholderGenerator(this.model)}
-          </div>
+          ${this.inEdgelessText
+            ? nothing
+            : html`
+                <div
+                  contenteditable="false"
+                  class="affine-paragraph-placeholder"
+                >
+                  ${this.service.placeholderGenerator(this.model)}
+                </div>
+              `}
         </div>
 
         ${children}

--- a/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-text/edgeless-edgeless-text.ts
+++ b/packages/blocks/src/root-block/edgeless/components/block-portal/edgeless-text/edgeless-edgeless-text.ts
@@ -18,7 +18,6 @@ export class EdgelessBlockPortalEdgelessText extends EdgelessPortalBase<Edgeless
   static override styles = css`
     .edgeless-text-block-container {
       position: absolute;
-      padding: 10px;
       box-sizing: border-box;
 
       &[data-max-width='false'] .inline-editor span {
@@ -160,6 +159,12 @@ export class EdgelessBlockPortalEdgelessText extends EdgelessPortalBase<Edgeless
           style=${styleMap({
             transform: `rotate(${rotate}deg)`,
             transformOrigin: 'center',
+            padding: '10px',
+            border: `1px solid ${this._editing ? 'var(--affine—primary—color, #1e96eb)' : 'transparent'}`,
+            borderRadius: '4px',
+            boxShadow: this._editing
+              ? '0px 0px 0px 2px rgba(30, 150, 235, 0.3)'
+              : 'none',
           })}
         >
           <div

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
@@ -97,7 +97,13 @@ function extractField<K extends keyof TextStyleProps>(
   element: BlockSuite.EdgelessTextModelType,
   field: K
 ) {
-  if (element instanceof EdgelessTextBlockModel) return null;
+  //TODO: It's not a very good handling method.
+  //      The edgeless-change-text-menu should be refactored into a widget to allow external registration of its own logic.
+  if (element instanceof EdgelessTextBlockModel) {
+    return field === 'fontSize'
+      ? null
+      : (element[field as keyof EdgelessTextBlockModel] as TextStyleProps[K]);
+  }
   return (
     element instanceof ConnectorElementModel
       ? element.labelStyle[field]


### PR DESCRIPTION

https://github.com/toeverything/blocksuite/assets/50035259/722b3466-32b7-4726-a15a-ab414e6ca448

In addition, the text field of the edgeless text model has been removed.