### PR TITLE
fix(blocks): preserve block ids when pasting

### DIFF
--- a/packages/blocks/src/_common/adapters/html.ts
+++ b/packages/blocks/src/_common/adapters/html.ts
@@ -657,7 +657,8 @@ export class HtmlAdapter extends BaseAdapter<Html> {
           break;
         }
         case 'body':
-        case 'div': {
+        case 'div':
+        case 'footer': {
           if (
             // Check if it is a paragraph like div
             o.parent?.node.type === 'element' &&
@@ -666,13 +667,18 @@ export class HtmlAdapter extends BaseAdapter<Html> {
               [
                 'span',
                 'strong',
+                'b',
+                'i',
                 'em',
                 'code',
+                'ins',
                 'del',
                 'u',
                 'a',
                 'mark',
                 'br',
+                'bdi',
+                'bdo',
               ].includes(child.tagName)
             ) ||
               o.node.children
@@ -864,6 +870,9 @@ export class HtmlAdapter extends BaseAdapter<Html> {
             Array.isArray(o.node.properties?.className)
           ) {
             if (
+              o.node.properties.className.includes(
+                'affine-paragraph-block-container'
+              ) ||
               o.node.properties.className.includes(
                 'affine-block-children-container'
               ) ||
@@ -1088,12 +1097,16 @@ export class HtmlAdapter extends BaseAdapter<Html> {
           case 'ul': {
             return [];
           }
-          case 'span': {
+          case 'span':
+          case 'bdi':
+          case 'bdo':
+          case 'ins': {
             return ast.children.flatMap(child =>
               this._hastToDeltaSpreaded(child, { trim: false })
             );
           }
-          case 'strong': {
+          case 'strong':
+          case 'b': {
             return ast.children.flatMap(child =>
               this._hastToDeltaSpreaded(child, { trim: false }).map(delta => {
                 delta.attributes = { ...delta.attributes, bold: true };
@@ -1101,6 +1114,7 @@ export class HtmlAdapter extends BaseAdapter<Html> {
               })
             );
           }
+          case 'i':
           case 'em': {
             return ast.children.flatMap(child =>
               this._hastToDeltaSpreaded(child, { trim: false }).map(delta => {

--- a/packages/blocks/src/root-block/clipboard/index.ts
+++ b/packages/blocks/src/root-block/clipboard/index.ts
@@ -156,7 +156,7 @@ export class PageClipboard {
             e,
             this._std.doc,
             ctx.parentBlock.model.id,
-            ctx.blockIndex ? ctx.blockIndex + 1 : undefined
+            ctx.blockIndex ? ctx.blockIndex + 1 : 1
           )
           .catch(console.error);
 

--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -17,8 +17,8 @@ import {
 } from '@blocksuite/store';
 
 import { matchFlavours } from '../../../_common/utils/index.js';
-import type { CodeBlockModel } from '../../../code-block/index.js';
 import type { ParagraphBlockModel } from '../../../paragraph-block/index.js';
+import type { QuickSearchService } from '../../root-service.js';
 
 const findLast = (snapshot: BlockSnapshot): BlockSnapshot => {
   if (snapshot.children && snapshot.children.length > 0) {
@@ -61,11 +61,16 @@ class PasteTr {
 
   private readonly to: TextRangePoint | null;
 
-  private readonly firstSnapshot: BlockSnapshot;
+  private firstSnapshot?: BlockSnapshot;
 
-  private lastSnapshot: BlockSnapshot;
+  private lastSnapshot?: BlockSnapshot;
 
   private readonly firstSnapshotIsPlainText: boolean;
+
+  // The model that the cursor should focus on after pasting
+  private pasteStartModel: BlockModel | null = null;
+
+  private pasteStartModelChildrenCount = 0;
 
   constructor(
     readonly std: EditorHost['std'],
@@ -92,7 +97,23 @@ class PasteTr {
       temp.set('text', text.yText);
       this.lastIndex = text.length;
     } else {
-      this.lastIndex = this.endPointState.text.length - end.index - end.length;
+      this.lastIndex =
+        this.fromPointState.point.index +
+        this.snapshot.content
+          .map(snapshot =>
+            this._textFromSnapshot(snapshot)
+              .delta.map(op => {
+                if (op.insert) {
+                  return op.insert.length;
+                } else if (op.delete) {
+                  return -op.delete;
+                } else {
+                  return 0;
+                }
+              })
+              .reduce((a, b) => a + b, 0)
+          )
+          .reduce((a, b) => a + b + 1, -1);
     }
     this.firstSnapshotIsPlainText =
       this.firstSnapshot.flavour === 'affine:paragraph' &&
@@ -100,12 +121,15 @@ class PasteTr {
   }
 
   private _textFromSnapshot = (snapshot: BlockSnapshot) => {
-    return snapshot.props.text as Record<'delta', DeltaOperation[]>;
+    return (snapshot.props.text ?? { delta: [] }) as Record<
+      'delta',
+      DeltaOperation[]
+    >;
   };
 
   private _getDeltas = () => {
-    const firstTextSnapshot = this._textFromSnapshot(this.firstSnapshot);
-    const lastTextSnapshot = this._textFromSnapshot(this.lastSnapshot);
+    const firstTextSnapshot = this._textFromSnapshot(this.firstSnapshot!);
+    const lastTextSnapshot = this._textFromSnapshot(this.lastSnapshot!);
     const fromDelta = this.fromPointState.text.sliceToDelta(
       0,
       this.fromPointState.point.index
@@ -127,14 +151,16 @@ class PasteTr {
   };
 
   private _mergeCode = () => {
-    const { firstTextSnapshot, fromDelta, toDelta } = this._getDeltas();
-
-    this.firstSnapshot.flavour = this.fromPointState.model.flavour;
-    const toLanguage = (this.fromPointState.model as CodeBlockModel).language;
-    if (toLanguage !== 'Plain Text') {
-      this.firstSnapshot.props.language = toLanguage;
-    }
-    const deltas: DeltaOperation[] = [...fromDelta];
+    const { toDelta } = this._getDeltas();
+    const deltas: DeltaOperation[] = [
+      { retain: this.fromPointState.point.index },
+      this.fromPointState.text.length - this.fromPointState.point.index
+        ? {
+            delete:
+              this.fromPointState.text.length - this.fromPointState.point.index,
+          }
+        : {},
+    ];
     let i = 0;
     for (const blockSnapshot of this.snapshot.content) {
       if (blockSnapshot.props.text) {
@@ -148,62 +174,139 @@ class PasteTr {
         break;
       }
     }
-    firstTextSnapshot.delta = deltas.concat(toDelta);
-    this.snapshot.content.splice(1, i);
+    this.fromPointState.text.applyDelta(deltas.concat(toDelta));
+    this.snapshot.content = [];
+  };
+
+  private _mergeSingle = () => {
+    const { firstDelta } = this._getDeltas();
+    this.fromPointState.text.applyDelta([
+      { retain: this.fromPointState.point.index },
+      this.fromPointState.point.length
+        ? { delete: this.fromPointState.point.length }
+        : {},
+      ...firstDelta,
+    ]);
+    this.snapshot.content.splice(0, 1);
+    this._updateSnapshot();
+  };
+
+  private _mergeMultiple = () => {
+    this.firstSnapshot!.flavour = this.fromPointState.model.flavour;
+    if (
+      this.firstSnapshot!.props.type &&
+      (this.fromPointState.text.length > 0 || this.firstSnapshotIsPlainText)
+    ) {
+      this.firstSnapshot!.props.type = (
+        this.fromPointState.model as ParagraphBlockModel
+      ).type;
+    }
+    if (this.lastSnapshot!.props.type && this.to) {
+      this.lastSnapshot!.flavour = this.endPointState.model.flavour;
+      this.lastSnapshot!.props.type = (
+        this.endPointState.model as ParagraphBlockModel
+      ).type;
+    }
+
+    const { lastTextSnapshot, toDelta, firstDelta, lastDelta } =
+      this._getDeltas();
+
+    this.fromPointState.text.applyDelta([
+      { retain: this.fromPointState.point.index },
+      this.fromPointState.text.length - this.fromPointState.point.index
+        ? {
+            delete:
+              this.fromPointState.text.length - this.fromPointState.point.index,
+          }
+        : {},
+      ...firstDelta,
+    ]);
+
+    const removedFirstSnapshot = this.snapshot.content.shift();
+    removedFirstSnapshot?.children.map(block => {
+      this.snapshot.content.unshift(block);
+    });
+    this.pasteStartModelChildrenCount =
+      removedFirstSnapshot?.children.length ?? 0;
+
+    this._updateSnapshot();
+
+    lastTextSnapshot.delta = [...lastDelta, ...toDelta];
+  };
+
+  private _updateSnapshot = () => {
+    if (this.snapshot.content.length === 0) {
+      this.firstSnapshot = this.lastSnapshot = undefined;
+      return;
+    }
+    this.firstSnapshot = this.snapshot.content[0];
     this.lastSnapshot = findLast(
       this.snapshot.content[this.snapshot.content.length - 1]
     );
   };
 
-  private _mergeSingle = () => {
-    this.firstSnapshot.flavour = this.fromPointState.model.flavour;
-    if (
-      this.firstSnapshot.props.type &&
-      (this.fromPointState.text.length > 0 || this.firstSnapshotIsPlainText)
-    ) {
-      this.firstSnapshot.props.type = (
-        this.fromPointState.model as ParagraphBlockModel
-      ).type;
+  private async _transformLinkDelta(
+    delta: DeltaOperation[],
+    linkToDocId: Map<string, string | null>,
+    quickSearchService: QuickSearchService
+  ) {
+    const needToConvert = new Map<DeltaOperation, string>();
+    for (const op of delta) {
+      if (op.attributes?.link) {
+        let docId = linkToDocId.get(op.attributes.link);
+        if (docId === undefined) {
+          const searchResult = await quickSearchService.searchDoc({
+            userInput: op.attributes.link,
+            skipSelection: true,
+            action: 'insert',
+          });
+          if (searchResult && 'docId' in searchResult) {
+            const doc = this.std.collection.getDoc(searchResult.docId);
+            if (doc) {
+              docId = doc.id;
+              linkToDocId.set(op.attributes.link, doc.id);
+            }
+          }
+        }
+        if (docId) {
+          needToConvert.set(op, docId);
+        }
+      }
     }
-    const { firstTextSnapshot, fromDelta, toDelta, firstDelta } =
-      this._getDeltas();
-
-    firstTextSnapshot.delta = [...fromDelta, ...firstDelta, ...toDelta];
-  };
-
-  private _mergeMultiple = () => {
-    this.firstSnapshot.flavour = this.fromPointState.model.flavour;
-    if (
-      this.firstSnapshot.props.type &&
-      (this.fromPointState.text.length > 0 || this.firstSnapshotIsPlainText)
-    ) {
-      this.firstSnapshot.props.type = (
-        this.fromPointState.model as ParagraphBlockModel
-      ).type;
-    }
-    if (this.lastSnapshot.props.type && this.to) {
-      this.lastSnapshot.flavour = this.endPointState.model.flavour;
-      this.lastSnapshot.props.type = (
-        this.endPointState.model as ParagraphBlockModel
-      ).type;
-    }
-
-    const {
-      firstTextSnapshot,
-      lastTextSnapshot,
-      fromDelta,
-      toDelta,
-      firstDelta,
-      lastDelta,
-    } = this._getDeltas();
-
-    firstTextSnapshot.delta = [...fromDelta, ...firstDelta];
-    lastTextSnapshot.delta = [...lastDelta, ...toDelta];
-  };
+    const newDelta = delta.map(op => {
+      if (needToConvert.has(op)) {
+        this.std.spec
+          .getService('affine:page')
+          .telemetryService?.track('LinkedDocCreated', {
+            page: 'doc editor',
+            category: 'pasted link',
+            type: 'doc',
+            other: 'existing doc',
+          });
+        return {
+          ...op,
+          attributes: {
+            reference: {
+              pageId: needToConvert.get(op),
+              type: 'LinkedPage',
+            },
+          },
+          insert: ' ',
+        };
+      }
+      return {
+        ...op,
+      };
+    });
+    return newDelta;
+  }
 
   canMerge = () => {
-    const firstTextSnapshot = this._textFromSnapshot(this.firstSnapshot);
-    const lastTextSnapshot = this._textFromSnapshot(this.lastSnapshot);
+    if (this.snapshot.content.length === 0) {
+      return false;
+    }
+    const firstTextSnapshot = this._textFromSnapshot(this.firstSnapshot!);
+    const lastTextSnapshot = this._textFromSnapshot(this.lastSnapshot!);
     return (
       firstTextSnapshot &&
       lastTextSnapshot &&
@@ -219,50 +322,70 @@ class PasteTr {
       return;
     }
 
-    const lastModel = this.std.doc.getBlockById(this.lastSnapshot.id);
-    assertExists(lastModel);
-
-    if (!this.to) {
-      this.std.doc.deleteBlock(this.fromPointState.model, {
-        bringChildrenTo: lastModel,
+    if (this.to) {
+      const context = this.std.command.exec('getSelectedModels', {
+        types: ['text'],
       });
-
-      return;
+      for (const model of context.selectedModels ?? []) {
+        if (
+          [this.fromPointState.model.id, this.endPointState.model.id].includes(
+            model.id
+          ) ||
+          this.snapshot.content.map(block => block.id).includes(model.id)
+        ) {
+          continue;
+        }
+        this.std.doc.deleteBlock(model);
+      }
+      this.std.doc.deleteBlock(
+        this.endPointState.model,
+        this.pasteStartModel
+          ? {
+              bringChildrenTo: this.pasteStartModel,
+            }
+          : undefined
+      );
     }
 
-    this.std.doc.deleteBlock(
-      this.endPointState.model,
-      lastModel
-        ? {
-            bringChildrenTo: lastModel,
-          }
-        : undefined
+    if (this.lastSnapshot) {
+      const lastBlock = this.std.doc.getBlock(this.lastSnapshot.id);
+      assertExists(lastBlock);
+      const { model: lastModel } = lastBlock;
+      this.std.doc.moveBlocks(this.fromPointState.model.children, lastModel);
+    }
+
+    this.std.doc.moveBlocks(
+      this.std.doc
+        .getNexts(this.fromPointState.model.id)
+        .slice(0, this.pasteStartModelChildrenCount),
+      this.fromPointState.model
     );
-    const parent = this.std.doc.getParent(this.fromPointState.model);
-    this.std.doc.deleteBlock(
-      this.fromPointState.model,
-      parent
-        ? {
-            bringChildrenTo: parent,
-          }
-        : undefined
-    );
+    if (
+      !this.firstSnapshotIsPlainText &&
+      this.fromPointState.text.length == 0
+    ) {
+      this.std.doc.deleteBlock(this.fromPointState.model);
+    }
   };
 
   focusPasted = () => {
     const host = this.std.host as EditorHost;
 
-    const lastModel = this.std.doc.getBlockById(this.lastSnapshot.id);
-    assertExists(lastModel);
+    const cursorBlock =
+      this.fromPointState.model.flavour === 'affine:code' || !this.lastSnapshot
+        ? this.std.doc.getBlock(this.fromPointState.model.id)
+        : this.std.doc.getBlock(this.lastSnapshot.id);
+    assertExists(cursorBlock);
+    const { model: cursorModel } = cursorBlock;
 
     host.updateComplete
       .then(() => {
         const target = this.std.host.querySelector<BlockElement>(
-          `[${host.blockIdAttr}="${lastModel.id}"]`
+          `[${host.blockIdAttr}="${cursorModel.id}"]`
         );
         assertExists(target);
-        if (!lastModel.text) {
-          if (matchFlavours(lastModel, ['affine:image'])) {
+        if (!cursorModel.text) {
+          if (matchFlavours(cursorModel, ['affine:image'])) {
             const selection = this.std.selection.create('image', {
               blockId: target.blockId,
             });
@@ -278,12 +401,7 @@ class PasteTr {
         const selection = this.std.selection.create('text', {
           from: {
             blockId: target.blockId,
-            index:
-              this.firstSnapshot === this.lastSnapshot
-                ? lastModel.text
-                  ? lastModel.text.length - this.lastIndex
-                  : 0
-                : this.lastIndex,
+            index: cursorModel.text ? this.lastIndex : 0,
             length: 0,
           },
           to: null,
@@ -307,9 +425,9 @@ class PasteTr {
     this._mergeMultiple();
   }
 
-  convertToLinkedDoc = async (std: EditorHost['std']) => {
+  convertToLinkedDoc = async () => {
     const quickSearchService =
-      std.spec.getService('affine:page').quickSearchService;
+      this.std.spec.getService('affine:page').quickSearchService;
 
     if (!quickSearchService) {
       return;
@@ -319,59 +437,15 @@ class PasteTr {
 
     for (const blockSnapshot of this.snapshot.content) {
       if (blockSnapshot.props.text) {
-        const text = this._textFromSnapshot(blockSnapshot);
-        const needToConvert = new Map<DeltaOperation, string>();
-        for (const op of text.delta) {
-          if (op.attributes?.link) {
-            let docId = linkToDocId.get(op.attributes.link);
-            if (docId === undefined) {
-              const searchResult = await quickSearchService.searchDoc({
-                userInput: op.attributes.link,
-                skipSelection: true,
-                action: 'insert',
-              });
-              if (searchResult && 'docId' in searchResult) {
-                const doc = std.collection.getDoc(searchResult.docId);
-                if (doc) {
-                  docId = doc.id;
-                  linkToDocId.set(op.attributes.link, doc.id);
-                }
-              }
-            }
-            if (docId) {
-              needToConvert.set(op, docId);
-            }
-          }
-        }
-        const delta = text.delta.map(op => {
-          if (needToConvert.has(op)) {
-            return {
-              ...op,
-              attributes: {
-                reference: {
-                  pageId: needToConvert.get(op),
-                  type: 'LinkedPage',
-                },
-              },
-              insert: ' ',
-            };
-          }
-          return {
-            ...op,
-          };
-        });
-        const model = std.doc.getBlockById(blockSnapshot.id);
+        const delta = await this._transformLinkDelta(
+          this._textFromSnapshot(blockSnapshot).delta,
+          linkToDocId,
+          quickSearchService
+        );
+        const model = this.std.doc.getBlockById(blockSnapshot.id);
         if (model) {
-          std.spec
-            .getService('affine:page')
-            .telemetryService?.track('LinkedDocCreated', {
-              page: 'doc editor',
-              category: 'pasted link',
-              type: 'doc',
-              other: 'existing doc',
-            });
-          std.doc.captureSync();
-          std.doc.transact(() => {
+          this.std.doc.captureSync();
+          this.std.doc.transact(() => {
             const text = model.text as Text;
             text.clear();
             text.applyDelta(delta);
@@ -379,6 +453,21 @@ class PasteTr {
         }
       }
     }
+
+    const fromPointStateText = this.fromPointState.model.text;
+    if (!fromPointStateText) {
+      return;
+    }
+    const delta = await this._transformLinkDelta(
+      fromPointStateText.toDelta(),
+      linkToDocId,
+      quickSearchService
+    );
+    this.std.doc.captureSync();
+    this.std.doc.transact(() => {
+      fromPointStateText.clear();
+      fromPointStateText.applyDelta(delta);
+    });
   };
 }
 
@@ -407,10 +496,18 @@ export const pasteMiddleware = (std: EditorHost['std']): JobMiddleware => {
       }
     });
     slots.afterImport.on(payload => {
+      if (payload.type === 'slice') {
+        const context = std.command.exec('getSelectedModels', {
+          types: ['block'],
+        });
+        for (const model of context.selectedModels ?? []) {
+          std.doc.deleteBlock(model);
+        }
+      }
       if (tr && payload.type === 'slice') {
         tr.pasted();
         tr.focusPasted();
-        tr.convertToLinkedDoc(std).catch(console.error);
+        tr.convertToLinkedDoc().catch(console.error);
       }
     });
   };

--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -110,7 +110,7 @@ test(scoped`clipboard copy paste title`, async ({ page }) => {
   await assertTitle(page, 'testtest');
 });
 
-test.skip(scoped`clipboard paste html`, async ({ page }) => {
+test(scoped`clipboard paste html`, async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
   await focusRichText(page);
@@ -136,7 +136,7 @@ test.skip(scoped`clipboard paste html`, async ({ page }) => {
   await assertText(page, 'aaabbbcccddd');
 });
 
-test.skip(
+test(
   scoped`clipboard paste HTML containing Markdown syntax code and image `,
   async ({ page }) => {
     test.info().annotations.push({
@@ -346,7 +346,7 @@ test(scoped`split block when paste`, async ({ page }) => {
     .locator('[data-block-id="2"] .inline-editor')
     .boundingBox();
   const bottomRight789 = await getEditorLocator(page)
-    .locator('[data-block-id="5"] .inline-editor')
+    .locator('[data-block-id="4"] .inline-editor')
     .boundingBox();
   assertExists(topLeft123);
   assertExists(bottomRight789);
@@ -1373,7 +1373,9 @@ test(scoped`clipboard copy multi selection`, async ({ page }) => {
   await focusRichText(page, 1);
   await pasteByKeyboard(page);
   await waitNextFrame(page);
-  await assertRichTexts(page, ['abc', 'defbc', 'd']);
+  await type(page, 'cursor');
+  await waitNextFrame(page);
+  await assertRichTexts(page, ['abc', 'defbc', 'dcursor']);
 });
 
 test.skip(scoped`clipboard copy nested items`, async ({ page }) => {


### PR DESCRIPTION
This closes #6366, closes BS-139.

This PR merges part of snapshot to the `fromPointState.model`. The first snapshot is deleted after being merged to the `fromPointState.model`, so the snapshot could probably be an empty array.
We delete snapshot from snapshots instead of block from blocks mainly because that if blocks are deleted immediately after they are created will cause errors as operations in `connectcallback` does not have any corresponding blocks attached.