### PR TITLE
fix: console error when paste markdown that ends with table

### DIFF
--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -257,9 +257,14 @@ class PasteTr {
 
     host.updateComplete
       .then(() => {
-        const target = this.std.host.querySelector<BlockElement>(
+        const target = host.querySelector<BlockElement>(
           `[${host.blockIdAttr}="${lastModel.id}"]`
         );
+        if (!target && host.querySelector(`[data-row-id="${lastModel.id}"]`)) {
+          // when we paste in markdown text that ends with a table,
+          //  do not change focus
+          return
+        }
         assertExists(target);
         if (!lastModel.text) {
           if (matchFlavours(lastModel, ['affine:image'])) {


### PR DESCRIPTION
When we paste in markdown text that ends with a table, we get an error. Example markdown:

```markdown
## test data

| col1  | col2   |
|-------|--------|
| text1 | text2  |
```

Screenshot of the error:

<img width="334" alt="Screenshot 2024-07-07 at 15 13 25" src="https://github.com/toeverything/blocksuite/assets/1597851/8ab596f6-424f-4b58-a99c-b27c50033e23">

This PR fixes that.
