### PR TITLE
fix(blocks): paragraph and code block can be inputed after switching to readonly

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/_common/components/rich-text/rich-text-operations.ts
@@ -211,7 +211,7 @@ export function handleIndent(
 ) {
   const doc = model.doc;
   const previousSibling = doc.getPrev(model);
-  if (!previousSibling || !supportsChildren(previousSibling)) {
+  if (doc.readonly || !previousSibling || !supportsChildren(previousSibling)) {
     // Bottom, can not indent, do nothing
     return;
   }
@@ -308,7 +308,7 @@ export function handleUnindent(
 ) {
   const doc = model.doc;
   const parent = doc.getParent(model);
-  if (!parent || parent.role !== 'content') {
+  if (doc.readonly || !parent || parent.role !== 'content') {
     // Top most, can not unindent, do nothing
     return;
   }

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -200,6 +200,7 @@ export class CodeBlockComponent extends BlockComponent<CodeBlockModel> {
         return;
       },
       Tab: ctx => {
+        if (this.doc.readonly) return;
         const state = ctx.get('keyboardState');
         const event = state.raw;
         const inlineEditor = this.inlineEditor;

--- a/packages/framework/inline/src/services/text.ts
+++ b/packages/framework/inline/src/services/text.ts
@@ -6,6 +6,8 @@ import { intersectInlineRange } from '../utils/inline-range.js';
 
 export class InlineTextService<TextAttributes extends BaseTextAttributes> {
   deleteText = (inlineRange: InlineRange): void => {
+    if (this.editor.isReadonly) return;
+
     this.transact(() => {
       this.yText.delete(inlineRange.index, inlineRange.length);
     });
@@ -19,6 +21,8 @@ export class InlineTextService<TextAttributes extends BaseTextAttributes> {
       mode?: 'replace' | 'merge';
     } = {}
   ): void => {
+    if (this.editor.isReadonly) return;
+
     const { match = () => true, mode = 'merge' } = options;
     const deltas = this.editor.deltaService.getDeltasByInlineRange(inlineRange);
 
@@ -50,6 +54,8 @@ export class InlineTextService<TextAttributes extends BaseTextAttributes> {
   };
 
   insertLineBreak = (inlineRange: InlineRange): void => {
+    if (this.editor.isReadonly) return;
+
     this.transact(() => {
       this.yText.delete(inlineRange.index, inlineRange.length);
       this.yText.insert(inlineRange.index, '\n');
@@ -61,6 +67,8 @@ export class InlineTextService<TextAttributes extends BaseTextAttributes> {
     text: string,
     attributes: TextAttributes = {} as TextAttributes
   ): void => {
+    if (this.editor.isReadonly) return;
+
     if (this.editor.attributeService.marks) {
       attributes = { ...attributes, ...this.editor.attributeService.marks };
     }
@@ -78,6 +86,8 @@ export class InlineTextService<TextAttributes extends BaseTextAttributes> {
   };
 
   resetText = (inlineRange: InlineRange): void => {
+    if (this.editor.isReadonly) return;
+
     const coverDeltas: DeltaInsert[] = [];
     for (
       let i = inlineRange.index;
@@ -109,6 +119,8 @@ export class InlineTextService<TextAttributes extends BaseTextAttributes> {
     text: string,
     attributes: TextAttributes = {} as TextAttributes
   ): void => {
+    if (this.editor.isReadonly) return;
+
     this.transact(() => {
       this.yText.delete(0, this.yText.length);
       this.yText.insert(0, text, attributes);

--- a/packages/framework/store/src/__tests__/collection.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/collection.unit.spec.ts
@@ -962,6 +962,22 @@ describe('collection search', () => {
   });
 });
 
+describe('flags', () => {
+  it('update flags', () => {
+    const options = createTestOptions();
+    const collection = new DocCollection(options);
+    collection.meta.initialize();
+
+    const awareness = collection.awarenessStore;
+
+    awareness.setFlag('enable_lasso_tool', false);
+    expect(awareness.getFlag('enable_lasso_tool')).toBe(false);
+
+    awareness.setFlag('enable_lasso_tool', true);
+    expect(awareness.getFlag('enable_lasso_tool')).toBe(true);
+  });
+});
+
 declare global {
   namespace BlockSuite {
     interface BlockModels {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,12 +1,10 @@
 import { expect } from '@playwright/test';
 
 import {
-  SHORT_KEY,
   addNoteByClick,
   captureHistory,
   click,
   disconnectByClick,
-  dragBetweenIndices,
   enterPlaygroundRoom,
   focusRichText,
   focusTitle,
@@ -25,7 +23,6 @@ import {
   redoByKeyboard,
   setSelection,
   switchEditorMode,
-  switchReadonly,
   toggleDarkMode,
   type,
   undoByClick,
@@ -247,41 +244,6 @@ test(scoped`undo after adding block twice`, async ({ page }) => {
   await redoByKeyboard(page);
   await assertRichTexts(page, ['hello', 'world']);
 });
-
-test(
-  scoped`should readonly mode not be able to modify text`,
-  async ({ page }) => {
-    await enterPlaygroundRoom(page);
-    const { paragraphId } = await initEmptyParagraphState(page);
-
-    await focusRichText(page);
-    await type(page, 'hello');
-    await switchReadonly(page);
-
-    await dragBetweenIndices(page, [0, 1], [0, 3]);
-    await page.keyboard.press(`${SHORT_KEY}+b`);
-    await assertStoreMatchJSX(
-      page,
-      `
-<affine:paragraph
-  prop:text="hello"
-  prop:type="text"
-/>`,
-      paragraphId
-    );
-
-    await undoByKeyboard(page);
-    await assertStoreMatchJSX(
-      page,
-      `
-<affine:paragraph
-  prop:text="hello"
-  prop:type="text"
-/>`,
-      paragraphId
-    );
-  }
-);
 
 test(scoped`undo/redo twice after adding block twice`, async ({ page }) => {
   await enterPlaygroundRoom(page);

--- a/tests/code.spec.ts
+++ b/tests/code.spec.ts
@@ -1047,28 +1047,6 @@ test('should open more menu and close on selecting', async ({ page }) => {
   await expect(moreMenu.menu).toBeHidden();
 });
 
-test('should code block works in read only mode', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyCodeBlockState(page);
-  await focusRichTextEnd(page);
-
-  await page.waitForTimeout(300);
-  await switchReadonly(page);
-
-  const codeBlockController = getCodeBlock(page);
-  const codeBlock = codeBlockController.codeBlock;
-  await codeBlock.hover();
-  await codeBlockController.clickLanguageButton();
-  await expect(codeBlockController.langList).toBeHidden();
-
-  await codeBlock.hover();
-  await expect(codeBlockController.codeToolbar).toBeVisible();
-  await expect(codeBlockController.moreButton).toHaveAttribute('disabled');
-
-  await expect(codeBlockController.copyButton).toBeVisible();
-  await expect(codeBlockController.moreMenu).toBeHidden();
-});
-
 test('should code block lang input supports alias', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyCodeBlockState(page);
@@ -1189,4 +1167,47 @@ test('code hotkey should not effect in global', async ({ page }) => {
   await assertTitle(page, 'aaa');
   await assertBlockCount(page, 'paragraph', 0);
   await assertBlockCount(page, 'code', 1);
+});
+
+test.describe('readonly mode', () => {
+  test('should code block widget be disabled in read only mode', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyCodeBlockState(page);
+    await focusRichTextEnd(page);
+
+    await page.waitForTimeout(300);
+    await switchReadonly(page);
+
+    const codeBlockController = getCodeBlock(page);
+    const codeBlock = codeBlockController.codeBlock;
+    await codeBlock.hover();
+    await codeBlockController.clickLanguageButton();
+    await expect(codeBlockController.langList).toBeHidden();
+
+    await codeBlock.hover();
+    await expect(codeBlockController.codeToolbar).toBeVisible();
+    await expect(codeBlockController.moreButton).toHaveAttribute('disabled');
+
+    await expect(codeBlockController.copyButton).toBeVisible();
+    await expect(codeBlockController.moreMenu).toBeHidden();
+  });
+
+  test('should not be able to modify code block in readonly mode', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyCodeBlockState(page);
+    await focusRichText(page);
+
+    await type(page, 'const a = 10;');
+    await assertRichTexts(page, ['const a = 10;']);
+
+    await switchReadonly(page);
+    await pressBackspace(page, 3);
+    await pressTab(page, 3);
+    await pressEnter(page, 2);
+    await assertRichTexts(page, ['const a = 10;']);
+  });
 });


### PR DESCRIPTION
Fix [BS-821](https://linear.app/affine-design/issue/BS-821/playground-%E5%88%87%E6%8D%A2readonly%E5%90%8E%EF%BC%8C%E4%BE%9D%E7%84%B6%E5%8F%AF%E4%BB%A5%E7%BC%96%E8%BE%91%E6%AE%B5%E8%90%BD)

### Before (paragraph)

https://github.com/toeverything/blocksuite/assets/20479050/805588a5-cf82-4ae3-bc61-a9f19d996f23

### After (paragraph)

https://github.com/toeverything/blocksuite/assets/20479050/1d6c1ca2-25c9-4dbc-a2fd-b73e5509c3a9

### Before (code block)

https://github.com/toeverything/blocksuite/assets/20479050/70868516-ff2f-4065-a5e7-9d18553aa7d3

### After (code block)

https://github.com/toeverything/blocksuite/assets/20479050/9ffa6580-b2e8-47d0-975e-46762896f58a