### PR TITLE
feat(blocks): add download button on attachment and image toolbar

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
@@ -12,9 +12,14 @@ import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
 } from '../../../_common/consts.js';
-import { CaptionIcon, PaletteIcon } from '../../../_common/icons/text.js';
+import {
+  CaptionIcon,
+  DownloadIcon,
+  PaletteIcon,
+} from '../../../_common/icons/text.js';
 import type { EmbedCardStyle } from '../../../_common/types.js';
 import { getEmbedCardIcons } from '../../../_common/utils/url.js';
+import { downloadAttachmentBlob } from '../../../attachment-block/utils.js';
 import type {
   AttachmentBlockComponent,
   AttachmentBlockModel,
@@ -87,6 +92,11 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
     this.model.doc.updateBlock(this.model, { style, xywh });
   };
 
+  private _download = () => {
+    if (!this._blockElement) return;
+    downloadAttachmentBlob(this._blockElement);
+  };
+
   override render() {
     return html`
       <editor-menu-button
@@ -105,6 +115,17 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
         >
         </card-style-panel>
       </editor-menu-button>
+
+      <editor-toolbar-separator></editor-toolbar-separator>
+
+      <editor-icon-button
+        aria-label="Download"
+        .tooltip=${'Download'}
+        ?disabled=${this._doc.readonly}
+        @click=${this._download}
+      >
+        ${DownloadIcon}
+      </editor-icon-button>
 
       <editor-toolbar-separator></editor-toolbar-separator>
 

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
@@ -1,13 +1,15 @@
 import '../../../_common/components/toolbar/icon-button.js';
+import '../../../_common/components/toolbar/separator.js';
 
 import { WithDisposable } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { CaptionIcon } from '../../../_common/icons/text.js';
+import { CaptionIcon, DownloadIcon } from '../../../_common/icons/text.js';
 import type { ImageBlockComponent } from '../../../image-block/image-block.js';
 import type { ImageBlockModel } from '../../../image-block/image-model.js';
+import { downloadImageBlob } from '../../../image-block/utils.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
 @customElement('edgeless-change-image-button')
@@ -39,18 +41,34 @@ export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
     return blockElement;
   }
 
-  private _showCaption() {
+  private _showCaption = () => {
     this._blockElement?.captionEditor.show();
-  }
+  };
+
+  private _download = () => {
+    if (!this._blockElement) return;
+    downloadImageBlob(this._blockElement).catch(console.error);
+  };
 
   override render() {
     return html`
+      <editor-icon-button
+        aria-label="Download"
+        .tooltip=${'Download'}
+        ?disabled=${this._doc.readonly}
+        @click=${this._download}
+      >
+        ${DownloadIcon}
+      </editor-icon-button>
+
+      <editor-toolbar-separator></editor-toolbar-separator>
+
       <editor-icon-button
         aria-label="Add caption"
         .tooltip=${'Add caption'}
         class="change-image-button caption"
         ?disabled=${this._doc.readonly}
-        @click=${() => this._showCaption()}
+        @click=${this._showCaption}
       >
         ${CaptionIcon}
       </editor-icon-button>


### PR DESCRIPTION
Closes: [BS-769](https://linear.app/affine-design/issue/BS-769/为-image-element-toolbar-添加下载入口)

<img width="649" alt="Screenshot 2024-07-08 at 09 48 39" src="https://github.com/toeverything/blocksuite/assets/27926/094beb09-3a43-49c9-94a4-00f9e2f6af33">
<img width="317" alt="Screenshot 2024-07-08 at 09 49 51" src="https://github.com/toeverything/blocksuite/assets/27926/667035ce-1292-45a7-9a52-8e9fc48f52ee">
<img width="327" alt="Screenshot 2024-07-08 at 09 50 01" src="https://github.com/toeverything/blocksuite/assets/27926/489121cc-0674-4ab4-b79e-573f84b7048f">
