### PR TITLE
fix(database): popup menu wrong position when cell is in editing state

### DIFF
--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/row.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/row.ts
@@ -271,12 +271,12 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
       },
       isEditing: false,
     };
-    popRowMenu(
-      this.dataViewEle,
-      e.target as HTMLElement,
-      this.rowId,
-      selection
-    );
+    const target =
+      cell ??
+      (e.target as HTMLElement).closest('.database-cell') ?? // for last add btn cell
+      (e.target as HTMLElement);
+
+    popRowMenu(this.dataViewEle, target, this.rowId, selection);
   };
 
   override connectedCallback() {


### PR DESCRIPTION
[BS-756](https://linear.app/affine-design/issue/BS-756/database-%E7%BC%96%E8%BE%91%E6%96%87%E6%9C%AC%E9%A1%B9%E6%97%B6%EF%BC%8C%E5%8F%B3%E9%94%AE%E8%8F%9C%E5%8D%95%E5%BC%B9%E5%87%BA%E4%BD%8D%E7%BD%AE%E4%B8%8D%E5%AF%B9)