### PR TITLE
fix(blocks): support azerty keyboard layout for slashmenu

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -104,7 +104,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
   config = AffineSlashMenuWidget.DEFAULT_CONFIG;
 
   private _getTriggerKey = (event: KeyboardEvent) => {
-    if (isControlledKeyboardEvent(event) || event.shiftKey) return undefined;
+    if (isControlledKeyboardEvent(event)) return undefined;
 
     const { triggerKeys } = this.config;
 


### PR DESCRIPTION
Remove <kbd>Shift</kbd> in slash menu trigger detection.

According to https://en.wikipedia.org/wiki/Keyboard_layout, there are some keyboard layouts that require the <kbd>Shift</kbd> key to input a slash character.

This case can not be easily tested by playwright since keyboard layout managered by system.


Before (test AZERTY):

https://github.com/toeverything/blocksuite/assets/20479050/224e2907-5b99-4c73-8568-af2ff9b3c8e4

After (test QWERT and AZERTY):

https://github.com/toeverything/blocksuite/assets/20479050/6f45912a-6c79-439d-ae81-d5c73c0e1274

