### PR TITLE
fix(blocks): image can not be peek by shift click

### DIFF
--- a/packages/blocks/src/image-block/components/page-image-block.ts
+++ b/packages/blocks/src/image-block/components/page-image-block.ts
@@ -105,21 +105,21 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
         return true;
       },
       Delete: ctx => {
-        if (!this._isSelected) return;
+        if (this._host.doc.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         this._doc.deleteBlock(this._model);
         return true;
       },
       Backspace: ctx => {
-        if (!this._isSelected) return;
+        if (this._host.doc.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         this._doc.deleteBlock(this._model);
         return true;
       },
       Enter: ctx => {
-        if (!this._isSelected) return;
+        if (this._host.doc.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         return true;
@@ -147,6 +147,9 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
       this.resizeImg,
       'click',
       (event: MouseEvent) => {
+        // the peek view need handle shift + click
+        if (event.shiftKey) return;
+
         event.stopPropagation();
         selection.update(selList => {
           return selList

--- a/packages/blocks/src/image-block/image-block.ts
+++ b/packages/blocks/src/image-block/image-block.ts
@@ -97,6 +97,9 @@ export class ImageBlockComponent extends BlockComponent<
   }
 
   private _handleClick(event: MouseEvent) {
+    // the peek view need handle shift + click
+    if (event.shiftKey) return;
+
     event.stopPropagation();
     if (!this.isInSurface) {
       this._selectBlock();


### PR DESCRIPTION
Related: [BS-798](https://linear.app/affine-design/issue/BS-798/%E5%8F%AA%E8%AF%BB%E6%A8%A1%E5%BC%8F%E4%B8%8B%E6%97%A0%E6%B3%95%E5%8F%8C%E5%87%BB%E6%94%BE%E5%A4%A7%E5%9B%BE%E7%89%87)

## What changes
- bypass click event handler when shift key is pressed so that the image can be peek
- check readonly for some key like `Backspace`

PS: Since peek view service is implemented in AFFiNE side, so the e2e test is not included in this PR