### PR TITLE
fix(edgeless): dragging area of shape tool is null

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
@@ -272,9 +272,10 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
 
   onPressSpaceBar(pressed: boolean): void {
     const { tools } = this._edgeless;
-    assertExists(this._draggingArea);
     if (tools.dragging) {
       if (pressed) {
+        assertExists(this._draggingArea);
+
         const x = this._draggingArea.end.x;
         const y = this._draggingArea.end.y;
         this._moveWithSpaceStartPos = [x, y];


### PR DESCRIPTION
Dragging area is null when switch to edgeless mode firstly.

https://github.com/toeverything/blocksuite/assets/20479050/df5cbceb-0f44-4e5a-9db4-a9dbc9d7c448

