### PR TITLE
chore: fix at in legacy canvas text

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -169,7 +169,9 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           if (
             std.selection.getGroup('note').length > 0 ||
             // eslint-disable-next-line unicorn/prefer-array-some
-            std.selection.find('text')
+            std.selection.find('text') ||
+            // eslint-disable-next-line unicorn/prefer-array-some
+            Boolean(std.selection.find('surface')?.editing)
           ) {
             return;
           }


### PR DESCRIPTION
Closes: [BS-560](https://linear.app/affine-design/issue/BS-560/%E9%80%9A%E8%BF%87-edgeless-text-%E6%96%87%E6%A1%A3%E5%90%8E-%E9%9D%A2%E6%9D%BF%E9%A3%9E%E4%BA%86)