### PR TITLE
refactor(blocks): refine image toolbar

### DIFF
--- a/packages/blocks/src/_common/components/toolbar/menu-button.ts
+++ b/packages/blocks/src/_common/components/toolbar/menu-button.ts
@@ -67,7 +67,10 @@ export class EditorMenuButton extends WithDisposable(LitElement) {
       ({ display }) => {
         this._trigger.showTooltip = display === 'hidden';
       },
-      12
+      {
+        mainAxis: 12,
+        ignoreShift: true,
+      }
     );
     this._disposables.addFromEvent(this, 'keydown', (e: KeyboardEvent) => {
       e.stopPropagation();
@@ -106,6 +109,8 @@ export class EditorMenuButton extends WithDisposable(LitElement) {
 export class EditorMenuContent extends LitElement {
   static override styles = css`
     :host {
+      --packed-height: 6px;
+      --offset-height: calc(-1 * var(--packed-height));
       display: none;
       outline: none;
     }
@@ -115,16 +120,16 @@ export class EditorMenuContent extends LitElement {
       content: '';
       display: block;
       position: absolute;
-      height: 6px;
+      height: var(--packed-height);
       width: 100%;
     }
 
     :host:before {
-      top: -6px;
+      top: var(--offset-height);
     }
 
     :host:after {
-      bottom: -6px;
+      bottom: var(--offset-height);
     }
 
     :host([data-show]) {

--- a/packages/blocks/src/_common/components/toolbar/separator.ts
+++ b/packages/blocks/src/_common/components/toolbar/separator.ts
@@ -22,7 +22,7 @@ export class EditorToolbarSeparator extends LitElement {
     }
 
     :host([data-orientation='horizontal']) {
-      height: var(--height, 4px);
+      height: 8px;
       width: unset;
     }
 

--- a/packages/blocks/src/_common/components/toolbar/toolbar.ts
+++ b/packages/blocks/src/_common/components/toolbar/toolbar.ts
@@ -14,6 +14,12 @@ export class EditorToolbar extends WithDisposable(LitElement) {
       box-sizing: content-box;
     }
 
+    :host([data-without-bg]) {
+      border-color: transparent;
+      background: transparent;
+      box-shadow: none;
+    }
+
     ::slotted(*) {
       display: flex;
       height: 100%;

--- a/packages/blocks/src/_common/components/toolbar/utils.ts
+++ b/packages/blocks/src/_common/components/toolbar/utils.ts
@@ -52,7 +52,6 @@ export function renderActions(
     () => html`
       <editor-toolbar-separator
         data-orientation="horizontal"
-        style="--height: 8px"
       ></editor-toolbar-separator>
     `
   );

--- a/packages/blocks/src/_common/styles.ts
+++ b/packages/blocks/src/_common/styles.ts
@@ -1,6 +1,12 @@
 import { baseTheme } from '@toeverything/theme';
 import { css, unsafeCSS } from 'lit';
 
+export const PANEL_BASE_COLORS = css`
+  color: var(--affine-icon-color);
+  background: var(--affine-background-overlay-panel-color);
+  box-shadow: var(--affine-shadow-4);
+`;
+
 export const PANEL_BASE = css`
   display: flex;
   align-items: center;
@@ -9,10 +15,7 @@ export const PANEL_BASE = css`
   padding: 0 6px;
   border-radius: 4px;
   border: 0.5px solid var(--affine-border-color);
-  background: var(--affine-background-overlay-panel-color);
-  box-shadow: var(--affine-shadow-4);
 
-  color: var(--affine-icon-color);
   font-family: ${unsafeCSS(baseTheme.fontSansFamily)};
   font-feature-settings:
     'clig' off,
@@ -21,4 +24,6 @@ export const PANEL_BASE = css`
   font-style: normal;
   font-weight: 500;
   line-height: 22px;
+
+  ${PANEL_BASE_COLORS}
 `;

--- a/packages/blocks/src/_common/utils/button-popper.ts
+++ b/packages/blocks/src/_common/utils/button-popper.ts
@@ -1,4 +1,5 @@
 import type { Disposable } from '@blocksuite/global/utils';
+import { autoUpdate } from '@floating-ui/dom';
 import {
   autoPlacement,
   computePosition,
@@ -49,11 +50,20 @@ export function createButtonPopper(
   stateUpdated: (state: { display: Display }) => void = () => {
     /** DEFAULT EMPTY FUNCTION */
   },
-  mainAxis?: number,
-  crossAxis?: number,
-  rootBoundary?: Rect | (() => Rect | undefined)
+  {
+    mainAxis,
+    crossAxis,
+    rootBoundary,
+    ignoreShift,
+  }: {
+    mainAxis?: number;
+    crossAxis?: number;
+    rootBoundary?: Rect | (() => Rect | undefined);
+    ignoreShift?: boolean;
+  } = {}
 ) {
   let display: Display = 'hidden';
+  let cleanup: (() => void) | void;
 
   const originMaxHeight = window.getComputedStyle(popperElement).maxHeight;
 
@@ -85,11 +95,15 @@ export function createButtonPopper(
       ],
     })
       .then(({ x, y, middlewareData: data }) => {
+        if (!ignoreShift) {
+          x += data.shift?.x ?? 0;
+          y += data.shift?.y ?? 0;
+        }
         Object.assign(popperElement.style, {
           position: 'absolute',
           zIndex: 1,
-          left: `${x + (data.shift?.x ?? 0)}px`,
-          top: `${y + (data.shift?.y ?? 0)}px`,
+          left: `${x}px`,
+          top: `${y}px`,
         });
       })
       .catch(console.error);
@@ -100,7 +114,10 @@ export function createButtonPopper(
     popperElement.setAttribute(ATTR_SHOW, '');
     display = 'show';
     stateUpdated({ display });
-    compute();
+
+    cleanup = autoUpdate(reference, popperElement, compute, {
+      animationFrame: true,
+    });
   };
 
   const hide = () => {
@@ -108,7 +125,7 @@ export function createButtonPopper(
     popperElement.removeAttribute(ATTR_SHOW);
     display = 'hidden';
     stateUpdated({ display });
-    compute();
+    cleanup?.();
   };
 
   const toggle = () => {
@@ -129,6 +146,7 @@ export function createButtonPopper(
     hide,
     toggle,
     dispose: () => {
+      cleanup?.();
       clickAway.dispose();
     },
   };

--- a/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/font-weight-and-style-panel.ts
@@ -161,7 +161,6 @@ export class EdgelessFontWeightAndStylePanel extends LitElement {
       () => html`
         <edgeless-menu-divider
           data-orientation="horizontal"
-          style="--height: 8px"
         ></edgeless-menu-divider>
       `
     );

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/present/frame-order-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/present/frame-order-button.ts
@@ -77,7 +77,9 @@ export class EdgelessFrameOrderButton extends WithDisposable(LitElement) {
       this._edgelessFrameOrderButton,
       this._edgelessFrameOrderMenu,
       ({ display }) => this.setPopperShow(display === 'show'),
-      22
+      {
+        mainAxis: 22,
+      }
     );
   }
 }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/present/navigator-setting-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/present/navigator-setting-button.ts
@@ -131,7 +131,9 @@ export class EdgelessNavigatorSettingButton extends WithDisposable(LitElement) {
       this._navigatorSettingButton,
       this._navigatorSettingMenu,
       ({ display }) => this.setPopperShow(display === 'show'),
-      22
+      {
+        mainAxis: 22,
+      }
     );
   }
 

--- a/packages/blocks/src/root-block/widgets/image-toolbar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/styles.ts
@@ -1,35 +1,24 @@
 import { css } from 'lit';
 
+import { PANEL_BASE_COLORS } from '../../../_common/styles.js';
+
 export const styles = css`
   :host {
-    z-index: 1;
     position: absolute;
     top: 0;
     right: 0;
+    z-index: var(--affine-z-index-popover);
   }
 
   .affine-image-toolbar-container {
-    display: flex;
-    flex-direction: row;
+    height: 24px;
     gap: 4px;
-    box-sizing: border-box;
-    list-style: none;
     padding: 4px;
     margin: 0;
   }
 
   .image-toolbar-button {
-    background: var(--affine-white);
-    color: var(--affine-icon-color);
-    box-shadow: var(--affine-shadow-1);
+    ${PANEL_BASE_COLORS}
     border-radius: 4px;
-  }
-
-  .image-toolbar-button:hover {
-    background: var(--affine-hover-color-filled);
-  }
-
-  .image-toolbar-button.more {
-    position: relative;
   }
 `;

--- a/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
@@ -1,4 +1,7 @@
 import '../../../_common/components/button.js';
+import '../../../_common/components/toolbar/icon-button.js';
+import '../../../_common/components/toolbar/menu-button.js';
+import '../../../_common/components/toolbar/separator.js';
 import '../../../_common/components/tooltip/tooltip.js';
 
 import { assertExists } from '@blocksuite/global/utils';
@@ -31,15 +34,16 @@ export function ConfigRenderer(
         case 'common': {
           const defaultItem = item as CommonItem;
           const buttonClass = `image-toolbar-button ${defaultItem.name.toLocaleLowerCase()}`;
-          template = html`<div class=${buttonClass}>
-            <icon-button
-              size="24px"
+          template = html`
+            <editor-icon-button
+              class=${buttonClass}
+              .tooltip=${defaultItem.tooltip}
+              .tooltipOffset=${4}
               @click=${() => defaultItem.action(blockElement, abortController)}
             >
               ${defaultItem.icon}
-              <affine-tooltip>${defaultItem.tooltip}</affine-tooltip>
-            </icon-button>
-          </div>`;
+            </editor-icon-button>
+          `;
           break;
         }
         case 'custom': {
@@ -72,23 +76,25 @@ export function MoreMenuRenderer(
         case 'more': {
           const moreItem = item as MoreItem;
           const buttonClass = `menu-item ${moreItem.name.toLocaleLowerCase()}`;
-          template = html`<div class=${buttonClass}>
-            <icon-button
-              width="183px"
-              height="30px"
-              text=${moreItem.name}
+          template = html`
+            <editor-menu-action
+              class=${buttonClass}
               @click=${(e: MouseEvent) => {
                 e.stopPropagation();
                 moreItem.action(blockElement, abortController);
               }}
             >
-              ${moreItem.icon}
-            </icon-button>
-          </div>`;
+              ${moreItem.icon} ${moreItem.name}
+            </editor-menu-action>
+          `;
           break;
         }
         case 'divider': {
-          template = html`<div class="divider"></div>`;
+          template = html`
+            <editor-toolbar-separator
+              data-orientation="horizontal"
+            ></editor-toolbar-separator>
+          `;
           break;
         }
         default:

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -185,8 +185,10 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
       ({ display }) => {
         this._settingPopperShow = display === 'show';
       },
-      14,
-      -100
+      {
+        mainAxis: 14,
+        crossAxis: -100,
+      }
     );
     disposables.add(this._framesSettingMenuPopper);
   }

--- a/packages/presets/src/fragments/outline-panel/card/outline-card.ts
+++ b/packages/presets/src/fragments/outline-panel/card/outline-card.ts
@@ -408,8 +408,10 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
       ({ display }) => {
         this._showPopper = display === 'show';
       },
-      8,
-      -60
+      {
+        mainAxis: 8,
+        crossAxis: -60,
+      }
     );
 
     this.disposables.add(this._displayModePopper);

--- a/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
+++ b/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
@@ -113,8 +113,10 @@ export class OutlinePanelHeader extends WithDisposable(LitElement) {
       ({ display }) => {
         this._settingPopperShow = display === 'show';
       },
-      14,
-      -30
+      {
+        mainAxis: 14,
+        crossAxis: -30,
+      }
     );
     _disposables.add(this._notePreviewSettingMenuPopper);
   }


### PR DESCRIPTION
Closes: [BS-743](https://linear.app/affine-design/issue/BS-743/image-toolbar)

<img width="203" alt="Screenshot 2024-07-08 at 09 17 02" src="https://github.com/toeverything/blocksuite/assets/27926/95edb6b9-597a-4053-9bb0-977507dfdabb">

You can check the latest status in https://github.com/toeverything/blocksuite/pull/7513.
