### PR TITLE
fix: keep connectors after note converted to linked doc

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -393,9 +393,9 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         other: 'new doc',
       });
       moveConnectors(element.id, cardId, this.edgeless.service);
-      // delete selected elements
+      // delete selected note
       this.doc.transact(() => {
-        deleteElements(this.surface, [element]);
+        this.surface.doc.deleteBlock(element);
       });
       this.edgeless.service.selection.set({
         elements: [cardId],


### PR DESCRIPTION
Use `doc.deleteBlock` instead of `deleteElements` to delete selected note element.

### Why make this change?
In function `deleteElements`,  the value get immediately from `service.surface.getConnectors` is outdated after modify the connector data. Because the `_elementToConnector` map is updated in the event thrown by Y.js, which is a  asynchronous process. 
@doouding @Saul-Mirone Maybe we should have a better way to update the `_elementToConnector` map.