### PR TITLE
refactor: add DocModeService for doc mode get, set, toogle and observe change

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/types.ts
+++ b/packages/blocks/src/_common/components/ai-item/types.ts
@@ -1,7 +1,7 @@
 import type { Chain, EditorHost, InitCommandCtx } from '@blocksuite/block-std';
 import type { TemplateResult } from 'lit';
 
-import type { EditorMode } from '../../utils/index.js';
+import type { DocMode } from '../../utils/index.js';
 
 export interface AIItemGroupConfig {
   name?: string;
@@ -13,7 +13,7 @@ export interface AIItemConfig {
   icon: TemplateResult | (() => HTMLElement);
   showWhen?: (
     chain: Chain<InitCommandCtx>,
-    editorMode: EditorMode,
+    editorMode: DocMode,
     host: EditorHost
   ) => boolean;
   subItem?: AISubItemConfig[];

--- a/packages/blocks/src/_common/components/doc-mode-service.ts
+++ b/packages/blocks/src/_common/components/doc-mode-service.ts
@@ -1,0 +1,45 @@
+import type { Disposable } from '@blocksuite/global/utils';
+import { Slot } from '@blocksuite/global/utils';
+import type { Doc } from '@blocksuite/store';
+
+import type { DocMode } from '../types.js';
+
+export interface DocModeService {
+  setMode: (mode: DocMode, docId?: string) => void;
+  getMode: (docId?: string) => DocMode;
+  toggleMode: (docId?: string) => DocMode;
+  onModeChange: (
+    handler: (mode: DocMode) => void,
+    docId?: string
+  ) => Disposable;
+}
+
+const DEFAULT_MODE = 'page';
+const modeMap = new Map<string, { mode: DocMode; slot: Slot<DocMode> }>();
+
+export function createDocModeService(doc: Doc) {
+  const docModeService: DocModeService = {
+    setMode: (mode: DocMode, id: string = doc.id) => {
+      modeMap.set(id, {
+        mode,
+        slot: modeMap.get(id)?.slot || new Slot(),
+      });
+      modeMap.get(id)?.slot.emit(mode);
+    },
+    getMode: (id: string = doc.id) => {
+      return modeMap.get(id)?.mode || DEFAULT_MODE;
+    },
+    toggleMode: (id: string = doc.id) => {
+      const mode = docModeService.getMode(id) === 'page' ? 'edgeless' : 'page';
+      docModeService.setMode(mode);
+      return mode;
+    },
+    onModeChange: (handler: (mode: DocMode) => void, id: string = doc.id) => {
+      if (!modeMap.get(id)) {
+        docModeService.setMode(DEFAULT_MODE, id);
+      }
+      return modeMap.get(id)!.slot.on(handler);
+    },
+  };
+  return docModeService;
+}

--- a/packages/blocks/src/_common/components/index.ts
+++ b/packages/blocks/src/_common/components/index.ts
@@ -2,6 +2,7 @@ export * from './ai-item/index.js';
 export * from './block-caption.js';
 export * from './block-component.js';
 export * from './block-selection.js';
+export * from './doc-mode-service.js';
 export * from './drag-indicator.js';
 export * from './file-drop-manager.js';
 export * from './hover/index.js';

--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -32,15 +32,16 @@ export interface EditingState {
 
 export type CommonSlots = RefNodeSlots;
 
-export type EditorMode = 'page' | 'edgeless';
+export type DocMode = 'page' | 'edgeless';
+
 type EditorSlots = {
-  editorModeSwitched: Slot<EditorMode>;
+  editorModeSwitched: Slot<DocMode>;
   docUpdated: Slot<{ newDocId: string }>;
 };
 
 export type AbstractEditor = {
   doc: Doc;
-  mode: EditorMode;
+  mode: DocMode;
   readonly slots: CommonSlots & EditorSlots;
 } & HTMLElement;
 

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -159,7 +159,7 @@ export function notifyDocCreated(host: EditorHost, doc: Doc) {
     accent: 'info',
     duration: 10 * 1000,
     action: {
-      label: 'undo',
+      label: 'Undo',
       onClick: () => {
         doc.undo();
         clear();
@@ -518,14 +518,14 @@ export function createLinkedDocFromNote(
 }
 
 export function createLinkedDocFromEdgelessElements(
-  doc: Doc,
+  host: EditorHost,
   elements: BlockSuite.EdgelessModelType[],
   docTitle?: string
 ) {
-  const linkedDoc = doc.collection.createDoc({});
+  const linkedDoc = host.doc.collection.createDoc({});
   linkedDoc.load(() => {
     const rootId = linkedDoc.addBlock('affine:page', {
-      title: new doc.Text(docTitle),
+      title: new host.doc.Text(docTitle),
     });
     const surfaceId = linkedDoc.addBlock('affine:surface', {}, rootId);
     const surface = getSurfaceBlock(linkedDoc);
@@ -557,6 +557,7 @@ export function createLinkedDocFromEdgelessElements(
       ids.set(model.id, newId);
     });
   });
-
+  const pageService = host.spec.getService('affine:page');
+  pageService.docModeService.setMode('edgeless', linkedDoc.id);
   return linkedDoc;
 }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -96,7 +96,9 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
       return;
     }
 
-    this._editorMode = this._rootService.getEditorMode(this.model.pageId);
+    this._editorMode = this._rootService.docModeService.getMode(
+      this.model.pageId
+    );
     this._docUpdatedAt = this._rootService.getDocUpdatedAt(this.model.pageId);
 
     if (!linkedDoc.loaded) {

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -182,7 +182,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     }
 
     this._checkCycle();
-    this._editorMode = this._rootService.getEditorMode(this.model.pageId);
+    this._editorMode = this._rootService.docModeService.getMode(
+      this.model.pageId
+    );
     this._docUpdatedAt = this._rootService.getDocUpdatedAt(this.model.pageId);
 
     if (!syncedDoc.loaded) {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -19,15 +19,20 @@ import { deserializeXYWH } from './surface-block/index.js';
 
 export * from './_common/adapters/index.js';
 export * from './_common/components/ai-item/index.js';
+export type {
+  DocModeService,
+  NotificationService,
+  PeekViewService,
+} from './_common/components/index.js';
 export {
   createLitPortal,
   HoverController,
   PeekableController,
-  type PeekViewService,
+  RichText,
+  scrollbarStyle,
   toast,
   Tooltip,
 } from './_common/components/index.js';
-export { RichText, scrollbarStyle } from './_common/components/index.js';
 export { type NavigatorMode } from './_common/edgeless/frame/consts.js';
 export {
   createEmbedBlock,
@@ -65,7 +70,11 @@ export {
   ThemeObserver,
 } from './_common/theme/theme-observer.js';
 export * from './_common/transformers/index.js';
-export { type AbstractEditor, NoteDisplayMode } from './_common/types.js';
+export {
+  type AbstractEditor,
+  type DocMode,
+  NoteDisplayMode,
+} from './_common/types.js';
 export {
   createButtonPopper,
   matchFlavours,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -166,8 +166,6 @@ export class EdgelessRootService extends RootService {
       blockId?: string;
     }>(),
     tagClicked: new Slot<{ tagId: string }>(),
-    editorModeSwitch: new Slot<'edgeless' | 'page'>(),
-
     toolbarLocked: new Slot<boolean>(),
   };
 

--- a/packages/blocks/src/root-block/index.ts
+++ b/packages/blocks/src/root-block/index.ts
@@ -15,7 +15,7 @@ export * from './page/page-root-block.js';
 export { PageRootService } from './page/page-root-service.js';
 export * from './preview/preview-root-block.js';
 export { type RootBlockModel, RootBlockSchema } from './root-model.js';
-export { RootService } from './root-service.js';
+export { type QuickSearchService, RootService } from './root-service.js';
 export * from './types.js';
 export * from './utils/index.js';
 export * from './widgets/index.js';

--- a/packages/blocks/src/root-block/page/page-root-service.ts
+++ b/packages/blocks/src/root-block/page/page-root-service.ts
@@ -13,6 +13,5 @@ export class PageRootService extends RootService {
       tagId: string;
     }>(),
     viewportUpdated: new Slot<Viewport>(),
-    editorModeSwitch: new Slot<'edgeless' | 'page'>(),
   };
 }

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -8,6 +8,8 @@ import {
   type FileDropOptions,
 } from '../_common/components/file-drop-manager.js';
 import {
+  createDocModeService,
+  type DocModeService,
   getSelectedPeekableBlocksCommand,
   type NotificationService,
   peekSelectedBlockCommand,
@@ -136,6 +138,8 @@ export class RootService extends BlockService<RootBlockModel> {
   notificationService: NotificationService | null = null;
 
   peekViewService: PeekViewService | null = null;
+
+  docModeService: DocModeService = createDocModeService(this.doc);
 
   transformers = {
     markdown: MarkdownTransformer,

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -401,7 +401,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       this.edgeless.surface.edgeless.service.frame
     );
     const linkedDoc = createLinkedDocFromEdgelessElements(
-      this.edgeless.host.doc,
+      this.edgeless.host,
       elements,
       title
     );

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -578,7 +578,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     const pageService = this.std.spec.getService('affine:page');
 
     pageService.editPropsStore.setItem('viewport', viewport);
-    pageService.slots.editorModeSwitch.emit('edgeless');
+    pageService.docModeService.setMode('edgeless');
   }
 
   override render() {

--- a/packages/playground/apps/_common/components/custom-chat-panel.ts
+++ b/packages/playground/apps/_common/components/custom-chat-panel.ts
@@ -37,15 +37,13 @@ export class CustomChatPanel extends WithDisposable(ShadowlessElement) {
   override connectedCallback(): void {
     super.connectedCallback();
     const { editor } = this;
-
+    const { docModeService } = editor.host.spec.getService('affine:page');
     this.disposables.add(
-      editor.host.spec
-        .getService('affine:page')
-        .slots.editorModeSwitch.on(() => {
-          this.editor.updateComplete
-            .then(() => this.requestUpdate())
-            .catch(console.error);
-        })
+      docModeService.onModeChange(() => {
+        this.editor.updateComplete
+          .then(() => this.requestUpdate())
+          .catch(console.error);
+      })
     );
   }
 

--- a/packages/playground/apps/_common/components/debug-menu.ts
+++ b/packages/playground/apps/_common/components/debug-menu.ts
@@ -263,7 +263,8 @@ export class DebugMenu extends ShadowlessElement {
   accessor blockTypeDropdown!: SlDropdown;
 
   private _switchEditorMode() {
-    this.mode = this.mode === 'page' ? 'edgeless' : 'page';
+    const { docModeService } = this.editor.host.spec.getService('affine:page');
+    this.mode = docModeService.toggleMode();
   }
 
   private _toggleOutlinePanel() {

--- a/packages/playground/apps/_common/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/_common/components/quick-edgeless-menu.ts
@@ -18,7 +18,11 @@ import '@shoelace-style/shoelace/dist/themes/dark.css';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
-import type { AffineTextAttributes, SerializedXYWH } from '@blocksuite/blocks';
+import type {
+  AffineTextAttributes,
+  DocMode,
+  SerializedXYWH,
+} from '@blocksuite/blocks';
 import { ColorVariables, extractCssVariables } from '@blocksuite/blocks';
 import type { DeltaInsert } from '@blocksuite/inline';
 import type { AffineEditorContainer } from '@blocksuite/presets';
@@ -97,7 +101,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   accessor chatPanel!: CustomChatPanel;
 
   @property({ attribute: false })
-  accessor mode: 'page' | 'edgeless' = 'page';
+  accessor mode: DocMode = 'page';
 
   @property({ attribute: false })
   accessor readonly = false;
@@ -109,16 +113,11 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   };
 
   private _switchEditorMode() {
-    const mode = this.editor.mode === 'page' ? 'edgeless' : 'page';
-    localStorage.setItem('playground:editorMode', mode);
-    this.mode = mode;
+    this.mode = this.rootService.docModeService.toggleMode();
   }
 
   private _restoreMode() {
-    const mode = localStorage.getItem('playground:editorMode');
-    if (mode && (mode === 'edgeless' || mode === 'page')) {
-      this.mode = mode;
-    }
+    this.mode = this.rootService.docModeService.getMode();
   }
 
   private _addNote() {

--- a/packages/playground/apps/_common/mock-services.ts
+++ b/packages/playground/apps/_common/mock-services.ts
@@ -1,0 +1,83 @@
+import type { EditorHost } from '@blocksuite/block-std';
+import {
+  type DocMode,
+  type DocModeService,
+  type NotificationService,
+  type PageRootService,
+  type QuickSearchService,
+  toast,
+} from '@blocksuite/blocks';
+import { type DocCollection, Slot } from '@blocksuite/store';
+
+const modeChange = new Slot<DocMode>();
+export function mockDocModeService() {
+  const docModeService: DocModeService = {
+    setMode: (mode: DocMode) => {
+      localStorage.setItem('playground:editorMode', mode);
+      modeChange.emit(mode);
+    },
+    getMode: () => {
+      return localStorage.getItem('playground:editorMode') as DocMode;
+    },
+    toggleMode: () => {
+      const mode = docModeService.getMode() === 'page' ? 'edgeless' : 'page';
+      docModeService.setMode(mode);
+      return mode;
+    },
+    onModeChange: (handler: (mode: DocMode) => void) => {
+      return modeChange.on(handler);
+    },
+  };
+  return docModeService;
+}
+
+export function mockNotificationService(service: PageRootService) {
+  const notificationService: NotificationService = {
+    toast: (message, options) => {
+      toast(service.host as EditorHost, message, options?.duration);
+    },
+    confirm: notification => {
+      return Promise.resolve(confirm(notification.title.toString()));
+    },
+    prompt: notification => {
+      return Promise.resolve(
+        prompt(notification.title.toString(), notification.autofill?.toString())
+      );
+    },
+    notify: notification => {
+      // todo: implement in playground
+      console.log(notification);
+    },
+  };
+  return notificationService;
+}
+
+export function mockQuickSearchService(collection: DocCollection) {
+  const quickSearchService: QuickSearchService = {
+    async searchDoc({ userInput }) {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      const docs = collection.search({
+        query: userInput,
+        limit: 1,
+      });
+      const doc = [...docs].at(0);
+      if (doc) {
+        return {
+          docId: doc[1],
+        };
+      } else if (userInput) {
+        return {
+          userInput: userInput,
+        };
+      } else {
+        // randomly pick a doc
+        return {
+          docId: [...collection.docs.values()][
+            Math.floor(Math.random() * collection.docs.size)
+          ].id,
+        };
+      }
+    },
+  };
+  return quickSearchService;
+}

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -4,7 +4,6 @@ import {
   AffineFormatBarWidget,
   EdgelessEditorBlockSpecs,
   PageEditorBlockSpecs,
-  toast,
   toolbarDefaultConfig,
 } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
@@ -24,6 +23,11 @@ import { DebugMenu } from '../../_common/components/debug-menu.js';
 import { DocsPanel } from '../../_common/components/docs-panel.js';
 import { LeftSidePanel } from '../../_common/components/left-side-panel.js';
 import { SidePanel } from '../../_common/components/side-panel.js';
+import {
+  mockDocModeService,
+  mockNotificationService,
+  mockQuickSearchService,
+} from '../../_common/mock-services.js';
 
 const params = new URLSearchParams(location.search);
 const defaultMode = params.get('mode') === 'edgeless' ? 'edgeless' : 'page';
@@ -151,51 +155,11 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
             }
           });
           disposable.add(onFormatBarConnected);
-          pageRootService.notificationService = {
-            toast: (message, options) => {
-              toast(service.host as EditorHost, message, options?.duration);
-            },
-            confirm: notification => {
-              return Promise.resolve(confirm(notification.title.toString()));
-            },
-            prompt: notification => {
-              return Promise.resolve(
-                prompt(
-                  notification.title.toString(),
-                  notification.autofill?.toString()
-                )
-              );
-            },
-            notify: notification => {
-              // todo: implement in playground
-              console.log(notification);
-            },
-          };
-          pageRootService.quickSearchService = {
-            async searchDoc({ userInput }) {
-              await new Promise(resolve => setTimeout(resolve, 500));
-              const docs = collection.search({
-                query: userInput,
-                limit: 1,
-              });
-              const doc = [...docs].at(0);
-              if (doc) {
-                return {
-                  docId: doc[1],
-                };
-              } else if (userInput) {
-                return {
-                  userInput: userInput,
-                };
-              } else {
-                // randomly create a doc
-                const newDoc = collection.createDoc();
-                return {
-                  docId: newDoc.id,
-                };
-              }
-            },
-          };
+          pageRootService.notificationService =
+            mockNotificationService(pageRootService);
+          pageRootService.quickSearchService =
+            mockQuickSearchService(collection);
+          pageRootService.docModeService = mockDocModeService();
         });
       },
     };

--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -178,8 +178,7 @@ describe('basic', () => {
 
     const switchEditor = vi.fn(() => {});
     const pageService = editor.host.std.spec.getService('affine:page');
-
-    pageService.slots.editorModeSwitch.once(switchEditor);
+    pageService.docModeService.onModeChange(switchEditor);
 
     expect(surfaceRef).instanceOf(Element);
     (surfaceRef as SurfaceRefBlockComponent).viewInEdgeless();

--- a/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/presets/src/ai/chat-panel/chat-panel-messages.ts
@@ -185,13 +185,8 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
           this.requestUpdate();
         })
       );
-      disposables.add(
-        this.host.spec
-          .getService('affine:page')
-          .slots.editorModeSwitch.on(() => {
-            this.requestUpdate();
-          })
-      );
+      const { docModeService } = this.host.spec.getService('affine:page');
+      disposables.add(docModeService.onModeChange(() => this.requestUpdate()));
     }
   }
 

