### PR TITLE
fix: icon button flex-shrink and text-overflow

### DIFF
--- a/packages/blocks/src/_common/components/button.ts
+++ b/packages/blocks/src/_common/components/button.ts
@@ -78,11 +78,12 @@ export class IconButton extends LitElement {
       display: flex;
       flex-direction: column;
       overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
     }
 
     :host .text {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
       font-size: var(--affine-font-sm);
       line-height: var(--affine-line-height);
     }
@@ -100,6 +101,7 @@ export class IconButton extends LitElement {
     }
 
     ::slotted(svg) {
+      flex-shrink: 0;
       color: var(--svg-icon-color);
     }
 


### PR DESCRIPTION
Fix issue [BS-793](https://linear.app/affine-design/issue/BS-793).

| Before | After |
| --- | --- |
| 
![截屏2024-07-09 10.58.44.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/2aa1ad9d-6b81-4690-83d1-67aa3b9ab783.png) | ![截屏2024-07-09 10.57.33.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/827104bd-5152-47ab-ad44-a68e33bdd809.png) |


