### PR TITLE
chore(blocks): refine format bar

### DIFF
--- a/packages/blocks/src/_common/components/toolbar/icon-button.ts
+++ b/packages/blocks/src/_common/components/toolbar/icon-button.ts
@@ -32,11 +32,11 @@ export class EditorIconButton extends LitElement {
       user-select: none;
     }
 
-    .icon-container.active-mode-color[active] {
+    :host([active]) .icon-container.active-mode-color {
       color: var(--affine-primary-color);
     }
 
-    .icon-container.active-mode-background[active] {
+    :host([active]) .icon-container.active-mode-background {
       background: var(--affine-hover-color);
     }
 

--- a/packages/blocks/src/_common/components/toolbar/menu-button.ts
+++ b/packages/blocks/src/_common/components/toolbar/menu-button.ts
@@ -112,7 +112,6 @@ export class EditorMenuContent extends LitElement {
     :host([data-show]) {
       ${PANEL_BASE}
       justify-content: center;
-      gap: 8px;
       padding: var(--content-padding, 0 6px);
     }
 
@@ -122,6 +121,10 @@ export class EditorMenuContent extends LitElement {
       align-self: stretch;
       gap: 8px;
       min-height: 36px;
+    }
+
+    ::slotted([slot]) {
+      min-width: 146px;
     }
 
     ::slotted([slot][data-size='small']) {
@@ -162,6 +165,7 @@ export class EditorMenuAction extends LitElement {
       gap: 8px;
       color: var(--affine-text-primary-color);
       font-weight: 400;
+      min-height: 30px; // 22 + 8
     }
 
     :host(:hover),

--- a/packages/blocks/src/_common/components/toolbar/toolbar.ts
+++ b/packages/blocks/src/_common/components/toolbar/toolbar.ts
@@ -33,7 +33,12 @@ export class EditorToolbar extends WithDisposable(LitElement) {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._disposables.addFromEvent(this, 'pointerdown', stopPropagation);
+
+    this._disposables.addFromEvent(this, 'pointerdown', (e: PointerEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+    });
+    this._disposables.addFromEvent(this, 'wheel', stopPropagation);
   }
 
   override render() {

--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -253,11 +253,7 @@ export const scrollbarStyle = (container: string) => {
     );
 
   // sanitize container name
-  if (
-    container.length > 50 ||
-    container.includes('{') ||
-    container.includes('}')
-  )
+  if (container.includes('{') || container.includes('}'))
     throw new Error('Invalid container name!');
 
   return css`

--- a/packages/blocks/src/root-block/widgets/format-bar/components/config-renderer.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/config-renderer.ts
@@ -1,5 +1,9 @@
+import '../../../../_common/components/toolbar/icon-button.js';
+import '../../../../_common/components/toolbar/separator.js';
+
 import { html, type TemplateResult } from 'lit';
 
+import { renderToolbarSeparator } from '../../../../_common/components/toolbar/separator.js';
 import { isFormatSupported } from '../../../../note-block/commands/utils.js';
 import type { AffineFormatBarWidget } from '../format-bar.js';
 import { HighlightButton } from './highlight/highlight-button.js';
@@ -26,7 +30,7 @@ export function ConfigRenderer(formatBar: AffineFormatBarWidget) {
       let template: TemplateResult | null = null;
       switch (item.type) {
         case 'divider':
-          template = html`<div class="divider"></div>`;
+          template = renderToolbarSeparator();
           break;
         case 'highlighter-dropdown': {
           template = HighlightButton(formatBar);
@@ -36,18 +40,19 @@ export function ConfigRenderer(formatBar: AffineFormatBarWidget) {
           template = ParagraphButton(formatBar);
           break;
         case 'inline-action': {
-          template = html`<icon-button
-            size="32px"
-            data-testid=${item.id}
-            ?active=${item.isActive(formatBar.std.command.chain(), formatBar)}
-            @click=${() => {
-              item.action(formatBar.std.command.chain(), formatBar);
-              formatBar.requestUpdate();
-            }}
-          >
-            ${typeof item.icon === 'function' ? item.icon() : item.icon}
-            <affine-tooltip>${item.name}</affine-tooltip>
-          </icon-button>`;
+          template = html`
+            <editor-icon-button
+              data-testid=${item.id}
+              ?active=${item.isActive(formatBar.std.command.chain(), formatBar)}
+              .tooltip=${item.name}
+              @click=${() => {
+                item.action(formatBar.std.command.chain(), formatBar);
+                formatBar.requestUpdate();
+              }}
+            >
+              ${typeof item.icon === 'function' ? item.icon() : item.icon}
+            </editor-icon-button>
+          `;
           break;
         }
         case 'custom': {

--- a/packages/blocks/src/root-block/widgets/format-bar/components/highlight/highlight-button.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/highlight/highlight-button.ts
@@ -1,3 +1,6 @@
+import '../../../../../_common/components/toolbar/icon-button.js';
+import '../../../../../_common/components/toolbar/menu-button.js';
+
 import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { computePosition, flip, offset, shift } from '@floating-ui/dom';
@@ -53,51 +56,56 @@ const HighlightPanel = (
   formatBar: AffineFormatBarWidget,
   containerRef?: RefOrCallback
 ) => {
-  return html`<div ${ref(containerRef)} class="highlight-panel">
-    <!-- Text Color Highlight -->
-    <div class="highligh-panel-heading">Color</div>
-    ${foregroundConfig.map(
-      ({ name, color }) =>
-        html`<icon-button
-          width="100%"
-          height="32px"
-          style="padding-left: 4px; justify-content: flex-start; gap: 8px;"
-          text="${name}"
-          data-testid="${color ?? 'unset'}"
-          @click="${() => {
-            updateHighlight(formatBar.host, color, HighlightType.Foreground);
-            formatBar.requestUpdate();
-          }}"
-        >
-          <span style="color: ${color}; display: flex; align-items: center;">
-            ${TextForegroundDuotoneIcon}
-          </span>
-        </icon-button>`
-    )}
+  return html`
+    <editor-menu-content class="highlight-panel" data-show ${ref(containerRef)}>
+      <div slot data-orientation="vertical">
+        <!-- Text Color Highlight -->
+        <div class="highligh-panel-heading">Color</div>
+        ${foregroundConfig.map(
+          ({ name, color }) => html`
+            <editor-menu-action
+              data-testid="${color ?? 'unset'}"
+              @click="${() => {
+                updateHighlight(
+                  formatBar.host,
+                  color,
+                  HighlightType.Foreground
+                );
+                formatBar.requestUpdate();
+              }}"
+            >
+              <span style="display: flex; color: ${color}">
+                ${TextForegroundDuotoneIcon}
+              </span>
+              ${name}
+            </editor-menu-action>
+          `
+        )}
 
-    <!-- Text Background Highlight -->
-    <div class="highligh-panel-heading">Background</div>
-    ${backgroundConfig.map(
-      ({ name, color }) =>
-        html`<icon-button
-          width="100%"
-          height="32px"
-          style="padding-left: 4px; justify-content: flex-start; gap: 8px;"
-          text="${name}"
-          @click="${() => {
-            updateHighlight(formatBar.host, color, HighlightType.Background);
-            formatBar.requestUpdate();
-          }}"
-        >
-          <span
-            style="color: ${color ??
-            'rgba(0,0,0,0)'}; display: flex; align-items: center;"
-          >
-            ${TextBackgroundDuotoneIcon}
-          </span>
-        </icon-button>`
-    )}
-  </div>`;
+        <!-- Text Background Highlight -->
+        <div class="highligh-panel-heading">Background</div>
+        ${backgroundConfig.map(
+          ({ name, color }) => html`
+            <editor-menu-action
+              @click="${() => {
+                updateHighlight(
+                  formatBar.host,
+                  color,
+                  HighlightType.Background
+                );
+                formatBar.requestUpdate();
+              }}"
+            >
+              <span style="display: flex; color: ${color ?? 'transparent'}">
+                ${TextBackgroundDuotoneIcon}
+              </span>
+              ${name}
+            </editor-menu-action>
+          `
+        )}
+      </div>
+    </editor-menu-content>
+  `;
 };
 
 export const HighlightButton = (formatBar: AffineFormatBarWidget) => {
@@ -117,12 +125,12 @@ export const HighlightButton = (formatBar: AffineFormatBarWidget) => {
       formatBar.shadowRoot?.querySelector<HTMLElement>('.highlight-panel');
     assertExists(button);
     assertExists(panel);
-    panel.style.display = 'block';
+    panel.style.display = 'flex';
     computePosition(button, panel, {
       placement: 'bottom',
       middleware: [
         flip(),
-        offset(10),
+        offset(6),
         shift({
           padding: 6,
         }),
@@ -137,21 +145,20 @@ export const HighlightButton = (formatBar: AffineFormatBarWidget) => {
 
   const highlightPanel = HighlightPanel(formatBar, setFloating);
 
-  return html`<div ${ref(setReference)} class="highlight-button">
-    <icon-button
-      class="highlight-icon"
-      data-last-used="${lastUsedColor ?? 'unset'}"
-      width="52px"
-      height="32px"
-      @click="${() =>
-        updateHighlight(editorHost, lastUsedColor, lastUsedHighlightType)}"
-    >
-      <span
-        style="color: ${lastUsedColor}; display: flex; align-items: center; "
-        >${HighLightDuotoneIcon}</span
+  return html`
+    <div class="highlight-button" ${ref(setReference)}>
+      <editor-icon-button
+        class="highlight-icon"
+        data-last-used="${lastUsedColor ?? 'unset'}"
+        @click="${() =>
+          updateHighlight(editorHost, lastUsedColor, lastUsedHighlightType)}"
       >
-      ${ArrowDownIcon}</icon-button
-    >
-    ${highlightPanel}
-  </div>`;
+        <span style="display: flex; color: ${lastUsedColor}">
+          ${HighLightDuotoneIcon}
+        </span>
+        ${ArrowDownIcon}
+      </editor-icon-button>
+      ${highlightPanel}
+    </div>
+  `;
 };

--- a/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
@@ -1,3 +1,6 @@
+import '../../../../_common/components/toolbar/icon-button.js';
+import '../../../../_common/components/toolbar/menu-button.js';
+
 import type { EditorHost } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { computePosition, flip, offset, shift } from '@floating-ui/dom';
@@ -33,22 +36,22 @@ const ParagraphPanel = ({
 
   const renderedConfig = repeat(
     config,
-    item =>
-      html`<icon-button
-        width="100%"
-        height="32px"
-        style="padding-left: 12px; justify-content: flex-start; gap: 8px;"
-        text="${item.name}"
+    item => html`
+      <editor-menu-action
         data-testid="${item.id}"
         @click="${() => item.action(formatBar.std.command.chain(), formatBar)}"
       >
         ${typeof item.icon === 'function' ? item.icon() : item.icon}
-      </icon-button>`
+        ${item.name}
+      </editor-menu-action>
+    `
   );
 
-  return html`<div ${ref(containerRef)} class="paragraph-panel">
-    ${renderedConfig}
-  </div>`;
+  return html`
+    <editor-menu-content class="paragraph-panel" data-show ${ref(containerRef)}>
+      <div slot data-orientation="vertical">${renderedConfig}</div>
+    </editor-menu-content>
+  `;
 };
 
 export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
@@ -93,12 +96,12 @@ export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
     assertExists(button);
     assertExists(panel);
     assertExists(formatQuickBarElement, 'format quick bar should exist');
-    panel.style.display = 'block';
+    panel.style.display = 'flex';
     computePosition(formatQuickBarElement, panel, {
       placement: 'top-start',
       middleware: [
         flip(),
-        offset(4),
+        offset(6),
         shift({
           padding: 6,
         }),
@@ -117,10 +120,12 @@ export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
     ref: setFloating,
   });
 
-  return html`<div ${ref(setReference)} class="paragraph-button">
-    <icon-button class="paragraph-button-icon" width="52px" height="32px">
-      ${paragraphIcon} ${ArrowDownIcon}</icon-button
-    >
-    ${paragraphPanel}
-  </div>`;
+  return html`
+    <div class="paragraph-button" ${ref(setReference)}>
+      <editor-icon-button class="paragraph-button-icon">
+        ${paragraphIcon} ${ArrowDownIcon}
+      </editor-icon-button>
+      ${paragraphPanel}
+    </div>
+  `;
 };

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -12,7 +12,6 @@ import {
   CodeIcon,
   CopyIcon,
   DatabaseTableViewIcon20,
-  FontLinkedDocIcon,
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
@@ -20,6 +19,7 @@ import {
   Heading5Icon,
   Heading6Icon,
   ItalicIcon,
+  LinkedDocIcon,
   LinkIcon,
   NumberedListIcon,
   QuoteIcon,
@@ -143,6 +143,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
       },
       showWhen: () => true,
     })
+    .addDivider()
     .addInlineAction({
       id: 'convert-to-database',
       name: 'Group as Database',
@@ -169,10 +170,11 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
         );
       },
     })
+    .addDivider()
     .addInlineAction({
       id: 'convert-to-linked-doc',
       name: 'Create Linked Doc',
-      icon: FontLinkedDocIcon,
+      icon: LinkedDocIcon,
       isActive: () => false,
       action: (chain, formatBar) => {
         const [_, ctx] = chain

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -1,4 +1,5 @@
 import '../../../_common/components/button.js';
+import '../../../_common/components/toolbar/toolbar.js';
 
 import type {
   BaseSelection,
@@ -24,7 +25,6 @@ import {
   type RichText,
 } from '../../../_common/components/index.js';
 import type { AffineTextAttributes } from '../../../_common/inline/presets/affine-inline-specs.js';
-import { stopPropagation } from '../../../_common/utils/event.js';
 import { matchFlavours } from '../../../_common/utils/model.js';
 import { isFormatSupported } from '../../../note-block/commands/utils.js';
 import { isRootElement } from '../../../root-block/utils/guard.js';
@@ -41,6 +41,8 @@ export const AFFINE_FORMAT_BAR_WIDGET = 'affine-format-bar-widget';
 
 @customElement(AFFINE_FORMAT_BAR_WIDGET)
 export class AffineFormatBarWidget extends WidgetElement {
+  static override styles = formatBarStyle;
+
   private get _selectionManager() {
     return this.host.selection;
   }
@@ -58,8 +60,6 @@ export class AffineFormatBarWidget extends WidgetElement {
     if (!sl || sl.rangeCount === 0) return null;
     return sl.getRangeAt(0);
   }
-
-  static override styles = formatBarStyle;
 
   @state()
   private accessor _dragging = false;
@@ -568,16 +568,11 @@ export class AffineFormatBarWidget extends WidgetElement {
 
     const items = ConfigRenderer(this);
 
-    return html`<div
-      class="${AFFINE_FORMAT_BAR_WIDGET}"
-      @pointerdown="${(event: Event) => {
-        event.stopPropagation();
-        event.preventDefault();
-      }}"
-      @wheel="${stopPropagation}"
-    >
-      ${items}
-    </div>`;
+    return html`
+      <editor-toolbar class="${AFFINE_FORMAT_BAR_WIDGET}">
+        ${items}
+      </editor-toolbar>
+    `;
   }
 }
 

--- a/packages/blocks/src/root-block/widgets/format-bar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/styles.ts
@@ -11,22 +11,6 @@ const paragraphButtonStyle = css`
     transform: rotate(180deg);
   }
 
