### PR TITLE
fix(blocks): ime compatibility of slash menu

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -121,7 +121,7 @@ export type SlashMenuContext = {
 };
 
 export const defaultSlashMenuConfig: SlashMenuConfig = {
-  triggerKeys: ['/'],
+  triggerKeys: ['/', '、'],
   ignoreBlockTypes: ['affine:code'],
   maxHeight: 344,
   tooltipTimeout: 800,

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -11,7 +11,6 @@ import { customElement } from 'lit/decorators.js';
 import {
   getCurrentNativeRange,
   getInlineEditorByModel,
-  isControlledKeyboardEvent,
   matchFlavours,
 } from '../../../_common/utils/index.js';
 import { isRootElement } from '../../utils/guard.js';
@@ -103,41 +102,12 @@ export class AffineSlashMenuWidget extends WidgetElement {
 
   config = AffineSlashMenuWidget.DEFAULT_CONFIG;
 
-  private _getTriggerKey = (event: KeyboardEvent) => {
-    if (isControlledKeyboardEvent(event)) return undefined;
+  private _onBeforeInput = (ctx: UIEventStateContext) => {
+    const eventState = ctx.get('defaultState');
+    const event = eventState.event as InputEvent;
 
-    const { triggerKeys } = this.config;
-
-    /** The case of IME input
-     * 1. under IME mode
-     * 2. Before IME start input
-     * 3. press a key
-     * 4. the pressed key in `triggerKeys`
-     */
-    let currTriggerKey: string | undefined;
-
-    if (
-      event.key === 'Process' &&
-      !event.isComposing &&
-      event.code === 'Slash' && // TODO may be not slash
-      triggerKeys.includes('/')
-    ) {
-      currTriggerKey = '/';
-    }
-    // The normal case
-    else {
-      currTriggerKey = triggerKeys.find(key => key === event.key);
-    }
-
-    return currTriggerKey;
-  };
-
-  private _onKeyDown = (ctx: UIEventStateContext) => {
-    const eventState = ctx.get('keyboardState');
-    const event = eventState.raw;
-
-    const triggerKey = this._getTriggerKey(event);
-    if (!triggerKey) return;
+    const triggerKey = event.data;
+    if (!triggerKey || !this.config.triggerKeys.includes(triggerKey)) return;
 
     const textSelection = this.host.selection.find('text');
     if (!textSelection) return;
@@ -189,7 +159,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
       throw new Error('Trigger key of slash menu should not be empty string');
     }
 
-    this.handleEvent('keyDown', this._onKeyDown);
+    this.handleEvent('beforeInput', this._onBeforeInput);
   }
 }
 

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -42,6 +42,22 @@ test.describe('slash menu should show and hide correctly', () => {
     await enterPlaygroundRoom(page);
   });
 
+  test("slash menu should show when user input '/'", async ({ page }) => {
+    await initEmptyParagraphState(page);
+    const slashMenu = page.locator(`.slash-menu`);
+    await focusRichText(page);
+    await type(page, '/');
+    await expect(slashMenu).toBeVisible();
+  });
+
+  test("slash menu should show when user input '、'", async ({ page }) => {
+    await initEmptyParagraphState(page);
+    const slashMenu = page.locator(`.slash-menu`);
+    await focusRichText(page);
+    await type(page, '、');
+    await expect(slashMenu).toBeVisible();
+  });
+
   test('slash menu should hide after click away', async ({ page }) => {
     const id = await initEmptyParagraphState(page);
     const paragraphId = id.paragraphId;


### PR DESCRIPTION
Closes:  #7451

## What changes
Use the `beforeInput` event instead of the `keyDown` event, as the latter cannot capture the actual input character when IME are active. For example, when pressing <kbd>/</kbd> with Sogou IME, the actual character input is `、`, but at this time `event.key` is equal to `Process`.

After using the `beforeInput` event, there is no need to check whether various modifier keys are pressed, such as in non-English keyboard layouts, like the French keyboard (`Shift + Slash = /`) and the German keyboard (`Shift + 7 = /`).

However, in the new implementation with Chinese IME actived, pressing<kbd> \ </kbd> key also tirgger slash menu becasue of `、` inputed.

## Test cases
- [x] Update a playwright test cases for '、'
- [x] Test on `fr` and `de` keyboard layout manually
- [x] Test on Microsoft Pinyin and Sougou Pinyin manually
- [x] Test mobile browser manually
  - [x] Andorid Chrome (known issue: can not close slash menu by pressing backspace)
  - [x] IOS Chrome & Safari