### PR TITLE
fix: add a 500ms delay time before showing the hover toolbar

### DIFF
--- a/packages/blocks/src/_common/components/hover/controller.ts
+++ b/packages/blocks/src/_common/components/hover/controller.ts
@@ -1,5 +1,5 @@
 import { DisposableGroup } from '@blocksuite/global/utils';
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { ReactiveController, ReactiveElement } from 'lit';
 import type { StyleInfo } from 'lit/directives/style-map.js';
 
 import type { AdvancedPortalOptions } from '../portal.js';
@@ -136,10 +136,10 @@ export class HoverController implements ReactiveController {
 
   protected _disposables = new DisposableGroup();
 
-  host: ReactiveControllerHost;
+  host: ReactiveElement;
 
   constructor(
-    host: ReactiveControllerHost,
+    host: ReactiveElement,
     onHover: (options: OptionsParams) => HoverPortalOptions | null,
     hoverOptions?: Partial<HoverOptions>
   ) {
@@ -161,6 +161,10 @@ export class HoverController implements ReactiveController {
     }
     // Start a timer when the host is connected
     const { setReference, setFloating, dispose } = whenHover(isHover => {
+      if (!this.host.isConnected) {
+        return;
+      }
+
       this._isHovering = isHover;
       if (!isHover) {
         this.onAbort();

--- a/packages/blocks/src/_common/components/hover/when-hover.ts
+++ b/packages/blocks/src/_common/components/hover/when-hover.ts
@@ -67,10 +67,9 @@ export const whenHover = (
     delayHide(leaveDelay),
   ].filter(v => typeof v !== 'boolean') as HoverMiddleware[];
 
-  let id = 0;
-  let resId = 0;
+  let currentEvent: Event | null = null;
   const onHoverChange = (async (e: Event) => {
-    const curId = id++;
+    currentEvent = e;
     for (const middleware of middlewares) {
       const go = await middleware({
         event: e,
@@ -80,17 +79,9 @@ export const whenHover = (
       if (!go) return;
     }
     // ignore expired event
-    if (curId < resId) return;
-    resId = curId;
-    if (e.type === 'mouseover') {
-      whenHoverChange(true, e);
-      return;
-    }
-    if (e.type === 'mouseleave') {
-      whenHoverChange(false, e);
-      return;
-    }
-    console.error('Unknown event type in whenHover', e);
+    if (e !== currentEvent) return;
+    const isHover = e.type === 'mouseover' ? true : false;
+    whenHoverChange(isHover, e);
   }) as (e: Event) => void;
 
   const addHoverListener = (element?: Element) => {

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
@@ -62,34 +62,38 @@ export class AffineLink extends ShadowlessElement {
     }
   `;
 
-  private _whenHover = new HoverController(this, ({ abortController }) => {
-    if (this.blockElement.doc.readonly) {
-      return null;
-    }
+  private _whenHover = new HoverController(
+    this,
+    ({ abortController }) => {
+      if (this.blockElement.doc.readonly) {
+        return null;
+      }
 
-    const selection = this.std.selection;
-    const textSelection = selection.find('text');
-    if (
-      !!textSelection &&
-      (!!textSelection.to || !!textSelection.from.length)
-    ) {
-      return null;
-    }
+      const selection = this.std.selection;
+      const textSelection = selection.find('text');
+      if (
+        !!textSelection &&
+        (!!textSelection.to || !!textSelection.from.length)
+      ) {
+        return null;
+      }
 
-    const blockSelections = selection.filter('block');
-    if (blockSelections.length) {
-      return null;
-    }
+      const blockSelections = selection.filter('block');
+      if (blockSelections.length) {
+        return null;
+      }
 
-    return {
-      template: toggleLinkPopup(
-        this.inlineEditor,
-        'view',
-        this.selfInlineRange,
-        abortController
-      ),
-    };
-  });
+      return {
+        template: toggleLinkPopup(
+          this.inlineEditor,
+          'view',
+          this.selfInlineRange,
+          abortController
+        ),
+      };
+    },
+    { enterDelay: 500 }
+  );
 
   @property({ type: Object })
   accessor delta: DeltaInsert<AffineTextAttributes> = {

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -154,7 +154,8 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
           abortController
         ),
       };
-    }
+    },
+    { enterDelay: 500 }
   );
 
   @property({ type: Object })


### PR DESCRIPTION
### What Changed?
- Prevents responding to hover state changes if the host element is disconnected from the DOM.
- Use current event flag to ignore expired event.
- Add a new property `enterDelay` with a value of 500ms to the constructor of the hover controller in link and refernce scenes. 


