### PR TITLE
fix: mindmap issue

### DIFF
--- a/packages/blocks/src/_common/edgeless/mindmap/index.ts
+++ b/packages/blocks/src/_common/edgeless/mindmap/index.ts
@@ -52,15 +52,16 @@ export function getNearestTranslation(
   }
 
   if (elementBound.y - padding[0] < viewportBound.y) {
-    dy = viewportBound.y - (elementBound.y - padding[0]);
+    dy = elementBound.y - padding[0] - viewportBound.y;
   } else if (
     elementBound.y + elementBound.h + padding[0] >
     viewportBound.y + viewportBound.h
   ) {
     dy =
-      viewportBound.y +
-      viewportBound.h -
-      (elementBound.y + elementBound.h + padding[0]);
+      elementBound.y +
+      elementBound.h +
+      padding[0] -
+      (viewportBound.y + viewportBound.h);
   }
 
   return [dx, dy];

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -449,32 +449,42 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
   private _getMindmapButtons():
     | [Direction, 'child' | 'sibling', LayoutType.LEFT | LayoutType.RIGHT][]
     | null {
-    const mindmap = this.current.group;
+    const mindmap = this.current.group as MindmapElementModel;
     const mindmapDirection =
       this.current instanceof ShapeElementModel &&
       mindmap instanceof MindmapElementModel
         ? mindmap.getLayoutDir(this.current.id)
         : null;
+    const isRoot = mindmap?.tree.id === this.current.id;
+
+    let result: ReturnType<typeof this._getMindmapButtons> = null;
 
     switch (mindmapDirection) {
       case LayoutType.LEFT:
-        return [
-          [Direction.Left, 'child', LayoutType.LEFT],
-          [Direction.Bottom, 'sibling', LayoutType.LEFT],
-        ];
+        result = [[Direction.Left, 'child', LayoutType.LEFT]];
+
+        if (!isRoot) {
+          result.push([Direction.Bottom, 'sibling', mindmapDirection]);
+        }
+        return result;
       case LayoutType.RIGHT:
-        return [
-          [Direction.Right, 'child', LayoutType.RIGHT],
-          [Direction.Bottom, 'sibling', LayoutType.RIGHT],
-        ];
+        result = [[Direction.Right, 'child', LayoutType.RIGHT]];
+
+        if (!isRoot) {
+          result.push([Direction.Bottom, 'sibling', mindmapDirection]);
+        }
+        return result;
       case LayoutType.BALANCE:
-        return [
+        result = [
           [Direction.Right, 'child', LayoutType.RIGHT],
           [Direction.Left, 'child', LayoutType.LEFT],
         ];
+        return result;
       default:
-        return null;
+        result = null;
     }
+
+    return result;
   }
 
   private _renderMindMapButtons() {

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
@@ -239,7 +239,7 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
       labelConstraints: { hasMaxWidth, maxWidth },
     } = connector;
 
-    const lineHeight = getLineHeight(fontFamily, fontSize);
+    const lineHeight = getLineHeight(fontFamily, fontSize, fontWeight);
     const { translateX, translateY, zoom } = this.edgeless.service.viewport;
     const [x, y] = Vec.mul(connector.getPointByOffsetDistance(distance), zoom);
     const transformOperation = [

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -155,11 +155,11 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
             const element = this.element;
             this.mountEditor?.(element, edgeless);
 
-            if (isElementOutsideViewport(service.viewport, element, [20, 20])) {
+            if (isElementOutsideViewport(service.viewport, element, [90, 20])) {
               const [dx, dy] = getNearestTranslation(
                 edgeless.service.viewport,
                 element,
-                [20, 20]
+                [100, 20]
               );
 
               edgeless.service.viewport.smoothTranslate(
@@ -186,11 +186,11 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
             const element = this.element;
             this.mountEditor?.(element, edgeless);
 
-            if (isElementOutsideViewport(service.viewport, element, [20, 20])) {
+            if (isElementOutsideViewport(service.viewport, element, [90, 20])) {
               const [dx, dy] = getNearestTranslation(
                 edgeless.service.viewport,
                 element,
-                [20, 20]
+                [100, 20]
               );
 
               edgeless.service.viewport.smoothTranslate(
@@ -333,7 +333,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       fontSize: this.element.fontSize + 'px',
       fontFamily: wrapFontFamily(this.element.fontFamily),
       fontWeight: this.element.fontWeight,
-      lineHeight: 'initial',
+      lineHeight: 'normal',
       outline: 'none',
       transform: `scale(${zoom}, ${zoom}) rotate(${rotate}deg)`,
       transformOrigin: 'top left',

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
@@ -349,7 +349,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
       hasMaxWidth,
       w,
     } = this.element;
-    const lineHeight = getLineHeight(fontFamily, fontSize);
+    const lineHeight = getLineHeight(fontFamily, fontSize, fontWeight);
     const rect = getSelectedRect([this.element]);
 
     const { translateX, translateY, zoom } = this.edgeless.service.viewport;

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -625,13 +625,13 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           isElementOutsideViewport(
             edgeless.service.viewport,
             targetNode,
-            [20, 20]
+            [90, 20]
           )
         ) {
           const [dx, dy] = getNearestTranslation(
             edgeless.service.viewport,
             targetNode,
-            [20, 20]
+            [100, 20]
           );
 
           edgeless.service.viewport.smoothTranslate(

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
@@ -29,12 +29,12 @@ const MINDMAP_STYLE_LIST = [
     icon: MindmapStyleOne,
   },
   {
-    value: MindmapStyle.THREE,
-    icon: MindmapStyleThree,
-  },
-  {
     value: MindmapStyle.FOUR,
     icon: MindmapStyleFour,
+  },
+  {
+    value: MindmapStyle.THREE,
+    icon: MindmapStyleThree,
   },
   {
     value: MindmapStyle.TWO,

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/connector/index.ts
@@ -219,7 +219,7 @@ function renderLabel(
   const cy = h / 2;
   const deltas = wrapTextDeltas(text!, font, w);
   const lines = deltaInsertsToChunks(deltas);
-  const lineHeight = getLineHeight(fontFamily, fontSize);
+  const lineHeight = getLineHeight(fontFamily, fontSize, fontWeight);
   const textHeight = (lines.length - 1) * lineHeight * 0.5;
 
   ctx.setTransform(matrix);

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/group/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/group/utils.ts
@@ -16,7 +16,11 @@ export function titleRenderParams(group: GroupElementModel, zoom: number) {
   let text = group.title.toJSON();
   const font = getGroupTitleFont(zoom);
   const lineWidth = getLineWidth(text, font);
-  const lineHeight = getLineHeight(TITLE_FONT, TITLE_FONT_SIZE / zoom);
+  const lineHeight = getLineHeight(
+    TITLE_FONT,
+    TITLE_FONT_SIZE / zoom,
+    'normal'
+  );
   const bound = group.elementBound;
   const padding = [
     Math.min(TITLE_PADDING[0] / zoom, TITLE_PADDING[0]),

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
@@ -75,4 +75,16 @@ export function rect(
       }
     );
   }
+
+  ctx.setTransform(
+    ctx
+      .getTransform()
+      .translateSelf(-cx, -cy)
+      .rotateSelf(-rotate)
+      .translateSelf(cx, cy)
+      .translateSelf(-renderOffset, -renderOffset)
+      .translateSelf(cx, cy)
+      .rotateSelf(rotate)
+      .translateSelf(-cx, -cy)
+  );
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/index.ts
@@ -41,7 +41,7 @@ export function text(
   });
   const deltas = wrapTextDeltas(model.text, font, w);
   const lines = deltaInsertsToChunks(deltas);
-  const lineHeightPx = getLineHeight(fontFamily, fontSize);
+  const lineHeightPx = getLineHeight(fontFamily, fontSize, fontWeight);
   const horizontalOffset =
     textAlign === 'center' ? w / 2 : textAlign === 'right' ? w : 0;
 

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/text/utils.ts
@@ -31,6 +31,71 @@ const getMeasureCtx = (function initMeasureContext() {
   };
 })();
 
+const textMeasureCache = new Map<
+  string,
+  {
+    lineHeight: number;
+    lineGap: number;
+    fontSize: number;
+  }
+>();
+
+export function measureTextInDOM(
+  fontFamily: string,
+  fontSize: number,
+  fontWeight: string
+) {
+  const cacheKey = `${wrapFontFamily(fontFamily)}-${fontWeight}`;
+
+  if (textMeasureCache.has(cacheKey)) {
+    const {
+      fontSize: cacheFontSize,
+      lineGap,
+      lineHeight,
+    } = textMeasureCache.get(cacheKey)!;
+
+    return {
+      lineHeight: lineHeight * (fontSize / cacheFontSize),
+      lineGap: lineGap * (fontSize / cacheFontSize),
+    };
+  }
+
+  const div = document.createElement('div');
+  const span = document.createElement('span');
+
+  div.append(span);
+
+  span.innerText = 'x';
+
+  div.style.position = 'absolute';
+  div.style.top = '0px';
+  div.style.left = '0px';
+  div.style.visibility = 'hidden';
+  div.style.fontFamily = wrapFontFamily(fontFamily);
+  div.style.fontWeight = fontWeight;
+  div.style.fontSize = `${fontSize}px`;
+
+  div.style.pointerEvents = 'none';
+
+  document.body.append(div);
+
+  const lineHeight = span.getBoundingClientRect().height;
+  const height = div.getBoundingClientRect().height;
+  const result = {
+    lineHeight,
+    lineGap: height - lineHeight,
+  };
+
+  div.remove();
+
+  textMeasureCache.set(cacheKey, {
+    ...result,
+    fontSize,
+  });
+
+  return result;
+}
+
 export function getFontString({
   fontStyle,
   fontWeight,
@@ -42,40 +107,63 @@ export function getFontString({
   fontSize: number;
   fontFamily: string;
 }): string {
-  const lineHeight = getLineHeight(fontFamily, fontSize);
+  const lineHeight = getLineHeight(fontFamily, fontSize, fontWeight);
   return `${fontStyle} ${fontWeight} ${fontSize}px/${lineHeight}px ${wrapFontFamily(
     fontFamily
   )}, sans-serif`.trim();
 }
 
-const cachedFontFamily = new Map<
+export function getLineHeight(
+  fontFamily: string,
+  fontSize: number,
+  fontWeight: string
+): number {
+  const { lineHeight } = measureTextInDOM(fontFamily, fontSize, fontWeight);
+  return lineHeight;
+}
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+type TextMetricsLike = Writeable<TextMetrics>;
+
+const metricsCache = new Map<
   string,
   {
     fontSize: number;
-    lineHeight: number;
+    metrics: TextMetrics;
   }
 >();
-export function getLineHeight(fontFamily: string, fontSize: number) {
+export function getFontMetrics(
+  fontFamily: string,
+  fontSize: number,
+  fontWeight: string
+) {
   const ctx = getMeasureCtx();
-  const wrappedFontFamily = wrapFontFamily(fontFamily);
+  const cacheKey = `${wrapFontFamily(fontFamily)}-${fontWeight}`;
 
-  if (cachedFontFamily.has(wrappedFontFamily)) {
-    const cache = cachedFontFamily.get(wrappedFontFamily)!;
-    return (fontSize / cache.fontSize) * cache.lineHeight;
+  if (metricsCache.has(cacheKey)) {
+    const { fontSize: cacheFontSize, metrics } = metricsCache.get(cacheKey)!;
+
+    return Object.keys(Object.getPrototypeOf(metrics)).reduce((acc, key) => {
+      acc[key as keyof TextMetrics] =
+        metrics[key as keyof TextMetrics] * (fontSize / cacheFontSize);
+      return acc;
+    }, {} as TextMetricsLike);
   }
 
-  const font = `${fontSize}px ${wrapFontFamily(fontFamily)}`;
-  ctx.font = `${fontSize}px ${wrapFontFamily(fontFamily)}`;
-  const textMetrcs = ctx.measureText('M');
-  const lineHeight =
-    textMetrcs.fontBoundingBoxAscent + textMetrcs.fontBoundingBoxDescent;
+  const font = `${fontWeight} ${fontSize}px ${wrapFontFamily(fontFamily)}`;
+  ctx.font = font;
+  const metrics = ctx.measureText('x');
 
-  // cached when font property does not fallback
-  if (font === ctx.font) {
-    cachedFontFamily.set(wrappedFontFamily, { fontSize, lineHeight });
+  // check if font does not fallback
+  if (ctx.font === font) {
+    metricsCache.set(cacheKey, {
+      fontSize,
+      metrics,
+    });
   }
 
-  return lineHeight;
+  return metrics;
 }
 
 function transformDelta(delta: TextDelta): (TextDelta | '\n')[] {
@@ -394,7 +482,7 @@ export function getTextCursorPosition(
   return [
     Math.floor(
       (mousePos[1] - leftTop[1]) /
-        getLineHeight(model.fontFamily, model.fontSize)
+        getLineHeight(model.fontFamily, model.fontSize, model.fontWeight)
     ),
     mousePos[0] - leftTop[0],
   ];
@@ -450,7 +538,7 @@ export function normalizeTextBound(
 ): Bound {
   if (!yText) return bound;
 
-  const lineHeightPx = getLineHeight(fontFamily, fontSize);
+  const lineHeightPx = getLineHeight(fontFamily, fontSize, fontWeight);
   const font = getFontString({
     fontStyle,
     fontWeight,

--- a/packages/blocks/src/surface-block/consts.ts
+++ b/packages/blocks/src/surface-block/consts.ts
@@ -208,6 +208,12 @@ export const AffineCanvasTextFonts: FontConfig[] = [
   },
   {
     font: FontFamily.Poppins,
+    url: 'https://cdn.affine.pro/fonts/Poppins-Medium.woff',
+    weight: FontWeight.Regular,
+    style: FontStyle.Normal,
+  },
+  {
+    font: FontFamily.Poppins,
     url: 'https://cdn.affine.pro/fonts/Poppins-SemiBold.woff',
     weight: FontWeight.SemiBold,
     style: FontStyle.Normal,
@@ -381,6 +387,12 @@ export const CommunityCanvasTextFonts: FontConfig[] = [
     font: FontFamily.Poppins,
     url: 'https://fonts.cdnfonts.com/s/16009/Poppins-Regular.woff',
     weight: FontWeight.Regular,
+    style: FontStyle.Normal,
+  },
+  {
+    font: FontFamily.Poppins,
+    url: 'https://fonts.cdnfonts.com/s/16009/Poppins-Medium.woff',
+    weight: FontWeight.Medium,
     style: FontStyle.Normal,
   },
   {

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -444,14 +444,21 @@ export abstract class SurfaceGroupLikeModel<
     });
   }
 
+  hasChild(element: string | BlockSuite.EdgelessModelType) {
+    return (
+      (typeof element === 'string'
+        ? this.children?.has(element)
+        : this.children?.has(element.id)) ?? false
+    );
+  }
+
   /**
    * Check if the group has the given descendant.
    */
   hasDescendant(element: string | BlockSuite.EdgelessModelType) {
-    const groups =
-      typeof element === 'string'
-        ? this.surface.getGroups(element)
-        : this.surface.getGroups(element.id);
+    const groups = this.surface.getGroups(
+      typeof element === 'string' ? element : element.id
+    );
 
     return groups.some(group => group.id === this.id);
   }

--- a/packages/blocks/src/surface-block/element-model/mindmap.ts
+++ b/packages/blocks/src/surface-block/element-model/mindmap.ts
@@ -165,7 +165,7 @@ export class MindmapElementModel extends SurfaceGroupLikeModel<MindmapElementPro
     instance.buildTree();
   })
   @yfield()
-  accessor layoutType: LayoutType = LayoutType.BALANCE;
+  accessor layoutType: LayoutType = LayoutType.RIGHT;
 
   @watch((_, instance: MindmapElementModel, local) => {
     if (local) {
@@ -743,7 +743,9 @@ export class MindmapElementModel extends SurfaceGroupLikeModel<MindmapElementPro
 
     surface.doc.transact(() => {
       remove(this._nodeMap.get(id)!);
-      this.setChildIds(Array.from(this.children.keys()), true);
+    });
+
+    queueMicrotask(() => {
       removedDescendants.forEach(id => surface.removeElement(id));
     });
 

--- a/packages/blocks/src/surface-block/element-model/shape.ts
+++ b/packages/blocks/src/surface-block/element-model/shape.ts
@@ -141,13 +141,13 @@ export class ShapeElementModel extends SurfaceElementModel<ShapeProps> {
   @yfield(false as false | number)
   accessor maxWidth: false | number = false;
 
-  @local()
+  @yfield([SHAPE_TEXT_VERTICAL_PADDING, SHAPE_TEXT_PADDING])
   accessor padding: [number, number] = [
     SHAPE_TEXT_VERTICAL_PADDING,
     SHAPE_TEXT_PADDING,
   ];
 
-  @local()
+  @yfield()
   accessor shadow: {
     blur: number;
     offsetX: number;

--- a/packages/blocks/src/surface-block/element-model/utils/mindmap/style.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/mindmap/style.ts
@@ -66,14 +66,14 @@ export class StyleOne extends MindmapStyleGetter {
     strokeColor: '#84CFFF',
 
     fontFamily: FontFamily.Poppins,
-    fontSize: 14,
+    fontSize: 20,
     fontWeight: FontWeight.SemiBold,
     color: '--affine-black',
 
     filled: true,
     fillColor: '--affine-white',
 
-    padding: [18, 22] as [number, number],
+    padding: [11, 22] as [number, number],
 
     shadow: {
       offsetX: 0,
@@ -108,14 +108,14 @@ export class StyleOne extends MindmapStyleGetter {
         strokeColor: color,
 
         fontFamily: FontFamily.Poppins,
-        fontSize: 14,
+        fontSize: 16,
         fontWeight: FontWeight.Medium,
         color: '--affine-black',
 
         filled: true,
         fillColor: '--affine-white',
 
-        padding: [12, 22] as [number, number],
+        padding: [6, 22] as [number, number],
 
         shadow: {
           offsetX: 0,
@@ -150,7 +150,7 @@ export class StyleTwo extends MindmapStyleGetter {
     filled: true,
     fillColor: '--affine-palette-shape-orange',
 
-    padding: [14, 22] as [number, number],
+    padding: [11, 22] as [number, number],
 
     shadow: {
       blur: 0,
@@ -194,7 +194,7 @@ export class StyleTwo extends MindmapStyleGetter {
         filled: true,
         fillColor: color,
 
-        padding: [9, 22] as [number, number],
+        padding: [6, 22] as [number, number],
 
         shadow: {
           blur: 0,
@@ -229,7 +229,7 @@ export class StyleThree extends MindmapStyleGetter {
     filled: true,
     fillColor: '--affine-palette-shape-yellow',
 
-    padding: [16, 22] as [number, number],
+    padding: [10, 22] as [number, number],
 
     shadow: {
       blur: 12,
@@ -264,7 +264,7 @@ export class StyleThree extends MindmapStyleGetter {
         filled: true,
         fillColor: '--affine-palette-shape-white',
 
-        padding: [12, 22] as [number, number],
+        padding: [6, 22] as [number, number],
 
         shadow: {
           blur: 12,
@@ -309,7 +309,7 @@ export class StyleFour extends MindmapStyleGetter {
     filled: true,
     fillColor: 'transparent',
 
-    padding: [8, 10] as [number, number],
+    padding: [0, 10] as [number, number],
   };
 
   private _getColor(order: number) {
@@ -334,7 +334,7 @@ export class StyleFour extends MindmapStyleGetter {
         ...this.root,
 
         fontSize: 18,
-        padding: [8, 10] as [number, number],
+        padding: [1.5, 10] as [number, number],
       },
     };
   }

--- a/packages/blocks/src/surface-block/managers/layer-manager.ts
+++ b/packages/blocks/src/surface-block/managers/layer-manager.ts
@@ -8,7 +8,10 @@ import { matchFlavours } from '../../_common/utils/model.js';
 import type { FrameBlockModel } from '../../frame-block/frame-model.js';
 import { EdgelessBlockModel } from '../../root-block/edgeless/edgeless-block-model.js';
 import { Bound } from '../../surface-block/utils/bound.js';
-import { SurfaceElementModel } from '../element-model/base.js';
+import {
+  SurfaceElementModel,
+  SurfaceGroupLikeModel,
+} from '../element-model/base.js';
 import type { GroupElementModel } from '../element-model/group.js';
 import { GridManager } from '../grid.js';
 import type { SurfaceBlockModel } from '../surface-model.js';
@@ -156,7 +159,8 @@ export class LayerManager {
         if (
           payload.props['index'] ||
           payload.props['xywh'] ||
-          payload.props['externalXYWH']
+          payload.props['externalXYWH'] ||
+          payload.props['childIds']
         ) {
           this.update(surface.getElementById(payload.id)!, payload.props);
         }
@@ -554,6 +558,7 @@ export class LayerManager {
     const type = 'flavour' in element ? element.flavour : element.type;
 
     const indexChanged = !props || 'index' in props;
+    const childIdsChanged = props && 'childIds' in props;
     const updateArray = (
       array: BlockSuite.EdgelessModelType[],
       element: BlockSuite.EdgelessModelType
@@ -568,7 +573,10 @@ export class LayerManager {
       updateArray(this.canvasElements, element);
       this.canvasGrid.update(element as SurfaceElementModel);
 
-      if (type === 'group' && indexChanged) {
+      if (
+        (type === 'group' || element instanceof SurfaceGroupLikeModel) &&
+        (indexChanged || childIdsChanged)
+      ) {
         (element as GroupElementModel).childElements.forEach(
           child => child && this._updateLayer(child)
         );
@@ -582,7 +590,7 @@ export class LayerManager {
       this.blocksGrid.update(element as EdgelessBlockModel);
     }
 
-    if (updateType && indexChanged) {
+    if (updateType && (indexChanged || childIdsChanged)) {
       this._removeFromLayer(
         element as BlockSuite.EdgelessModelType,
         updateType
@@ -607,7 +615,7 @@ export class LayerManager {
       insertToOrderedArray(this.canvasElements, element);
       this.canvasGrid.add(element as SurfaceElementModel);
 
-      if (type === 'group') {
+      if (type === 'group' || element instanceof SurfaceGroupLikeModel) {
         (element as GroupElementModel).childElements.forEach(
           child => child && this._updateLayer(child)
         );

--- a/packages/framework/global/index.d.ts
+++ b/packages/framework/global/index.d.ts
@@ -7,7 +7,6 @@ declare type BlockSuiteFlags = {
   enable_legacy_validation: boolean;
   enable_expand_database_block: boolean;
   enable_lasso_tool: boolean;
-  enable_mindmap_entry: boolean;
   enable_new_image_actions: boolean;
   enable_edgeless_text: boolean;
   readonly: Record<string, boolean>;

--- a/packages/framework/store/src/store/store.ts
+++ b/packages/framework/store/src/store/store.ts
@@ -75,7 +75,6 @@ const FLAGS_PRESET = {
   enable_expand_database_block: false,
   enable_block_query: false,
   enable_lasso_tool: false,
-  enable_mindmap_entry: false,
   enable_new_image_actions: false,
   enable_edgeless_text: false,
   readonly: {},

--- a/packages/playground/apps/default/utils/collection.ts
+++ b/packages/playground/apps/default/utils/collection.ts
@@ -75,7 +75,6 @@ export async function createDefaultDocCollection() {
       enable_synced_doc_block: true,
       enable_pie_menu: true,
       enable_lasso_tool: true,
-      enable_mindmap_entry: true,
       enable_edgeless_text: true,
       ...flags,
     },

--- a/packages/playground/apps/starter/utils/collection.ts
+++ b/packages/playground/apps/starter/utils/collection.ts
@@ -64,7 +64,6 @@ export function createStarterDocCollection() {
       enable_synced_doc_block: true,
       enable_pie_menu: true,
       enable_lasso_tool: true,
-      enable_mindmap_entry: true,
       enable_edgeless_text: true,
       ...flags,
     },

--- a/packages/presets/src/__tests__/edgeless/group.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/group.spec.ts
@@ -220,6 +220,7 @@ describe('mindmap', () => {
     doc.captureSync();
 
     service.removeElement(mindmap().tree.element);
+    await wait();
     expect(service.surface.elementModels.length).toBe(0);
     doc.captureSync();
     await wait();
@@ -229,6 +230,7 @@ describe('mindmap', () => {
     await wait();
 
     service.removeElement(mindmap().tree.children[2].element);
+    await wait();
     expect(service.surface.elementModels.length).toBe(4);
     await wait();
 


### PR DESCRIPTION
### Change
- Mindmap style and issue
- Shape text rendering
- Add extra `padding` and `shadow` yfield

### Detail
#### Shape text rendering
The shape text always shifts when entering the editing mode. The reason is that the text is rendering on `ideographic` baseline not `alphabetic` which is used in CSS rendering. So, to align with the DOM rendering, the baseline has changed to `alphabetic` and the start vertical position is the ascent and line gap of the font.

