### PR TITLE
fix: create linked doc from mindmap

### DIFF
--- a/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
@@ -2,12 +2,11 @@ import type { BlockStdScope } from '@blocksuite/block-std';
 import { Job } from '@blocksuite/store';
 
 import { groupBy } from '../../../_common/utils/iterable.js';
-import {
-  type SerializedElement,
-  SurfaceGroupLikeModel,
-} from '../../../surface-block/element-model/base.js';
+import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
 import type { SerializedConnectorElement } from '../../../surface-block/element-model/connector.js';
 import type { SerializedGroupElement } from '../../../surface-block/element-model/group.js';
+import type { SerializedMindmapElement } from '../../../surface-block/element-model/mindmap.js';
+import type { NodeDetail } from '../../../surface-block/element-model/utils/mindmap/layout.js';
 import {
   ConnectorElementModel,
   GroupElementModel,
@@ -161,11 +160,11 @@ export function mapGroupIds(
  * @returns updated element props
  */
 export function mapMindmapIds(
-  props: SerializedElement,
+  props: SerializedMindmapElement,
   ids: Map<string, string>
 ) {
   if (props.children) {
-    const newMap: Record<string, boolean> = {};
+    const newMap: Record<string, NodeDetail> = {};
     for (const [key, value] of Object.entries(props.children)) {
       const newKey = ids.get(key);
       if (value.parent) {

--- a/packages/blocks/src/surface-block/element-model/group.ts
+++ b/packages/blocks/src/surface-block/element-model/group.ts
@@ -16,6 +16,7 @@ type GroupElementProps = IBaseProps & {
 };
 
 export type SerializedGroupElement = SerializedElement & {
+  title: string;
   children: Record<string, boolean>;
 };
 
@@ -79,9 +80,9 @@ export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> 
     return linePolygonIntersects(start, end, bound.points);
   }
 
-  static override propsToY(props: GroupElementProps) {
+  static override propsToY(props: Record<string, unknown>) {
     if (props.title && !(props.title instanceof DocCollection.Y.Text)) {
-      props.title = new DocCollection.Y.Text(props.title);
+      props.title = new DocCollection.Y.Text(props.title as string);
     }
 
     if (props.children && !(props.children instanceof DocCollection.Y.Map)) {
@@ -94,7 +95,7 @@ export class GroupElementModel extends SurfaceGroupLikeModel<GroupElementProps> 
       props.children = children;
     }
 
-    return props;
+    return props as GroupElementProps;
   }
 }
 

--- a/tests/edgeless/linked-doc.spec.ts
+++ b/tests/edgeless/linked-doc.spec.ts
@@ -310,4 +310,30 @@ test.describe('multiple edgeless elements to linked doc', () => {
       elements: ['shape', 'connector'],
     });
   });
+
+  test('multi-select with mindmap, turn it into a linked doc', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    await triggerComponentToolbarAction(page, 'addMindmap');
+
+    await selectAllByKeyboard(page);
+    await triggerComponentToolbarAction(page, 'createLinkedDoc');
+    await waitNextFrame(page, 200);
+    const linkedSyncedBlock = page.locator('affine-linked-synced-doc-block');
+    assertExists(linkedSyncedBlock);
+
+    await triggerComponentToolbarAction(page, 'openLinkedDoc');
+    await waitNextFrame(page, 200);
+    const nodes = await page.evaluate(() => {
+      const container = document.querySelector('affine-edgeless-root');
+      const elements = container!.service.elements.map(s => s.type);
+      const blocks = container!.service.blocks.map(b => b.flavour);
+      return { blocks, elements };
+    });
+    expect(nodes).toEqual({
+      blocks: [],
+      elements: ['mindmap', 'shape', 'shape', 'shape', 'shape'],
+    });
+  });
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -855,6 +855,7 @@ type Action =
   | 'changeConnectorShape'
   | 'addFrame'
   | 'addGroup'
+  | 'addMindmap'
   | 'createGroupOnMoreOption'
   | 'ungroup'
   | 'releaseFromGroup'
@@ -1023,6 +1024,13 @@ export async function triggerComponentToolbarAction(
         'edgeless-add-group-button'
       );
       await button.click();
+      break;
+    }
+    case 'addMindmap': {
+      const button = page.locator('edgeless-mindmap-tool-button');
+      await button.click();
+      await page.mouse.move(400, 400);
+      await page.mouse.click(400, 400);
       break;
     }
     case 'createGroupOnMoreOption': {


### PR DESCRIPTION
Fix issue [BS-625](https://linear.app/affine-design/issue/BS-625).

### What Changed?
- Add `SerializedMindmapElement ` typescript interface.
- Override `propsToY` in class ` MindmapElementModel` to transfer serialized object to `Y.Map`.
- Add e2e test of create linked doc from mindmap.

https://github.com/toeverything/blocksuite/assets/12724894/ef01a5c4-3b61-4211-b6ee-974d848cb9fa

