### PR TITLE
fix(blocks): code block and image block pop-over z-index issues in affine

### DIFF
--- a/packages/blocks/src/_common/components/filterable-list/index.ts
+++ b/packages/blocks/src/_common/components/filterable-list/index.ts
@@ -7,7 +7,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { PAGE_HEADER_HEIGHT } from '../../consts.js';
 import { DoneIcon } from '../../icons/database.js';
 import { SearchIcon } from '../../icons/text.js';
-import { createLitPortal } from '../portal.js';
+import { type AdvancedPortalOptions, createLitPortal } from '../portal.js';
 import { filterableListStyles } from './styles.js';
 import type { FilterableListItem, FilterableListOptions } from './types.js';
 
@@ -181,6 +181,7 @@ export function showPopFilterableList({
   referenceElement,
   container,
   maxHeight = 440,
+  portalStyles,
 }: {
   options: FilterableListComponent['options'];
   referenceElement: Element;
@@ -188,6 +189,7 @@ export function showPopFilterableList({
   abortController?: AbortController;
   filter?: FilterableListComponent['listFilter'];
   maxHeight?: number;
+  portalStyles?: AdvancedPortalOptions['portalStyles'];
 }) {
   const portalPadding = {
     top: PAGE_HEADER_HEIGHT + 12,
@@ -209,6 +211,7 @@ export function showPopFilterableList({
       return list;
     },
     container,
+    portalStyles,
     computePosition: {
       referenceElement,
       placement: 'bottom-start',

--- a/packages/blocks/src/_common/components/portal.ts
+++ b/packages/blocks/src/_common/components/portal.ts
@@ -108,6 +108,8 @@ type PortalOptions = {
    * If true, the portalRoot will be added a class `blocksuite-portal`. It's useful for finding the portalRoot.
    */
   identifyWrapper?: boolean;
+
+  portalStyles?: Record<string, string | number | undefined | null>;
 };
 
 /**
@@ -295,6 +297,8 @@ export function createLitPortal({
   portalRoot.style.position = 'fixed';
   portalRoot.style.left = '0';
   portalRoot.style.top = '0';
+
+  Object.assign(portalRoot.style, portalOptions.portalStyles);
 
   const computePositionOptions =
     positionConfigOrFn instanceof Function

--- a/packages/blocks/src/code-block/styles.ts
+++ b/packages/blocks/src/code-block/styles.ts
@@ -3,7 +3,6 @@ import { css } from 'lit';
 export const codeBlockStyles = css`
   affine-code {
     position: relative;
-    z-index: 1;
   }
 
   .affine-code-block-container {

--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -104,7 +104,12 @@ export class LanguageListButton extends LitElement {
         getLanguagePriority(a.name as BundledLanguage) -
         getLanguagePriority(b.name as BundledLanguage),
       referenceElement: this._langButton,
+      container: this.blockElement.host,
       abortController: this._abortController,
+      // stacking-context(editor-host)
+      portalStyles: {
+        zIndex: 'var(--affine-z-index-popover)',
+      },
     });
   };
 

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -61,6 +61,11 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
           }}
         >
         </language-list-button>`,
+        // stacking-context(editor-host)
+        portalStyles: {
+          zIndex: 'var(--affine-z-index-popover)',
+        },
+        container: this.blockElement,
         computePosition: {
           referenceElement: this.blockElement,
           placement: 'left-start',

--- a/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
@@ -15,7 +15,6 @@ import { CodeToolbarItemRenderer, MoreMenuRenderer } from '../utils.js';
 export class AffineCodeToolbar extends WithDisposable(LitElement) {
   static override styles = css`
     :host {
-      z-index: 1;
       position: absolute;
       top: 0;
       right: 0;
@@ -98,12 +97,16 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
     assertExists(this._moreButton);
     createLitPortal({
       template: moreMenu,
-      container: this._moreButton,
+      // should be greater than block-selection z-index as selection and popover wil share the same stacking context(editor-host)
+      portalStyles: {
+        zIndex: 'var(--affine-z-index-popover)',
+      },
+      container: this.blockElement.host,
       computePosition: {
         referenceElement: this._moreButton,
         placement: 'bottom-start',
         middleware: [flip(), offset(4)],
-        autoUpdate: true,
+        autoUpdate: { animationFrame: true },
       },
       abortController: this._popMenuAbortController,
       closeOnClickAway: true,

--- a/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
@@ -64,6 +64,11 @@ export class AffineCodeToolbarWidget extends WidgetElement<
               }
             }}
           ></affine-code-toolbar>`,
+          container: this.blockElement,
+          // stacking-context(editor-host)
+          portalStyles: {
+            zIndex: 'var(--affine-z-index-popover)',
+          },
           computePosition: {
             referenceElement: codeBlock,
             placement: 'right-start',

--- a/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
@@ -90,12 +90,16 @@ export class AffineImageToolbar extends LitElement {
     assertExists(this._moreButton);
     createLitPortal({
       template: moreMenu,
-      container: this._moreButton,
+      container: this.blockElement.host,
+      // stacking-context(editor-host)
+      portalStyles: {
+        zIndex: 'var(--affine-z-index-popover)',
+      },
       computePosition: {
         referenceElement: this._moreButton,
         placement: 'bottom-start',
         middleware: [flip(), offset(4)],
-        autoUpdate: true,
+        autoUpdate: { animationFrame: true },
       },
       abortController: this._popMenuAbortController,
       closeOnClickAway: true,

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -70,6 +70,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
               }
             }}
           ></affine-image-toolbar>`,
+          container: this.blockElement,
           computePosition: {
             referenceElement: imageContainer,
             placement: 'right-start',

--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -50,6 +50,7 @@ export class EditorHost extends WithDisposable(ShadowlessElement) {
   static override styles = css`
     editor-host {
       outline: none;
+      isolation: isolate;
     }
   `;
 


### PR DESCRIPTION
Create a new stacking context at the `editor-host`, allowing popups to use it as the parent context instead of `body`.

##### DOM
- editor-host
   - code-block
      - language-list-btn-portal *
      - code-toolbar-portal *
   - image-block
      - image-toolbar-portal *
    
   - lang-list
   - code-more-menu *
   - image-more-menu *

- All items marked with "*" will share the same stacking context at `editor-host`

[BS-667](https://linear.app/affine-design/issue/BS-667/code-and-image-block-popover-z-index-issues-in-affine)
[BS-635](https://linear.app/affine-design/issue/BS-635/center-peek-%E4%B8%AD%E7%9A%84-code-block-%E4%B8%8D%E6%98%BE%E7%A4%BA-toolbar-%E7%AD%89-widget)
## Before

https://github.com/toeverything/blocksuite/assets/123532141/6bfdff21-4d3f-4fb1-afd2-09b9ceb32130

## After

https://github.com/toeverything/blocksuite/assets/123532141/1182f012-dbcd-40c1-8f92-f9063744e5fc


- [x] in page header
- [x] in center peek
- [ ] in ai panel