### PR TITLE
feat: hide resize handles when dragging or resizing selected elements

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -1295,7 +1295,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
       _updateCursor,
     } = this;
 
-    const hasResizeHandles = !selection.editing && !doc.readonly;
+    const hasResizeHandles =
+      !selection.editing && !doc.readonly && !edgeless.tools.dragging;
     const inoperable = selection.inoperable;
     const handlers = [];
 
@@ -1324,7 +1325,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
             ) => {
               if (!this._canRotate() && options?.type === 'rotate') return;
               _updateCursor(dragging, options);
-            }
+            },
+            this.dragDirection
           )
         : nothing;
 

--- a/packages/blocks/src/root-block/edgeless/components/resize/resize-handles.ts
+++ b/packages/blocks/src/root-block/edgeless/components/resize/resize-handles.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 
 import type { IVec } from '../../../../surface-block/index.js';
 
@@ -11,6 +11,7 @@ export enum HandleDirection {
   BottomLeft = 'bottom-left',
   TopRight = 'top-right',
   BottomRight = 'bottom-right',
+  None = 'none',
 }
 
 function ResizeHandle(
@@ -96,29 +97,72 @@ export function ResizeHandles(
       target?: HTMLElement;
       point?: IVec;
     }
-  ) => void
+  ) => void,
+  activeHandle?: HandleDirection
 ) {
   const getCornerHandles = () => {
-    const handleTopLeft = ResizeHandle(
-      HandleDirection.TopLeft,
-      onPointerDown,
-      updateCursor
-    );
-    const handleTopRight = ResizeHandle(
-      HandleDirection.TopRight,
-      onPointerDown,
-      updateCursor
-    );
-    const handleBottomLeft = ResizeHandle(
-      HandleDirection.BottomLeft,
-      onPointerDown,
-      updateCursor
-    );
-    const handleBottomRight = ResizeHandle(
-      HandleDirection.BottomRight,
-      onPointerDown,
-      updateCursor
-    );
+    let handleTopLeft: TemplateResult | null = null;
+    let handleTopRight: TemplateResult | null = null;
+    let handleBottomLeft: TemplateResult | null = null;
+    let handleBottomRight: TemplateResult | null = null;
+
+    switch (activeHandle) {
+      case HandleDirection.Left:
+      case HandleDirection.Top:
+      case HandleDirection.Right:
+      case HandleDirection.Bottom:
+        break;
+      case HandleDirection.TopLeft:
+        handleTopLeft = ResizeHandle(
+          HandleDirection.TopLeft,
+          onPointerDown,
+          updateCursor
+        );
+        break;
+      case HandleDirection.TopRight:
+        handleTopRight = ResizeHandle(
+          HandleDirection.TopRight,
+          onPointerDown,
+          updateCursor
+        );
+        break;
+      case HandleDirection.BottomLeft:
+        handleBottomLeft = ResizeHandle(
+          HandleDirection.BottomLeft,
+          onPointerDown,
+          updateCursor
+        );
+        break;
+      case HandleDirection.BottomRight:
+        handleBottomRight = ResizeHandle(
+          HandleDirection.BottomRight,
+          onPointerDown,
+          updateCursor
+        );
+        break;
+      default:
+        handleTopLeft = ResizeHandle(
+          HandleDirection.TopLeft,
+          onPointerDown,
+          updateCursor
+        );
+        handleTopRight = ResizeHandle(
+          HandleDirection.TopRight,
+          onPointerDown,
+          updateCursor
+        );
+        handleBottomLeft = ResizeHandle(
+          HandleDirection.BottomLeft,
+          onPointerDown,
+          updateCursor
+        );
+        handleBottomRight = ResizeHandle(
+          HandleDirection.BottomRight,
+          onPointerDown,
+          updateCursor
+        );
+        break;
+    }
     return {
       handleTopLeft,
       handleTopRight,

--- a/packages/blocks/src/root-block/edgeless/components/resize/resize-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/components/resize/resize-manager.ts
@@ -64,7 +64,7 @@ export class HandleResizeManager {
 
   private _onDragEnd: DragEndHandler;
 
-  private _dragDirection: HandleDirection = HandleDirection.Left;
+  private _dragDirection: HandleDirection = HandleDirection.None;
 
   private _dragPos: {
     start: { x: number; y: number };
@@ -665,6 +665,7 @@ export class HandleResizeManager {
 
     const _onPointerUp = (_: PointerEvent) => {
       this._dragging = false;
+      this._dragDirection = HandleDirection.None;
       this._onDragEnd();
 
       const { x, y, width, height } = this._currentRect;


### PR DESCRIPTION
for a better experience?
hide all handles when dragging and hide all handles but the currently in use when resizing.

