### PR TITLE
feat: add markdown export from synced doc block

### DIFF
--- a/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
@@ -1,9 +1,14 @@
-import type { BlockSnapshot, SliceSnapshot } from '@blocksuite/store';
+import type {
+  BlockSnapshot,
+  DocSnapshot,
+  SliceSnapshot,
+} from '@blocksuite/store';
 import { AssetsManager, MemoryBlobCRUD } from '@blocksuite/store';
 import { describe, expect, test } from 'vitest';
 
 import { MarkdownAdapter } from '../../_common/adapters/markdown.js';
 import { nanoidReplacement } from '../../_common/test-utils/test-utils.js';
+import { embedSyncedDocMiddleware } from '../../_common/transformers/middlewares.js';
 import { NoteDisplayMode } from '../../_common/types.js';
 import { createJob } from '../utils/create-job.js';
 
@@ -1586,6 +1591,413 @@ hhh
       snapshot: blockSnapshot,
     });
     expect(target.file).toBe(markdown);
+  });
+
+  test('synced-doc', async () => {
+    // doc -> synced doc block -> deepest synced doc block
+    // The deepest synced doc block only export it's title
+
+    const deepestSyncedDocSnapshot: DocSnapshot = {
+      type: 'page',
+      meta: {
+        id: 'deepestSyncedDoc',
+        title: 'Deepest Doc',
+        createDate: 1715762171116,
+        tags: [],
+      },
+      blocks: {
+        type: 'block',
+        id: '8WdJmN5FTT',
+        flavour: 'affine:page',
+        version: 2,
+        props: {
+          title: {
+            '$blocksuite:internal:text$': true,
+            delta: [
+              {
+                insert: 'Deepest Doc',
+              },
+            ],
+          },
+        },
+        children: [
+          {
+            type: 'block',
+            id: 'zVN1EZFuZe',
+            flavour: 'affine:surface',
+            version: 5,
+            props: {
+              elements: {},
+            },
+            children: [],
+          },
+          {
+            type: 'block',
+            id: '2s9sJlphLH',
+            flavour: 'affine:note',
+            version: 1,
+            props: {
+              xywh: '[0,0,800,95]',
+              background: '--affine-background-secondary-color',
+              index: 'a0',
+              hidden: false,
+              displayMode: 'both',
+              edgeless: {
+                style: {
+                  borderRadius: 8,
+                  borderSize: 4,
+                  borderStyle: 'solid',
+                  shadowType: '--affine-note-shadow-box',
+                },
+              },
+            },
+            children: [
+              {
+                type: 'block',
+                id: 'vNp5XrR5yw',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'JTdfSl1ygZ',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'Hello, This is deepest doc.',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const syncedDocSnapshot: DocSnapshot = {
+      type: 'page',
+      meta: {
+        id: 'syncedDoc',
+        title: 'Synced Doc',
+        createDate: 1719212435051,
+        tags: [],
+      },
+      blocks: {
+        type: 'block',
+        id: 'AGOahFisBN',
+        flavour: 'affine:page',
+        version: 2,
+        props: {
+          title: {
+            '$blocksuite:internal:text$': true,
+            delta: [
+              {
+                insert: 'Synced Doc',
+              },
+            ],
+          },
+        },
+        children: [
+          {
+            type: 'block',
+            id: 'gfVzx5tGpB',
+            flavour: 'affine:surface',
+            version: 5,
+            props: {
+              elements: {},
+            },
+            children: [],
+          },
+          {
+            type: 'block',
+            id: 'CzEfaUret4',
+            flavour: 'affine:note',
+            version: 1,
+            props: {
+              xywh: '[0,0,800,95]',
+              background: '--affine-note-background-blue',
+              index: 'a0',
+              hidden: false,
+              displayMode: 'both',
+              edgeless: {
+                style: {
+                  borderRadius: 0,
+                  borderSize: 4,
+                  borderStyle: 'none',
+                  shadowType: '--affine-note-shadow-sticker',
+                },
+              },
+            },
+            children: [
+              {
+                type: 'block',
+                id: 'yFlNufsgke',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'h1',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'Heading 1',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'oMuLcD6XS3',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'h2',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'heading 2',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'PQ8FhGV6VM',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'paragraph',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'sA9paSrdEN',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'strike',
+                        attributes: {
+                          strike: true,
+                        },
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'DF26giFpKX',
+                flavour: 'affine:code',
+                version: 1,
+                props: {
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'Hello world!',
+                      },
+                    ],
+                  },
+                  language: 'cpp',
+                  wrap: false,
+                  caption: '',
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: '-3bbVQTvI2',
+                flavour: 'affine:embed-synced-doc',
+                version: 1,
+                props: {
+                  index: 'a0',
+                  xywh: '[0,0,0,0]',
+                  rotate: 0,
+                  pageId: 'deepestSyncedDoc',
+                  style: 'syncedDoc',
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const syncedDocMd =
+      '# Synced Doc\n\n# Heading 1\n\n## heading 2\n\nparagraph\n\n~~strike~~\n\n```cpp\nHello world!\n```';
+
+    const docSnapShot: DocSnapshot = {
+      type: 'page',
+      meta: {
+        id: 'y5nsrywQtr',
+        title: 'Test Doc',
+        createDate: 1719222172042,
+        tags: [],
+      },
+      blocks: {
+        type: 'block',
+        id: 'VChAZIX7DM',
+        flavour: 'affine:page',
+        version: 2,
+        props: {
+          title: {
+            '$blocksuite:internal:text$': true,
+            delta: [
+              {
+                insert: 'Test Doc',
+              },
+            ],
+          },
+        },
+        children: [
+          {
+            type: 'block',
+            id: 'uRj8gejH4d',
+            flavour: 'affine:surface',
+            version: 5,
+            props: {
+              elements: {},
+            },
+            children: [],
+          },
+          {
+            type: 'block',
+            id: 'AqFoVDUoW9',
+            flavour: 'affine:note',
+            version: 1,
+            props: {
+              xywh: '[0,0,800,95]',
+              background: '--affine-note-background-blue',
+              index: 'a0',
+              hidden: false,
+              displayMode: 'both',
+              edgeless: {
+                style: {
+                  borderRadius: 0,
+                  borderSize: 4,
+                  borderStyle: 'none',
+                  shadowType: '--affine-note-shadow-sticker',
+                },
+              },
+            },
+            children: [
+              {
+                type: 'block',
+                id: 'cWBI4UGTqh',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'Hello',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'AqFoVxas19',
+                flavour: 'affine:embed-synced-doc',
+                version: 1,
+                props: {
+                  index: 'a0',
+                  xywh: '[0,0,0,0]',
+                  rotate: 0,
+                  pageId: 'syncedDoc',
+                  style: 'syncedDoc',
+                },
+                children: [],
+              },
+              {
+                type: 'block',
+                id: 'Db976U9v18',
+                flavour: 'affine:paragraph',
+                version: 1,
+                props: {
+                  type: 'text',
+                  text: {
+                    '$blocksuite:internal:text$': true,
+                    delta: [
+                      {
+                        insert: 'World!',
+                      },
+                    ],
+                  },
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const docMd = `\
+# Test Doc
+
+Hello
+
+${syncedDocMd}
+
+Deepest Doc
+
+World!
+`;
+
+    const job = createJob([embedSyncedDocMiddleware('content')]);
+
+    // workaround for adding docs to collection
+    await job.snapshotToDoc(deepestSyncedDocSnapshot);
+    await job.snapshotToDoc(syncedDocSnapshot);
+    await job.snapshotToDoc(docSnapShot);
+
+    const mdAdapter = new MarkdownAdapter(job);
+    const target = await mdAdapter.fromDocSnapshot({
+      snapshot: docSnapShot,
+    });
+    expect(target.file).toBe(docMd);
   });
 });
 

--- a/packages/blocks/src/__tests__/utils/create-job.ts
+++ b/packages/blocks/src/__tests__/utils/create-job.ts
@@ -1,8 +1,15 @@
-import { DocCollection, Job, Schema } from '@blocksuite/store';
+import {
+  DocCollection,
+  Job,
+  type JobMiddleware,
+  Schema,
+} from '@blocksuite/store';
 
-export function createJob() {
-  const schema = new Schema();
-  const collection = new DocCollection({ schema });
-  collection.meta.initialize();
-  return new Job({ collection });
+import { AffineSchemas } from '../../schemas.js';
+
+export function createJob(middlewares?: JobMiddleware[]) {
+  const schema = new Schema().register(AffineSchemas);
+  const docCollection = new DocCollection({ schema });
+  docCollection.meta.initialize();
+  return new Job({ collection: docCollection, middlewares });
 }

--- a/packages/blocks/src/_common/transformers/index.ts
+++ b/packages/blocks/src/_common/transformers/index.ts
@@ -3,6 +3,7 @@ export { MarkdownTransformer } from './markdown.js';
 export {
   customImageProxyMiddleware,
   defaultImageProxyMiddleware,
+  embedSyncedDocMiddleware,
   replaceIdMiddleware,
   setImageProxyMiddlewareURL,
   titleMiddleware,

--- a/packages/blocks/src/_common/transformers/middlewares.ts
+++ b/packages/blocks/src/_common/transformers/middlewares.ts
@@ -197,3 +197,9 @@ export const setImageProxyMiddlewareURL = defaultImageProxyMiddlewarBuilder.set;
 
 export const defaultImageProxyMiddleware =
   defaultImageProxyMiddlewarBuilder.get();
+
+export const embedSyncedDocMiddleware =
+  (type: 'content'): JobMiddleware =>
+  ({ adapterConfigs }) => {
+    adapterConfigs.set('embedSyncedDocExportType', type);
+  };

--- a/packages/framework/store/src/transformer/job.ts
+++ b/packages/framework/store/src/transformer/job.ts
@@ -35,6 +35,10 @@ export type JobConfig = {
 };
 
 export class Job {
+  get collection() {
+    return this._collection;
+  }
+
   get assetsManager() {
     return this._assetsManager;
   }


### PR DESCRIPTION
Closes: [BS-665](https://linear.app/affine-design/issue/BS-665/%E6%94%AF%E6%8C%81-embed-synced-doc-%E7%9A%84-markdown-%E5%AF%BC%E5%87%BA)

### TL;DR

This PR adds support for exporting synced documents using `embedSyncedDocMiddleware` with `MakrdownAdapter`.

### Example
```ts
const job = new Job({
  collection,
  middlewares: [embedSyncedDocMiddleware('content')],
});
const adapter = new MarkdownAdapter(job);
// Do what you want to exporting here using markdown adapter
const content = adapter.fromSliceSnapshot({snapshot});
```

There is a output example that export `doc -> synced doc -> nested synced doc`
```md
# Doc

Hello, I' m Doc

// Begin: Embed synced doc block, export all content of synced doc
# Synced Doc

Hello, I'm Synced Doc

// Begin: Nested embed synced doc block, just export it's title
Nested Doc
// End: Nested embed synced doc block 
// End: Embed synced doc block
```

### What changed?

1. **Transformers**: Updated middlewares to include `embedSyncedDocMiddleware`.
2. **MarkdownAdapter**: Added logic to handle 'embedSyncedDoc' nodes.
3. **Job Class**: Added `collection` getter.
4. **Tests**: Added unit tests for the synced-doc export logic.
5. **Uint Test Utilities**: Modified `createJob` to accept middlewares and initialize with `AffineSchemas`.

### Why make this change?

To enable loading content of `embed-synced-doc` for AI context. Related issue: [BS-632](https://linear.app/affine-design/issue/BS-632/synced-block-%E6%96%87%E6%A1%A3%E6%94%AF%E6%8C%81%EF%BC%9A%E8%AF%BB%E5%8F%96%E6%96%87%E6%A1%A3%E5%86%85%E5%AE%B9%E4%BD%9C%E4%B8%BA-ai-%E7%9A%84%E4%B8%8A%E4%B8%8B%E6%96%87-cotent)