### PR TITLE
fix(edgeless): rerender `edgeless-element-toolbar-widget` when `readonly` changes

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -351,6 +351,10 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
         this._recalculatePosition();
       })
     );
+
+    _disposables.add(
+      edgeless.slots.readonlyUpdated.on(() => this.requestUpdate())
+    );
   }
 
   registerEntry(entry: CustomEntry) {


### PR DESCRIPTION
Now when changing `readonly` the `edgeless-element-toolbar-widget` does not hide