### PR TITLE
docs: switch to stackblitz for online examples

### DIFF
--- a/examples/angular-basic/package.json
+++ b/examples/angular-basic/package.json
@@ -40,7 +40,6 @@
     "typescript": "~5.4.5"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/preact-basic/package.json
+++ b/examples/preact-basic/package.json
@@ -20,7 +20,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/react-basic-next/package.json
+++ b/examples/react-basic-next/package.json
@@ -23,5 +23,8 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",
     "typescript": "^5.4.5"
+  },
+  "stackblitz": {
+    "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/react-basic/package.json
+++ b/examples/react-basic/package.json
@@ -30,7 +30,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/react-indexeddb/package.json
+++ b/examples/react-indexeddb/package.json
@@ -31,7 +31,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/react-sqlite/package.json
+++ b/examples/react-sqlite/package.json
@@ -32,7 +32,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/react-websocket/package.json
+++ b/examples/react-websocket/package.json
@@ -43,7 +43,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/solid-basic/package.json
+++ b/examples/solid-basic/package.json
@@ -20,7 +20,6 @@
     "vite-plugin-solid": "^2.10.2"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/svelte-basic/package.json
+++ b/examples/svelte-basic/package.json
@@ -24,7 +24,6 @@
     "vite": "^5.2.11"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/vanilla-indexeddb/package.json
+++ b/examples/vanilla-indexeddb/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "typescript": "^5.4.5",
     "vite": "^5.2.11"
+  },
+  "stackblitz": {
+    "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/examples/vue-basic/package.json
+++ b/examples/vue-basic/package.json
@@ -21,7 +21,6 @@
     "vue-tsc": "^2.0.17"
   },
   "stackblitz": {
-    "installDependencies": false,
     "startCommand": "pnpm i && pnpm dev"
   }
 }

--- a/packages/docs/guide/quick-start.md
+++ b/packages/docs/guide/quick-start.md
@@ -18,7 +18,7 @@ BlockSuite works with all common frameworks, you can start from these examples t
   </tr>
   <tr>
     <td><Icon name="TypeScript" />Vanilla</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/vanilla-indexeddb" target="_blank">vanilla-indexeddb</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/vanilla-indexeddb" target="_blank">vanilla-indexeddb</a></td>
     <td>✅</td>
   </tr>
   <tr>
@@ -28,12 +28,12 @@ BlockSuite works with all common frameworks, you can start from these examples t
   </tr>
   <tr>
     <td><Icon name="React" />React</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/react-basic" target="_blank">react-basic</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/react-basic" target="_blank">react-basic</a></td>
     <td>✅</td>
   </tr>
   <tr>
     <td><Icon name="Vue" />Vue</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/vue-basic" target="_blank">vue-basic</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/vue-basic" target="_blank">vue-basic</a></td>
     <td>✅</td>
   </tr>
   <tr>
@@ -43,17 +43,17 @@ BlockSuite works with all common frameworks, you can start from these examples t
   </tr>
   <tr>
     <td><Icon name="Preact" icon="https://raw.githubusercontent.com/preactjs/preact-www/master/src/assets/branding/symbol.svg" />Preact</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/preact-basic" target="_blank">preact-basic</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/preact-basic" target="_blank">preact-basic</a></td>
     <td>✅</td>
   </tr>
   <tr>
     <td><Icon name="Svelte" />Svelte</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/svelte-basic" target="_blank">svelte-basic</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/svelte-basic" target="_blank">svelte-basic</a></td>
     <td>✅</td>
   </tr>
   <tr>
     <td><Icon name="Solid" icon="https://www.solidjs.com/img/favicons/favicon-32x32.png" />Solid</td>
-    <td><a href="https://github.com/toeverything/blocksuite/tree/master/examples/solid-basic" target="_blank">solid-basic</a></td>
+    <td><a href="https://stackblitz.com/github/toeverything/blocksuite/tree/master/examples/solid-basic" target="_blank">solid-basic</a></td>
     <td>✅</td>
   </tr>
 </table>


### PR DESCRIPTION
Remaining examples that are not compatible with StackBlitz yet:

* `react-basic-next`
* `angular-basic`
