### PR TITLE
fix(examples): provider init pattern and sqlite deps

### DIFF
--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -284,8 +284,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       sql.js:
-        specifier: ^1.10.3
-        version: 1.10.3
+        specifier: 1.10.2
+        version: 1.10.2
     devDependencies:
       '@types/react':
         specifier: ^18.3.2
@@ -492,9 +492,6 @@ importers:
       '@blocksuite/store':
         specifier: 0.15.0-canary-202406291027-8aed732
         version: 0.15.0-canary-202406291027-8aed732(lit@3.1.4)(yjs@13.6.15)
-      sql.js:
-        specifier: ^1.10.3
-        version: 1.10.3
       vue:
         specifier: ^3.4.27
         version: 3.4.27(typescript@5.4.5)
@@ -5937,8 +5934,8 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
-  sql.js@1.10.3:
-    resolution: {integrity: sha512-H46aWtQkdyjZwFQgraUruy5h/DyJBbAK3EA/WEMqiqF6PGPfKBSKBj/er3dVyYqVIoYfRf5TFM/loEjtQIrqJg==}
+  sql.js@1.10.2:
+    resolution: {integrity: sha512-jnKFtdHxuVUNgu1vHwFoTjjwfTuVDVqzGpw7H05Zq3YMNMDOpLFyFGvpgTRIQGd/mqcYntuMy7iygYCytD62jQ==}
 
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
@@ -13187,7 +13184,7 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
-  sql.js@1.10.3: {}
+  sql.js@1.10.2: {}
 
   ssri@10.0.6:
     dependencies:

--- a/examples/react-indexeddb/src/editor/provider/provider.ts
+++ b/examples/react-indexeddb/src/editor/provider/provider.ts
@@ -20,6 +20,7 @@ export class CollectionProvider {
     const id = `${Math.random()}`.slice(2, 12);
     provider.collection = createCollection(id);
     provider._connectCollection();
+    provider.collection.meta.initialize();
 
     await client.insertRoot(id);
     createFirstDoc(provider.collection);
@@ -81,7 +82,6 @@ function createCollection(id: string): DocCollection {
       main: new ClientBlobSource(),
     },
   });
-  collection.meta.initialize();
   return collection;
 }
 

--- a/examples/react-sqlite/package.json
+++ b/examples/react-sqlite/package.json
@@ -16,7 +16,7 @@
     "@blocksuite/sync": "0.15.0-canary-202406291027-8aed732",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sql.js": "^1.10.3"
+    "sql.js": "1.10.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.2",

--- a/examples/react-sqlite/src/editor/provider/provider.ts
+++ b/examples/react-sqlite/src/editor/provider/provider.ts
@@ -36,7 +36,6 @@ function createCollection(db: Database, id: string) {
       main: new ClientBlobSource(),
     },
   });
-  collection.meta.initialize();
   return collection;
 }
 
@@ -78,6 +77,8 @@ export class CollectionProvider {
     const id = `${Math.random()}`.slice(2, 12);
     provider.collection = createCollection(db, id);
     provider._connectCollection();
+    provider.collection.meta.initialize();
+
     client.insertRoot(db, id);
     createFirstDoc(provider.collection);
     return provider;
@@ -128,3 +129,7 @@ export class CollectionProvider {
     });
   }
 }
+
+export const provider = await CollectionProvider.init();
+// @ts-expect-error dev
+window.provider = provider;

--- a/examples/react-sqlite/src/editor/provider/provider.ts
+++ b/examples/react-sqlite/src/editor/provider/provider.ts
@@ -129,7 +129,3 @@ export class CollectionProvider {
     });
   }
 }
-
-export const provider = await CollectionProvider.init();
-// @ts-expect-error dev
-window.provider = provider;

--- a/examples/vanilla-indexeddb/src/main.ts
+++ b/examples/vanilla-indexeddb/src/main.ts
@@ -8,6 +8,8 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 
 const schema = new Schema().register(AffineSchemas);
 const collection = new DocCollection({ schema });
+collection.meta.initialize();
+
 const doc = collection.createDoc();
 const editor = new AffineEditorContainer();
 editor.doc = doc;

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -12,7 +12,6 @@
     "@blocksuite/blocks": "0.15.0-canary-202406291027-8aed732",
     "@blocksuite/presets": "0.15.0-canary-202406291027-8aed732",
     "@blocksuite/store": "0.15.0-canary-202406291027-8aed732",
-    "sql.js": "^1.10.3",
     "vue": "^3.4.27"
   },
   "devDependencies": {


### PR DESCRIPTION
Following #7455, this PR fixes following examples:

- `react-indexeddb`
- `react-sqlite`
- `vanilla-indexeddb`

The `react-sqlite` fix requires rolling back to `1.10.2`.