### PR TITLE
fix(blocks): database title affect the global contenteditable

### DIFF
--- a/packages/blocks/src/database-block/columns/title/text.ts
+++ b/packages/blocks/src/database-block/columns/title/text.ts
@@ -141,7 +141,6 @@ export class HeaderAreaTextCell extends BaseTextCell {
     return html`${this.renderIcon()}
       <rich-text
         .yText=${this.value}
-        .inlineEventSource=${this.topContenteditableElement}
         .attributesSchema=${this.attributesSchema}
         .attributeRenderer=${this.attributeRenderer}
         .embedChecker=${this.inlineManager?.embedChecker}


### PR DESCRIPTION
When the title is set to readonly, `inlineEditor` will set `eventSource` to `contenteditable=false`, causing editing functionality issues.