### PR TITLE
fix: error linked doc card view UI

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/styles.ts
+++ b/packages/blocks/src/embed-linked-doc-block/styles.ts
@@ -107,6 +107,7 @@ export const styles = css`
     line-height: 20px;
   }
 
+  .affine-embed-linked-doc-card-content-reload,
   .affine-embed-linked-doc-content-date {
     display: flex;
     height: 20px;
@@ -115,6 +116,34 @@ export const styles = css`
     gap: 8px;
     width: max-content;
     max-width: 100%;
+    line-height: 20px;
+  }
+
+  .affine-embed-linked-doc-card-content-reload-button {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+  }
+  .affine-embed-linked-doc-card-content-reload-button svg {
+    width: 12px;
+    height: 12px;
+    fill: var(--affine-background-primary-color);
+  }
+  .affine-embed-linked-doc-card-content-reload-button > span {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    word-break: break-all;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--affine-brand-color);
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-xs);
+    font-style: normal;
+    font-weight: 500;
     line-height: 20px;
   }
 
@@ -179,7 +208,7 @@ export const styles = css`
     }
   }
 
-  .affine-embed-linked-doc-block:not(.loading):not(.deleted):not(
+  .affine-embed-linked-doc-block:not(.loading):not(.deleted):not(.error):not(
       .empty
     ).banner-empty {
     .affine-embed-linked-doc-content {
@@ -195,6 +224,7 @@ export const styles = css`
       display: none;
     }
   }
+  .affine-embed-linked-doc-block:not(.loading).error,
   .affine-embed-linked-doc-block:not(.loading).deleted {
     background: var(--affine-background-secondary-color);
 
@@ -287,8 +317,8 @@ export const styles = css`
     }
   }
   .affine-embed-linked-doc-block.vertical:not(.loading):not(.deleted):not(
-      .empty
-    ).banner-empty {
+      .error
+    ):not(.empty).banner-empty {
     .affine-embed-linked-doc-content {
       width: 100%;
       height: 100%;

--- a/packages/blocks/src/embed-linked-doc-block/utils.ts
+++ b/packages/blocks/src/embed-linked-doc-block/utils.ts
@@ -5,8 +5,13 @@ import {
   EmbedEdgelessIcon,
   EmbedPageIcon,
   LightLoadingIcon,
+  ReloadIcon,
 } from '../_common/icons/text.js';
 import { getThemeMode } from '../_common/utils/query.js';
+import {
+  DarkSyncedDocErrorBanner,
+  LightSyncedDocErrorBanner,
+} from '../embed-synced-doc-block/styles.js';
 import type { EmbedLinkedDocStyles } from './embed-linked-doc-model.js';
 import {
   DarkLinkedEdgelessDeletedLargeBanner,
@@ -30,10 +35,12 @@ import {
 
 type EmbedCardImages = {
   LoadingIcon: TemplateResult<1>;
+  ReloadIcon: TemplateResult<1>;
   LinkedDocIcon: TemplateResult<1>;
   LinkedDocDeletedIcon: TemplateResult<1>;
   LinkedDocEmptyBanner: TemplateResult<1>;
   LinkedDocDeletedBanner: TemplateResult<1>;
+  SyncedDocErrorBanner: TemplateResult<1>;
 };
 
 export function getEmbedLinkedDocIcons(
@@ -46,6 +53,7 @@ export function getEmbedLinkedDocIcons(
     if (theme === 'light') {
       return {
         LoadingIcon: LightLoadingIcon,
+        ReloadIcon,
         LinkedDocIcon: EmbedPageIcon,
         LinkedDocDeletedIcon,
         LinkedDocEmptyBanner: small
@@ -54,9 +62,11 @@ export function getEmbedLinkedDocIcons(
         LinkedDocDeletedBanner: small
           ? LightLinkedPageDeletedSmallBanner
           : LightLinkedPageDeletedLargeBanner,
+        SyncedDocErrorBanner: LightSyncedDocErrorBanner,
       };
     } else {
       return {
+        ReloadIcon,
         LoadingIcon: DarkLoadingIcon,
         LinkedDocIcon: EmbedPageIcon,
         LinkedDocDeletedIcon,
@@ -66,11 +76,13 @@ export function getEmbedLinkedDocIcons(
         LinkedDocDeletedBanner: small
           ? DarkLinkedPageDeletedSmallBanner
           : DarkLinkedPageDeletedLargeBanner,
+        SyncedDocErrorBanner: DarkSyncedDocErrorBanner,
       };
     }
   } else {
     if (theme === 'light') {
       return {
+        ReloadIcon,
         LoadingIcon: LightLoadingIcon,
         LinkedDocIcon: EmbedEdgelessIcon,
         LinkedDocDeletedIcon,
@@ -80,9 +92,11 @@ export function getEmbedLinkedDocIcons(
         LinkedDocDeletedBanner: small
           ? LightLinkedEdgelessDeletedSmallBanner
           : LightLinkedEdgelessDeletedLargeBanner,
+        SyncedDocErrorBanner: LightSyncedDocErrorBanner,
       };
     } else {
       return {
+        ReloadIcon,
         LoadingIcon: DarkLoadingIcon,
         LinkedDocIcon: EmbedEdgelessIcon,
         LinkedDocDeletedIcon,
@@ -92,6 +106,7 @@ export function getEmbedLinkedDocIcons(
         LinkedDocDeletedBanner: small
           ? DarkLinkedEdgelessDeletedSmallBanner
           : DarkLinkedEdgelessDeletedLargeBanner,
+        SyncedDocErrorBanner: DarkSyncedDocErrorBanner,
       };
     }
   }


### PR DESCRIPTION
Fix issie [BS-663](https://linear.app/affine-design/issue/BS-663). Add error card style for linked doc card.

Loading Card:
| Light Mode   | Dark Mode  |
|  ----  | ----  |
| <img width="1761" alt="截屏2024-06-27 15 09 41" src="https://github.com/toeverything/blocksuite/assets/12724894/e1646dee-30c5-4a4a-a3fa-73fc7ca3bc94">|<img width="1661" alt="截屏2024-06-27 15 10 08" src="https://github.com/toeverything/blocksuite/assets/12724894/0b8553cd-aaa1-4e60-831f-d7319ea9e301">|
| <img width="1784" alt="截屏2024-06-27 15 09 22" src="https://github.com/toeverything/blocksuite/assets/12724894/0ea69b59-ecca-491b-8ad0-b8c1cda3c032">|<img width="1660" alt="截屏2024-06-27 15 10 16" src="https://github.com/toeverything/blocksuite/assets/12724894/0d93a059-eb1f-4da8-86cc-a47f1a0d93a6">|

Error Card:
| Light Mode   | Dark Mode  |
|  ----  | ----  |
| <img width="1766" alt="截屏2024-06-27 15 08 28" src="https://github.com/toeverything/blocksuite/assets/12724894/148c13c1-f6a6-4a31-ba06-31a48c48a180"> | <img width="1809" alt="截屏2024-06-27 15 07 47" src="https://github.com/toeverything/blocksuite/assets/12724894/57484bfa-edc2-439e-aff0-ef9efa3d4332"> |
| <img width="1756" alt="截屏2024-06-27 15 09 07" src="https://github.com/toeverything/blocksuite/assets/12724894/4c47fec2-b675-4d6b-b1ce-03757524e45a">  | <img width="1798" alt="截屏2024-06-27 15 07 59" src="https://github.com/toeverything/blocksuite/assets/12724894/abd4ce52-1923-45aa-972b-7a6ec7ef0fe8"> |