### PR TITLE
chore(blocks): sort query result of slash menu by substring score

### DIFF
--- a/packages/blocks/src/__tests__/common/string.unit.spec.ts
+++ b/packages/blocks/src/__tests__/common/string.unit.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { isFuzzyMatch } from '../../_common/utils/string.js';
+import {
+  isFuzzyMatch,
+  substringMatchScore,
+} from '../../_common/utils/string.js';
 
 describe('fuzzyMatch', () => {
   it('basic case', () => {
@@ -19,5 +22,51 @@ describe('fuzzyMatch', () => {
   it('should works with IME', () => {
     // IME will generate a space between 'da' and 't'
     expect(isFuzzyMatch('database', 'da t')).toEqual(true);
+  });
+});
+
+describe('substringMatchScore', () => {
+  it('should return a fraction if there exists a common maximal length substring. ', () => {
+    const result = substringMatchScore('testing the function', 'tet');
+    expect(result).toBeLessThan(1);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('should return bigger score for longer match', () => {
+    const result = substringMatchScore('testing the function', 'functin');
+    const result2 = substringMatchScore('testing the function', 'tet');
+    // because th length of common substring of 'functin' is bigger than 'tet'
+    expect(result).toBeGreaterThan(result2);
+  });
+
+  it('should return bigger score when using same query to search a shorter string', () => {
+    const result = substringMatchScore('test', 'test');
+    const result2 = substringMatchScore('testing the function', 'test');
+    expect(result).toBeGreaterThan(result2);
+  });
+
+  it('should return 0 when there is no match', () => {
+    const result = substringMatchScore('abc', 'defghijk');
+    expect(result).toBe(0);
+  });
+
+  it('should handle cases where the query is longer than the string', () => {
+    const result = substringMatchScore('short', 'longer substring');
+    expect(result).toBe(0);
+  });
+
+  it('should handle empty strings correctly', () => {
+    const result = substringMatchScore('any string', '');
+    expect(result).toBe(0);
+  });
+
+  it('should handle both strings being empty', () => {
+    const result = substringMatchScore('', '');
+    expect(result).toBe(0);
+  });
+
+  it('should handle cases where both strings are identical', () => {
+    const result = substringMatchScore('identical', 'identical');
+    expect(result).toBe(1);
   });
 });

--- a/packages/blocks/src/_common/utils/string.ts
+++ b/packages/blocks/src/_common/utils/string.ts
@@ -32,3 +32,44 @@ export function isFuzzyMatch(name: string, query: string) {
   );
   return regex.test(pureName);
 }
+
+/**
+ * Calculate the score of the substring match.
+ * s = [0.5, 1] if the query is a substring of the name
+ * s = (0, 0.5) if there exists a common non-maximal length substring
+ * s = 0 if there is no match
+ *
+ * s is greater if the query has a longer substring.
+ */
+export function substringMatchScore(name: string, query: string) {
+  if (query.length === 0) return 0;
+  if (name.length === 0) return 0;
+  if (query.length > name.length) return 0;
+
+  query = query.toLowerCase();
+  name = name.toLocaleLowerCase();
+
+  let score;
+  if (name.includes(query)) {
+    score = 1 + query.length / name.length;
+  } else {
+    let maxMatchLength = 0;
+    for (let i = 0; i < query.length; i++) {
+      for (let j = 0; j < name.length; j++) {
+        let matchLength = 0;
+        while (
+          i + matchLength < query.length &&
+          j + matchLength < name.length &&
+          query[i + matchLength] === name[j + matchLength]
+        ) {
+          matchLength++;
+        }
+        maxMatchLength = Math.max(maxMatchLength, matchLength);
+      }
+    }
+    score = maxMatchLength / name.length;
+  }
+
+  // normalize
+  return 0.5 * score;
+}

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -16,7 +16,10 @@ import {
   getInlineEditorByModel,
   isControlledKeyboardEvent,
 } from '../../../_common/utils/index.js';
-import { isFuzzyMatch } from '../../../_common/utils/string.js';
+import {
+  isFuzzyMatch,
+  substringMatchScore,
+} from '../../../_common/utils/string.js';
 import type {
   SlashMenuActionItem,
   SlashMenuContext,
@@ -135,22 +138,11 @@ export class SlashMenu extends WithDisposable(LitElement) {
       depth++;
     }
 
-    // make items in the same group in order
     this._filteredItems = this._filteredItems.sort((a, b) => {
-      if (a.name.toLowerCase() === searchStr) return -1;
-      if (b.name.toLowerCase() === searchStr) return 1;
-
-      const aPath = this._itemPathMap.get(a);
-      const bPath = this._itemPathMap.get(b);
-
-      assertExists(aPath);
-      assertExists(bPath);
-
-      for (let i = 0; i < Math.min(aPath.length, bPath.length); i++) {
-        if (aPath[i] < bPath[i]) return -1;
-        if (aPath[i] > bPath[i]) return 1;
-      }
-      return aPath.length - bPath.length;
+      return -(
+        substringMatchScore(a.name, searchStr) -
+        substringMatchScore(b.name, searchStr)
+      );
     });
 
     this._query = query;

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -259,8 +259,9 @@ test(scoped`copy url to create bookmark in edgeless mode`, async ({ page }) => {
   await copyByKeyboard(page);
   await pressArrowRight(page);
   await waitNextFrame(page);
-  await type(page, '/link');
+  await type(page, '/link', 100);
   await pressEnter(page);
+  await page.waitForTimeout(100);
   await waitNextFrame(page);
   await page.keyboard.press(`${SHORT_KEY}+v`);
   await pressEnter(page);
@@ -481,6 +482,7 @@ test('press backspace after bookmark block can select bookmark block', async ({
   await pressArrowUp(page);
   await type(page, '/link');
   await pressEnter(page);
+  await page.waitForTimeout(100);
   await type(page, inputUrl);
   await pressEnter(page);
 

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -542,8 +542,8 @@ test.describe('slash search', () => {
     // search should active the first item
     await type(page, 'co');
     await expect(slashItems).toHaveCount(2);
-    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
-    await expect(slashItems.nth(1).locator('.text')).toHaveText(['Copy']);
+    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Copy']);
+    await expect(slashItems.nth(1).locator('.text')).toHaveText(['Code Block']);
     await expect(slashItems.nth(0)).toHaveAttribute('hover', 'true');
 
     await type(page, 'p');
@@ -553,8 +553,8 @@ test.describe('slash search', () => {
     // assert backspace works
     await pressBackspace(page);
     await expect(slashItems).toHaveCount(2);
-    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
-    await expect(slashItems.nth(1).locator('.text')).toHaveText(['Copy']);
+    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Copy']);
+    await expect(slashItems.nth(1).locator('.text')).toHaveText(['Code Block']);
     await expect(slashItems.nth(0)).toHaveAttribute('hover', 'true');
   });
 
@@ -571,13 +571,13 @@ test.describe('slash search', () => {
 
     await type(page, 'c');
     await expect(slashItems).toHaveCount(7);
-    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
+    await expect(slashItems.nth(0).locator('.text')).toHaveText(['Copy']);
     await expect(slashItems.nth(1).locator('.text')).toHaveText(['Italic']);
     await expect(slashItems.nth(2).locator('.text')).toHaveText(['New Doc']);
-    await expect(slashItems.nth(3).locator('.text')).toHaveText(['Linked Doc']);
-    await expect(slashItems.nth(4).locator('.text')).toHaveText(['Attachment']);
-    await expect(slashItems.nth(5).locator('.text')).toHaveText(['Copy']);
-    await expect(slashItems.nth(6).locator('.text')).toHaveText(['Duplicate']);
+    await expect(slashItems.nth(3).locator('.text')).toHaveText(['Duplicate']);
+    await expect(slashItems.nth(4).locator('.text')).toHaveText(['Code Block']);
+    await expect(slashItems.nth(5).locator('.text')).toHaveText(['Linked Doc']);
+    await expect(slashItems.nth(6).locator('.text')).toHaveText(['Attachment']);
     await type(page, 'b');
     await expect(slashItems.nth(0).locator('.text')).toHaveText(['Code Block']);
   });


### PR DESCRIPTION
closes [BS-774](https://github.com/toeverything/blocksuite/pull/7519)

## What changes
- Use max common length of substring to sort query result of slash menu
- substring matching socre function and unit tests
```ts
/**
 * Calculate the score of the substring match.
 * s = [0.5, 1] if the query is a substring of the name
 * s = (0, 0.5) if there exists a common non-maximal length substring
 * s = 0 if there is no match
 *
 * s is greater if the query has a longer substring.
 */
export function substringMatchScore(name: string, query: string);
```

### Before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/095a623b-178e-4b0e-bef4-3574f7552cc5.png)


### After
![image](https://github.com/toeverything/blocksuite/assets/20479050/c27dce7b-a67b-4dc9-8c0d-e73a6a0f0667)

