### PR TITLE
fix: can not create linked doc from text selection

### DIFF
--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -177,7 +177,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
       action: (chain, formatBar) => {
         const [_, ctx] = chain
           .getSelectedModels({
-            types: ['block'],
+            types: ['block', 'text'],
             mode: 'highest',
           })
           .run();
@@ -223,7 +223,8 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
       showWhen: chain => {
         const [_, ctx] = chain
           .getSelectedModels({
-            types: ['block'],
+            types: ['block', 'text'],
+            mode: 'highest',
           })
           .run();
         const { selectedModels } = ctx;


### PR DESCRIPTION
Fix issue [BS-607](https://linear.app/affine-design/issue/BS-607).

Support create linked doc from text selection.


https://github.com/toeverything/blocksuite/assets/12724894/a86c4d8e-bb2b-4fab-9768-ea99a296b1a6

