### PR TITLE
fix(edgeless): bind shortcuts in toolbar should dispose when tool disconnected

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/eraser/eraser-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/eraser/eraser-tool-button.ts
@@ -41,15 +41,17 @@ export class EdgelessEraserToolButton extends EdgelessToolbarToolMixin(
   override enableActiveBackground = true;
 
   override firstUpdated() {
-    this.edgeless.bindHotKey(
-      {
-        Escape: () => {
-          if (this.edgelessTool.type === 'eraser') {
-            this.setEdgelessTool({ type: 'default' });
-          }
+    this.disposables.add(
+      this.edgeless.bindHotKey(
+        {
+          Escape: () => {
+            if (this.edgelessTool.type === 'eraser') {
+              this.setEdgelessTool({ type: 'default' });
+            }
+          },
         },
-      },
-      { global: true }
+        { global: true }
+      )
     );
   }
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
@@ -224,7 +224,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
       },
     });
 
-    this.edgeless.bindHotKey(
+    const dispose = this.edgeless.bindHotKey(
       {
         m: () => {
           const service = this.edgeless.service;
@@ -254,6 +254,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
       },
       { global: true }
     );
+    this.disposables.add(dispose);
   }
 
   override updated(_changedProperties: Map<PropertyKey, unknown>) {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/toolbar-button-with-menu.mixin.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/toolbar-button-with-menu.mixin.ts
@@ -101,15 +101,17 @@ export const ToolbarButtonWithMenuMixin = <
       this.initLastPropsSlot();
 
       // TODO: move to edgeless root block?
-      edgeless.bindHotKey(
-        {
-          Escape: () => {
-            if (this.edgelessTool.type === this._type) {
-              edgeless.tools.setEdgelessTool({ type: 'default' });
-            }
+      this.disposables.add(
+        edgeless.bindHotKey(
+          {
+            Escape: () => {
+              if (this.edgelessTool.type === this._type) {
+                edgeless.tools.setEdgelessTool({ type: 'default' });
+              }
+            },
           },
-        },
-        { global: true }
+          { global: true }
+        )
       );
     }
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
@@ -237,22 +237,24 @@ export class PresentationToolbar extends EdgelessToolbarToolMixin(LitElement) {
     const { _disposables, edgeless } = this;
     const { slots } = edgeless;
 
-    edgeless.bindHotKey(
-      {
-        ArrowLeft: () => {
-          const { type } = this.edgelessTool;
-          if (type !== 'frameNavigator') return;
-          this._previousFrame();
+    _disposables.add(
+      edgeless.bindHotKey(
+        {
+          ArrowLeft: () => {
+            const { type } = this.edgelessTool;
+            if (type !== 'frameNavigator') return;
+            this._previousFrame();
+          },
+          ArrowRight: () => {
+            const { type } = this.edgelessTool;
+            if (type !== 'frameNavigator') return;
+            this._nextFrame();
+          },
         },
-        ArrowRight: () => {
-          const { type } = this.edgelessTool;
-          if (type !== 'frameNavigator') return;
-          this._nextFrame();
-        },
-      },
-      {
-        global: true,
-      }
+        {
+          global: true,
+        }
+      )
     );
 
     _disposables.add(

--- a/packages/framework/block-std/src/view/element/block-element.ts
+++ b/packages/framework/block-std/src/view/element/block-element.ts
@@ -236,7 +236,9 @@ export class BlockElement<
           : undefined,
       path: options?.global || options?.flavour ? undefined : this.path,
     };
-    this._disposables.add(this.host.event.bindHotkey(keymap, config));
+    const dispose = this.host.event.bindHotkey(keymap, config);
+    this._disposables.add(dispose);
+    return dispose;
   }
 
   renderChildren = (model: BlockModel): TemplateResult => {


### PR DESCRIPTION
Tool buttons in edgeless toolbar may destroy and re-mount, so it's better to dispose the hot-key events when it disconnected.