### PR TITLE
fix(edgeless): exit shape text editing by pressing Escape

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -203,19 +203,6 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
           (this.ownerDocument.activeElement as HTMLElement).blur();
           break;
         }
-        case 'Escape': {
-          const service = this.edgeless.service;
-          const element = this.element;
-
-          requestAnimationFrame(() => {
-            service.selection.set({
-              elements: [element.id],
-              editing: false,
-            });
-          });
-
-          (this.ownerDocument.activeElement as HTMLElement).blur();
-        }
       }
     });
   }
@@ -279,6 +266,19 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
         );
       })
       .catch(console.error);
+
+    this.disposables.addFromEvent(this, 'keydown', evt => {
+      if (evt.key === 'Escape') {
+        requestAnimationFrame(() => {
+          this.edgeless.service.selection.set({
+            elements: [this.element.id],
+            editing: false,
+          });
+        });
+
+        (this.ownerDocument.activeElement as HTMLElement).blur();
+      }
+    });
 
     this._initMindmapKeyBindings();
   }

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -29,6 +29,7 @@ import {
   focusRichText,
   initEmptyEdgelessState,
   pasteByKeyboard,
+  pressEscape,
   type,
   waitNextFrame,
 } from '../utils/actions/index.js';
@@ -437,6 +438,30 @@ test('dbclick to add text in shape', async ({ page }) => {
 
   await pasteByKeyboard(page);
   await assertEdgelessCanvasText(page, 'hdddello');
+});
+
+test('should show selected rect after exiting editing by pressing Escape', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+
+  await setEdgelessTool(page, 'shape');
+  await waitNextFrame(page, 500);
+
+  await dragBetweenCoords(page, { x: 100, y: 100 }, { x: 200, y: 200 });
+
+  await waitNextFrame(page);
+  await page.mouse.dblclick(150, 150);
+  await waitNextFrame(page);
+
+  await type(page, 'hello');
+  await assertEdgelessCanvasText(page, 'hello');
+
+  await pressEscape(page);
+  await assertEdgelessSelectedRect(page, [100, 100, 100, 100]);
 });
 
 test('auto wrap text in shape', async ({ page }) => {


### PR DESCRIPTION
closes BS-747

Before:

https://github.com/toeverything/blocksuite/assets/20479050/d74d02e6-ef1c-472d-ab61-903dc693d091

After:


https://github.com/toeverything/blocksuite/assets/20479050/a93866e2-6d9b-43a8-bf8f-c499e53e47b2

