### PR TITLE
feat: support seperated doc mode in playground

### DIFF
--- a/packages/blocks/src/_common/components/doc-mode-service.ts
+++ b/packages/blocks/src/_common/components/doc-mode-service.ts
@@ -1,6 +1,5 @@
 import type { Disposable } from '@blocksuite/global/utils';
 import { Slot } from '@blocksuite/global/utils';
-import type { Doc } from '@blocksuite/store';
 
 import type { DocMode } from '../types.js';
 
@@ -15,30 +14,28 @@ export interface DocModeService {
 }
 
 const DEFAULT_MODE = 'page';
-const modeMap = new Map<string, { mode: DocMode; slot: Slot<DocMode> }>();
+const modeMap = new Map<string, DocMode>();
+const slotMap = new Map<string, Slot<DocMode>>();
 
-export function createDocModeService(doc: Doc) {
+export function createDocModeService(curDocId: string) {
   const docModeService: DocModeService = {
-    setMode: (mode: DocMode, id: string = doc.id) => {
-      modeMap.set(id, {
-        mode,
-        slot: modeMap.get(id)?.slot || new Slot(),
-      });
-      modeMap.get(id)?.slot.emit(mode);
+    setMode: (mode: DocMode, id: string = curDocId) => {
+      modeMap.set(id, mode);
+      slotMap.get(id)?.emit(mode);
     },
-    getMode: (id: string = doc.id) => {
-      return modeMap.get(id)?.mode ?? DEFAULT_MODE;
+    getMode: (id: string = curDocId) => {
+      return modeMap.get(id) ?? DEFAULT_MODE;
     },
-    toggleMode: (id: string = doc.id) => {
+    toggleMode: (id: string = curDocId) => {
       const mode = docModeService.getMode(id) === 'page' ? 'edgeless' : 'page';
       docModeService.setMode(mode);
       return mode;
     },
-    onModeChange: (handler: (mode: DocMode) => void, id: string = doc.id) => {
-      if (!modeMap.get(id)) {
-        docModeService.setMode(DEFAULT_MODE, id);
+    onModeChange: (handler: (mode: DocMode) => void, id: string = curDocId) => {
+      if (!slotMap.get(id)) {
+        slotMap.set(id, new Slot());
       }
-      return modeMap.get(id)!.slot.on(handler);
+      return slotMap.get(id)!.on(handler);
     },
   };
   return docModeService;

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -19,6 +19,7 @@ import { deserializeXYWH } from './surface-block/index.js';
 
 export * from './_common/adapters/index.js';
 export * from './_common/components/ai-item/index.js';
+export * from './_common/components/doc-mode-service.js';
 export type {
   DocModeService,
   NotificationService,

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -173,7 +173,7 @@ export class RootService extends BlockService<RootBlockModel> {
 
   peekViewService: PeekViewService | null = null;
 
-  docModeService: DocModeService = createDocModeService(this.doc);
+  docModeService: DocModeService = createDocModeService(this.doc.id);
 
   quickSearchService: QuickSearchService | null = null;
 

--- a/packages/playground/apps/_common/components/docs-panel.ts
+++ b/packages/playground/apps/_common/components/docs-panel.ts
@@ -7,6 +7,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { removeModeFromStorage } from '../mock-services.js';
+
 @customElement('docs-panel')
 export class DocsPanel extends WithDisposable(ShadowlessElement) {
   private get collection() {
@@ -93,6 +95,7 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
             const isDeleteCurrent = doc.id === this.editor.doc.id;
 
             collection.removeDoc(doc.id);
+            removeModeFromStorage(doc.id);
             // When delete the current doc, we need to set the editor doc to the first remaining doc
             if (isDeleteCurrent) {
               this.editor.doc = this.docs[0].getDoc();

--- a/packages/playground/apps/_common/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/_common/components/quick-edgeless-menu.ts
@@ -89,6 +89,9 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   @state()
   private accessor _dark = localStorage.getItem('blocksuite:dark') === 'true';
 
+  @state()
+  private accessor _docMode: DocMode = 'page';
+
   @property({ attribute: false })
   accessor collection!: DocCollection;
 
@@ -105,9 +108,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   accessor chatPanel!: CustomChatPanel;
 
   @property({ attribute: false })
-  accessor mode: DocMode = 'page';
-
-  @property({ attribute: false })
   accessor readonly = false;
 
   private _keydown = (e: KeyboardEvent) => {
@@ -117,11 +117,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
   };
 
   private _switchEditorMode() {
-    this.mode = this.rootService.docModeService.toggleMode();
-  }
-
-  private _restoreMode() {
-    this.mode = this.rootService.docModeService.getMode();
+    this._docMode = this.rootService.docModeService.toggleMode();
   }
 
   private _addNote() {
@@ -312,8 +308,16 @@ export class QuickEdgelessMenu extends ShadowlessElement {
 
   override connectedCallback() {
     super.connectedCallback();
+
+    this._docMode = this.editor.mode;
+    this.rootService.docModeService.onModeChange(mode => {
+      this._docMode = mode;
+    });
+    this.editor.slots.docUpdated.on(() => {
+      this._docMode = this.editor.mode;
+    });
+
     document.body.addEventListener('keydown', this._keydown);
-    this._restoreMode();
   }
 
   override disconnectedCallback() {
@@ -329,15 +333,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
       this._canUndo = this.doc.canUndo;
       this._canRedo = this.doc.canRedo;
     });
-  }
-
-  override update(changedProperties: Map<string, unknown>) {
-    if (changedProperties.has('mode')) {
-      const mode = this.mode;
-      this.editor.mode = mode;
-    }
-
-    super.update(changedProperties);
   }
 
   override render() {
@@ -547,7 +542,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
 
           <div style="display: flex; gap: 12px">
             <!-- Present button -->
-            ${this.mode === 'edgeless'
+            ${this._docMode === 'edgeless'
               ? html`<sl-tooltip content="Present" placement="bottom" hoist>
                   <sl-button
                     size="small"
@@ -571,7 +566,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
                   pill
                   size="small"
                   content="Page"
-                  .disabled=${this.mode !== 'edgeless'}
+                  .disabled=${this._docMode !== 'edgeless'}
                   @click=${this._switchEditorMode}
                 >
                   <sl-icon name="filetype-doc" label="Page"></sl-icon>
@@ -583,7 +578,7 @@ export class QuickEdgelessMenu extends ShadowlessElement {
                   pill
                   size="small"
                   content="Edgeless"
-                  .disabled=${this.mode !== 'page'}
+                  .disabled=${this._docMode !== 'page'}
                   @click=${this._switchEditorMode}
                 >
                   <sl-icon name="palette" label="Edgeless"></sl-icon>


### PR DESCRIPTION
Support seperated doc mode in playground and persistent the data in localStorage.

https://github.com/toeverything/blocksuite/assets/12724894/7e719b00-4114-4032-af9f-38aa07d170c3


---

