### PR TITLE
feat(page): modify UI interaction of embed doc card according to the design draft

### DIFF
--- a/packages/blocks/src/_common/components/block-component.ts
+++ b/packages/blocks/src/_common/components/block-component.ts
@@ -24,6 +24,8 @@ export class BlockComponent<
 
   protected accessor useCaptionEditor = false;
 
+  protected accessor showBlockSelection = true;
+
   protected accessor blockContainerStyles: StyleInfo | undefined = undefined;
 
   constructor() {
@@ -42,7 +44,9 @@ export class BlockComponent<
       ${this.useCaptionEditor
         ? html`<block-caption-editor .block=${this}></block-caption-editor>`
         : nothing}
-      <affine-block-selection .block=${this}></affine-block-selection>
+      ${this.showBlockSelection
+        ? html`<affine-block-selection .block=${this}></affine-block-selection>`
+        : nothing}
     </div>`;
   }
 }

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -3,6 +3,7 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 import { html, render } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import type { DragHandleOption } from '../../root-block/widgets/drag-handle/config.js';
@@ -19,7 +20,12 @@ import { Bound } from '../../surface-block/index.js';
 import { BlockComponent } from '../components/block-component.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../consts.js';
 import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
-import { type EmbedCardStyle, matchFlavours } from '../utils/index.js';
+import {
+  type EmbedCardStyle,
+  getThemeMode,
+  matchFlavours,
+} from '../utils/index.js';
+import { styles } from './styles.js';
 
 export class EmbedBlockElement<
   Model extends
@@ -48,6 +54,8 @@ export class EmbedBlockElement<
       (this.edgeless?.service.getElementById(this.model.id) ?? this.model).xywh
     );
   }
+
+  static override styles = styles;
 
   private _isInSurface = false;
 
@@ -157,6 +165,8 @@ export class EmbedBlockElement<
 
   override accessor useCaptionEditor = true;
 
+  override accessor showBlockSelection = false;
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -183,10 +193,17 @@ export class EmbedBlockElement<
   }
 
   renderEmbed = (children: () => TemplateResult) => {
+    const theme = getThemeMode();
+    const isSelected = !!this.selected?.is('block');
+
     if (!this.isInSurface) {
       return html`
         <div
-          class="embed-block-container"
+          class=${classMap({
+            'embed-block-container': true,
+            [theme]: true,
+            selected: isSelected,
+          })}
           style=${styleMap({
             position: 'relative',
             width: '100%',

--- a/packages/blocks/src/_common/embed-block-helper/styles.ts
+++ b/packages/blocks/src/_common/embed-block-helper/styles.ts
@@ -1,0 +1,13 @@
+import { css } from 'lit';
+
+export const styles = css`
+  .embed-block-container {
+    border-radius: 8px;
+  }
+  .embed-block-container.selected.light {
+    box-shadow: 0px 0px 0px 1px var(--affine-brand-color);
+  }
+  .embed-block-container.selected.dark {
+    box-shadow: 0px 0px 0px 1px var(--affine-brand-color);
+  }
+`;

--- a/packages/blocks/src/embed-synced-doc-block/styles.ts
+++ b/packages/blocks/src/embed-synced-doc-block/styles.ts
@@ -7,10 +7,6 @@ export const SYNCED_MIN_WIDTH = 370;
 export const SYNCED_MIN_HEIGHT = 64;
 
 export const blockStyles = css`
-  edgeless-block-portal-embed:has(.affine-embed-synced-doc-block.editing) {
-    z-index: 1000 !important;
-  }
-
   .edgeless-block-portal-embed
     > affine-embed-synced-doc-block[data-nested-editor] {
     position: relative;
@@ -52,33 +48,49 @@ export const blockStyles = css`
   }
   .affine-embed-synced-doc-container.edgeless {
     display: block;
-    padding: 18px 24px;
     width: 100%;
     height: calc(${EMBED_CARD_HEIGHT.syncedDoc}px + 36px);
   }
-  .affine-embed-synced-doc-container:hover.light,
-  .affine-embed-synced-doc-container.selected.light,
-  affine-embed-synced-doc-block.with-drag-handle
-    > .affine-embed-synced-doc-container.light {
+  .affine-embed-synced-doc-container:hover.light {
     box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.08);
   }
-  .affine-embed-synced-doc-container:hover.dark,
-  .affine-embed-synced-doc-container.selected.dark,
-  affine-embed-synced-doc-block.with-drag-handle
-    > .affine-embed-synced-doc-container.dark {
+  .affine-embed-synced-doc-container:hover.dark {
     box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.14);
   }
-  .affine-embed-synced-doc-container.editing.light {
-    box-shadow:
-      0px 0px 0px 2px rgba(0, 0, 0, 0.08),
-      0px 0px 0px 1px var(--affine-brand-color);
+  .affine-embed-synced-doc-header-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 34px;
+    width: 100%;
+    background-color: var(--affine-white);
+    opacity: 0;
   }
-  .affine-embed-synced-doc-container.editing.dark {
-    box-shadow:
-      0px 0px 0px 2px rgba(255, 255, 255, 0.14),
-      0px 0px 0px 1px var(--affine-brand-color);
+  .affine-embed-synced-doc-header-wrapper.selected {
+    opacity: 1;
+    transition: all 0.23s ease;
   }
-
+  .affine-embed-synced-doc-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 0 24px;
+    background-color: var(--affine-hover-color);
+  }
+  .affine-embed-synced-doc-header svg {
+    flex-shrink: 0;
+  }
+  .affine-embed-synced-doc-title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 22px;
+    margin-left: 8px;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .affine-embed-synced-doc-editor-overlay {
     position: absolute;
     top: 0;
@@ -137,7 +149,6 @@ export const blockStyles = css`
   }
 
   .affine-embed-synced-doc-editor .affine-page-root-block-container {
-    padding: 0 24px;
     width: 100%;
     max-width: 100%;
   }

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -114,7 +114,6 @@ export class AffineEditorContainer
       overflow-y: auto;
       container-name: viewport;
       container-type: inline-size;
-      background: var(--affine-background-primary-color);
       font-family: var(--affine-font-family);
     }
     .affine-page-viewport * {

--- a/tests/embed-synced-doc.spec.ts
+++ b/tests/embed-synced-doc.spec.ts
@@ -59,6 +59,36 @@ test.describe('Embed synced doc', () => {
     await createAndConvertToEmbedSyncedDoc(page);
   });
 
+  test('can change embed synced doc to card view', async ({ page }) => {
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    await createAndConvertToEmbedSyncedDoc(page);
+
+    const syncedDoc = page.locator(`affine-embed-synced-doc-block`);
+    const syncedDocBox = await syncedDoc.boundingBox();
+    assertExists(syncedDocBox);
+    await page.mouse.click(
+      syncedDocBox.x + syncedDocBox.width / 2,
+      syncedDocBox.y + syncedDocBox.height / 2
+    );
+
+    await waitNextFrame(page, 200);
+    const toolbar = page.locator('.embed-card-toolbar');
+    await expect(toolbar).toBeVisible();
+
+    const cardBtn = page.locator(
+      '.embed-card-toolbar .embed-card-toolbar-button.card'
+    );
+    await expect(cardBtn).toBeVisible();
+
+    await cardBtn.click();
+    await waitNextFrame(page, 200);
+
+    const embedSyncedBlock = page.locator('affine-embed-linked-doc-block');
+    expect(await embedSyncedBlock.count()).toBe(1);
+  });
+
   // FIXME(mirone/#6534)
   test.skip('drag embed synced doc to whiteboard should fit in height', async ({
     page,


### PR DESCRIPTION
Fix issue [BS-581](https://linear.app/affine-design/issue/BS-581).

### What Changed?
- If the selected element is an embed block, the selection mask is hidden and the card border is hightlighted.
- Remove useless `_editing ` state and related logic, causing embed document card to now is readonly.
- Single click to select the embed document card and a floating toolbar appears.
- Modify CSS styles.
- Add e2e tests.

The new UI interaction works like:

https://github.com/toeverything/blocksuite/assets/12724894/094e1a0d-986c-4a10-9331-321d7fd10600

