### PR TITLE
fix: bs-588 disable editable contents in synced block

### DIFF
--- a/packages/blocks/src/embed-synced-doc-block/styles.ts
+++ b/packages/blocks/src/embed-synced-doc-block/styles.ts
@@ -38,6 +38,10 @@ export const blockStyles = css`
     padding: 0 24px;
   }
 
+  .affine-embed-synced-doc-editor {
+    pointer-events: none;
+  }
+
   .affine-embed-synced-doc-container {
     border-radius: 8px;
     overflow: hidden;


### PR DESCRIPTION
Closes: [BS-588](https://linear.app/affine-design/issue/BS-588/embed-view%E4%B8%ADblock%E6%B2%A1%E6%9C%89%E5%85%A8%E9%83%A8%E7%A6%81%E6%AD%A2%E7%BC%96%E8%BE%91) and [BS-601](https://linear.app/affine-design/issue/BS-601/%E5%BE%80synced-block%E9%87%8C%E9%9D%A2%E6%8B%96%E5%86%85%E5%AE%B9%E7%BB%99%E5%87%BA%E4%BA%86%E8%99%9A%E5%81%87%E7%9A%84%E5%8F%AF%E7%BC%96%E8%BE%91%E6%89%BF%E8%AF%BA).

Add `pointer-events: none` to the synced editor host to prevent active and selected status triggered by pointer events.