### PR TITLE
refactor(edgeless): remove hard writing edgeless tool types

### DIFF
--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -1,16 +1,11 @@
 import type { Slot } from '@blocksuite/global/utils';
 import type { BlockModel, Doc } from '@blocksuite/store';
 
-import type {
-  ConnectorElementModel,
-  ConnectorMode,
-} from '../surface-block/element-model/connector.js';
+import type { ConnectorElementModel } from '../surface-block/element-model/connector.js';
 import type {
   BrushElementModel,
   GroupElementModel,
-  ShapeType,
 } from '../surface-block/index.js';
-import type { NavigatorMode } from './edgeless/frame/consts.js';
 import type { RefNodeSlots } from './inline/presets/nodes/reference-node/reference-node.js';
 import type { BlockComponent } from './utils/query.js';
 import type { Point } from './utils/rect.js';
@@ -53,15 +48,6 @@ export type Connectable = Exclude<
   ConnectorElementModel | BrushElementModel | GroupElementModel
 >;
 
-export type DefaultTool = {
-  type: 'default';
-};
-
-export type ShapeTool = {
-  type: 'shape';
-  shapeType: ShapeType | 'roundedRect';
-};
-
 export enum LineWidth {
   Two = 2,
   // Thin
@@ -78,45 +64,6 @@ export enum LassoMode {
   Polygonal,
 }
 
-export type TextTool = {
-  type: 'text';
-};
-
-export type BrushTool = {
-  type: 'brush';
-};
-
-export type EraserTool = {
-  type: 'eraser';
-};
-
-export type FrameTool = {
-  type: 'frame';
-};
-
-export type FrameNavigatorTool = {
-  type: 'frameNavigator';
-  mode?: NavigatorMode;
-};
-
-export type PanTool = {
-  type: 'pan';
-  panning: boolean;
-};
-
-export type CopilotSelectionTool = {
-  type: 'copilot';
-};
-
-export type LassoTool = {
-  type: 'lasso';
-  mode: LassoMode;
-};
-
-export type TemplateTool = {
-  type: 'template';
-};
-
 export type NoteChildrenFlavour =
   | 'affine:paragraph'
   | 'affine:list'
@@ -129,43 +76,11 @@ export type NoteChildrenFlavour =
   | 'affine:attachment'
   | 'affine:surface-ref';
 
-export type NoteTool = {
-  type: 'affine:note';
-  childFlavour: NoteChildrenFlavour;
-  childType: string | null;
-  tip: string;
-};
-
 export enum NoteDisplayMode {
   DocAndEdgeless = 'both',
   EdgelessOnly = 'edgeless',
   DocOnly = 'doc',
 }
-
-export type ConnectorTool = {
-  type: 'connector';
-  mode: ConnectorMode;
-};
-
-export type MindmapTool = {
-  type: 'mindmap';
-};
-
-export type EdgelessTool =
-  | DefaultTool
-  | TextTool
-  | ShapeTool
-  | BrushTool
-  | PanTool
-  | NoteTool
-  | ConnectorTool
-  | EraserTool
-  | FrameTool
-  | FrameNavigatorTool
-  | CopilotSelectionTool
-  | LassoTool
-  | TemplateTool
-  | MindmapTool;
 
 export interface Viewport {
   left: number;

--- a/packages/blocks/src/root-block/edgeless/components/panel/shape-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/shape-panel.ts
@@ -5,8 +5,8 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { ShapeTool } from '../../../../_common/utils/index.js';
 import { ShapeStyle } from '../../../../surface-block/index.js';
+import type { ShapeTool } from '../../controllers/tools/shape-tool.js';
 import { ShapeComponentConfig } from '../toolbar/shape/shape-menu-config.js';
 
 @customElement('edgeless-shape-panel')

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
@@ -5,7 +5,7 @@ import '../common/slide-menu.js';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { EdgelessTool } from '../../../../../_common/types.js';
+import type { EdgelessTool } from '../../../types.js';
 import type { ColorEvent } from '../../panel/color-panel.js';
 import type { LineWidthEvent } from '../../panel/line-width-panel.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
@@ -9,8 +9,8 @@ import {
   ConnectorLWithArrowIcon,
   ConnectorXWithArrowIcon,
 } from '../../../../../_common/icons/index.js';
-import type { EdgelessTool } from '../../../../../_common/utils/index.js';
 import { ConnectorMode } from '../../../../../surface-block/index.js';
+import type { EdgelessTool } from '../../../types.js';
 import type { ColorEvent } from '../../panel/color-panel.js';
 import type { LineWidthEvent } from '../../panel/line-width-panel.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/default/default-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/default/default-tool-button.ts
@@ -6,7 +6,7 @@ import {
   HandIcon,
   SelectIcon,
 } from '../../../../../_common/icons/index.js';
-import type { EdgelessTool } from '../../../../../_common/types.js';
+import type { EdgelessTool } from '../../../types.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { QuickToolMixin } from '../mixins/quick-tool.mixin.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -23,10 +23,10 @@ import {
   MoreHorizontalIcon,
 } from '../../../../_common/icons/index.js';
 import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
-import type { EdgelessTool } from '../../../../_common/types.js';
 import { stopPropagation } from '../../../../_common/utils/event.js';
 import { getThemeMode } from '../../../../_common/utils/query.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
+import type { EdgelessTool } from '../../types.js';
 import {
   type EdgelessToolbarSlots,
   edgelessToolbarSlotsContext,

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/eraser/eraser-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/eraser/eraser-tool-button.ts
@@ -5,7 +5,7 @@ import {
   EdgelessEraserDarkIcon,
   EdgelessEraserLightIcon,
 } from '../../../../../_common/icons/index.js';
-import type { EdgelessTool } from '../../../../../_common/utils/index.js';
+import type { EdgelessTool } from '../../../types.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/frame/frame-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/frame/frame-menu.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { EdgelessTool } from '../../../../../_common/utils/index.js';
+import type { EdgelessTool } from '../../../types.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import { FrameConfig } from './config.js';
 import { createFrame } from './service.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/frame/frame-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/frame/frame-tool-button.ts
@@ -9,8 +9,8 @@ import {
   ArrowUpIcon,
   LargeFrameIcon,
 } from '../../../../../_common/icons/index.js';
-import type { EdgelessTool } from '../../../../../_common/utils/index.js';
 import { getTooltipWithShortcut } from '../../../components/utils.js';
+import type { EdgelessTool } from '../../../types.js';
 import { QuickToolMixin } from '../mixins/quick-tool.mixin.js';
 
 @customElement('edgeless-frame-tool-button')

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/image/image-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/image/image-tool-button.ts
@@ -2,8 +2,8 @@ import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { EdgelessImageIcon } from '../../../../../_common/icons/edgeless.js';
-import type { EdgelessTool } from '../../../../../_common/types.js';
 import { getImageFilesFromLocal } from '../../../../../_common/utils/filesys.js';
+import type { EdgelessTool } from '../../../types.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 
 @customElement('edgeless-image-tool-button')

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
@@ -6,8 +6,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EdgelessTool } from '../../../../../_common/types.js';
 import { MindmapStyle } from '../../../../../surface-block/index.js';
+import type { EdgelessTool } from '../../../types.js';
 import { EdgelessDraggableElementController } from '../common/draggable/draggable-element.controller.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import { getMindMaps } from './assets.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/tool.mixin.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/tool.mixin.ts
@@ -5,8 +5,8 @@ import { cssVar } from '@toeverything/theme';
 import type { LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
-import type { EdgelessTool } from '../../../../../_common/types.js';
 import type { EdgelessRootBlockComponent } from '../../../edgeless-root-block.js';
+import type { EdgelessTool } from '../../../types.js';
 import { createPopper, type MenuPopper } from '../common/create-popper.js';
 import { edgelessToolbarThemeContext } from '../context.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
@@ -7,13 +7,13 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import { AttachmentIcon, LinkIcon } from '../../../../../_common/icons/text.js';
 import {
-  type EdgelessTool,
   getImageFilesFromLocal,
   type NoteChildrenFlavour,
-  type NoteTool,
   openFileOrFiles,
 } from '../../../../../_common/utils/index.js';
 import { ImageIcon } from '../../../../../image-block/styles.js';
+import type { NoteTool } from '../../../controllers/tools/note-tool.js';
+import type { EdgelessTool } from '../../../types.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import { NOTE_MENU_ITEMS } from './note-menu-config.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-senior-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-senior-button.ts
@@ -8,7 +8,7 @@ import {
   LinkIcon,
   TextIcon,
 } from '../../../../../_common/icons/text.js';
-import type { NoteTool } from '../../../../../_common/types.js';
+import type { NoteTool } from '../../../controllers/tools/note-tool.js';
 import { DEFAULT_NOTE_BACKGROUND_COLOR } from '../../auto-complete/utils.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-tool-button.ts
@@ -6,11 +6,9 @@ import { customElement, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { ArrowUpIcon, NoteIcon } from '../../../../../_common/icons/index.js';
-import type {
-  EdgelessTool,
-  NoteTool,
-} from '../../../../../_common/utils/index.js';
 import { getTooltipWithShortcut } from '../../../components/utils.js';
+import type { NoteTool } from '../../../controllers/tools/note-tool.js';
+import type { EdgelessTool } from '../../../types.js';
 import { createPopper, type MenuPopper } from '../common/create-popper.js';
 import { QuickToolMixin } from '../mixins/quick-tool.mixin.js';
 import type { EdgelessNoteMenu } from './note-menu.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/present/present-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/present/present-button.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { FrameNavigatorIcon } from '../../../../../_common/icons/edgeless.js';
-import type { EdgelessTool } from '../../../../../_common/types.js';
+import type { EdgelessTool } from '../../../types.js';
 import { QuickToolMixin } from '../mixins/quick-tool.mixin.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
@@ -11,10 +11,10 @@ import {
   NavigatorExitFullScreenIcon,
   NavigatorFullScreenIcon,
 } from '../../../../_common/icons/edgeless.js';
-import type { EdgelessTool } from '../../../../_common/types.js';
 import type { FrameBlockModel } from '../../../../frame-block/frame-model.js';
 import { Bound, clamp } from '../../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
+import type { EdgelessTool } from '../../types.js';
 import { isFrameBlock } from '../../utils/query.js';
 import { launchIntoFullscreen } from '../utils.js';
 import { EdgelessToolbarToolMixin } from './mixins/tool.mixin.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu-config.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu-config.ts
@@ -12,8 +12,8 @@ import {
   SquareIcon,
   TriangleIcon,
 } from '../../../../../_common/icons/index.js';
-import type { ShapeTool } from '../../../../../_common/utils/index.js';
 import { ShapeType } from '../../../../../surface-block/index.js';
+import type { ShapeTool } from '../../../controllers/tools/shape-tool.js';
 
 const { Rect, Ellipse, Triangle, Diamond } = ShapeType;
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
@@ -9,8 +9,8 @@ import {
   ScribbledStyleIcon,
 } from '../../../../../_common/icons/index.js';
 import type { CssVariableName } from '../../../../../_common/theme/css-variables.js';
-import type { EdgelessTool } from '../../../../../_common/types.js';
 import { ShapeStyle } from '../../../../../surface-block/index.js';
+import type { EdgelessTool } from '../../../types.js';
 import { type ColorEvent, isTransparent } from '../../panel/color-panel.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -9,14 +9,16 @@ import { customElement, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { isTransparent } from '../../../../../_common/theme/css-variables.js';
-import type { ShapeTool } from '../../../../../_common/types.js';
 import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
   ShapeType,
 } from '../../../../../surface-block/elements/shape/consts.js';
 import { ShapeStyle } from '../../../../../surface-block/index.js';
-import { ShapeToolController } from '../../../controllers/tools/shape-tool.js';
+import {
+  type ShapeTool,
+  ShapeToolController,
+} from '../../../controllers/tools/shape-tool.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { ToolbarButtonWithMenuMixin } from '../mixins/toolbar-button-with-menu.mixin.js';
 import type { EdgelessShapeMenu } from './shape-menu.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/utils.ts
@@ -1,6 +1,6 @@
 import { render, type TemplateResult } from 'lit';
 
-import type { ShapeTool } from '../../../../../_common/types.js';
+import type { ShapeTool } from '../../../controllers/tools/shape-tool.js';
 
 type TransformState = {
   /** horizental offset base on center */

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-tool-button.ts
@@ -11,8 +11,8 @@ import { css, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { ArrowDownSmallIcon } from '../../../../../_common/icons/text.js';
-import type { EdgelessTool } from '../../../../../_common/types.js';
 import { once } from '../../../../../_common/utils/event.js';
+import type { EdgelessTool } from '../../../types.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import { TemplateCard1, TemplateCard2, TemplateCard3 } from './icon.js';
 import type { EdgelessTemplatePanel } from './template-panel.js';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/text/text-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/text/text-menu.ts
@@ -5,7 +5,7 @@ import '../common/slide-menu.js';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { EdgelessTool } from '../../../../../_common/types.js';
+import type { EdgelessTool } from '../../../types.js';
 import type { ColorEvent } from '../../panel/color-panel.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/tools.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/tools.ts
@@ -17,8 +17,8 @@ import './link/link-tool-button.js';
 import { html, type TemplateResult } from 'lit';
 
 import type { Menu } from '../../../../_common/components/index.js';
-import type { EdgelessTool } from '../../../../_common/types.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
+import type { EdgelessTool } from '../../types.js';
 import { buildConnectorDenseMenu } from './connector/connector-dense-menu.js';
 import { buildFrameDenseMenu } from './frame/frame-dense-menu.js';
 import { buildLinkDenseMenu } from './link/link-dense-menu.js';

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/brush-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/brush-tool.ts
@@ -1,13 +1,16 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
 
-import type { BrushTool } from '../../../../_common/utils/index.js';
 import type { BrushElementModel } from '../../../../surface-block/index.js';
 import {
   CanvasElementType,
   type IVec,
 } from '../../../../surface-block/index.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+type BrushTool = {
+  type: 'brush';
+};
 
 export class BrushToolController extends EdgelessToolController<BrushTool> {
   static BRUSH_POP_GAP = 20;
@@ -206,5 +209,13 @@ export class BrushToolController extends EdgelessToolController<BrushTool> {
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      brush: BrushToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
@@ -1,7 +1,7 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
 
-import type { ConnectorTool } from '../../../../_common/utils/index.js';
+import type { ConnectorMode } from '../../../../surface-block/index.js';
 import {
   Bound,
   CanvasElementType,
@@ -12,7 +12,7 @@ import {
   type IVec,
 } from '../../../../surface-block/index.js';
 import { calculateNearestLocation } from '../../../../surface-block/managers/connector-manager.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
 
 enum ConnectorToolMode {
   // Dragging connect
@@ -20,6 +20,11 @@ enum ConnectorToolMode {
   // Quick connect
   Quick,
 }
+
+export type ConnectorTool = {
+  type: 'connector';
+  mode: ConnectorMode;
+};
 
 export class ConnectorToolController extends EdgelessToolController<ConnectorTool> {
   private _mode: ConnectorToolMode = ConnectorToolMode.Dragging;
@@ -155,10 +160,11 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
 
   onContainerMouseMove(e: PointerEventState) {
     if (this._mode === ConnectorToolMode.Dragging) return;
-    const sourceId = this._connector?.source.id;
 
     assertExists(this._sourceBounds);
     assertExists(this._connector);
+
+    const sourceId = this._connector.source.id;
     assertExists(sourceId);
 
     const point = this._service.viewport.toModelCoord(e.x, e.y);
@@ -206,5 +212,13 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      connector: ConnectorToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/copilot-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/copilot-tool.ts
@@ -1,18 +1,31 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { Slot } from '@blocksuite/store';
 
-import type {
-  CopilotSelectionTool,
-  EdgelessTool,
-} from '../../../../_common/utils/index.js';
 import { Bound, getElementsBound } from '../../../../surface-block/index.js';
 import {
   AFFINE_AI_PANEL_WIDGET,
   type AffineAIPanelWidget,
 } from '../../../widgets/ai-panel/ai-panel.js';
-import { EdgelessToolController } from './index.js';
+import type { EdgelessTool } from '../../types.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+type CopilotSelectionTool = {
+  type: 'copilot';
+};
 
 export class CopilotSelectionController extends EdgelessToolController<CopilotSelectionTool> {
+  private _dragging = false;
+
+  readonly tool = {
+    type: 'copilot',
+  } as CopilotSelectionTool;
+
+  dragStartPoint: [number, number] = [0, 0];
+
+  dragLastPoint: [number, number] = [0, 0];
+
+  draggingAreaUpdated = new Slot<boolean | void>();
+
   get selection() {
     return this._edgeless.service.selection;
   }
@@ -41,18 +54,6 @@ export class CopilotSelectionController extends EdgelessToolController<CopilotSe
     ) as AffineAIPanelWidget;
     return aiPanel && aiPanel.state !== 'hidden';
   }
-
-  private _dragging = false;
-
-  readonly tool = {
-    type: 'copilot',
-  } as CopilotSelectionTool;
-
-  dragStartPoint: [number, number] = [0, 0];
-
-  dragLastPoint: [number, number] = [0, 0];
-
-  draggingAreaUpdated = new Slot<boolean | void>();
 
   private _initDragState(e: PointerEventState) {
     this.dragStartPoint = this._service.viewport.toModelCoord(e.x, e.y);
@@ -165,4 +166,12 @@ export class CopilotSelectionController extends EdgelessToolController<CopilotSe
   }
 
   afterModeSwitch(): void {}
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      'copilot-selection': CopilotSelectionController;
+    }
+  }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -4,10 +4,8 @@ import { DisposableGroup, noop } from '@blocksuite/global/utils';
 import {
   asyncFocusRichText,
   buildPath,
-  type EdgelessTool,
 } from '../../../../_common/utils/index.js';
 import {
-  type DefaultTool,
   handleNativeRangeAtPoint,
   resetNativeSelection,
 } from '../../../../_common/utils/index.js';
@@ -41,6 +39,7 @@ import {
 } from '../../../../surface-block/index.js';
 import { isConnectorAndBindingsAllSelected } from '../../../../surface-block/managers/connector-manager.js';
 import { intersects } from '../../../../surface-block/utils/math-utils.js';
+import type { EdgelessTool } from '../../types.js';
 import { edgelessElementsBound } from '../../utils/bound-utils.js';
 import { prepareCloneData } from '../../utils/clone-utils.js';
 import { calPanDelta } from '../../utils/panning-utils.js';
@@ -58,7 +57,7 @@ import {
   mountShapeTextEditor,
   mountTextElementEditor,
 } from '../../utils/text.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
 
 export enum DefaultModeDragType {
   /** Moving selected contents */
@@ -77,37 +76,11 @@ export enum DefaultModeDragType {
   ConnectorLabelMoving = 'connector-label-moving',
 }
 
+type DefaultTool = {
+  type: 'default';
+};
+
 export class DefaultToolController extends EdgelessToolController<DefaultTool> {
-  override get draggingArea() {
-    if (this.dragType === DefaultModeDragType.Selecting) {
-      const [startX, startY] = this._service.viewport.toViewCoord(
-        this._dragStartModelCoord[0],
-        this._dragStartModelCoord[1]
-      );
-      const [endX, endY] = this._service.viewport.toViewCoord(
-        this._dragLastModelCoord[0],
-        this._dragLastModelCoord[1]
-      );
-      return {
-        start: new DOMPoint(startX, startY),
-        end: new DOMPoint(endX, endY),
-      };
-    }
-    return null;
-  }
-
-  get edgelessSelectionManager() {
-    return this._edgeless.service.selection;
-  }
-
-  get zoom() {
-    return this._edgeless.service.viewport.zoom;
-  }
-
-  get readonly() {
-    return this._edgeless.doc.readonly;
-  }
-
   private _dragStartPos: IVec = [0, 0];
 
   private _dragLastPos: IVec = [0, 0];
@@ -171,6 +144,36 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
   override enableHover = true;
 
   dragType = DefaultModeDragType.None;
+
+  override get draggingArea() {
+    if (this.dragType === DefaultModeDragType.Selecting) {
+      const [startX, startY] = this._service.viewport.toViewCoord(
+        this._dragStartModelCoord[0],
+        this._dragStartModelCoord[1]
+      );
+      const [endX, endY] = this._service.viewport.toViewCoord(
+        this._dragLastModelCoord[0],
+        this._dragLastModelCoord[1]
+      );
+      return {
+        start: new DOMPoint(startX, startY),
+        end: new DOMPoint(endX, endY),
+      };
+    }
+    return null;
+  }
+
+  get edgelessSelectionManager() {
+    return this._edgeless.service.selection;
+  }
+
+  get zoom() {
+    return this._edgeless.service.viewport.zoom;
+  }
+
+  get readonly() {
+    return this._edgeless.doc.readonly;
+  }
 
   private _pick(x: number, y: number, options?: IHitTestOptions) {
     const service = this._service;
@@ -1066,5 +1069,13 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      default: DefaultToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/edgeless-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/edgeless-tool.ts
@@ -1,0 +1,67 @@
+import type { PointerEventState } from '@blocksuite/block-std';
+
+import type { EdgelessBlockModel } from '../../edgeless-block-model.js';
+import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
+import type { EdgelessRootService } from '../../edgeless-root-service.js';
+import type { SelectionArea } from '../../services/tools-manager.js';
+import type { EdgelessTool } from '../../types.js';
+
+export abstract class EdgelessToolController<
+  Tool extends EdgelessTool = EdgelessTool,
+> {
+  get draggingArea() {
+    return this._draggingArea;
+  }
+
+  protected get _surface() {
+    return this._edgeless.surface;
+  }
+
+  protected get _doc() {
+    return this._edgeless.doc;
+  }
+
+  protected get _blocks(): EdgelessBlockModel[] {
+    return this._edgeless.service.blocks;
+  }
+
+  protected _edgeless!: EdgelessRootBlockComponent;
+
+  protected _draggingArea: SelectionArea | null = null;
+
+  protected _service: EdgelessRootService;
+
+  enableHover = false;
+
+  abstract tool: Tool;
+
+  constructor(service: EdgelessRootService) {
+    this._service = service;
+  }
+
+  mount(edgeless: EdgelessRootBlockComponent) {
+    this._edgeless = edgeless;
+  }
+  abstract onContainerPointerDown(e: PointerEventState): void;
+  abstract onContainerDragStart(e: PointerEventState): void;
+  abstract onContainerDragMove(e: PointerEventState): void;
+  abstract onContainerDragEnd(e: PointerEventState): void;
+  abstract onContainerClick(e: PointerEventState): void;
+  abstract onContainerDblClick(e: PointerEventState): void;
+  abstract onContainerTripleClick(e: PointerEventState): void;
+  abstract onContainerMouseMove(e: PointerEventState): void;
+  abstract onContainerMouseOut(e: PointerEventState): void;
+  abstract onContainerContextMenu(e: PointerEventState): void;
+  abstract beforeModeSwitch(prevMode: Tool): void;
+  abstract afterModeSwitch(newMode: Tool): void;
+
+  /**
+   * @warning Check `!ev.repeat` before calling this function in KeyboardEvents where needed
+   */
+  abstract onPressShiftKey(pressed: boolean): void;
+
+  /**
+   * @warning Check `!ev.repeat` before calling this function in KeyboardEvents where needed
+   */
+  abstract onPressSpaceBar(pressed: boolean): void;
+}

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/eraser-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/eraser-tool.ts
@@ -2,7 +2,7 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
 import type { IPoint } from '../../../../_common/utils/index.js';
-import { buildPath, type EraserTool } from '../../../../_common/utils/index.js';
+import { buildPath } from '../../../../_common/utils/index.js';
 import {
   Bound,
   getStroke,
@@ -14,7 +14,7 @@ import {
 import type { IVec2 } from '../../../../surface-block/utils/vec.js';
 import { deleteElements } from '../../utils/crud.js';
 import { isTopLevelBlock } from '../../utils/query.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
 
 class EraserOverlay extends Overlay {
   d = '';
@@ -26,6 +26,10 @@ class EraserOverlay extends Overlay {
     ctx.fill(path);
   }
 }
+
+type EraserTool = {
+  type: 'eraser';
+};
 
 export class EraserToolController extends EdgelessToolController<EraserTool> {
   private _overlay = new EraserOverlay();
@@ -200,5 +204,13 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
 
   override afterModeSwitch(_newMode: EraserTool): void {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      eraser: EraserToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/frame-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/frame-tool.ts
@@ -2,10 +2,14 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
 
-import type { FrameTool, IPoint } from '../../../../_common/utils/index.js';
+import type { IPoint } from '../../../../_common/utils/index.js';
 import type { FrameBlockModel } from '../../../../frame-block/index.js';
 import { Bound, type IVec, Vec } from '../../../../surface-block/index.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+type FrameTool = {
+  type: 'frame';
+};
 
 export class FrameToolController extends EdgelessToolController<FrameTool> {
   private _startPoint: IVec | null = null;
@@ -111,5 +115,13 @@ export class FrameToolController extends EdgelessToolController<FrameTool> {
 
   override afterModeSwitch(): void {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      frame: FrameToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/index.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/index.ts
@@ -1,67 +1,15 @@
-import type { PointerEventState } from '@blocksuite/block-std';
-
-import type { EdgelessTool as EdgelessTool } from '../../../../_common/utils/index.js';
-import type { EdgelessBlockModel } from '../../edgeless-block-model.js';
-import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
-import type { EdgelessRootService } from '../../edgeless-root-service.js';
-import type { SelectionArea } from '../../services/tools-manager.js';
-
-export abstract class EdgelessToolController<
-  Tool extends EdgelessTool = EdgelessTool,
-> {
-  get draggingArea() {
-    return this._draggingArea;
-  }
-
-  protected get _surface() {
-    return this._edgeless.surface;
-  }
-
-  protected get _doc() {
-    return this._edgeless.doc;
-  }
-
-  protected get _blocks(): EdgelessBlockModel[] {
-    return this._edgeless.service.blocks;
-  }
-
-  protected _edgeless!: EdgelessRootBlockComponent;
-
-  protected _draggingArea: SelectionArea | null = null;
-
-  protected _service: EdgelessRootService;
-
-  enableHover = false;
-
-  abstract tool: Tool;
-
-  constructor(service: EdgelessRootService) {
-    this._service = service;
-  }
-
-  mount(edgeless: EdgelessRootBlockComponent) {
-    this._edgeless = edgeless;
-  }
-  abstract onContainerPointerDown(e: PointerEventState): void;
-  abstract onContainerDragStart(e: PointerEventState): void;
-  abstract onContainerDragMove(e: PointerEventState): void;
-  abstract onContainerDragEnd(e: PointerEventState): void;
-  abstract onContainerClick(e: PointerEventState): void;
-  abstract onContainerDblClick(e: PointerEventState): void;
-  abstract onContainerTripleClick(e: PointerEventState): void;
-  abstract onContainerMouseMove(e: PointerEventState): void;
-  abstract onContainerMouseOut(e: PointerEventState): void;
-  abstract onContainerContextMenu(e: PointerEventState): void;
-  abstract beforeModeSwitch(prevMode: Tool): void;
-  abstract afterModeSwitch(newMode: Tool): void;
-
-  /**
-   * @warning Check `!ev.repeat` before calling this function in KeyboardEvents where needed
-   */
-  abstract onPressShiftKey(pressed: boolean): void;
-
-  /**
-   * @warning Check `!ev.repeat` before calling this function in KeyboardEvents where needed
-   */
-  abstract onPressSpaceBar(pressed: boolean): void;
-}
+export { BrushToolController } from './brush-tool.js';
+export { ConnectorToolController } from './connector-tool.js';
+export { CopilotSelectionController } from './copilot-tool.js';
+export { DefaultToolController } from './default-tool.js';
+export { EdgelessToolController } from './edgeless-tool.js';
+export { EraserToolController } from './eraser-tool.js';
+export { PresentToolController } from './frame-navigator-tool.js';
+export { FrameToolController } from './frame-tool.js';
+export { LassoToolController } from './lasso-tool.js';
+export { MindmapToolController } from './mindmap-tool.js';
+export { NoteToolController } from './note-tool.js';
+export { PanToolController } from './pan-tool.js';
+export { ShapeToolController } from './shape-tool.js';
+export { TemplateToolController } from './template-tool.js';
+export { TextToolController } from './text-tool.js';

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/lasso-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/lasso-tool.ts
@@ -1,12 +1,7 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
-import {
-  type EdgelessTool,
-  type IPoint,
-  LassoMode,
-  type LassoTool,
-} from '../../../../_common/types.js';
+import { type IPoint, LassoMode } from '../../../../_common/types.js';
 import { Bound } from '../../../../surface-block/index.js';
 import {
   getBoundFromPoints,
@@ -21,7 +16,8 @@ import {
   pointInPolygon,
   rotatePoints,
 } from '../../../../surface-block/utils/math-utils.js';
-import { EdgelessToolController } from './index.js';
+import type { EdgelessTool } from '../../types.js';
+import { EdgelessToolController } from './edgeless-tool.js';
 
 class LassoOverlay extends Overlay {
   d = '';
@@ -57,6 +53,11 @@ class LassoOverlay extends Overlay {
     ctx.restore();
   }
 }
+
+export type LassoTool = {
+  type: 'lasso';
+  mode: LassoMode;
+};
 
 export class LassoToolController extends EdgelessToolController<LassoTool> {
   get selection() {
@@ -335,5 +336,13 @@ export class LassoToolController extends EdgelessToolController<LassoTool> {
 
   override onPressSpaceBar(): void {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      lasso: LassoToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/mindmap-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/mindmap-tool.ts
@@ -1,17 +1,15 @@
 import { noop } from '@blocksuite/global/utils';
 
-import type { NavigatorMode } from '../../../../_common/edgeless/frame/consts.js';
 import { EdgelessToolController } from './edgeless-tool.js';
 
-type FrameNavigatorTool = {
-  type: 'frameNavigator';
-  mode?: NavigatorMode;
+type MindmapTool = {
+  type: 'mindmap';
 };
 
-export class PresentToolController extends EdgelessToolController<FrameNavigatorTool> {
+export class MindmapToolController extends EdgelessToolController<MindmapTool> {
   readonly tool = {
-    type: 'frameNavigator',
-  } as FrameNavigatorTool;
+    type: 'mindmap',
+  } as MindmapTool;
 
   override onContainerPointerDown(): void {
     noop();
@@ -73,7 +71,7 @@ export class PresentToolController extends EdgelessToolController<FrameNavigator
 declare global {
   namespace BlockSuite {
     interface EdgelessToolMap {
-      'frame-navigator': PresentToolController;
+      mindmap: MindmapToolController;
     }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/note-tool.ts
@@ -2,12 +2,12 @@ import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
 
 import {
-  type EdgelessTool,
   hasClassNameInList,
-  type NoteTool,
+  type NoteChildrenFlavour,
   Point,
 } from '../../../../_common/utils/index.js';
 import type { SelectionArea } from '../../services/tools-manager.js';
+import type { EdgelessTool } from '../../types.js';
 import {
   EXCLUDING_MOUSE_OUT_CLASS_LIST,
   NOTE_INIT_HEIGHT,
@@ -15,7 +15,14 @@ import {
 } from '../../utils/consts.js';
 import { addNote } from '../../utils/note.js';
 import { DraggingNoteOverlay, NoteOverlay } from '../../utils/tool-overlay.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+export type NoteTool = {
+  type: 'affine:note';
+  childFlavour: NoteChildrenFlavour;
+  childType: string | null;
+  tip: string;
+};
 
 export class NoteToolController extends EdgelessToolController<NoteTool> {
   private _noteOverlay: NoteOverlay | null = null;
@@ -224,5 +231,13 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     this._noteOverlay = new NoteOverlay(this._edgeless, background);
     this._noteOverlay.text = newTool.tip;
     this._edgeless.surface.renderer.addOverlay(this._noteOverlay);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      note: NoteToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/pan-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/pan-tool.ts
@@ -1,8 +1,12 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
-import type { PanTool } from '../../../../_common/utils/index.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+type PanTool = {
+  type: 'pan';
+  panning: boolean;
+};
 
 export class PanToolController extends EdgelessToolController<PanTool> {
   private _lastPoint: [number, number] | null = null;
@@ -84,5 +88,13 @@ export class PanToolController extends EdgelessToolController<PanTool> {
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      pan: PanToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
@@ -1,18 +1,18 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { assertExists, noop } from '@blocksuite/global/utils';
 
-import type {
-  EdgelessTool,
-  ShapeTool,
-} from '../../../../_common/utils/index.js';
 import { hasClassNameInList } from '../../../../_common/utils/index.js';
-import type { ShapeElementModel } from '../../../../surface-block/index.js';
+import type {
+  ShapeElementModel,
+  ShapeType,
+} from '../../../../surface-block/index.js';
 import {
   Bound,
   CanvasElementType,
   type IVec,
 } from '../../../../surface-block/index.js';
 import type { SelectionArea } from '../../services/tools-manager.js';
+import type { EdgelessTool } from '../../types.js';
 import {
   EXCLUDING_MOUSE_OUT_CLASS_LIST,
   SHAPE_OVERLAY_HEIGHT,
@@ -20,7 +20,12 @@ import {
   SHAPE_OVERLAY_WIDTH,
 } from '../../utils/consts.js';
 import { ShapeOverlay } from '../../utils/tool-overlay.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+export type ShapeTool = {
+  type: 'shape';
+  shapeType: ShapeType | 'roundedRect';
+};
 
 export class ShapeToolController extends EdgelessToolController<ShapeTool> {
   private _draggingElement: ShapeElementModel | null = null;
@@ -335,5 +340,13 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
       strokeColor: options.stroke,
     });
     this._edgeless.surface.renderer.addOverlay(this._shapeOverlay);
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      shape: ShapeToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/template-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/template-tool.ts
@@ -1,7 +1,10 @@
 import { noop } from '@blocksuite/global/utils';
 
-import type { TemplateTool } from '../../../../_common/types.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+export type TemplateTool = {
+  type: 'template';
+};
 
 export class TemplateToolController extends EdgelessToolController<TemplateTool> {
   readonly tool = {
@@ -62,5 +65,13 @@ export class TemplateToolController extends EdgelessToolController<TemplateTool>
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      template: TemplateToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/text-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/text-tool.ts
@@ -1,9 +1,12 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 
-import type { TextTool } from '../../../../_common/utils/index.js';
 import { addText } from '../../utils/text.js';
-import { EdgelessToolController } from './index.js';
+import { EdgelessToolController } from './edgeless-tool.js';
+
+export type TextTool = {
+  type: 'text';
+};
 
 export class TextToolController extends EdgelessToolController<TextTool> {
   readonly tool = {
@@ -83,5 +86,13 @@ export class TextToolController extends EdgelessToolController<TextTool> {
 
   afterModeSwitch() {
     noop();
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface EdgelessToolMap {
+      text: TextToolController;
+    }
   }
 }

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -5,7 +5,7 @@ import {
   isElementOutsideViewport,
   isSelectSingleMindMap,
 } from '../../_common/edgeless/mindmap/index.js';
-import { type EdgelessTool, LassoMode } from '../../_common/types.js';
+import { LassoMode } from '../../_common/types.js';
 import { matchFlavours } from '../../_common/utils/model.js';
 import { MindmapElementModel } from '../../surface-block/element-model/mindmap.js';
 import { LayoutType } from '../../surface-block/element-model/utils/mindmap/layout.js';
@@ -23,6 +23,7 @@ import { LassoToolController } from './controllers/tools/lasso-tool.js';
 import { ShapeToolController } from './controllers/tools/shape-tool.js';
 import { EdgelessBlockModel } from './edgeless-block-model.js';
 import type { EdgelessRootBlockComponent } from './edgeless-root-block.js';
+import type { EdgelessTool } from './types.js';
 import {
   DEFAULT_NOTE_CHILD_FLAVOUR,
   DEFAULT_NOTE_CHILD_TYPE,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -1,6 +1,6 @@
-import './components/toolbar/edgeless-toolbar.js';
 import '../../surface-block/surface-block.js';
 import './components/block-portal/frame/edgeless-frame.js';
+import './components/toolbar/edgeless-toolbar.js';
 
 import type { SurfaceSelection } from '@blocksuite/block-std';
 import { BlockElement } from '@blocksuite/block-std';
@@ -19,18 +19,15 @@ import {
 } from '../../_common/consts.js';
 import { ThemeObserver } from '../../_common/theme/theme-observer.js';
 import {
-  type EdgelessTool,
+  asyncFocusRichText,
+  handleNativeRangeAtPoint,
   type IPoint,
   isPinchEvent,
   NoteDisplayMode,
+  on,
   Point,
   requestConnectedFrame,
   type Viewport,
-} from '../../_common/utils/index.js';
-import {
-  asyncFocusRichText,
-  handleNativeRangeAtPoint,
-  on,
 } from '../../_common/utils/index.js';
 import { humanFileSize } from '../../_common/utils/math.js';
 import type { AttachmentBlockProps } from '../../attachment-block/attachment-model.js';
@@ -62,22 +59,25 @@ import type { EdgelessBlockPortalContainer } from './components/block-portal/edg
 import { EdgelessToolbar } from './components/toolbar/edgeless-toolbar.js';
 import { calcBoundByOrigin, readImageSize } from './components/utils.js';
 import { EdgelessClipboardController } from './controllers/clipboard.js';
-import { BrushToolController } from './controllers/tools/brush-tool.js';
-import { ConnectorToolController } from './controllers/tools/connector-tool.js';
-import { CopilotSelectionController } from './controllers/tools/copilot-tool.js';
-import { DefaultToolController } from './controllers/tools/default-tool.js';
-import { EraserToolController } from './controllers/tools/eraser-tool.js';
-import { PresentToolController } from './controllers/tools/frame-navigator-tool.js';
-import { FrameToolController } from './controllers/tools/frame-tool.js';
-import { LassoToolController } from './controllers/tools/lasso-tool.js';
-import { NoteToolController } from './controllers/tools/note-tool.js';
-import { PanToolController } from './controllers/tools/pan-tool.js';
-import { ShapeToolController } from './controllers/tools/shape-tool.js';
-import { TemplateToolController } from './controllers/tools/template-tool.js';
-import { TextToolController } from './controllers/tools/text-tool.js';
+import {
+  BrushToolController,
+  ConnectorToolController,
+  CopilotSelectionController,
+  DefaultToolController,
+  EraserToolController,
+  FrameToolController,
+  LassoToolController,
+  NoteToolController,
+  PanToolController,
+  PresentToolController,
+  ShapeToolController,
+  TemplateToolController,
+  TextToolController,
+} from './controllers/tools/index.js';
 import { EdgelessPageKeyboardManager } from './edgeless-keyboard.js';
 import type { EdgelessRootService } from './edgeless-root-service.js';
 import type { EdgelessToolConstructor } from './services/tools-manager.js';
+import type { EdgelessTool } from './types.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import {
   DEFAULT_NOTE_HEIGHT,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -2,7 +2,6 @@ import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlockModel, Slot } from '@blocksuite/store';
 
-import type { EdgelessTool } from '../../_common/types.js';
 import { last } from '../../_common/utils/iterable.js';
 import { clamp } from '../../_common/utils/math.js';
 import type { FrameBlockModel } from '../../frame-block/index.js';
@@ -40,6 +39,7 @@ import {
 } from './services/template-middlewares.js';
 import type { EdgelessToolConstructor } from './services/tools-manager.js';
 import { EdgelessToolsManager } from './services/tools-manager.js';
+import type { EdgelessTool } from './types.js';
 import { FIT_TO_SCREEN_PADDING } from './utils/consts.js';
 import { getCursorMode } from './utils/query.js';
 import { EdgelessSnapManager } from './utils/snap-manager.js';

--- a/packages/blocks/src/root-block/edgeless/index.ts
+++ b/packages/blocks/src/root-block/edgeless/index.ts
@@ -1,0 +1,7 @@
+export { FramePreview } from './components/frame/frame-preview.js';
+export { EdgelessToolController } from './controllers/tools/index.js';
+export { EdgelessBlockModel } from './edgeless-block-model.js';
+export * from './edgeless-root-block.js';
+export { EdgelessRootService } from './edgeless-root-service.js';
+export * from './types.js';
+export { Viewport } from './utils/viewport.js';

--- a/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
@@ -9,7 +9,6 @@ import { IS_MAC } from '@blocksuite/global/env';
 import { DisposableGroup } from '@blocksuite/global/utils';
 
 import {
-  type EdgelessTool,
   isMiddleButtonPressed,
   isRightButtonPressed,
   NoteDisplayMode,
@@ -19,6 +18,7 @@ import { CopilotSelectionController } from '../controllers/tools/copilot-tool.js
 import type { EdgelessToolController } from '../controllers/tools/index.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 import type { EdgelessRootService } from '../edgeless-root-service.js';
+import type { EdgelessTool } from '../types.js';
 import { edgelessElementsBound } from '../utils/bound-utils.js';
 import { isNoteBlock } from '../utils/query.js';
 import type { EdgelessSelectionState } from './selection-manager.js';

--- a/packages/blocks/src/root-block/edgeless/types.ts
+++ b/packages/blocks/src/root-block/edgeless/types.ts
@@ -1,5 +1,7 @@
 import type { EdgelessBlockModel } from './edgeless-block-model.js';
 
+export type EdgelessTool = BlockSuite.EdgelessToolType;
+
 declare global {
   namespace BlockSuite {
     interface EdgelessBlockModelMap {}
@@ -14,5 +16,11 @@ declare global {
     interface EdgelessTextModelMap {}
     type EdgelessTextModelKeyType = keyof EdgelessTextModelMap;
     type EdgelessTextModelType = EdgelessTextModelMap[EdgelessTextModelKeyType];
+
+    interface EdgelessToolControllerMap {}
+    type EdgelessToolControllerKeyType = keyof EdgelessToolMap;
+    type EdgelessToolControllerType =
+      EdgelessToolMap[EdgelessToolControllerKeyType];
+    type EdgelessToolType = EdgelessToolControllerType['tool'];
   }
 }

--- a/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
@@ -1,5 +1,5 @@
-import type { ShapeTool } from '../../../_common/types.js';
 import { ShapeType } from '../../../surface-block/index.js';
+import type { ShapeTool } from '../controllers/tools/shape-tool.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
 const shapeMap: Record<ShapeTool['shapeType'], number> = {

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -1,10 +1,7 @@
 import type { BlockModel } from '@blocksuite/store';
 
 import type { EmbedBlockModel } from '../../../_common/embed-block-helper/embed-block-model.js';
-import type {
-  Connectable,
-  EdgelessTool,
-} from '../../../_common/utils/index.js';
+import type { Connectable } from '../../../_common/utils/index.js';
 import type { AttachmentBlockModel } from '../../../attachment-block/index.js';
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
 import type { EdgelessTextBlockModel } from '../../../edgeless-text/edgeless-text-model.js';
@@ -33,6 +30,7 @@ import {
   TextElementModel,
 } from '../../../surface-block/index.js';
 import type { EdgelessBlockModel } from '../edgeless-block-model.js';
+import type { EdgelessTool } from '../types.js';
 import { getElementsWithoutGroup } from './group.js';
 import type { Viewport } from './viewport.js';
 

--- a/packages/blocks/src/root-block/index.ts
+++ b/packages/blocks/src/root-block/index.ts
@@ -5,12 +5,7 @@ import type { PageRootService } from './page/page-root-service.js';
 import type { RootBlockModel } from './root-model.js';
 
 export * from './clipboard/index.js';
-export { FramePreview } from './edgeless/components/frame/frame-preview.js';
-export { EdgelessBlockModel } from './edgeless/edgeless-block-model.js';
-export * from './edgeless/edgeless-root-block.js';
-export { EdgelessRootService } from './edgeless/edgeless-root-service.js';
-export * from './edgeless/types.js';
-export { Viewport } from './edgeless/utils/viewport.js';
+export * from './edgeless/index.js';
 export * from './page/page-root-block.js';
 export { PageRootService } from './page/page-root-service.js';
 export * from './preview/preview-root-block.js';

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -20,7 +20,6 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import {
-  type EdgelessTool,
   getBlockElementsExcludeSubtrees,
   getCurrentNativeRange,
   getModelByBlockComponent,
@@ -45,6 +44,7 @@ import { autoScroll } from '../../../root-block/text-selection/utils.js';
 import { SpecProvider } from '../../../specs/utils/spec-provider.js';
 import { Bound, type IVec } from '../../../surface-block/index.js';
 import type { EdgelessBlockModel } from '../../edgeless/edgeless-block-model.js';
+import type { EdgelessTool } from '../../edgeless/types.js';
 import { DragPreview } from './components/drag-preview.js';
 import { DropIndicator } from './components/drop-indicator.js';
 import type { DragHandleOption, DropResult, DropType } from './config.js';

--- a/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/zoom-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/zoom-toolbar.ts
@@ -8,9 +8,9 @@ import {
   PlusIcon,
   ViewBarIcon,
 } from '../../../_common/icons/edgeless.js';
-import type { EdgelessTool } from '../../../_common/types.js';
 import { stopPropagation } from '../../../_common/utils/event.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
+import type { EdgelessTool } from '../../edgeless/types.js';
 import { ZOOM_STEP } from '../../edgeless/utils/viewport.js';
 
 @customElement('edgeless-zoom-toolbar')

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -21,7 +21,7 @@ import {
   SmallArrowDownIcon,
 } from '../../../_common/icons/index.js';
 import type { CssVariableName } from '../../../_common/theme/css-variables.js';
-import { LineWidth, type ShapeTool } from '../../../_common/types.js';
+import { LineWidth } from '../../../_common/types.js';
 import { countBy, maxBy } from '../../../_common/utils/iterable.js';
 import { FontFamily } from '../../../surface-block/consts.js';
 import {
@@ -43,6 +43,7 @@ import {
 } from '../../edgeless/components/panel/color-panel.js';
 import type { LineStyleEvent } from '../../edgeless/components/panel/line-styles-panel.js';
 import type { EdgelessShapePanel } from '../../edgeless/components/panel/shape-panel.js';
+import type { ShapeTool } from '../../edgeless/controllers/tools/shape-tool.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 import {
   SHAPE_FILL_COLOR_BLACK,

--- a/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
@@ -1,7 +1,7 @@
-import type { EdgelessTool } from '../../../_common/types.js';
 import type { IVec } from '../../../surface-block/index.js';
 import { ShapeToolController } from '../../edgeless/controllers/tools/shape-tool.js';
 import { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
+import type { EdgelessTool } from '../../edgeless/types.js';
 import type {
   ActionFunction,
   IPieNodeWithAction,


### PR DESCRIPTION

# What changed?

This PR changes the way declarations of edgeless tool.

## Before
```ts
export type MyCustomEdgelessTool = {
    type: "my-custom-tool";
    // ...
};

export class MyCustomEdgelessToolController extends EdgelessToolController<MyCustomEdgelessTool> {
    // ...
};

// Update the type `EdgelessTool`
export type EdgelessTool = 
    DefaultTool |
    // ...
    MyCustomEdgelessTool;
```


## After
```ts
export type MyCustomEdgelessTool = {
    type: "my-custom-tool";
    // ...
};

export class MyCustomEdgelessToolController extends EdgelessToolController<MyCustomEdgelessTool> {
    // ...
};

// Non-invasive update type `EdgelessTool`
declare global {
  namespace BlockSuite {
    interface EdgelessToolMap {
      "my-custom-tool": MyCustomEdgelessToolController;
    }
  }
}
```
The implementation is in https://github.com/toeverything/blocksuite/pull/7296/files#diff-20771409cc72bce6e327202907e2dbd6fef600e2786129af4834017a0aca6de6
