### PR TITLE
fix: bs-644 nested synced doc can have one depth at most

### DIFF
--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -96,6 +96,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
   };
 
   @state()
+  accessor depth = 0;
+
+  @state()
   private accessor _syncedDocMode: DocMode = 'page';
 
   @state()
@@ -210,6 +213,35 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     this._selectBlock();
   }
 
+  private _buildPreviewSpec = (name: 'page:preview' | 'edgeless:preview') => {
+    const nextDepth = this.depth + 1;
+    const previewSpecBuilder = SpecProvider.getInstance().getSpec(name);
+    const currentDisposables = this.disposables;
+
+    previewSpecBuilder.setup(
+      'affine:embed-synced-doc',
+      (slots, disposableGroup) => {
+        disposableGroup.add(
+          slots.viewConnected.on(({ component }) => {
+            const nextComponent = component as EmbedSyncedDocBlockComponent;
+            nextComponent.depth = nextDepth;
+            currentDisposables.add(() => {
+              nextComponent.depth = 0;
+            });
+          })
+        );
+        disposableGroup.add(
+          slots.viewDisconnected.on(({ component }) => {
+            const nextComponent = component as EmbedSyncedDocBlockComponent;
+            nextComponent.depth = 0;
+          })
+        );
+      }
+    );
+
+    return previewSpecBuilder.value;
+  };
+
   private _renderSyncedView = () => {
     const syncedDoc = this.syncedDoc;
     const isInSurface = this.isInSurface;
@@ -258,7 +290,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
             <div class="affine-page-viewport">
               ${this.host.renderSpecPortal(
                 syncedDoc,
-                SpecProvider.getInstance().getSpec('page:preview').value
+                this._buildPreviewSpec('page:preview')
               )}
             </div>
           `,
@@ -269,7 +301,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
             <div class="affine-edgeless-viewport">
               ${this.host.renderSpecPortal(
                 syncedDoc,
-                SpecProvider.getInstance().getSpec('edgeless:preview').value
+                this._buildPreviewSpec('edgeless:preview')
               )}
             </div>
           `,
@@ -550,8 +582,16 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     const syncedDoc = this.syncedDoc;
     const { isLoading, isError, isDeleted, isCycle } = this.blockState;
     const isInSurface = this.isInSurface;
+    const isCardOnly = this.depth >= 1;
 
-    if (isLoading || isError || isDeleted || isCycle || !syncedDoc) {
+    if (
+      isLoading ||
+      isError ||
+      isDeleted ||
+      isCardOnly ||
+      isCycle ||
+      !syncedDoc
+    ) {
       let cardStyleMap = styleMap({
         position: 'relative',
         display: 'block',

--- a/packages/blocks/src/specs/utils/spec-builder.ts
+++ b/packages/blocks/src/specs/utils/spec-builder.ts
@@ -12,16 +12,22 @@ export class SpecBuilder {
     return this._value;
   }
 
-  setup(
-    flavour: BlockSuite.Flavour,
-    setup: (slots: BlockSpecSlots, disposableGroup: DisposableGroup) => void
+  setup<Flavour extends BlockSuite.ServiceKeys>(
+    flavour: Flavour,
+    setup: (
+      slots: BlockSpecSlots<BlockSuite.BlockServices[Flavour]>,
+      disposableGroup: DisposableGroup
+    ) => void
   ) {
     const spec = this._value.find(s => s.schema.model.flavour === flavour);
     assertExists(spec, `BlockSpec not found for ${flavour}`);
     const oldSetup = spec.setup;
     spec.setup = (slots, disposableGroup) => {
       oldSetup?.(slots, disposableGroup);
-      setup(slots, disposableGroup);
+      setup(
+        slots as unknown as BlockSpecSlots<BlockSuite.BlockServices[Flavour]>,
+        disposableGroup
+      );
     };
   }
 }

--- a/tests/embed-synced-doc.spec.ts
+++ b/tests/embed-synced-doc.spec.ts
@@ -142,6 +142,69 @@ test.describe('Embed synced doc', () => {
     expect(EmbedSyncedDocPortalBox.height).toBeCloseTo(height + border, 1);
   });
 
+  test('nested embed synced doc should be rendered as card when depth >=1', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const { doc, collection } = window;
+      const rootId = doc.addBlock('affine:page', {
+        title: new doc.Text(),
+      });
+
+      const noteId = doc.addBlock('affine:note', {}, rootId);
+      doc.addBlock('affine:paragraph', {}, noteId);
+
+      const doc2 = collection.createDoc({ id: 'doc2' });
+      doc2.load();
+      const rootId2 = doc2.addBlock('affine:page', {
+        title: new doc.Text('Doc 2'),
+      });
+
+      const noteId2 = doc2.addBlock('affine:note', {}, rootId2);
+      doc2.addBlock(
+        'affine:paragraph',
+        {
+          text: new doc.Text('Hello from Doc 2'),
+        },
+        noteId2
+      );
+
+      const doc3 = collection.createDoc({ id: 'doc3' });
+      doc3.load();
+      const rootId3 = doc3.addBlock('affine:page', {
+        title: new doc.Text('Doc 3'),
+      });
+
+      const noteId3 = doc3.addBlock('affine:note', {}, rootId3);
+      doc3.addBlock(
+        'affine:paragraph',
+        {
+          text: new doc.Text('Hello from Doc 3'),
+        },
+        noteId3
+      );
+
+      doc2.addBlock(
+        'affine:embed-synced-doc',
+        {
+          pageId: 'doc3',
+        },
+        noteId2
+      );
+      doc.addBlock(
+        'affine:embed-synced-doc',
+        {
+          pageId: 'doc2',
+        },
+        noteId
+      );
+    });
+    expect(await page.locator('affine-embed-synced-doc-block').count()).toBe(2);
+    expect(await page.locator('affine-paragraph').count()).toBe(2);
+    expect(await page.locator('affine-embed-synced-doc-card').count()).toBe(1);
+    expect(await page.locator('editor-host').count()).toBe(2);
+  });
+
   test.describe('synced doc should be readonly', () => {
     test('synced doc should be readonly', async ({ page }) => {
       await initEmptyParagraphState(page);


### PR DESCRIPTION
Closes: [BS-644](https://linear.app/affine-design/issue/BS-644/%E6%9C%AA%E5%A4%84%E7%90%86%E5%A4%9A%E5%B1%82%E5%B5%8C%E5%A5%97%E7%9A%84%E9%97%AE%E9%A2%98%EF%BC%88%E5%8F%AA%E4%B8%8B%E9%92%BB%E4%B8%80%E5%B1%82%EF%BC%89)

Add a state to control the depth of nested synced block.

@akumatus We may need a better solution to communicate between editors.