### PR TITLE
refactor(blocks): move embed card toolbar to root widget container

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/type.ts
+++ b/packages/blocks/src/_common/components/embed-card/type.ts
@@ -1,18 +1,20 @@
-import type { BookmarkBlockComponent } from '../../../bookmark-block/bookmark-block.js';
+import type { BlockElement } from '@blocksuite/block-std';
+
+import { BookmarkBlockComponent } from '../../../bookmark-block/bookmark-block.js';
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
-import type { EmbedFigmaBlockComponent } from '../../../embed-figma-block/embed-figma-block.js';
+import { EmbedFigmaBlockComponent } from '../../../embed-figma-block/embed-figma-block.js';
 import type { EmbedFigmaModel } from '../../../embed-figma-block/embed-figma-model.js';
-import type { EmbedGithubBlockComponent } from '../../../embed-github-block/embed-github-block.js';
+import { EmbedGithubBlockComponent } from '../../../embed-github-block/embed-github-block.js';
 import type { EmbedGithubModel } from '../../../embed-github-block/embed-github-model.js';
-import type {
+import {
   EmbedLinkedDocBlockComponent,
-  EmbedLinkedDocModel,
+  type EmbedLinkedDocModel,
 } from '../../../embed-linked-doc-block/index.js';
-import type { EmbedLoomBlockComponent } from '../../../embed-loom-block/embed-loom-block.js';
+import { EmbedLoomBlockComponent } from '../../../embed-loom-block/embed-loom-block.js';
 import type { EmbedLoomModel } from '../../../embed-loom-block/embed-loom-model.js';
-import type { EmbedSyncedDocBlockComponent } from '../../../embed-synced-doc-block/embed-synced-doc-block.js';
+import { EmbedSyncedDocBlockComponent } from '../../../embed-synced-doc-block/embed-synced-doc-block.js';
 import type { EmbedSyncedDocModel } from '../../../embed-synced-doc-block/embed-synced-doc-model.js';
-import type { EmbedYoutubeBlockComponent } from '../../../embed-youtube-block/embed-youtube-block.js';
+import { EmbedYoutubeBlockComponent } from '../../../embed-youtube-block/embed-youtube-block.js';
 import type { EmbedYoutubeModel } from '../../../embed-youtube-block/embed-youtube-model.js';
 
 export type EmbedToolbarBlockElement =
@@ -32,3 +34,17 @@ export type EmbedToolbarModel =
   | EmbedLinkedDocModel
   | EmbedSyncedDocModel
   | EmbedLoomModel;
+
+export function isEmbedCardBlockElement(
+  block: BlockElement
+): block is EmbedToolbarBlockElement {
+  return (
+    block instanceof BookmarkBlockComponent ||
+    block instanceof EmbedGithubBlockComponent ||
+    block instanceof EmbedYoutubeBlockComponent ||
+    block instanceof EmbedFigmaBlockComponent ||
+    block instanceof EmbedLinkedDocBlockComponent ||
+    block instanceof EmbedSyncedDocBlockComponent ||
+    block instanceof EmbedLoomBlockComponent
+  );
+}

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -1,6 +1,6 @@
 import './components/bookmark-card.js';
 
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -121,8 +121,6 @@ export class BookmarkBlockComponent extends BlockComponent<
           .error=${this.error}
         ></bookmark-card>
       </div>
-
-      ${this.isInSurface ? nothing : Object.values(this.widgets)}
     `;
   }
 }

--- a/packages/blocks/src/bookmark-block/bookmark-spec.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-spec.ts
@@ -1,7 +1,6 @@
 import type { BlockSpec } from '@blocksuite/block-std';
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import { BookmarkBlockSchema } from './bookmark-model.js';
 import { BookmarkBlockService } from './bookmark-service.js';
 
@@ -9,9 +8,6 @@ export const BookmarkBlockSpec: BlockSpec = {
   schema: BookmarkBlockSchema,
   view: {
     component: literal`affine-bookmark`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: BookmarkBlockService,
 };

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -180,8 +180,6 @@ export class EmbedFigmaBlockComponent extends EmbedBlockElement<
             </div>
           </div>
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   }

--- a/packages/blocks/src/embed-figma-block/embed-figma-spec.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/index.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedFigmaBlockProps,
   EmbedFigmaModel,
@@ -27,9 +26,6 @@ export const EmbedFigmaBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-figma-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedFigmaBlockService,
 });

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -285,8 +285,6 @@ export class EmbedGithubBlockComponent extends EmbedBlockElement<
             <div class="affine-embed-github-banner">${bannerImage}</div>
           </div>
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   }

--- a/packages/blocks/src/embed-github-block/embed-github-spec.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/index.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedGithubBlockProps,
   EmbedGithubModel,
@@ -36,9 +35,6 @@ export const EmbedGithubBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-github-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedGithubBlockService,
 });

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -466,8 +466,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
             <div class="affine-embed-linked-doc-block-overlay"></div>
           </div>
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/helper.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedLinkedDocBlockProps,
   EmbedLinkedDocModel,
@@ -24,9 +23,6 @@ export const EmbedLinkedDocBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-linked-doc-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedLinkedDocBlockService,
 });

--- a/packages/blocks/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-block.ts
@@ -1,5 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -215,8 +215,6 @@ export class EmbedLoomBlockComponent extends EmbedBlockElement<
             </div>
           </div>
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   }

--- a/packages/blocks/src/embed-loom-block/embed-loom-spec.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/index.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedLoomBlockProps,
   EmbedLoomModel,
@@ -29,9 +28,6 @@ export const EmbedLoomBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-loom-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedLoomBlockService,
 });

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -19,7 +19,7 @@ import { matchFlavours } from '../_common/utils/model.js';
 import { getThemeMode } from '../_common/utils/query.js';
 import type { NoteBlockModel } from '../note-block/note-model.js';
 import type { RootBlockComponent } from '../root-block/index.js';
-import { SpecProvider } from '../specs/index.js';
+import { SpecProvider } from '../specs/utils/spec-provider.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import type { EmbedSyncedDocCard } from './components/embed-synced-doc-card.js';
 import type { EmbedSyncedDocModel } from './embed-synced-doc-model.js';
@@ -340,8 +340,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
             ? html` <div class="affine-embed-synced-doc-editor-overlay"></div> `
             : nothing}
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   };

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-spec.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/helper.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedSyncedDocBlockProps,
   EmbedSyncedDocModel,
@@ -25,9 +24,6 @@ export const EmbedSyncedDocBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-synced-doc-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedSyncedDocBlockService,
 });

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -261,8 +261,6 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
             </div>
           </div>
         </div>
-
-        ${this.isInSurface ? nothing : Object.values(this.widgets)}
       `
     );
   }

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-spec.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-spec.ts
@@ -1,7 +1,6 @@
-import { literal, unsafeStatic } from 'lit/static-html.js';
+import { literal } from 'lit/static-html.js';
 
 import { createEmbedBlock } from '../_common/embed-block-helper/index.js';