--- a/packages/presets/src/ai/entries/slash-menu/setup-slash-menu.ts
+++ b/packages/presets/src/ai/entries/slash-menu/setup-slash-menu.ts
@@ -38,7 +38,9 @@ export function setupSlashMenuEntry(slashMenu: AffineSlashMenuWidget) {
       if (affineAIPanelWidget === null) return false;
 
       const chain = rootElement.host.command.chain();
-      const editorMode = rootElement.service.getEditorMode(rootElement.doc.id);
+      const editorMode = rootElement.service.docModeService.getMode(
+        rootElement.doc.id
+      );
 
       return item?.showWhen?.(chain, editorMode, rootElement.host) ?? true;
     };

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -6,6 +6,7 @@ import '../fragments/doc-meta-tags/doc-meta-tags.js';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import type {
   AbstractEditor,
+  DocMode,
   EdgelessRootBlockComponent,
   PageRootBlockComponent,
   PageRootService,
@@ -54,10 +55,9 @@ export class AffineEditorContainer
           setup: (slots, disposable) => {
             setup?.(slots, disposable);
             slots.mounted.once(({ service }) => {
+              const { docModeService } = service as PageRootService;
               disposable.add(
-                (service as PageRootService).slots.editorModeSwitch.on(
-                  this.switchEditor.bind(this)
-                )
+                docModeService.onModeChange(this.switchEditor.bind(this))
               );
             });
           },
@@ -76,10 +76,9 @@ export class AffineEditorContainer
           setup: (slots, disposable) => {
             setup?.(slots, disposable);
             slots.mounted.once(({ service }) => {
+              const { docModeService } = service as PageRootService;
               disposable.add(
-                (service as PageRootService).slots.editorModeSwitch.on(
-                  this.switchEditor.bind(this)
-                )
+                docModeService.onModeChange(this.switchEditor.bind(this))
               );
             });
           },
@@ -151,7 +150,7 @@ export class AffineEditorContainer
   accessor doc!: Doc;
 
   @property({ attribute: false })
-  accessor mode: 'page' | 'edgeless' = 'page';
+  accessor mode: DocMode = 'page';
 
   @property({ attribute: false })
   accessor pageSpecs = PageEditorBlockSpecs;
@@ -177,7 +176,7 @@ export class AffineEditorContainer
     tagClicked: new Slot<{ tagId: string }>(),
   };
 
