### PR TITLE
fix: disable embed view button if linked document references itself

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -86,6 +86,12 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
     return this.block.doc;
   }
 
+  get _openButtonDisabled() {
+    return (
+      isEmbedLinkedDocBlock(this._model) && this._model.pageId === this._doc.id
+    );
+  }
+
   private _open() {
     this.block.open();
     this.abortController.abort();
@@ -142,6 +148,7 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
             class="menu-item open"
             text="Open"
             @click=${() => this._open()}
+            ?disabled=${this._openButtonDisabled}
           >
             ${OpenIcon}
           </icon-button>

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup-more-menu-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup-more-menu-popup.ts
@@ -94,6 +94,10 @@ export class ReferencePopupMoreMenu extends WithDisposable(LitElement) {
     return std;
   }
 
+  get _openButtonDisabled() {
+    return this.referenceDocId === this.blockElement.doc.id;
+  }
+
   private _openDoc() {
     const refDocId = this.referenceDocId;
     const blockElement = this.blockElement;
@@ -124,6 +128,7 @@ export class ReferencePopupMoreMenu extends WithDisposable(LitElement) {
             class="menu-item open"
             text="Open this doc"
             @click=${() => this._openDoc()}
+            ?disabled=${this._openButtonDisabled}
           >
             ${OpenIcon}
           </icon-button>

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -53,8 +53,18 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     return doc;
   }
 
-  get _isInsideEmbedSyncedDocBlock() {
-    return !!this.blockElement.closest('affine-embed-synced-doc-block');
+  get _embedViewButtonDisabled() {
+    if (this.blockElement.doc.readonly) {
+      return true;
+    }
+    return (
+      !!this.blockElement.closest('affine-embed-synced-doc-block') ||
+      this.referenceDocId === this.doc.id
+    );
+  }
+
+  get _openButtonDisabled() {
+    return this.referenceDocId === this.doc.id;
   }
 
   static override styles = styles;
@@ -232,6 +242,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
               size="24px"
               class="affine-reference-popover-open-button"
               @click=${this._openDoc}
+              ?disabled=${this._openButtonDisabled}
             >
               ${OpenIcon}
               <affine-tooltip .offset=${12}>${'Open this doc'}</affine-tooltip>
@@ -278,7 +289,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
                       class="affine-reference-popover-view-selector-button embed embed-view"
                       .hover=${false}
                       @click=${() => this._convertToEmbedView()}
-                      ?disabled=${this._isInsideEmbedSyncedDocBlock}
+                      ?disabled=${this._embedViewButtonDisabled}
                     >
                       ${EmbedWebIcon}
                       <affine-tooltip .offset=${12}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -239,6 +239,23 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     return block.docTitle;
   }
 
+  private get _embedViewButtonDisabled() {
+    if (this._doc.readonly) {
+      return true;
+    }
+    return (
+      isEmbedLinkedDocBlock(this.model) &&
+      (!!this._blockElement?.closest('affine-embed-synced-doc-block') ||
+        this.model.pageId === this._doc.id)
+    );
+  }
+
+  get _openButtonDisabled() {
+    return (
+      isEmbedLinkedDocBlock(this.model) && this.model.pageId === this._doc.id
+    );
+  }
+
   static override styles = css`
     .change-embed-card-button {
       width: 24px;
@@ -604,6 +621,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               .tooltip=${'Open this doc'}
               class="change-embed-card-button open"
               @click=${this._open}
+              .disabled=${this._openButtonDisabled}
             >
               ${OpenIcon}
             </edgeless-tool-icon-button>
@@ -663,7 +681,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
                   })}
                   arai-label="Embed view"
                   .tooltip=${'Embed view'}
-                  ?disabled=${this._doc.readonly}
+                  .disabled=${this._embedViewButtonDisabled}
                   .hover=${false}
                   @click=${this._convertToEmbedView}
                 >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -230,6 +230,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
 
     .action-item[data-disabled] {
       cursor: not-allowed;
+      color: var(--affine-text-disable-color);
     }
   `;
 
@@ -315,7 +316,11 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       (isEmbedLinkedDocBlock(firstElement) ||
         isEmbedSyncedDocBlock(firstElement))
     ) {
-      result.push(OPEN_ACTION);
+      const disabled = firstElement.pageId === this.doc.id;
+      result.push({
+        ...OPEN_ACTION,
+        disabled,
+      });
     }
 
     if (

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -116,9 +116,19 @@ export class EmbedCardToolbar extends WidgetElement<
   }
 
   private get _embedViewButtonDisabled() {
+    if (this.model.doc.readonly) {
+      return true;
+    }
     return (
       isEmbedLinkedDocBlock(this.model) &&
-      !!this.blockElement.closest('affine-embed-synced-doc-block')
+      (!!this.blockElement.closest('affine-embed-synced-doc-block') ||
+        this.model.pageId === this.doc.id)
+    );
+  }
+
+  get _openButtonDisabled() {
+    return (
+      isEmbedLinkedDocBlock(this.model) && this.model.pageId === this.doc.id
     );
   }
 
@@ -497,6 +507,7 @@ export class EmbedCardToolbar extends WidgetElement<
                 size="24px"
                 class="embed-card-toolbar-button doc-info"
                 @click=${() => this.blockElement.open()}
+                ?disabled=${this._openButtonDisabled}
               >
                 ${isEmbedLinkedDocBlock(model)
                   ? nothing
@@ -560,8 +571,7 @@ export class EmbedCardToolbar extends WidgetElement<
                     'current-view': this._isEmbedView,
                   })}
                   .hover=${false}
-                  ?disabled=${model.doc.readonly ||
-                  this._embedViewButtonDisabled}
+                  ?disabled=${this._embedViewButtonDisabled}
                   @click=${() => this._convertToEmbedView()}
                 >
                   ${EmbedWebIcon}


### PR DESCRIPTION
Fix issue [BS-628](https://linear.app/affine-design/issue/BS-628).

If linked document references itself:
- Disable open this doc button 
- Disable open in more menu 
- Disable embed view button

![截屏2024-06-25 11.20.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/96e6ac48-52c3-4350-bd43-c798b7cf47d8.png)