### PR TITLE
chore: unify signal lib

### DIFF
--- a/packages/framework/store/package.json
+++ b/packages/framework/store/package.json
@@ -18,7 +18,7 @@
     "@blocksuite/global": "workspace:*",
     "@blocksuite/inline": "workspace:*",
     "@blocksuite/sync": "workspace:*",
-    "@preact/signals-core": "^1.6.1",
+    "@lit-labs/preact-signals": "^1.0.2",
     "@types/flexsearch": "^0.7.6",
     "flexsearch": "0.7.43",
     "lib0": "^0.2.94",

--- a/packages/framework/store/src/schema/base.ts
+++ b/packages/framework/store/src/schema/base.ts
@@ -1,5 +1,5 @@
 import { type Disposable, Slot } from '@blocksuite/global/utils';
-import { computed, signal } from '@preact/signals-core';
+import { computed, signal } from '@lit-labs/preact-signals';
 import type * as Y from 'yjs';
 import { z } from 'zod';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,9 +395,9 @@ importers:
       '@blocksuite/sync':
         specifier: workspace:*
         version: link:../sync
-      '@preact/signals-core':
-        specifier: ^1.6.1
-        version: 1.6.1
+      '@lit-labs/preact-signals':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@types/flexsearch':
         specifier: ^0.7.6
         version: 0.7.6


### PR DESCRIPTION
Also use `@lit-labs/preact-signals` in store to avoid version diverge.