### PR TITLE
fix: doc update time outdated

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -97,8 +97,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
       return;
     }
 
-    this._docUpdatedAt = this._rootService.getDocUpdatedAt(this.model.pageId);
-
     if (!linkedDoc.loaded) {
       try {
         linkedDoc.load();
@@ -133,6 +131,14 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
       return false;
     }
     return !!linkedDoc && this.isNoteContentEmpty && this.isBannerEmpty;
+  }
+
+  private _setDocUpdatedAt() {
+    const meta = this.doc.collection.meta.getDocMeta(this.model.pageId);
+    if (meta) {
+      const date = meta.updatedDate || meta.createDate;
+      this._docUpdatedAt = new Date(date);
+    }
   }
 
   private _selectBlock() {
@@ -321,6 +327,13 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
         })
       );
 
+      this._setDocUpdatedAt();
+      this.disposables.add(
+        this.doc.collection.meta.docMetaUpdated.on(() => {
+          this._setDocUpdatedAt();
+        })
+      );
+
       this._linkedDocMode = this._rootService.docModeService.getMode(
         this.model.pageId
       );
@@ -409,7 +422,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
           ? 'Preview of the doc will be displayed here.'
           : '';
 
-    const dateText = this._docUpdatedAt.toLocaleTimeString();
+    const dateText = this._docUpdatedAt.toLocaleString();
 
     const showDefaultBanner = isDeleted || isEmpty;
 

--- a/packages/blocks/src/embed-synced-doc-block/components/embed-synced-doc-card.ts
+++ b/packages/blocks/src/embed-synced-doc-block/components/embed-synced-doc-card.ts
@@ -193,7 +193,7 @@ export class EmbedSyncedDocCard extends WithDisposable(ShadowlessElement) {
             ? 'Preview of the page will be displayed here.'
             : '';
 
-    const dateText = this.block.docUpdatedAt.toLocaleTimeString();
+    const dateText = this.block.docUpdatedAt.toLocaleString();
 
     const showDefaultBanner = isLoading || error || isDeleted || isEmpty;
 

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -151,7 +151,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     }
 
     this._checkCycle();
-    this._docUpdatedAt = this._rootService.getDocUpdatedAt(this.model.pageId);
 
     if (!syncedDoc.loaded) {
       try {
@@ -169,6 +168,14 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     }
 
     this._loading = false;
+  }
+
+  private _setDocUpdatedAt() {
+    const meta = this.doc.collection.meta.getDocMeta(this.model.pageId);
+    if (meta) {
+      const date = meta.updatedDate || meta.createDate;
+      this._docUpdatedAt = new Date(date);
+    }
   }
 
   private _isClickAtBorder(
@@ -471,6 +478,13 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
         })
       );
     }
+
+    this._setDocUpdatedAt();
+    this.disposables.add(
+      this.doc.collection.meta.docMetaUpdated.on(() => {
+        this._setDocUpdatedAt();
+      })
+    );
 
     this._syncedDocMode = this._rootService.docModeService.getMode(
       this.model.pageId

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -120,14 +120,6 @@ export class RootService extends BlockService<RootBlockModel> {
     return viewportElement;
   }
 
-  get getDocUpdatedAt() {
-    return this._getDocUpdatedAt;
-  }
-
-  set getDocUpdatedAt(value) {
-    this._getDocUpdatedAt = value;
-  }
-
   get selectedBlocks() {
     let result: BlockElement[] = [];
     this.std.command
@@ -184,8 +176,6 @@ export class RootService extends BlockService<RootBlockModel> {
     html: HtmlTransformer,
     zip: ZipTransformer,
   };
-
-  private _getDocUpdatedAt: (docId: string) => Date = () => new Date();
 
   private _getLastNoteBlock() {
     const { doc } = this;

--- a/packages/framework/store/src/store/meta.ts
+++ b/packages/framework/store/src/store/meta.ts
@@ -11,6 +11,7 @@ export interface DocMeta {
   title: string;
   tags: string[];
   createDate: number;
+  updatedDate?: number;
 }
 
 export type Tag = {


### PR DESCRIPTION
Fix issue [BS-603](https://linear.app/affine-design/issue/BS-603).

- get `updatedDate` from doc meta data.
- Add observer for `docMetaUpdated` slot, thus the updated time on embed card can be refresh automatically.
- Use `toLocaleString` to show updated date.

https://github.com/toeverything/AFFiNE/pull/7344


https://github.com/toeverything/blocksuite/assets/12724894/eebf9a71-1961-4b81-8afd-f60c12420b13

