### PR TITLE
fix: embed linked doc failed to load after created

### DIFF
--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -16,9 +16,8 @@ import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-ele
 import { EmbedEdgelessIcon, EmbedPageIcon } from '../_common/icons/text.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
 import type { DocMode } from '../_common/types.js';
-import { matchFlavours } from '../_common/utils/model.js';
 import { getThemeMode } from '../_common/utils/query.js';
-import type { NoteBlockModel } from '../note-block/note-model.js';
+import { isEmptyDoc } from '../_common/utils/render-linked-doc.js';
 import type {
   EdgelessRootService,
   RootBlockComponent,
@@ -48,7 +47,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
       isError: this._error,
       isDeleted: this._deleted,
       isCycle: this._cycle,
-      isEmpty: this._empty,
     };
   }
 
@@ -80,6 +78,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   private accessor _syncedDocMode: DocMode = 'page';
 
   @state()
+  private accessor _isEmptySyncedDoc: boolean = true;
+
+  @state()
   private accessor _docUpdatedAt: Date = new Date();
 
   @state()
@@ -93,9 +94,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
 
   @state()
   private accessor _cycle = false;
-
-  @state()
-  private accessor _empty = false;
 
   override accessor useCaptionEditor = false;
 
@@ -118,49 +116,11 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     }
   }
 
-  private _checkEmpty() {
-    const syncedDoc = this.syncedDoc;
-    const rootModel = syncedDoc?.root;
-    if (!syncedDoc || !rootModel) {
-      this._empty = false;
-      return;
-    }
-
-    const noteBlocks = rootModel.children.filter(child =>
-      matchFlavours(child, ['affine:note'])
-    ) as NoteBlockModel[];
-    if (noteBlocks.length === 0) {
-      this._empty = true;
-
-      syncedDoc.withoutTransact(() => {
-        const noteId = syncedDoc.addBlock('affine:note', {}, rootModel.id);
-        syncedDoc.addBlock('affine:paragraph', {}, noteId);
-      });
-
-      return;
-    }
-
-    const contentBlocks = noteBlocks.flatMap(note => note.children);
-    if (contentBlocks.length === 0) {
-      this._empty = true;
-
-      syncedDoc.withoutTransact(() => {
-        syncedDoc.addBlock('affine:paragraph', {}, noteBlocks[0].id);
-      });
-
-      return;
-    }
-
-    this._empty =
-      contentBlocks.length === 1 && contentBlocks[0].text?.length === 0;
-  }
-
   private async _load() {
     this._loading = true;
     this._error = false;
     this._deleted = false;
     this._cycle = false;
-    this._empty = false;
 
     const syncedDoc = this.syncedDoc;
     if (!syncedDoc) {
@@ -185,10 +145,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
       await new Promise<void>(resolve => {
         syncedDoc.slots.rootAdded.once(() => resolve());
       });
-    }
-
-    if (this.isPageMode) {
-      this._checkEmpty();
     }
 
     this._loading = false;
@@ -228,7 +184,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
 
   private _renderSyncedView = () => {
     const syncedDoc = this.syncedDoc;
-    const { isEmpty } = this.blockState;
     const isInSurface = this.isInSurface;
     const editorMode = this._syncedDocMode;
 
@@ -311,8 +266,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
           ?data-scale=${scale}
         >
           <div class="affine-embed-synced-doc-editor">
-            ${guard([editorMode, syncedDoc], renderEditor)}
-            ${isEmpty && editorMode === 'page'
+            ${this.isPageMode && this._isEmptySyncedDoc
               ? html`
                   <div class="affine-embed-synced-doc-editor-empty">
                     <span>
@@ -320,7 +274,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
                     </span>
                   </div>
                 `
-              : nothing}
+              : guard([editorMode, syncedDoc], renderEditor)}
           </div>
           ${isInSurface
             ? nothing
@@ -500,11 +454,23 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     this._syncedDocMode = this._rootService.docModeService.getMode(
       this.model.pageId
     );
+    this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this._syncedDocMode);
     this.disposables.add(
       this._rootService.docModeService.onModeChange(mode => {
         this._syncedDocMode = mode;
+        this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, mode);
       }, this.model.pageId)
     );
+
+    this.syncedDoc &&
+      this.disposables.add(
+        this.syncedDoc.slots.blockUpdated.on(() => {
+          this._isEmptySyncedDoc = isEmptyDoc(
+            this.syncedDoc,
+            this._syncedDocMode
+          );
+        })
+      );
   }
 
   override firstUpdated() {

--- a/packages/blocks/src/embed-synced-doc-block/styles.ts
+++ b/packages/blocks/src/embed-synced-doc-block/styles.ts
@@ -105,14 +105,11 @@ export const blockStyles = css`
   }
 
   .affine-embed-synced-doc-editor-empty {
-    position: absolute;
-    top: 0;
-    left: 24px;
     display: flex;
     align-items: center;
     width: 100%;
     height: 100%;
-    z-index: -1;
+    min-height: 44px;
   }
 
   .affine-embed-synced-doc-container.surface


### PR DESCRIPTION
Fix [BS-624](https://linear.app/affine-design/issue/BS-624).

### What Changed?
- Add `isEmptyDoc` and `isEmptyNote` utils
- Remove `syncedDoc.addBlock('affine:paragraph')` side effects, cause there are no need to do this in rendering lifecycle.
- Add observer to `blockUpdated`.