### PR TITLE
fix: refine padding with scrollbar

### DIFF
--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -261,6 +261,9 @@ export const scrollbarStyle = (container: string) => {
     throw new Error('Invalid container name!');
 
   return css`
+    ${unsafeCSS(container)} {
+      scrollbar-gutter: stable;
+    }
     ${unsafeCSS(container)}::-webkit-scrollbar {
       -webkit-appearance: none;
       width: 4px;

--- a/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot-panel/index.ts
@@ -6,6 +6,7 @@ import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import type { AIItemGroupConfig } from '../../../_common/components/ai-item/types.js';
+import { scrollbarStyle } from '../../../_common/components/utils.js';
 import { on, stopPropagation } from '../../../_common/utils/event.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
@@ -19,7 +20,7 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
 
     .edgeless-copilot-panel {
       box-sizing: border-box;
-      padding: 8px;
+      padding: 8px 4px 8px 8px;
       min-width: 330px;
       max-height: 374px;
       overflow-y: auto;
@@ -29,18 +30,9 @@ export class EdgelessCopilotPanel extends WithDisposable(LitElement) {
       z-index: var(--affine-z-index-popover);
     }
 
-    .edgeless-copilot-panel::-webkit-scrollbar {
-      width: 5px;
-      max-height: 40px;
-    }
-    .edgeless-copilot-panel::-webkit-scrollbar-thumb {
-      border-radius: 20px;
-    }
+    ${scrollbarStyle('.edgeless-copilot-panel')}
     .edgeless-copilot-panel:hover::-webkit-scrollbar-thumb {
       background-color: var(--affine-black-30);
-    }
-    .edgeless-copilot-panel::-webkit-scrollbar-corner {
-      display: none;
     }
   `;
 

--- a/packages/blocks/src/root-block/widgets/format-bar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/styles.ts
@@ -41,7 +41,7 @@ const paragraphButtonStyle = css`
     box-sizing: border-box;
     position: absolute;
     min-width: 178px;
-    padding: 8px 8px;
+    padding: 8px 4px 8px 8px;
     max-height: 380px;
     overflow-y: auto;
 

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -344,7 +344,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
         referenceElement: itemElement,
         autoUpdate: true,
         middleware: [
-          offset(22),
+          offset(12),
           autoPlacement({
             allowedPlacements: ['right-start', 'right-end'],
           }),

--- a/packages/blocks/src/root-block/widgets/slash-menu/styles.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/styles.ts
@@ -18,7 +18,7 @@ export const styles = css`
     left: 0;
     top: 0;
     box-sizing: border-box;
-    padding: 8px;
+    padding: 8px 4px 8px 8px;
     width: 258px;
     overflow-y: auto;
     font-family: ${unsafeCSS(baseTheme.fontSansFamily)};
@@ -48,7 +48,7 @@ export const styles = css`
   }
 
   .slash-menu-item {
-    padding: 2px 4px 2px 8px;
+    padding: 2px 8px 2px 8px;
     justify-content: flex-start;
     gap: 10px;
   }


### PR DESCRIPTION
Related: [AF-928](https://linear.app/affine-design/issue/AF-928/ask-ai-出现在底部的时候-menu-弹出位置不对#comment-33f1e925)

Considering the space occupied by the scrollbar, adjust the padding of the menu to make it symmetric on both sides, which also ensure the correct pop-up position of the submenu.

The affected components include:
- Edgeless Mode Ask AI panel
- Slash Menu
- Page Mode Ask AI panel ( [PR on AFFiNE side](https://github.com/toeverything/AFFiNE/pull/7287) )

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/760b8a25-4976-427c-882a-79bb80dc19f4.png)