-  switchEditor(mode: typeof this.mode) {
+  switchEditor(mode: DocMode) {
     this.mode = mode;
   }
 

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -250,7 +250,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
 
       const rootService = this.editorHost.spec.getService('affine:page');
       rootService.editPropsStore.setItem('viewport', viewport);
-      rootService.slots.editorModeSwitch.emit('edgeless');
+      rootService.docModeService.setMode('edgeless');
     } else {
       this.edgeless.service.viewport.setViewportByBound(
         bound,

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -130,8 +130,9 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
   accessor edgeless!: EdgelessRootBlockComponent | null;
 
   private _enterPresentationMode = () => {
-    if (!this.edgeless)
-      this.rootService.slots.editorModeSwitch.emit('edgeless');
+    if (!this.edgeless) {
+      this.rootService.docModeService.setMode('edgeless');
+    }
 
     setTimeout(() => {
       this.edgeless?.updateComplete


### PR DESCRIPTION
### TL;DR

This refactor introduces a new `DocModeService` to get document mode, set or toggle mode and observe mode changes. You can also get or set sepcific document mode by pass through id, not only the current document mode.

### Why make this change?
- The old `editorModeSwitch` slot only support manipulating current doc, can not change other doucment mode.
- The old `editorModeSwitch.on` only react to `editorModeSwitch.emit` which is not strict equal to mode change.
- Explicitly calling the `setMode` function should be more intuitive than emitting an event.

### What changed?
- Introduced `DocModeService` to manage document mode, which can be overwritten by upper business logic (eg. in playground or affine)
```typeacript
interface DocModeService {
  setMode: (mode: DocMode, docId?: string) => void;
  getMode: (docId?: string) => DocMode;
  toggleMode: (docId?: string) => DocMode;
  onModeChange: (
    handler: (mode: DocMode) => void,
    docId?: string
  ) => Disposable;
}
```
- Add a default implement of doc mode service in blocksuites
- Mock `DocModeService` with localstorage in playground
- Overwritte `DocModeService`  in [AFFiNE](https://github.com/toeverything/AFFiNE/pull/7200)
- Updated all references from `pageService.slots.editorModeSwitch` to `pageService.docModeService`
- Updated all references from `pageService.getEditorMode` to `pageService.docModeService.getMode`
- Set doc mode to edgeless after linked doc created from edgeless elements

### How to test?
1.  Lots of e2e tests include mode switch case.
2. Toggling between 'edgeless' and 'page' modes in the document editor.

### Problems
I think all the services should be injected into the constructor instead of overwritting public function during the `slots.mounted` lifecycle, which might have hidden asynchronous problems. Hope there are better solutions for this case. @Saul-Mirone 

---

