### PR TITLE
fix(examples): missing root model and incorrect rendering order

### DIFF
--- a/packages/playground/examples/store/main.ts
+++ b/packages/playground/examples/store/main.ts
@@ -12,7 +12,9 @@ function initDoc() {
   const workspace = new DocCollection({ schema });
   workspace.meta.initialize();
   const doc = workspace.createDoc({ id: 'doc:home' });
-  doc.addBlock('todo:container');
+  doc.load();
+  const rootId = doc.addBlock('todo:root');
+  doc.addBlock('todo:container', {}, rootId);
   return doc;
 }
 
@@ -28,6 +30,8 @@ function bindEvents(doc: Doc, container: TodoContainerBlockModel) {
       todoItemBlock.propsUpdated.on(() => {
         render(container);
       });
+
+      render(container);
       addInput.value = '';
       addInput.focus();
     }
@@ -65,9 +69,7 @@ function main() {
     'todo:container'
   )[0] as TodoContainerBlockModel;
   bindEvents(doc, container);
-  container.childrenUpdated.on(() => {
-    render(container);
-  });
+  render(container);
 }
 
 main();

--- a/packages/playground/examples/store/schema.ts
+++ b/packages/playground/examples/store/schema.ts
@@ -1,6 +1,14 @@
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 import { literal } from 'lit/static-html.js';
 
+const TodoRootBlockSchema = defineBlockSchema({
+  flavour: 'todo:root',
+  metadata: {
+    version: 1,
+    role: 'root',
+  },
+});
+
 const TodoContainerBlockSchema = defineBlockSchema({
   flavour: 'todo:container',
   metadata: {
@@ -20,10 +28,16 @@ const TodoItemBlockSchema = defineBlockSchema({
     version: 1,
     role: 'content',
     tag: literal`todo-item`,
+    parent: ['todo:container'],
   },
 });
 
-export const TodoSchema = [TodoContainerBlockSchema, TodoItemBlockSchema];
+export const TodoSchema = [
+  TodoRootBlockSchema,
+  TodoContainerBlockSchema,
+  TodoItemBlockSchema,
+];
+export type TodoRootBlockModel = SchemaToModel<typeof TodoRootBlockSchema>;
 export type TodoContainerBlockModel = SchemaToModel<
   typeof TodoContainerBlockSchema
 >;
@@ -32,6 +46,7 @@ export type TodoItemBlockModel = SchemaToModel<typeof TodoItemBlockSchema>;
 declare global {
   namespace BlockSuite {
     interface BlockModels {
+      'todo:root': TodoRootBlockModel;
       'todo:container': TodoContainerBlockModel;
       'todo:item': TodoItemBlockModel;
     }


### PR DESCRIPTION
Close: #7509

There are some issues in the store example:
- The demo miss a `role: root` model (`todo:container`  need a parent)
- The todolist rendering is always one item behind. See the comment below.