### PR TITLE
fix: embed linked doc empty style

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -132,12 +132,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
     if (!linkedDoc) {
       return false;
     }
-    return (
-      !!linkedDoc &&
-      !linkedDoc.meta?.title.length &&
-      this.isNoteContentEmpty &&
-      this.isBannerEmpty
-    );
+    return !!linkedDoc && this.isNoteContentEmpty && this.isBannerEmpty;
   }
 
   private _selectBlock() {


### PR DESCRIPTION
Closes: [BS-513](https://linear.app/affine-design/issue/BS-513/%E6%8F%92%E5%85%A5%E7%9A%84%E5%88%9B%E5%BB%BA%E7%9A%84doc%E6%9C%89%E6%A6%82%E7%8E%87%E6%A0%B7%E5%BC%8F%E9%94%99%E8%AF%AF)