### PR TITLE
feat(blocks): support shortcut C to switch connector mode

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -79,13 +79,10 @@ export class EdgelessConnectorToolButton extends QuickToolMixin(LitElement) {
     applyLastProps(edgeless.service, type, stateKeys, states);
 
     this.disposables.add(
-      observeLastProps(
-        edgeless.service,
-        type,
-        stateKeys,
-        states,
-        updates => (this.states = { ...this.states, ...updates })
-      )
+      observeLastProps(edgeless.service, type, stateKeys, states, updates => {
+        this.states = { ...this.states, ...updates };
+        this.updateMenu();
+      })
     );
   }
 

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/connector-tool.ts
@@ -52,6 +52,10 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
   // Likes pressing `ESC`
   private _allowCancel = false;
 
+  get connector() {
+    return this._connector;
+  }
+
   readonly tool = {
     type: 'connector',
   } as ConnectorTool;
@@ -190,8 +194,8 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
   onContainerMouseMove(e: PointerEventState) {
     if (this._mode === ConnectorToolMode.Dragging) return;
 
-    assertExists(this._sourceBounds);
     assertExists(this._connector);
+    assertExists(this._sourceBounds);
 
     const sourceId = this._connector.source.id;
     assertExists(sourceId);
@@ -226,7 +230,9 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
   }
 
   beforeModeSwitch(edgelessTool: EdgelessTool) {
-    if (edgelessTool.type === 'connector') return;
+    if (edgelessTool.type === 'connector') {
+      return;
+    }
 
     const id = this._connector?.id;
     if (this._allowCancel && id) {

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -20,6 +20,7 @@ import {
   ShapeType,
 } from '../../surface-block/index.js';
 import { PageKeyboardManager } from '../keyboard/keyboard-manager.js';
+import type { ConnectorToolController } from './controllers/tools/connector-tool.js';
 import { CopilotSelectionController } from './controllers/tools/copilot-tool.js';
 import { LassoToolController } from './controllers/tools/lasso-tool.js';
 import { ShapeToolController } from './controllers/tools/shape-tool.js';
@@ -52,7 +53,30 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           });
         },
         c: () => {
-          const mode = ConnectorMode.Curve;
+          const isConnectorTool =
+            rootElement.tools.edgelessTool.type === 'connector';
+          let mode =
+            rootElement.service.editPropsStore.getLastProps('connector').mode ??
+            ConnectorMode.Curve;
+
+          if (isConnectorTool) {
+            const connectorController = rootElement.tools.controllers[
+              'connector'
+            ] as ConnectorToolController;
+            if (connectorController.connector) {
+              return;
+            }
+
+            const modes = [
+              ConnectorMode.Curve,
+              ConnectorMode.Orthogonal,
+              ConnectorMode.Straight,
+            ];
+
+            const nextIndex = modes.findIndex(m => m === mode) + 1;
+            mode = modes[nextIndex % 3];
+          }
+
           rootElement.service.editPropsStore.record('connector', { mode });
           this._setEdgelessTool(rootElement, { type: 'connector', mode });
         },


### PR DESCRIPTION
Closes: [BS-423](https://linear.app/affine-design/issue/BS-423/连续按-connector-快捷键-c-可以切换-shape)

* [ ] add test