### PR TITLE
fix: hover style of icon button

### DIFF
--- a/packages/blocks/src/_common/components/button.ts
+++ b/packages/blocks/src/_common/components/button.ts
@@ -58,7 +58,7 @@ export class IconButton extends LitElement {
     }
 
     /* You can add a 'hover' attribute to the button to show the hover style */
-    :host([hover]) {
+    :host([hover='true']) {
       background: var(--affine-hover-color);
     }
     :host([hover='false']) {
@@ -128,8 +128,8 @@ export class IconButton extends LitElement {
   @property({ attribute: true, type: Boolean })
   accessor active: boolean = false;
 
-  @property({ attribute: true, type: Boolean })
-  accessor hover: boolean | undefined = undefined;
+  @property({ attribute: true, type: String })
+  accessor hover: 'true' | 'false' | undefined = undefined;
 
   // Do not add `{ attribute: false }` option here, otherwise the `disabled` styles will not work
   @property({ attribute: true, type: Boolean })

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -274,7 +274,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
               <icon-button
                 size="24px"
                 class="affine-reference-popover-view-selector-button link current-view"
-                .hover=${false}
+                hover=${false}
               >
                 ${LinkIcon}
                 <affine-tooltip .offset=${12}>${'Inline view'}</affine-tooltip>
@@ -283,7 +283,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
               <icon-button
                 size="24px"
                 class="affine-reference-popover-view-selector-button embed card-view"
-                .hover=${false}
+                hover=${false}
                 @click=${() => this._convertToCardView()}
               >
                 ${BookmarkIcon}
@@ -295,7 +295,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
                     <icon-button
                       size="24px"
                       class="affine-reference-popover-view-selector-button embed embed-view"
-                      .hover=${false}
+                      hover=${false}
                       @click=${() => this._convertToEmbedView()}
                       ?disabled=${this._embedViewButtonDisabled}
                     >

--- a/packages/blocks/src/embed-html-block/components/fullscreen-toolbar.ts
+++ b/packages/blocks/src/embed-html-block/components/fullscreen-toolbar.ts
@@ -152,7 +152,7 @@ export class EmbedHtmlFullscreenToolbar extends LitElement {
         <icon-button @click=${this.embedHtml.close}
           >${ExpandCloseIcon}</icon-button
         >
-        <icon-button @click=${this._popSettings} ?hover=${this._popperVisible}
+        <icon-button @click=${this._popSettings} hover=${this._popperVisible}
           >${SettingsIcon}</icon-button
         >
 

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -553,7 +553,7 @@ export class EmbedCardToolbar extends WidgetElement<
           <icon-button
             size="24px"
             class="embed-card-toolbar-button link"
-            .hover=${false}
+            hover=${false}
             ?disabled=${model.doc.readonly}
             @click=${() => this._turnIntoInlineView()}
           >
@@ -568,7 +568,7 @@ export class EmbedCardToolbar extends WidgetElement<
               card: true,
               'current-view': this._isCardView,
             })}
-            .hover=${false}
+            hover=${false}
             ?disabled=${model.doc.readonly}
             @click=${() => this._convertToCardView()}
           >
@@ -585,7 +585,7 @@ export class EmbedCardToolbar extends WidgetElement<
                     embed: true,
                     'current-view': this._isEmbedView,
                   })}
-                  .hover=${false}
+                  hover=${false}
                   ?disabled=${this._embedViewButtonDisabled}
                   @click=${() => this._convertToEmbedView()}
                 >

--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -172,7 +172,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
                   height="32px"
                   data-id=${key}
                   text=${name}
-                  ?hover=${this._activatedItemIndex === curIdx}
+                  hover=${this._activatedItemIndex === curIdx}
                   @click=${() => {
                     this.abortController.abort();
                     cleanSpecifiedTail(

--- a/tests/utils/actions/linked-doc.ts
+++ b/tests/utils/actions/linked-doc.ts
@@ -46,9 +46,9 @@ export function getLinkedDocPopover(page: Page) {
 
   const assertActivePageIdx = async (idx: number) => {
     if (idx !== 0) {
-      await expect(pageBtn.nth(0)).not.toHaveAttribute('hover', '');
+      await expect(pageBtn.nth(0)).toHaveAttribute('hover', 'false');
     }
-    await expect(pageBtn.nth(idx)).toHaveAttribute('hover', '');
+    await expect(pageBtn.nth(idx)).toHaveAttribute('hover', 'true');
   };
 
   return {


### PR DESCRIPTION
Fix issue [BS-721](https://linear.app/affine-design/issue/BS-721).

Cause we have css style like:
```
:host([hover='false']) {
  background: transparent;
}
```
If the `hover` is used as boolean attribute binding, the attribute will be added or removed based on the boolean value. Which means `host([hover='false'])` style will never happened to work.

### What changed?
- Make the `hover` attribute treated as a string
- Use standard attribute binding instead of boolean attribute binding or property binding


