### PR TITLE
fix(presets): refine style of divider and focus outline in chat panel

### DIFF
--- a/packages/presets/src/ai/messages/text.ts
+++ b/packages/presets/src/ai/messages/text.ts
@@ -131,6 +131,12 @@ export class AIAnswerText extends WithDisposable(LitElement) {
       rich-text .nowrap-lines v-element span {
         white-space: pre;
       }
+      editor-host:focus-visible {
+        outline: none;
+      }
+      editor-host * {
+        box-sizing: border-box;
+      }
     }
 
     ${textBlockStyles}


### PR DESCRIPTION
Closes: [AFF-1088](https://linear.app/affine-design/issue/AFF-1088/chat-%E5%9B%9E%E7%AD%94-%E5%88%86%E5%89%B2%E7%BA%BF%E4%B8%8E%E9%80%89%E5%8C%BA%E9%94%99%E4%BD%8D)