### PR TITLE
fix: empty linked doc display

### DIFF
--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -255,7 +255,6 @@ async function renderNoteContent(
   if (!notes) {
     return;
   }
-  card.isNoteContentEmpty = false;
 
   const noteChildren = notes.flatMap(note =>
     note.children.filter(filterTextModel)
@@ -264,6 +263,8 @@ async function renderNoteContent(
   if (!noteChildren.length) {
     return;
   }
+
+  card.isNoteContentEmpty = false;
 
   const cardStyle = card.model.style;
 


### PR DESCRIPTION
Set `isNoteContentEmpty` after `filterTextModel` logic, which is more accurate to the content displayed.

|   | Page  | Edgeless  | 
|  ----  | ----  | ----  |
| Linked Page  | <img width="1035" alt="截屏2024-07-02 10 45 38" src="https://github.com/toeverything/blocksuite/assets/12724894/f38cac45-4e28-452b-81f3-f3426287a17c"> |<img width="867" alt="截屏2024-07-02 10 46 11" src="https://github.com/toeverything/blocksuite/assets/12724894/1cb52983-3978-4b37-99fa-661ba19fcf79"> |
| Linked Edgeless | <img width="978" alt="截屏2024-07-02 10 47 40" src="https://github.com/toeverything/blocksuite/assets/12724894/c847712c-4a5d-44a4-9554-fbc4c2fa29a9">|<img width="941" alt="截屏2024-07-02 10 47 50" src="https://github.com/toeverything/blocksuite/assets/12724894/b4a0ff74-309b-4194-9857-d46d6e83e330">|
