### PR TITLE
fix(blocks): rich-text can't redo since pressing shift causes e.key to be uppercase

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text.ts
@@ -351,7 +351,7 @@ export class RichText extends WithDisposable(ShadowlessElement) {
     if (this.enableUndoRedo) {
       this.disposables.addFromEvent(this, 'keydown', (e: KeyboardEvent) => {
         if (e.ctrlKey || e.metaKey) {
-          if (e.key === 'z') {
+          if (e.key === 'z' || e.key === 'Z') {
             if (e.shiftKey) {
               this.undoManager.redo();
             } else {


### PR DESCRIPTION
As described here https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#value.

> `If the pressed key is the B key, the returned value is the string "b". However, if the Shift key is pressed at the same time (so shiftKey is true), the returned value is the string "B"`

This means that when using the rich-text component you are unable to redo since pressing `ctrl + shift + z` makes `e.key == 'Z'`.
It also means that after pressing `CapsLock` pressing `ctrl + z` to undo doesn't work since `CapsLock` makes e.key be uppercase 'Z'.

Simple fix by accepting either lowercase or uppercase `Z`.