### PR TITLE
feat(blocks): connector supports shortcut keys for label editing

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
@@ -144,6 +144,27 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
         });
 
         this.disposables.add(
+          dispatcher.add('keyDown', ctx => {
+            const state = ctx.get('keyboardState');
+            const { key, ctrlKey, metaKey, altKey, shiftKey, isComposing } =
+              state.raw;
+            const onlyCmd = (ctrlKey || metaKey) && !altKey && !shiftKey;
+            const isModEnter = onlyCmd && key === 'Enter';
+            const isEscape = key === 'Escape';
+            if (!isComposing && (isModEnter || isEscape)) {
+              this.inlineEditorContainer.blur();
+
+              edgeless.service.selection.set({
+                elements: [connector.id],
+                editing: false,
+              });
+              return true;
+            }
+            return false;
+          })
+        );
+
+        this.disposables.add(
           edgeless.service.surface.elementUpdated.on(({ id }) => {
             if (id === connector.id) this.requestUpdate();
           })

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -34,7 +34,10 @@ import {
 import { deleteElements } from './utils/crud.js';
 import { getNextShapeType, updateShapeProps } from './utils/hotkey-utils.js';
 import { isCanvasElement, isNoteBlock } from './utils/query.js';
-import { mountShapeTextEditor } from './utils/text.js';
+import {
+  mountConnectorLabelEditor,
+  mountShapeTextEditor,
+} from './utils/text.js';
 
 export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   constructor(override rootElement: EdgelessRootBlockComponent) {
@@ -350,22 +353,35 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           const { service } = rootElement;
           const selection = service.selection;
           const elements = selection.selectedElements;
+          const onlyOne = elements.length === 1;
 
-          if (
-            elements.length === 1 &&
-            elements[0] instanceof EdgelessTextBlockModel
-          ) {
-            const id = elements[0].id;
-            selection.set({
-              elements: [id],
-              editing: true,
-            });
-            const textBlock = this.rootElement.host.view.getBlock(id);
-            if (textBlock instanceof EdgelessTextBlockComponent) {
-              textBlock.tryFocusEnd();
+          if (onlyOne) {
+            const element = elements[0];
+            const id = element.id;
+
+            if (element instanceof ConnectorElementModel) {
+              selection.set({
+                elements: [id],
+                editing: true,
+              });
+              requestAnimationFrame(() => {
+                mountConnectorLabelEditor(element, rootElement);
+              });
+              return;
             }
 
-            return;
+            if (element instanceof EdgelessTextBlockModel) {
+              selection.set({
+                elements: [id],
+                editing: true,
+              });
+              const textBlock = rootElement.host.view.getBlock(id);
+              if (textBlock instanceof EdgelessTextBlockComponent) {
+                textBlock.tryFocusEnd();
+              }
+
+              return;
+            }
           }
 
           if (!isSelectSingleMindMap(elements)) {

--- a/tests/edgeless/connector.spec.ts
+++ b/tests/edgeless/connector.spec.ts
@@ -27,6 +27,7 @@ import {
   pressBackspace,
   redoByClick,
   selectAllByKeyboard,
+  SHORT_KEY,
   type,
   undoByClick,
   waitNextFrame,
@@ -656,6 +657,46 @@ test.describe('connector label with straight shape', () => {
 
     [cx, cy] = await getEditorCenter(page);
     assertPointAlmostEqual([cx, cy], [x, y]);
+  });
+
+  test('should enter the label editing state when pressing `Enter`', async ({
+    page,
+  }) => {
+    await commonSetup(page);
+    const start = { x: 100, y: 200 };
+    const end = { x: 300, y: 300 };
+    await addBasicConnectorElement(page, start, end);
+    await page.mouse.click(105, 200);
+
+    await page.keyboard.press('Enter');
+    await type(page, ' a ');
+    await assertEdgelessCanvasText(page, ' a ');
+  });
+
+  test('should exit the label editing state when pressing `Mod-Enter` or `Escape`', async ({
+    page,
+  }) => {
+    await commonSetup(page);
+    const start = { x: 100, y: 200 };
+    const end = { x: 300, y: 300 };
+    await addBasicConnectorElement(page, start, end);
+    await page.mouse.click(105, 200);
+
+    await page.keyboard.press('Enter');
+    await type(page, ' a ');
+    await assertEdgelessCanvasText(page, ' a ');
+
+    await page.keyboard.press(`${SHORT_KEY}+Enter`);
+
+    await page.keyboard.press('Enter');
+    await type(page, 'b');
+    await assertEdgelessCanvasText(page, 'b');
+
+    await page.keyboard.press('Escape');
+
+    await page.keyboard.press('Enter');
+    await type(page, 'c');
+    await assertEdgelessCanvasText(page, 'c');
   });
 });
 


### PR DESCRIPTION
Closes: [BS-678](https://linear.app/affine-design/issue/BS-678/connector-添加-entermod-enter-快捷键)

### Shortcut keys
* `Enter`: enter the label editing state
* `Ctrl-Enter` | `Cmd+Enter` | `Escape`:  exit label editing state and select current connector