### PR TITLE
chore: remove ai preset export by default

### DIFF
--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -38,6 +38,7 @@
         "module": "./dist/index.js",
         "import": "./dist/index.js"
       },
+      "./ai": "./dist/index.js",
       "./themes/*": "./themes/*"
     }
   },

--- a/packages/presets/src/index.ts
+++ b/packages/presets/src/index.ts
@@ -1,4 +1,3 @@
-export * from './ai/index.js';
 export * from './editors/index.js';
 export * from './fragments/index.js';
 export * from './helpers/index.js';


### PR DESCRIPTION
Remove the default export of the AI preset, as it causes global type declaration conflicts in AFFiNE side.