### PR TITLE
fix(blocks): inline link text overflow in note

### DIFF
--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -91,7 +91,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
 
   static override styles = css`
     .affine-reference {
-      white-space: nowrap;
+      white-space: normal;
       word-break: break-word;
       color: var(--affine-text-primary-color);
       fill: var(--affine-icon-color);

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -79,7 +79,6 @@ export const listBlockStyles = css`
   .affine-list-rich-text-wrapper {
     position: relative;
     display: flex;
-    position: relative;
   }
   .affine-list-rich-text-wrapper rich-text {
     flex: 1;


### PR DESCRIPTION
Closes: [BS-508](https://linear.app/affine-design/issue/BS-508/note-中-inline-yuan素超出后宽度后：)