### PR TITLE
feat(blocks): add more menu button on format bar

### DIFF
--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -49,6 +49,7 @@ export const quickActionConfig: QuickActionConfig[] = [
             toast(host, 'Copied to clipboard');
           },
         })
+        .draftSelectedModels()
         .copySelectedModels()
         .run();
     },

--- a/packages/blocks/src/root-block/clipboard/index.ts
+++ b/packages/blocks/src/root-block/clipboard/index.ts
@@ -35,6 +35,7 @@ export class PageClipboard {
       .chain()
       .with({ onCopy })
       .getSelectedModels()
+      .draftSelectedModels()
       .copySelectedModels();
   };
 

--- a/packages/blocks/src/root-block/commands/model-crud/copy-selected-models.ts
+++ b/packages/blocks/src/root-block/commands/model-crud/copy-selected-models.ts
@@ -1,41 +1,18 @@
 import type { Command } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
-import { type DraftModel, toDraftModel } from '@blocksuite/store';
 import { Slice } from '@blocksuite/store';
 
-export const copySelectedModelsCommand: Command<'selectedModels' | 'onCopy'> = (
+export const copySelectedModelsCommand: Command<'draftedModels' | 'onCopy'> = (
   ctx,
   next
 ) => {
-  const models = ctx.selectedModels;
+  const models = ctx.draftedModels;
   assertExists(
     models,
-    '`selectedModels` is required, you need to use `getSelectedModels` command before adding this command to the pipeline.'
+    '`draftedModels` is required, you need to use `draftSelectedModels` command before adding this command to the pipeline.'
   );
 
-  const drafts = models.map(toDraftModel);
-
-  const traverse = (model: DraftModel) => {
-    const isDatabase = model.flavour === 'affine:database';
-    const children = isDatabase
-      ? model.children
-      : model.children.filter(child => {
-          const idx = drafts.findIndex(m => m.id === child.id);
-          return idx >= 0;
-        });
-
-    children.forEach(child => {
-      const idx = drafts.findIndex(m => m.id === child.id);
-      if (idx >= 0) {
-        drafts.splice(idx, 1);
-      }
-      traverse(child);
-    });
-    model.children = children;
-  };
-  drafts.forEach(traverse);
-
-  const slice = Slice.fromModels(ctx.std.doc, drafts);
+  const slice = Slice.fromModels(ctx.std.doc, models);
 
   ctx.std.clipboard
     .copy(slice)

--- a/packages/blocks/src/root-block/commands/model-crud/draft-selected-models.ts
+++ b/packages/blocks/src/root-block/commands/model-crud/draft-selected-models.ts
@@ -1,0 +1,52 @@
+import type { Command } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
+import type { BlockModel } from '@blocksuite/store';
+import { type DraftModel, toDraftModel } from '@blocksuite/store';
+
+export const draftSelectedModelsCommand: Command<
+  'selectedModels',
+  'draftedModels'
+> = (ctx, next) => {
+  const models = ctx.selectedModels;
+  assertExists(
+    models,
+    '`selectedModels` is required, you need to use `getSelectedModels` command before adding this command to the pipeline.'
+  );
+
+  const draftedModels = models.map(toDraftModel);
+
+  const traverse = (model: DraftModel) => {
+    const isDatabase = model.flavour === 'affine:database';
+    const children = isDatabase
+      ? model.children
+      : model.children.filter(child => {
+          const idx = draftedModels.findIndex(m => m.id === child.id);
+          return idx >= 0;
+        });
+
+    children.forEach(child => {
+      const idx = draftedModels.findIndex(m => m.id === child.id);
+      if (idx >= 0) {
+        draftedModels.splice(idx, 1);
+      }
+      traverse(child);
+    });
+    model.children = children;
+  };
+
+  draftedModels.forEach(traverse);
+
+  return next({ draftedModels });
+};
+
+declare global {
+  namespace BlockSuite {
+    interface CommandContext {
+      draftedModels?: DraftModel<BlockModel<object>>[];
+    }
+
+    interface Commands {
+      draftSelectedModels: typeof draftSelectedModelsCommand;
+    }
+  }
+}

--- a/packages/blocks/src/root-block/commands/model-crud/index.ts
+++ b/packages/blocks/src/root-block/commands/model-crud/index.ts
@@ -1,3 +1,4 @@
 export * from './copy-selected-models.js';
 export * from './delete-selected-models.js';
+export * from './draft-selected-models.js';
 export * from './get-selected-models.js';

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -38,6 +38,7 @@ import {
   copySelectedModelsCommand,
   deleteSelectedModelsCommand,
   deleteTextCommand,
+  draftSelectedModelsCommand,
   formatBlockCommand,
   formatNativeCommand,
   formatTextCommand,
@@ -342,6 +343,7 @@ export class RootService extends BlockService<RootBlockModel> {
       .add('getSelectedBlocks', getSelectedBlocksCommand)
       .add('copySelectedModels', copySelectedModelsCommand)
       .add('deleteSelectedModels', deleteSelectedModelsCommand)
+      .add('draftSelectedModels', draftSelectedModelsCommand)
       .add('getSelectedModels', getSelectedModelsCommand)
       .add('getBlockSelections', getBlockSelectionsCommand)
       .add('getImageSelections', getImageSelectionsCommand)

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -34,6 +34,7 @@ import {
   type InlineActionConfigItem,
   type ParagraphActionConfigItem,
   toolbarDefaultConfig,
+  toolbarMoreButton,
 } from './config.js';
 import { formatBarStyle } from './styles.js';
 
@@ -83,11 +84,6 @@ export class AffineFormatBarWidget extends WidgetElement {
 
   @state()
   accessor configItems: FormatBarConfigItem[] = [];
-
-  private _reset() {
-    this._displayType = 'none';
-    this._selectedBlockElements = [];
-  }
 
   private _shouldDisplay() {
     const readonly = this.doc.awarenessStore.isReadonly(
@@ -200,7 +196,7 @@ export class AffineFormatBarWidget extends WidgetElement {
         if (this.displayType === 'text' || this.displayType === 'native') {
           const range = this.nativeRange;
           if (!range) {
-            this._reset();
+            this.reset();
             return;
           }
           targetRect = range.getBoundingClientRect();
@@ -278,7 +274,7 @@ export class AffineFormatBarWidget extends WidgetElement {
               return;
             }
 
-            this._reset();
+            this.reset();
             return;
           }
 
@@ -295,7 +291,7 @@ export class AffineFormatBarWidget extends WidgetElement {
             return;
           }
 
-          this._reset();
+          this.reset();
         };
 
         update().catch(console.error);
@@ -308,7 +304,7 @@ export class AffineFormatBarWidget extends WidgetElement {
       }
 
       const reset = () => {
-        this._reset();
+        this.reset();
         this.requestUpdate();
       };
       const viewSelection = databaseSelection.viewSelection;
@@ -428,6 +424,11 @@ export class AffineFormatBarWidget extends WidgetElement {
     }
   }
 
+  reset() {
+    this._displayType = 'none';
+    this._selectedBlockElements = [];
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     this._abortController = new AbortController();
@@ -470,7 +471,7 @@ export class AffineFormatBarWidget extends WidgetElement {
   override disconnectedCallback() {
     super.disconnectedCallback();
     this._abortController.abort();
-    this._reset();
+    this.reset();
     this._lastCursor = undefined;
   }
 
@@ -571,6 +572,8 @@ export class AffineFormatBarWidget extends WidgetElement {
     return html`
       <editor-toolbar class="${AFFINE_FORMAT_BAR_WIDGET}">
         ${items}
+        <editor-toolbar-separator></editor-toolbar-separator>
+        ${toolbarMoreButton(this)}
       </editor-toolbar>
     `;
   }

--- a/packages/framework/block-std/src/clipboard/index.ts
+++ b/packages/framework/block-std/src/clipboard/index.ts
@@ -244,8 +244,7 @@ export class Clipboard {
     parent?: string,
     index?: number
   ) => {
-    const job = this._getJob();
-    return job.snapshotToBlock(snapshot, doc, parent, index);
+    return this._getJob().snapshotToBlock(snapshot, doc, parent, index);
   };
 
   copySlice = async (slice: Slice) => {
@@ -264,5 +263,24 @@ export class Clipboard {
       );
       return items;
     });
+  };
+
+  duplicateSlice = async (
+    slice: Slice,
+    doc: Doc,
+    parent?: string,
+    index?: number,
+    type = 'BLOCKSUITE/SNAPSHOT'
+  ) => {
+    const items = {
+      [type]: await this._getClipboardItem(slice, type),
+    };
+
+    await this._getSnapshotByPriority(
+      type => (items[type] as string | File[]) ?? '',
+      doc,
+      parent,
+      index
+    );
   };
 }

--- a/tests/format-bar.spec.ts
+++ b/tests/format-bar.spec.ts
@@ -18,6 +18,7 @@ import {
   pressArrowDown,
   pressArrowUp,
   pressEnter,
+  pressEscape,
   pressTab,
   scrollToBottom,
   scrollToTop,
@@ -817,26 +818,6 @@ test('should format quick bar be able to change to heading paragraph type', asyn
   await page.waitForTimeout(10);
   // The paragraph button should prevent selection after click
   await assertRichTextInlineRange(page, 0, 0, 3);
-});
-
-test('should format quick bar be able to copy', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
-  await initThreeParagraphs(page);
-  // drag only the `456` paragraph
-  await dragBetweenIndices(page, [1, 0], [1, 3]);
-
-  const { copyBtn } = getFormatBar(page);
-  await expect(copyBtn).toBeVisible();
-  await assertRichTextInlineRange(page, 1, 0, 3);
-  await copyBtn.click();
-  await assertRichTextInlineRange(page, 1, 0, 3);
-
-  await focusRichText(page, 1);
-  await pasteByKeyboard(page);
-  await waitNextFrame(page);
-
-  await assertRichTexts(page, ['123', '456456', '789']);
 });
 
 test('should format quick bar show when double click text', async ({
@@ -1649,4 +1630,66 @@ test('create linked doc from block selection with format bar', async ({
   </affine:note>
 </affine:page>`
   );
+});
+
+test.describe('more menu button', () => {
+  test('should be able to perform the copy action', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await initThreeParagraphs(page);
+    // drag only the `456` paragraph
+    await dragBetweenIndices(page, [1, 0], [1, 3]);
+
+    const { openMoreMenu, copyBtn } = getFormatBar(page);
+    await openMoreMenu();
+    await expect(copyBtn).toBeVisible();
+    await assertRichTextInlineRange(page, 1, 0, 3);
+    await copyBtn.click();
+    await assertRichTextInlineRange(page, 1, 0, 3);
+
+    await focusRichText(page, 1);
+    await pasteByKeyboard(page);
+    await waitNextFrame(page);
+
+    await assertRichTexts(page, ['123', '456456', '789']);
+  });
+
+  // fixme: Copy and paste is broken(ctrl-c/ctrl-v).
+  test.skip('should be able to perform the duplicate action', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await initThreeParagraphs(page);
+
+    await focusRichText(page, 1);
+    await pressEscape(page);
+
+    const { openMoreMenu, duplicateBtn } = getFormatBar(page);
+    await openMoreMenu();
+    await expect(duplicateBtn).toBeVisible();
+    await duplicateBtn.click();
+
+    await waitNextFrame(page);
+
+    await assertRichTexts(page, ['123', '456', '456', '789']);
+  });
+
+  test('should be able to perform the delete action', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await initThreeParagraphs(page);
+
+    await focusRichText(page, 1);
+    await pressEscape(page);
+
+    const { openMoreMenu, deleteBtn } = getFormatBar(page);
+    await openMoreMenu();
+    await expect(deleteBtn).toBeVisible();
+    await deleteBtn.click();
+
+    await waitNextFrame(page);
+
+    await assertRichTexts(page, ['123', '789']);
+  });
 });

--- a/tests/utils/query.ts
+++ b/tests/utils/query.ts
@@ -11,7 +11,6 @@ export function getFormatBar(page: Page) {
   const strikeBtn = formatBar.getByTestId('strike');
   const codeBtn = formatBar.getByTestId('code');
   const linkBtn = formatBar.getByTestId('link');
-  const copyBtn = formatBar.getByTestId('copy');
   // highlight
   const highlightBtn = formatBar.locator('.highlight-icon');
   const redForegroundBtn = formatBar.getByTestId(
@@ -36,6 +35,15 @@ export function getFormatBar(page: Page) {
   const bulletedBtn = formatBar.getByTestId('affine:list/bulleted');
   const codeBlockBtn = formatBar.getByTestId('affine:code/');
 
+  const moreBtn = formatBar.getByRole('button', { name: 'More' });
+  const copyBtn = formatBar.getByRole('button', { name: 'Copy' });
+  const duplicateBtn = formatBar.getByRole('button', { name: 'Duplicate' });
+  const deleteBtn = formatBar.getByRole('button', { name: 'Delete' });
+  const openMoreMenu = async () => {
+    await expect(formatBar).toBeVisible();
+    await moreBtn.click();
+  };
+
   const assertBoundingBox = async (x: number, y: number) => {
     const boundingBox = await formatBar.boundingBox();
     if (!boundingBox) {
@@ -53,7 +61,6 @@ export function getFormatBar(page: Page) {
     strikeBtn,
     codeBtn,
     linkBtn,
-    copyBtn,
     highlight,
     createLinkedDocBtn,
 
@@ -62,6 +69,12 @@ export function getFormatBar(page: Page) {
     h1Btn,
     bulletedBtn,
     codeBlockBtn,
+
+    moreBtn,
+    openMoreMenu,
+    copyBtn,
+    duplicateBtn,
+    deleteBtn,
 
     assertBoundingBox,
   };


### PR DESCRIPTION
Closes: [BS-814](https://linear.app/affine-design/issue/BS-814/在-format-bar-上-添加-more-menu-button)

Adds `more` menu button on the format-bar.

### Includes actions:

* copy
* duplicate
* delete

### Other:

* [x] tests

<img width="463" alt="Screenshot 2024-07-09 at 16 36 34" src="https://github.com/toeverything/blocksuite/assets/27926/272405da-8722-48b5-8209-4b03af41fbd3">

