### PR TITLE
feat(edgeless): support using last props for edgeless text

### DIFF
--- a/packages/blocks/src/edgeless-text/edgeless-text-service.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-service.ts
@@ -1,9 +1,7 @@
 import { BlockService } from '@blocksuite/block-std';
 
 import { asyncFocusRichText } from '../_common/utils/selection.js';
-import { GET_DEFAULT_TEXT_COLOR } from '../root-block/edgeless/components/panel/color-panel.js';
 import type { EdgelessRootBlockComponent } from '../root-block/index.js';
-import { FontFamily } from '../surface-block/consts.js';
 import { Bound } from '../surface-block/utils/bound.js';
 import {
   EDGELESS_TEXT_BLOCK_MIN_HEIGHT,
@@ -31,8 +29,6 @@ export class EdgelessTextBlockService extends BlockService<EdgelessTextBlockMode
           EDGELESS_TEXT_BLOCK_MIN_WIDTH * zoom,
           EDGELESS_TEXT_BLOCK_MIN_HEIGHT * zoom
         ).serialize(),
-        color: GET_DEFAULT_TEXT_COLOR(),
-        fontFamily: FontFamily.Kalam,
       },
       edgeless.surface.blockId
     );

--- a/packages/blocks/src/embed-html-block/components/fullscreen-toolbar.ts
+++ b/packages/blocks/src/embed-html-block/components/fullscreen-toolbar.ts
@@ -12,14 +12,14 @@ import { DoneIcon } from './../../_common/icons/index.js';
 export class EmbedHtmlFullscreenToolbar extends LitElement {
   private get autoHideToolbar() {
     return (
-      this.embedHtml.edgeless?.service.editPropsStore.getItem(
+      this.embedHtml.edgeless?.service.editPropsStore.getStorage(
         'autoHideEmbedHTMLFullScreenToolbar'
       ) ?? false
     );
   }
 
   private set autoHideToolbar(val: boolean) {
-    this.embedHtml.edgeless?.service.editPropsStore.setItem(
+    this.embedHtml.edgeless?.service.editPropsStore.setStorage(
       'autoHideEmbedHTMLFullScreenToolbar',
       val
     );

--- a/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
@@ -230,7 +230,7 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
     if (!this.edgeless) return;
 
     this.fillScreen =
-      this.edgeless.service.editPropsStore.getItem('presentFillScreen') ??
+      this.edgeless.service.editPropsStore.getStorage('presentFillScreen') ??
       false;
   }
 

--- a/packages/blocks/src/root-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
+++ b/packages/blocks/src/root-block/edgeless/components/presentation/edgeless-navigator-black-background.ts
@@ -32,7 +32,7 @@ export class EdgelessNavigatorBlackBackground extends WithDisposable(
   accessor edgeless!: EdgelessRootBlockComponent;
 
   private _tryLoadBlackBackground() {
-    const value = this.edgeless.service.editPropsStore.getItem(
+    const value = this.edgeless.service.editPropsStore.getStorage(
       'presentBlackBackground'
     );
     this._blackBackground = value ?? true;
@@ -49,7 +49,7 @@ export class EdgelessNavigatorBlackBackground extends WithDisposable(
     _disposables.add(
       edgeless.slots.navigatorSettingUpdated.on(({ blackBackground }) => {
         if (blackBackground !== undefined) {
-          this.edgeless.service.editPropsStore.setItem(
+          this.edgeless.service.editPropsStore.setStorage(
             'presentBlackBackground',
             blackBackground
           );

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -70,7 +70,7 @@ export class EdgelessBrushToolButton extends EdgelessToolbarToolMixin(
     Object.assign(menu.element, {
       edgeless: this.edgeless,
       onChange: (props: Record<string, unknown>) => {
-        this.edgeless.service.editPropsStore.record('brush', props);
+        this.edgeless.service.editPropsStore.recordLastProps('brush', props);
         this.setEdgelessTool({ type: 'brush' });
       },
     });

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/common/observe-last-props.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/common/observe-last-props.ts
@@ -1,7 +1,10 @@
-import type { LastProps } from '../../../../../surface-block/managers/edit-session.js';
+import type {
+  LastProps,
+  LastPropsKey,
+} from '../../../../../surface-block/managers/edit-session.js';
 import type { EdgelessRootService } from '../../../edgeless-root-service.js';
 
-export const observeLastProps = <T extends keyof LastProps>(
+export const observeLastProps = <T extends LastPropsKey>(
   edgelessService: EdgelessRootService,
   toolType: T,
   fields: Array<keyof LastProps[T]>,
@@ -28,7 +31,7 @@ export const observeLastProps = <T extends keyof LastProps>(
   );
 };
 
-export const applyLastProps = <T extends keyof LastProps>(
+export const applyLastProps = <T extends LastPropsKey>(
   service: EdgelessRootService,
   toolType: T,
   fields: Array<keyof LastProps[T]>,

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-dense-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-dense-menu.ts
@@ -18,7 +18,8 @@ export const buildConnectorDenseMenu: DenseMenuBuilder = edgeless => {
     (mode: ConnectorMode, record = true) =>
     () => {
       edgeless.tools.setEdgelessTool({ type: 'connector', mode });
-      record && edgeless.service.editPropsStore.record('connector', { mode });
+      record &&
+        edgeless.service.editPropsStore.recordLastProps('connector', { mode });
     };
 
   return {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -57,7 +57,7 @@ export class EdgelessConnectorToolButton extends QuickToolMixin(LitElement) {
     const menu = this.createPopper('edgeless-connector-menu', this);
     menu.element.edgeless = this.edgeless;
     menu.element.onChange = (props: Record<string, unknown>) => {
-      this.edgeless.service.editPropsStore.record(this.type, props);
+      this.edgeless.service.editPropsStore.recordLastProps(this.type, props);
       this.updateMenu();
       this.setEdgelessTool({
         type: this.type,

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -56,7 +56,9 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
   }
 
   private get _cachedPresentHideToolbar() {
-    return !!this.edgeless.service.editPropsStore.getItem('presentHideToolbar');
+    return !!this.edgeless.service.editPropsStore.getStorage(
+      'presentHideToolbar'
+    );
   }
 
   /**
@@ -612,11 +614,13 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     // This state from `editPropsStore` is not reactive,
     // if the value is updated outside of this component, it will not be reflected.
     _disposables.add(
-      this.edgeless.service.editPropsStore.slots.itemUpdated.on(({ key }) => {
-        if (key === 'presentHideToolbar') {
-          this.requestUpdate();
+      this.edgeless.service.editPropsStore.slots.storageUpdated.on(
+        ({ key }) => {
+          if (key === 'presentHideToolbar') {
+            this.requestUpdate();
+          }
         }
-      })
+      )
     );
   }
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/present/navigator-setting-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/present/navigator-setting-button.ts
@@ -105,7 +105,7 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
   accessor edgeless!: EdgelessRootBlockComponent;
 
   private _tryRestoreSettings() {
-    const blackBackground = this.edgeless.service.editPropsStore.getItem(
+    const blackBackground = this.edgeless.service.editPropsStore.getStorage(
       'presentBlackBackground'
     );
     this.blackBackground = blackBackground ?? true;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/presentation-toolbar.ts
@@ -24,11 +24,16 @@ import { EdgelessToolbarToolMixin } from './mixins/tool.mixin.js';
 @customElement('presentation-toolbar')
 export class PresentationToolbar extends EdgelessToolbarToolMixin(LitElement) {
   private get _cachedPresentHideToolbar() {
-    return !!this.edgeless.service.editPropsStore.getItem('presentHideToolbar');
+    return !!this.edgeless.service.editPropsStore.getStorage(
+      'presentHideToolbar'
+    );
   }
 
   private set _cachedPresentHideToolbar(value) {
-    this.edgeless.service.editPropsStore.setItem('presentHideToolbar', !!value);
+    this.edgeless.service.editPropsStore.setStorage(
+      'presentHideToolbar',
+      !!value
+    );
   }
 
   private get _frames(): FrameBlockModel[] {
@@ -290,7 +295,8 @@ export class PresentationToolbar extends EdgelessToolbarToolMixin(LitElement) {
     );
 
     this._navigatorMode =
-      this.edgeless.service.editPropsStore.getItem('presentFillScreen') === true
+      this.edgeless.service.editPropsStore.getStorage('presentFillScreen') ===
+      true
         ? 'fill'
         : 'fit';
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -70,7 +70,7 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
     Object.assign(menu.element, {
       edgeless: this.edgeless,
       onChange: (props: Record<string, unknown>) => {
-        this.edgeless.service.editPropsStore.record('shape', props);
+        this.edgeless.service.editPropsStore.recordLastProps('shape', props);
         this.updateMenu();
         this._updateOverlay();
 
@@ -95,7 +95,10 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
     if (name !== this.states.shapeType) {
       const shapeConfig = ShapeComponentConfig.find(s => s.name === name);
       if (!shapeConfig) return;
-      this.edgeless.service.editPropsStore.record('shape', shapeConfig?.value);
+      this.edgeless.service.editPropsStore.recordLastProps(
+        'shape',
+        shapeConfig?.value
+      );
       this.updateMenu();
     }
     if (!this.popper) this._toggleMenu();

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
@@ -284,7 +284,7 @@ export class EdgelessTemplatePanel extends WithDisposable(LitElement) {
   }
 
   private _getLocalSelectedCategory() {
-    return this.edgeless.service.editPropsStore.getItem('templateCache');
+    return this.edgeless.service.editPropsStore.getStorage('templateCache');
   }
 
   private _createTemplateJob(type: string, center: { x: number; y: number }) {
@@ -410,7 +410,7 @@ export class EdgelessTemplatePanel extends WithDisposable(LitElement) {
     this.addEventListener('keydown', stopPropagation, false);
     this._disposables.add(() => {
       if (this._currentCategory) {
-        this.edgeless.service.editPropsStore.setItem(
+        this.edgeless.service.editPropsStore.setStorage(
           'templateCache',
           this._currentCategory
         );

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -56,7 +56,9 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
         c: () => {
           const mode = ConnectorMode.Curve;
-          rootElement.service.editPropsStore.record('connector', { mode });
+          rootElement.service.editPropsStore.recordLastProps('connector', {
+            mode,
+          });
           this._setEdgelessTool(rootElement, { type: 'connector', mode });
         },
         l: () => {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -374,7 +374,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
 
     const run = () => {
       const viewport =
-        service.editPropsStore.getItem('viewport') ??
+        service.editPropsStore.getStorage('viewport') ??
         service.getFitToScreenData();
 
       if ('xywh' in viewport) {
@@ -393,7 +393,7 @@ export class EdgelessRootBlockComponent extends BlockElement<
     }
 
     this._disposables.add(() => {
-      service.editPropsStore.setItem('viewport', {
+      service.editPropsStore.setStorage('viewport', {
         centerX: service.viewport.centerX,
         centerY: service.viewport.centerY,
         zoom: service.viewport.zoom,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -273,7 +273,7 @@ export class EdgelessRootService extends RootService {
     // @ts-ignore
     props['type'] = type;
 
-    this.editPropsStore.apply(
+    this.editPropsStore.applyLastProps(
       type as CanvasElementType,
       props as Record<string, unknown>
     );
@@ -289,7 +289,7 @@ export class EdgelessRootService extends RootService {
   ) {
     props['index'] = this.generateIndex(flavour);
 
-    this.editPropsStore.apply(
+    this.editPropsStore.applyLastProps(
       flavour as BlockSuite.EdgelessModelKeyType,
       props
     );
@@ -306,7 +306,7 @@ export class EdgelessRootService extends RootService {
   updateElement(id: string, props: Record<string, unknown>) {
     const element = this._surface.getElementById(id);
     if (element) {
-      this.editPropsStore.record(
+      this.editPropsStore.recordLastProps(
         element.type as BlockSuite.EdgelessModelKeyType,
         props
       );
@@ -316,7 +316,7 @@ export class EdgelessRootService extends RootService {
 
     const block = this.doc.getBlockById(id);
     if (block) {
-      this.editPropsStore.record(
+      this.editPropsStore.recordLastProps(
         block.flavour as BlockSuite.EdgelessModelKeyType,
         props
       );

--- a/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
@@ -30,5 +30,5 @@ export function updateShapeProps(
           radius: 0,
         };
 
-  edgeless.service.editPropsStore.record('shape', props);
+  edgeless.service.editPropsStore.recordLastProps('shape', props);
 }

--- a/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
+++ b/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
@@ -12,7 +12,8 @@ export class RemoteColorManager {
   }
 
   constructor(readonly host: EditorHost) {
-    const sessionColor = this.rootService.editPropsStore.getItem('remoteColor');
+    const sessionColor =
+      this.rootService.editPropsStore.getStorage('remoteColor');
     if (sessionColor) {
       this.awareness.awareness.setLocalStateField('color', sessionColor);
       return;
@@ -20,7 +21,7 @@ export class RemoteColorManager {
 
     const pickColor = multiPlayersColor.pick();
     this.awareness.awareness.setLocalStateField('color', pickColor);
-    this.rootService.editPropsStore.setItem('remoteColor', pickColor);
+    this.rootService.editPropsStore.setStorage('remoteColor', pickColor);
   }
 
   get(id: number) {
@@ -31,7 +32,8 @@ export class RemoteColorManager {
 
     if (id !== this.awareness.awareness.clientID) return null;
 
-    const sessionColor = this.rootService.editPropsStore.getItem('remoteColor');
+    const sessionColor =
+      this.rootService.editPropsStore.getStorage('remoteColor');
     if (sessionColor) {
       this.awareness.awareness.setLocalStateField('color', sessionColor);
       return sessionColor;
@@ -39,7 +41,7 @@ export class RemoteColorManager {
 
     const pickColor = multiPlayersColor.pick();
     this.awareness.awareness.setLocalStateField('color', pickColor);
-    this.rootService.editPropsStore.setItem('remoteColor', pickColor);
+    this.rootService.editPropsStore.setStorage('remoteColor', pickColor);
     return pickColor;
   }
 }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -96,7 +96,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     this.notes.forEach(note => {
       this.doc.updateBlock(note, { background });
     });
-    this.edgeless.service.editPropsStore.record('affine:note', {
+    this.edgeless.service.editPropsStore.recordLastProps('affine:note', {
       background,
     } as Record<string, unknown>);
   }

--- a/packages/blocks/src/root-block/widgets/pie-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/config.ts
@@ -77,7 +77,7 @@ pie.expandableCommand({
       label: 'Pen Color',
       active: getActiveConnectorStrokeColor,
       onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-        rootElement.service.editPropsStore.record('brush', {
+        rootElement.service.editPropsStore.recordLastProps('brush', {
           color: color as LastProps['brush']['color'],
         });
       },
@@ -216,7 +216,7 @@ pie.colorPicker({
   label: 'Line Color',
   active: getActiveConnectorStrokeColor,
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.record('connector', {
+    rootElement.service.editPropsStore.recordLastProps('connector', {
       stroke: color as LastProps['connector']['stroke'],
     });
   },
@@ -272,7 +272,7 @@ shapes.forEach(shape => {
         type: 'shape',
         shapeType: shape.type,
       });
-      rootElement.service.editPropsStore.record('shape', {
+      rootElement.service.editPropsStore.recordLastProps('shape', {
         shapeType: shape.type,
       });
       updateShapeOverlay(rootElement);
@@ -298,7 +298,7 @@ pie.command({
         ? ShapeStyle.Scribbled
         : ShapeStyle.General;
 
-    rootElement.service.editPropsStore.record('shape', {
+    rootElement.service.editPropsStore.recordLastProps('shape', {
       shapeStyle: toggleType,
     });
 
@@ -310,7 +310,7 @@ pie.colorPicker({
   label: 'Fill',
   active: getActiveShapeColor('fill'),
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.record('shape', {
+    rootElement.service.editPropsStore.recordLastProps('shape', {
       fillColor: color as LastProps['shape']['fillColor'],
     });
     updateShapeOverlay(rootElement);
@@ -323,7 +323,7 @@ pie.colorPicker({
   hollow: true,
   active: getActiveShapeColor('stroke'),
   onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.record('shape', {
+    rootElement.service.editPropsStore.recordLastProps('shape', {
       strokeColor: color as LastProps['shape']['strokeColor'],
     });
     updateShapeOverlay(rootElement);

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -594,7 +594,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     };
     const pageService = this.std.spec.getService('affine:page');
 
-    pageService.editPropsStore.setItem('viewport', viewport);
+    pageService.editPropsStore.setStorage('viewport', viewport);
     pageService.docModeService.setMode('edgeless');
   }
 

--- a/packages/presets/src/fragments/bi-directional-link/bi-directional-link-panel.ts
+++ b/packages/presets/src/fragments/bi-directional-link/bi-directional-link-panel.ts
@@ -282,7 +282,10 @@ export class BiDirectionalLinkPanel extends WithDisposable(LitElement) {
 
   private _toggleShow() {
     this._show = !this._show;
-    this._rootService.editPropsStore.setItem('showBidirectional', this._show);
+    this._rootService.editPropsStore.setStorage(
+      'showBidirectional',
+      this._show
+    );
   }
 
   private _renderLinks(ids: string[]) {
@@ -562,7 +565,7 @@ export class BiDirectionalLinkPanel extends WithDisposable(LitElement) {
     }
 
     this._show =
-      !!this._rootService.editPropsStore.getItem('showBidirectional');
+      !!this._rootService.editPropsStore.getStorage('showBidirectional');
   }
 }
 

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -249,7 +249,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
       };
 
       const rootService = this.editorHost.spec.getService('affine:page');
-      rootService.editPropsStore.setItem('viewport', viewport);
+      rootService.editPropsStore.setStorage('viewport', viewport);
       rootService.docModeService.setMode('edgeless');
     } else {
       this.edgeless.service.viewport.setViewportByBound(

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -149,7 +149,7 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
   private _tryLoadNavigatorStateLocalRecord() {
     this._navigatorMode = this.editorHost.spec
       .getService('affine:page')
-      .editPropsStore.getItem('presentFillScreen')
+      .editPropsStore.getStorage('presentFillScreen')
       ? 'fill'
       : 'fit';
   }

--- a/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
@@ -91,11 +91,11 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
 
   private _tryRestoreSettings() {
     const { editPropsStore } = this._rootService;
-    const blackBackground = editPropsStore.getItem('presentBlackBackground');
+    const blackBackground = editPropsStore.getStorage('presentBlackBackground');
 
     this.blackBackground = blackBackground ?? true;
-    this.fillScreen = editPropsStore.getItem('presentFillScreen') ?? false;
-    this.hideToolbar = editPropsStore.getItem('presentHideToolbar') ?? false;
+    this.fillScreen = editPropsStore.getStorage('presentFillScreen') ?? false;
+    this.hideToolbar = editPropsStore.getStorage('presentHideToolbar') ?? false;
   }
 
   private _onBlackBackgroundChange = (checked: boolean) => {
@@ -110,7 +110,7 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
     this.edgeless?.slots.navigatorSettingUpdated.emit({
       fillScreen: this.fillScreen,
     });
-    this._rootService.editPropsStore.setItem(
+    this._rootService.editPropsStore.setStorage(
       'presentFillScreen',
       this.fillScreen
     );
@@ -121,7 +121,7 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
     this.edgeless?.slots.navigatorSettingUpdated.emit({
       hideToolbar: this.hideToolbar,
     });
-    this._rootService.editPropsStore.setItem(
+    this._rootService.editPropsStore.setStorage(
       'presentHideToolbar',
       this.hideToolbar
     );


### PR DESCRIPTION
Support memory for style changes to edgeless text and optimize some naming in `EditPropsStore`.

Before:

https://github.com/toeverything/blocksuite/assets/50035259/cd9656c9-b79c-427a-98db-dc0484ec4295

After:

https://github.com/toeverything/blocksuite/assets/50035259/cbfb6c45-7768-4f73-9952-88714c25d89b