### PR TITLE
fix(blocks): model of embed card toolbar changed back to the root

### DIFF
--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -10,7 +10,7 @@ import {
   type Placement,
   type ReferenceElement,
 } from '@floating-ui/dom';
-import { html, nothing } from 'lit';
+import { html, nothing, type PropertyValues } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -60,6 +60,7 @@ import {
   isEmbedLinkedDocBlock,
   isEmbedSyncedDocBlock,
 } from '../../edgeless/utils/query.js';
+import { RootBlockModel } from '../../root-model.js';
 import type { EmbedOptions } from '../../root-service.js';
 import { embedCardToolbarStyle } from './styles.js';
 
@@ -451,6 +452,20 @@ export class EmbedCardToolbar extends WidgetElement<
         this._show();
       })
     );
+  }
+
+  override willUpdate(changedProperties: PropertyValues<typeof this>) {
+    // avoid no selection change on the first update so that `this.model` will be root block model
+    if (!this.hasUpdated) return;
+
+    // `this.model` is only controlled by selection changed event
+    if (changedProperties.has('model')) {
+      const previousModel = changedProperties.get('model');
+      assertExists(previousModel);
+      if (this.model instanceof RootBlockModel) {
+        this.model = previousModel;
+      }
+    }
   }
 
   override render() {


### PR DESCRIPTION
Closes: [BS-656](https://linear.app/affine-design/issue/BS-656/card-view-%E7%82%B9%E5%87%BB%E5%90%8E%EF%BC%8C-%E5%8F%AF%E8%83%BD%E4%BC%9A%E8%8E%B7%E5%8F%96%E4%B8%8D%E5%88%B0-%E5%BD%93%E5%89%8D%E7%9A%84%E7%8A%B6%E6%80%81%EF%BC%9A-toolbar-%E4%B8%8A%E6%B2%A1%E6%9C%89%E5%AF%B9%E5%BA%94%E7%9A%84%E6%BF%80%E6%B4%BB%E6%A0%B7%E5%BC%8F)

This issue happen on re-render editor but selection is not changed in AFFiNE side.

Before:
![image](https://github.com/toeverything/blocksuite/assets/20479050/c9daf404-46e3-46ac-a063-75eb3845ca97)

After:
![image](https://github.com/toeverything/blocksuite/assets/20479050/50b65340-11af-4f4e-9700-4ab21bbdc6aa)