-  .paragraph-panel {
-    display: none;
-
-    font-size: var(--affine-font-sm);
-    box-sizing: border-box;
-    position: absolute;
-    min-width: 173px;
-    padding: 8px 4px;
-    overflow-y: auto;
-
-    background: var(--affine-background-overlay-panel-color);
-    box-shadow: var(--affine-shadow-2);
-    border-radius: 8px;
-    z-index: var(--affine-z-index-popover);
-  }
-
   .highlight-icon > svg:nth-child(2) {
     transition-duration: 0.3s;
   }
@@ -35,52 +19,37 @@ const paragraphButtonStyle = css`
   }
 
   .highlight-panel {
-    display: none;
-
-    font-size: var(--affine-font-sm);
-    box-sizing: border-box;
-    position: absolute;
-    min-width: 178px;
-    padding: 8px 4px 8px 8px;
     max-height: 380px;
-    overflow-y: auto;
-
-    background: var(--affine-background-overlay-panel-color);
-    box-shadow: var(--affine-shadow-2);
-    border-radius: 8px;
-    z-index: var(--affine-z-index-popover);
   }
 
-  ${scrollbarStyle('.highlight-panel')}
-
   .highligh-panel-heading {
+    display: flex;
     color: var(--affine-text-secondary-color);
     padding: 4px;
   }
+
+  editor-menu-content {
+    display: none;
+    position: absolute;
+    padding: 0;
+    z-index: var(--affine-z-index-popover);
+    --packed-height: 6px;
+  }
+
+  editor-menu-content > div[data-orientation='vertical'] {
+    padding: 8px;
+    overflow-y: auto;
+  }
+
+  ${scrollbarStyle('editor-menu-content > div[data-orientation="vertical"]')}
 `;
 
 export const formatBarStyle = css`
   .affine-format-bar-widget {
-    box-sizing: border-box;
     position: absolute;
     display: none;
-    align-items: center;
-    padding: 4px 8px;
-    gap: 8px;
-    height: 40px;
-    width: max-content;
-
-    border-radius: 8px;
-    background: var(--affine-background-overlay-panel-color);
-    box-shadow: var(--affine-shadow-2);
     z-index: var(--affine-z-index-popover);
     user-select: none;
-  }
-
-  .divider {
-    width: 1px;
-    height: 24px;
-    background-color: var(--affine-border-color);
   }
 
   ${paragraphButtonStyle}

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -93,7 +93,7 @@ test('should format quick bar show when clicking drag handle', async ({
   if (!box) {
     throw new Error("formatBar doesn't exist");
   }
-  assertAlmostEqual(box.x, 222.5, 5);
+  assertAlmostEqual(box.x, 251, 5);
   assertAlmostEqual(box.y - dragHandleRect.y, -55.5, 5);
 });
 
@@ -996,7 +996,7 @@ test('should format quick bar work in single block selection', async ({
   const selectionRect = await blockSelections.boundingBox();
   assertExists(formatRect);
   assertExists(selectionRect);
-  assertAlmostEqual(formatRect.x - selectionRect.x, 118.5, 10);
+  assertAlmostEqual(formatRect.x - selectionRect.x, 147.5, 10);
   assertAlmostEqual(formatRect.y - selectionRect.y, 33, 10);
 
   const boldBtn = formatBar.getByTestId('bold');
@@ -1089,7 +1089,7 @@ test('should format quick bar work in multiple block selection', async ({
   }
   const rect = await blockSelections.first().boundingBox();
   assertExists(rect);
-  assertAlmostEqual(box.x - rect.x, 118.5, 10);
+  assertAlmostEqual(box.x - rect.x, 147.5, 10);
   assertAlmostEqual(box.y - rect.y, 99, 10);
 
   await formatBarController.boldBtn.click();
@@ -1292,7 +1292,7 @@ test('should format quick bar show after convert to code block', async ({
     { x: 0, y: 0 }
   );
   await expect(formatBarController.formatBar).toBeVisible();
-  await formatBarController.assertBoundingBox(222.5, 343);
+  await formatBarController.assertBoundingBox(251, 343);
 
   await formatBarController.openParagraphMenu();
   await formatBarController.codeBlockBtn.click();


### PR DESCRIPTION
Closes: [BS-741](https://linear.app/affine-design/issue/BS-741/format-bar)

<img width="504" alt="Screenshot 2024-07-09 at 10 44 53" src="https://github.com/toeverything/blocksuite/assets/27926/cb861d6b-157a-4cf0-b334-998081054b87">
<img width="533" alt="Screenshot 2024-07-09 at 10 45 10" src="https://github.com/toeverything/blocksuite/assets/27926/2315cbfe-8a51-47b8-9d64-6de896dc82ff">
<img width="592" alt="Screenshot 2024-07-09 at 15 44 56" src="https://github.com/toeverything/blocksuite/assets/27926/384bfd07-c9db-4fdb-9cee-4efc69a62fc2">
