### PR TITLE
fix: ignore composing event in slash menu

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -455,6 +455,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
       'keydown',
       event => {
         if (this._currentSubMenu) return;
+        if (event.isComposing) return;
 
         const { key, ctrlKey, metaKey, altKey, shiftKey } = event;
 


### PR DESCRIPTION
This pull request fixes an issue where the slash menu was not ignoring composing events.

Before

https://github.com/toeverything/blocksuite/assets/18554747/a5da4c83-3412-4e04-b02e-30971277dc86

After

https://github.com/toeverything/blocksuite/assets/18554747/def918aa-2649-4d30-a178-04789fef7cee

