### PR TITLE
fix: cursor moves out of blocks with multiple lines when using arrow keys

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -113,6 +113,20 @@ export const bindContainerHotkey = (blockElement: BlockElement) => {
   };
 
   blockElement.bindHotKey({
+    ArrowUp: () => {
+      if (!blockElement.selected?.is('text')) return false;
+
+      const inlineEditor = _getInlineEditor();
+      const inlineRange = inlineEditor.getInlineRange();
+      return !inlineEditor.isFirstLine(inlineRange);
+    },
+    ArrowDown: () => {
+      if (!blockElement.selected?.is('text')) return false;
+
+      const inlineEditor = _getInlineEditor();
+      const inlineRange = inlineEditor.getInlineRange();
+      return !inlineEditor.isLastLine(inlineRange);
+    },
     Escape: () => {
       if (blockElement.selected?.is('text')) {
         return _selectBlock();

--- a/packages/framework/inline/src/services/range.ts
+++ b/packages/framework/inline/src/services/range.ts
@@ -237,11 +237,7 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
    * 2. soft break
    */
   isFirstLine = (inlineRange: InlineRange | null): boolean => {
-    if (!inlineRange) return false;
-
-    if (inlineRange.length > 0) {
-      throw new Error('Inline range should be collapsed');
-    }
+    if (!inlineRange || inlineRange.length > 0) return false;
 
     const range = this.toDomRange(inlineRange);
     if (!range) {
@@ -272,7 +268,8 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
     // We use last rect here to make sure we get the second rect.
     // (Based on the assumption that the cursor can not in the first line)
     const rangeRect = rangeRects[rangeRects.length - 1];
-    return rangeRect.top === containerRect.top;
+    const tolerance = 1;
+    return Math.abs(rangeRect.top - containerRect.top) < tolerance;
   };
 
   /**
@@ -281,11 +278,7 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
    * 2. soft break
    */
   isLastLine = (inlineRange: InlineRange | null): boolean => {
-    if (!inlineRange) return false;
-
-    if (inlineRange.length > 0) {
-      throw new Error('Inline range should be collapsed');
-    }
+    if (!inlineRange || inlineRange.length > 0) return false;
 
     // check case 1:
     const afterText = this.editor.yTextString.slice(inlineRange.index);
@@ -304,7 +297,7 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
     // aaaaaaaa| or aaaaaaaa
     // bb           |bb
     // We have no way to distinguish them and we just assume that the cursor
-    // can not in the first line because if we apply the inline ranage manually the
+    // can not in the first line because if we apply the inline range manually the
     // cursor will jump to the second line.
     const container = range.commonAncestorContainer.parentElement;
     assertExists(container);
@@ -314,13 +307,15 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
     // bb           |bb
     const rangeRects = range.getClientRects();
     // We use last rect here to make sure we get the second rect.
-    // (Based on the assumption that the cursor can not in the first line)
+    // (Based on the assumption that the cursor can not be in the first line)
     const rangeRect = rangeRects[rangeRects.length - 1];
-    return rangeRect.bottom === containerRect.bottom;
+
+    const tolerance = 1;
+    return Math.abs(rangeRect.bottom - containerRect.bottom) < tolerance;
   };
 
   /**
-   * the inline ranage is synced to the native selection asynchronically
+   * the inline range is synced to the native selection asynchronously
    * if sync is true, the native selection will be synced immediately
    */
   setInlineRange = (inlineRange: InlineRange | null, sync = true): void => {

--- a/tests/hotkey.spec.ts
+++ b/tests/hotkey.spec.ts
@@ -19,6 +19,7 @@ import {
   pressArrowUp,
   pressEnter,
   pressForwardDelete,
+  pressShiftEnter,
   pressShiftTab,
   pressTab,
   readClipboardText,
@@ -37,6 +38,7 @@ import {
 } from './utils/actions/index.js';
 import {
   assertBlockChildrenIds,
+  assertBlockSelections,
   assertRichTextInlineRange,
   assertRichTextModelType,
   assertRichTexts,
@@ -1155,6 +1157,31 @@ test('should ctrl+enter create new block', async ({ page }) => {
   await assertRichTexts(page, ['1', '23']);
   await page.keyboard.press(`${SHORT_KEY}+Enter`);
   await assertRichTexts(page, ['1', '23', '']);
+});
+
+test('arrow up and down behavior on multiline text blocks when previous is non-text', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  await pressEnter(page);
+  await pressArrowUp(page);
+  await type(page, '--- ');
+  await pressEnter(page);
+
+  await focusRichText(page);
+  await type(page, '124');
+  await pressShiftEnter(page);
+  await type(page, '1234');
+
+  await pressArrowUp(page);
+  await waitNextFrame(page, 100);
+  await assertRichTextInlineRange(page, 0, 3);
+
+  await pressArrowUp(page);
+  await assertBlockSelections(page, ['4']);
 });
 
 test.describe('bracket auto complete', () => {


### PR DESCRIPTION
Close [BS-648](https://linear.app/affine-design/issue/BS-648/cursor-unexpectedly-moves-out-of-code-block-when-using-up-arrow-key)

- [x] add tests