### PR TITLE
chore(blocks): refine slash menu style

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -70,7 +70,8 @@ export type SlashMenuConfig = {
   triggerKeys: string[];
   ignoreBlockTypes: BlockSuite.Flavour[];
   items: SlashMenuItem[];
-  maxHeight: 344;
+  maxHeight: number;
+  tooltipTimeout: number;
 };
 
 export type SlashMenuStaticConfig = Omit<SlashMenuConfig, 'items'> & {
@@ -123,6 +124,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
   triggerKeys: ['/'],
   ignoreBlockTypes: ['affine:code'],
   maxHeight: 344,
+  tooltipTimeout: 800,
   items: [
     // ---------------------------------------------------------
     { groupName: 'Basic' },

--- a/packages/blocks/src/root-block/widgets/slash-menu/styles.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/styles.ts
@@ -61,6 +61,7 @@ export const styles = css`
     border: 1px solid var(--affine-border-color, #e3e2e4);
     border-radius: 4px;
     color: var(--affine-icon-color);
+    background: var(--affine-background-overlay-panel-color);
 
     display: flex;
     justify-content: center;
@@ -71,11 +72,6 @@ export const styles = css`
     display: block;
   }
 
-  .slash-menu-item.delete:hover {
-    background: var(--affine-background-error-color);
-    color: var(--affine-error-color);
-    fill: var(--affine-error-color);
-  }
   .slash-menu-item.ask-ai {
     color: var(--affine-brand-color);
   }

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -221,6 +221,35 @@ test.describe('slash menu should show and hide correctly', () => {
     await expect(slashItems.nth(1)).toHaveAttribute('hover', 'false');
   });
 
+  test('should open tooltip when hover on item', async ({ page }) => {
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+    await type(page, '/');
+    const slashMenu = page.locator(`.slash-menu`);
+    await expect(slashMenu).toBeVisible();
+
+    const slashItems = slashMenu.locator('icon-button');
+    const tooltip = page.locator('.affine-tooltip');
+
+    await slashItems.nth(0).hover();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveText(['Text']);
+    await page.mouse.move(0, 0);
+    await expect(tooltip).toBeHidden();
+
+    await slashItems.nth(1).hover();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveText(['Heading #1']);
+    await page.mouse.move(0, 0);
+    await expect(tooltip).toBeHidden();
+
+    await expect(slashItems.nth(4).locator('.text')).toHaveText([
+      'Other Headings',
+    ]);
+    await slashItems.nth(4).hover();
+    await expect(tooltip).toBeHidden();
+  });
+
   test('press tab should move up and down', async ({ page }) => {
     await initEmptyParagraphState(page);
     const slashMenu = page.locator(`.slash-menu`);


### PR DESCRIPTION
Related: [BS-570](https://linear.app/affine-design/issue/BS-570/slash-menu-%E4%BC%98%E5%8C%96%E6%94%B9%E8%BF%9B)

refine styles:
- remove red background color of `Delete` item when hover it
- change background color of icon  to background color of menu

Bug fix:
- When the mouse hovers over a menu item, and the keyboard is used to navigate the menu options, the current hover item flickers.


https://github.com/toeverything/blocksuite/assets/20479050/a61a4df1-ed66-4370-8f53-1ef3609c1aee


https://github.com/toeverything/blocksuite/assets/20479050/aa5f9c1a-0283-4397-ad2f-622d98bcae9e


