### PR TITLE
fix(edgeless): elements should be clickable after opening mindmap menu

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
@@ -176,8 +176,6 @@ export const textRender: DraggableTool['render'] = (
     mountTextElementEditor(textElement, edgeless);
   }
 
-  edgeless.tools.setEdgelessTool({ type: 'default' });
-
   service.telemetryService?.track('CanvasElementAdded', {
     control: 'toolbar:dnd',
     page: 'whiteboard editor',

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-menu.ts
@@ -111,6 +111,8 @@ export class EdgelessMindmapMenu extends EdgelessToolbarToolMixin(LitElement) {
             { type: 'default' },
             { elements: [id], editing: false }
           );
+        } else if (element.data.type === 'text') {
+          this.setEdgelessTool({ type: 'default' });
         }
       },
     });

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
@@ -161,8 +161,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
 
   private _toggleMenu() {
     if (this.tryDisposePopper()) return;
-
-    this.setEdgelessTool({ type: 'mindmap' });
+    this.setEdgelessTool({ type: 'default' });
 
     const menu = this.createPopper('edgeless-mindmap-menu', this);
     Object.assign(menu.element, {
@@ -226,6 +225,8 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
             { type: 'default' },
             { elements: [id], editing: false }
           );
+        } else if (el.data.name === 'text') {
+          this.setEdgelessTool({ type: 'default' });
         }
       },
     });
@@ -253,6 +254,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
             });
             return;
           }
+          this.setEdgelessTool({ type: 'mindmap' });
           const icon = this.mindmapElement;
           assertExists(icon);
           const { x, y } = service.tool.lastMousePos;

--- a/tests/edgeless/mindmap.spec.ts
+++ b/tests/edgeless/mindmap.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test';
+import {
+  addBasicRectShapeElement,
+  edgelessCommonSetup,
+} from 'utils/actions/edgeless.js';
+import { assertEdgelessSelectedRect } from 'utils/asserts.js';
+
+import { test } from '../utils/playwright.js';
+
+test('elements should be selectable after open mindmap menu', async ({
+  page,
+}) => {
+  await edgelessCommonSetup(page);
+
+  const start = { x: 100, y: 100 };
+  const end = { x: 200, y: 200 };
+  await addBasicRectShapeElement(page, start, end);
+
+  await page.locator('.basket-wrapper').click({ position: { x: 0, y: 0 } });
+  await expect(page.locator('edgeless-mindmap-menu')).toBeVisible();
+
+  await page.mouse.click(start.x + 5, start.y + 5);
+  await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
+});


### PR DESCRIPTION
closes [BS-739](https://linear.app/affine-design/issue/BS-739/%E6%89%93%E5%BC%80mindmap%E8%8F%9C%E5%8D%95%E5%90%8E%EF%BC%8C%E6%97%A0%E6%B3%95%E9%80%89%E4%B8%AD%E4%BB%BB%E4%BD%95yuan%E7%B4%A0)

Before:

https://github.com/toeverything/blocksuite/assets/20479050/387b6a8f-851f-4ca8-bd1c-3eaa58ada9fe

After:

https://github.com/toeverything/blocksuite/assets/20479050/735ff196-72d9-4acf-8688-40d26e63ce21


