### PR TITLE
fix: more button do not re-render after selected elements changed

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -435,6 +435,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
 
     buttons.push(html`
       <edgeless-more-button
+        .elements=${selectedElements}
         .edgeless=${edgeless}
         .vertical=${true}
       ></edgeless-more-button>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -234,7 +234,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
   `;
 
   @property({ attribute: false })
-  accessor elements: string[] = [];
+  accessor elements: BlockSuite.EdgelessModelType[] = [];
 
   @property({ attribute: false })
   accessor edgeless!: EdgelessRootBlockComponent;


### PR DESCRIPTION
Pass selectedElements as the `elements` property to the <edgeless-more-button> component. Make sure the menu for more buttons triggers a re-render after selected elements changes.