-import { EMBED_CARD_TOOLBAR } from '../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
 import {
   type EmbedYoutubeBlockProps,
   EmbedYoutubeModel,
@@ -32,9 +31,6 @@ export const EmbedYoutubeBlockSpec = createEmbedBlock({
   },
   view: {
     component: literal`affine-embed-youtube-block`,
-    widgets: {
-      [EMBED_CARD_TOOLBAR]: literal`${unsafeStatic(EMBED_CARD_TOOLBAR)}`,
-    },
   },
   service: EmbedYoutubeBlockService,
 });

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -12,6 +12,7 @@ import { AFFINE_DRAG_HANDLE_WIDGET } from '../widgets/drag-handle/drag-handle.js
 import { AFFINE_EDGELESS_AUTO_CONNECT_WIDGET } from '../widgets/edgeless-auto-connect/edgeless-auto-connect.js';
 import { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from '../widgets/edgeless-remote-selection/index.js';
 import { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from '../widgets/edgeless-zoom-toolbar/index.js';
+import { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from '../widgets/embed-card-toolbar/embed-card-toolbar.js';
 import { AFFINE_FORMAT_BAR_WIDGET } from '../widgets/format-bar/format-bar.js';
 import { EDGELESS_ELEMENT_TOOLBAR_WIDGET } from '../widgets/index.js';
 import { AFFINE_INNER_MODAL_WIDGET } from '../widgets/inner-modal/inner-modal.js';
@@ -31,6 +32,7 @@ export type EdgelessRootBlockWidgetName =
   | typeof AFFINE_SLASH_MENU_WIDGET
   | typeof AFFINE_LINKED_DOC_WIDGET
   | typeof AFFINE_DRAG_HANDLE_WIDGET
+  | typeof AFFINE_EMBED_CARD_TOOLBAR_WIDGET
   | typeof AFFINE_FORMAT_BAR_WIDGET
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET
@@ -59,6 +61,9 @@ export const EdgelessRootBlockSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
       )}`,
       [AFFINE_DRAG_HANDLE_WIDGET]: literal`${unsafeStatic(
         AFFINE_DRAG_HANDLE_WIDGET
+      )}`,
+      [AFFINE_EMBED_CARD_TOOLBAR_WIDGET]: literal`${unsafeStatic(
+        AFFINE_EMBED_CARD_TOOLBAR_WIDGET
       )}`,
       [AFFINE_FORMAT_BAR_WIDGET]: literal`${unsafeStatic(
         AFFINE_FORMAT_BAR_WIDGET

--- a/packages/blocks/src/root-block/page/page-root-spec.ts
+++ b/packages/blocks/src/root-block/page/page-root-spec.ts
@@ -4,6 +4,7 @@ import { literal, unsafeStatic } from 'lit/static-html.js';
 import { RootBlockSchema } from '../root-model.js';
 import { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from '../widgets/doc-remote-selection/doc-remote-selection.js';
 import { AFFINE_DRAG_HANDLE_WIDGET } from '../widgets/drag-handle/drag-handle.js';
+import { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from '../widgets/embed-card-toolbar/embed-card-toolbar.js';
 import { AFFINE_FORMAT_BAR_WIDGET } from '../widgets/format-bar/format-bar.js';
 import { AFFINE_INNER_MODAL_WIDGET } from '../widgets/inner-modal/inner-modal.js';
 import { AFFINE_LINKED_DOC_WIDGET } from '../widgets/linked-doc/index.js';
@@ -21,6 +22,7 @@ export type PageRootBlockWidgetName =
   | typeof AFFINE_LINKED_DOC_WIDGET
   | typeof AFFINE_PAGE_DRAGGING_AREA_WIDGET
   | typeof AFFINE_DRAG_HANDLE_WIDGET
+  | typeof AFFINE_EMBED_CARD_TOOLBAR_WIDGET
   | typeof AFFINE_FORMAT_BAR_WIDGET
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET;
@@ -44,6 +46,9 @@ export const PageRootBlockSpec: BlockSpec<PageRootBlockWidgetName> = {
       )}`,
       [AFFINE_DRAG_HANDLE_WIDGET]: literal`${unsafeStatic(
         AFFINE_DRAG_HANDLE_WIDGET
+      )}`,
+      [AFFINE_EMBED_CARD_TOOLBAR_WIDGET]: literal`${unsafeStatic(
+        AFFINE_EMBED_CARD_TOOLBAR_WIDGET
       )}`,
       [AFFINE_FORMAT_BAR_WIDGET]: literal`${unsafeStatic(
         AFFINE_FORMAT_BAR_WIDGET

--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -7,6 +7,7 @@ import type { AFFINE_DRAG_HANDLE_WIDGET } from './widgets/drag-handle/drag-handl
 import type { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from './widgets/edgeless-remote-selection/index.js';
 import type { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from './widgets/edgeless-zoom-toolbar/index.js';
 import type { EDGELESS_ELEMENT_TOOLBAR_WIDGET } from './widgets/element-toolbar/index.js';
+import type { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from './widgets/embed-card-toolbar/embed-card-toolbar.js';
 import type { AFFINE_FORMAT_BAR_WIDGET } from './widgets/format-bar/format-bar.js';
 import type { AFFINE_INNER_MODAL_WIDGET } from './widgets/inner-modal/inner-modal.js';
 import type { AFFINE_LINKED_DOC_WIDGET } from './widgets/linked-doc/index.js';
@@ -25,6 +26,7 @@ export type PageRootBlockWidgetName =
   | typeof AFFINE_LINKED_DOC_WIDGET
   | typeof AFFINE_PAGE_DRAGGING_AREA_WIDGET
   | typeof AFFINE_DRAG_HANDLE_WIDGET
+  | typeof AFFINE_EMBED_CARD_TOOLBAR_WIDGET
   | typeof AFFINE_FORMAT_BAR_WIDGET
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET;
@@ -37,6 +39,7 @@ export type EdgelessRootBlockWidgetName =
   | typeof AFFINE_SLASH_MENU_WIDGET
   | typeof AFFINE_LINKED_DOC_WIDGET
   | typeof AFFINE_DRAG_HANDLE_WIDGET
+  | typeof AFFINE_EMBED_CARD_TOOLBAR_WIDGET
   | typeof AFFINE_FORMAT_BAR_WIDGET
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -18,9 +18,10 @@ import { EmbedCardMoreMenu } from '../../../_common/components/embed-card/embed-
 import { EmbedCardStyleMenu } from '../../../_common/components/embed-card/embed-card-style-popper.js';
 import { toggleEmbedCardCaptionEditModal } from '../../../_common/components/embed-card/modal/embed-card-caption-edit-modal.js';
 import { toggleEmbedCardEditModal } from '../../../_common/components/embed-card/modal/embed-card-edit-modal.js';
-import type {
-  EmbedToolbarBlockElement,
-  EmbedToolbarModel,
+import {
+  type EmbedToolbarBlockElement,
+  type EmbedToolbarModel,
+  isEmbedCardBlockElement,
 } from '../../../_common/components/embed-card/type.js';
 import { isPeekable, peek } from '../../../_common/components/index.js';
 import { createLitPortal } from '../../../_common/components/portal.js';
@@ -42,6 +43,10 @@ import {
   PaletteIcon,
 } from '../../../_common/icons/text.js';
 import {
+  getBlockComponentByPath,
+  getModelByBlockComponent,
+} from '../../../_common/utils/query.js';
+import {
   type BookmarkBlockModel,
   BookmarkStyles,
 } from '../../../bookmark-block/bookmark-model.js';
@@ -58,9 +63,9 @@ import {
 import type { EmbedOptions } from '../../root-service.js';
 import { embedCardToolbarStyle } from './styles.js';
 
-export const EMBED_CARD_TOOLBAR = 'embed-card-toolbar';
+export const AFFINE_EMBED_CARD_TOOLBAR_WIDGET = 'affine-embed-card-toolbar';
 
-@customElement(EMBED_CARD_TOOLBAR)
+@customElement(AFFINE_EMBED_CARD_TOOLBAR_WIDGET)
 export class EmbedCardToolbar extends WidgetElement<
   EmbedToolbarModel,
   EmbedToolbarBlockElement
@@ -416,14 +421,22 @@ export class EmbedCardToolbar extends WidgetElement<
         }
 
         const blockSelections = this._selection.filter('block');
-        if (
-          !blockSelections ||
-          blockSelections.length !== 1 ||
-          blockSelections[0].blockId !== this.blockElement.blockId
-        ) {
+        if (!blockSelections || blockSelections.length !== 1) {
           this._hide();
           return;
         }
+
+        const block = getBlockComponentByPath(
+          this.host,
+          blockSelections[0].blockId
+        );
+        if (!block || !isEmbedCardBlockElement(block)) {
+          this._hide();
+          return;
+        }
+
+        this.blockElement = block;
+        this.model = getModelByBlockComponent(block) as EmbedToolbarModel;
 
         this._show();
       })
@@ -601,6 +614,6 @@ export class EmbedCardToolbar extends WidgetElement<
 
 declare global {
   interface HTMLElementTagNameMap {
-    [EMBED_CARD_TOOLBAR]: EmbedCardToolbar;
+    [AFFINE_EMBED_CARD_TOOLBAR_WIDGET]: EmbedCardToolbar;
   }
 }

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -22,6 +22,10 @@ export {
   EDGELESS_ELEMENT_TOOLBAR_WIDGET,
   EdgelessElementToolbarWidget,
 } from './element-toolbar/index.js';
+export {
+  AFFINE_EMBED_CARD_TOOLBAR_WIDGET,
+  EmbedCardToolbar,
+} from './embed-card-toolbar/embed-card-toolbar.js';
 export { toolbarDefaultConfig } from './format-bar/config.js';
 export {
   AFFINE_FORMAT_BAR_WIDGET,

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -1,6 +1,5 @@
 import './utils/declare-test-window.js';
 
-import { sleep } from '@global/utils.js';
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { getEmbedCardToolbar } from 'utils/query.js';
@@ -52,9 +51,10 @@ const createBookmarkBlockBySlashMenu = async (page: Page) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await focusRichText(page);
-  await type(page, '/link');
+  await page.waitForTimeout(100);
+  await type(page, '/link', 100);
   await pressEnter(page);
-  await sleep(100);
+  await page.waitForTimeout(100);
   await type(page, inputUrl);
   await pressEnter(page);
 };

--- a/tests/utils/query.ts
+++ b/tests/utils/query.ts
@@ -81,7 +81,7 @@ export function getEmbedCardToolbar(page: Page) {
   const embedButton = createButtonLocator('embed');
   const cardStyleButton = createButtonLocator('card-style');
   const captionButton = createButtonLocator('caption');
-  const moreButton = createButtonLocator('more');
+  const moreButton = createButtonLocator('more-button');
   const cardStyleHorizontalButton = page.locator(
     '.card-style-button-horizontal'
   );


### PR DESCRIPTION
Closes: [BS-493](https://linear.app/affine-design/issue/BS-493/edgeless-%E4%B8%8A%E5%B5%8C%E5%A5%97-linked-doc-%E5%90%8E-toolbar-%E6%98%BE%E7%A4%BA-bug), [BS-492](https://linear.app/affine-design/issue/BS-492/edgeless-%E4%B8%8A%E5%B5%8C%E5%A5%97-linked-doc-drag-handler-bug)

Move `embed-card-toolbar` to root blocks widgets container. The previous implementation made it difficult to control the z-index between widgets.

## Before
drag handler show above toolbar
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/3e582fec-2aba-4b4d-a6ac-e4009519f6d9.png)

toolbar overflow error
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/949f62db-238d-4fb6-9950-1f11f6d473e3.png)


## After
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/56369edb-c810-42f1-9796-80e63bcfbd0e.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/4049ccda-39d0-4915-9904-01ed1eeab36a.png)

