### PR TITLE
chore(blocks): expose insertContent utility

### DIFF
--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -49,5 +49,6 @@ export {
   type AffineSlashMenuItemGenerator,
   AffineSlashMenuWidget,
   type AffineSlashSubMenu,
+  insertContent,
 } from './slash-menu/index.js';
 export { AffineSurfaceRefToolbar } from './surface-ref-toolbar/surface-ref-toolbar.js';

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -28,6 +28,8 @@ import {
 import { SlashMenu } from './slash-menu-popover.js';
 import { filterEnabledSlashMenuItems } from './utils.js';
 
+export { insertContent } from './utils.js';
+
 export type AffineSlashMenuContext = SlashMenuContext;
 export type AffineSlashMenuItem = SlashMenuItem;
 export type AffineSlashMenuActionItem = SlashMenuActionItem;


### PR DESCRIPTION
allows affine to overwrite functions easier.