### PR TITLE
fix: image uploaded status was set unexpectedly

### DIFF
--- a/packages/blocks/src/image-block/utils.ts
+++ b/packages/blocks/src/image-block/utils.ts
@@ -38,7 +38,6 @@ export async function uploadBlobForImage(
   let sourceId: string | undefined;
 
   try {
-    setImageUploaded(blockId);
     sourceId = await doc.blobSync.set(blob);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
When adding images using slash menu, there's always an error from "fetchImageBlob" function.

![图片](https://github.com/toeverything/blocksuite/assets/6285483/1aa9b3bd-b0e8-4200-848e-3909e44b7940)

The reason is that uploaded status was set before the image uploading process was completed, as shown in the snapshot below. 
Considering there is a "setImageUploaded(blockId);" in the subsequent "finally" block, the same code in "try" block before upload was removed to solve.

![图片](https://github.com/toeverything/blocksuite/assets/6285483/0b1d35f6-ddf1-4f68-b595-f08c30509991)
