### PR TITLE
fix(blocks): signal based readonly mode of database

### DIFF
--- a/packages/blocks/src/database-block/data-view/column/base-cell.ts
+++ b/packages/blocks/src/database-block/data-view/column/base-cell.ts
@@ -1,4 +1,5 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { property } from 'lit/decorators.js';
 
 import type {
@@ -11,7 +12,7 @@ export abstract class BaseCellRenderer<
     Value,
     Data extends Record<string, unknown> = Record<string, unknown>,
   >
-  extends WithDisposable(ShadowlessElement)
+  extends SignalWatcher(WithDisposable(ShadowlessElement))
   implements DataViewCellLifeCycle, CellRenderProps<Data, Value>
 {
   beforeEnterEditMode(): boolean {

--- a/packages/blocks/src/database-block/data-view/common/component/overflow/overflow.ts
+++ b/packages/blocks/src/database-block/data-view/common/component/overflow/overflow.ts
@@ -1,4 +1,5 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { type PropertyValues, type TemplateResult, css, html } from 'lit';
 import {
   customElement,
@@ -11,7 +12,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 @customElement('component-overflow')
-export class Overflow extends WithDisposable(ShadowlessElement) {
+export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
   static override styles = css`
     component-overflow {
       display: flex;

--- a/packages/blocks/src/database-block/data-view/utils/uni-component/render-template.ts
+++ b/packages/blocks/src/database-block/data-view/utils/uni-component/render-template.ts
@@ -1,10 +1,11 @@
 import type { TemplateResult } from 'lit';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { customElement, property } from 'lit/decorators.js';
 
 @customElement('any-render')
-export class AnyRender<T> extends ShadowlessElement {
+export class AnyRender<T> extends SignalWatcher(ShadowlessElement) {
   override render() {
     return this.renderTemplate(this.props);
   }

--- a/packages/blocks/src/database-block/data-view/utils/uni-component/uni-component.ts
+++ b/packages/blocks/src/database-block/data-view/utils/uni-component/uni-component.ts
@@ -2,6 +2,7 @@ import type { LitElement, PropertyValues, TemplateResult } from 'lit';
 import type { Ref } from 'lit/directives/ref.js';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
@@ -111,6 +112,7 @@ export const createUniComponentFromWebComponent = <
     return {
       update: props => {
         Object.assign(ins, props);
+        ins.requestUpdate();
       },
       unmount: () => {
         ins.remove();
@@ -124,7 +126,7 @@ export const createUniComponentFromWebComponent = <
 class UniAnyRender<
   T,
   Expose extends NonNullable<unknown>,
-> extends ShadowlessElement {
+> extends SignalWatcher(ShadowlessElement) {
   override render() {
     return this.renderTemplate(this.props, this.expose);
   }
@@ -150,6 +152,7 @@ export const defineUniComponent = <T, Expose extends NonNullable<unknown>>(
     return {
       update: props => {
         ins.props = props;
+        ins.requestUpdate();
       },
       unmount: () => {
         ins.remove();

--- a/packages/blocks/src/database-block/data-view/view/data-view-base.ts
+++ b/packages/blocks/src/database-block/data-view/view/data-view-base.ts
@@ -7,6 +7,7 @@ import type { Disposable, Slot } from '@blocksuite/global/utils';
 import type { Doc } from '@blocksuite/store';
 
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { property } from 'lit/decorators.js';
 
 import type { DataSource } from '../common/data-source/base.js';
@@ -21,7 +22,7 @@ export abstract class DataViewBase<
     T extends DataViewManager = DataViewManager,
     Selection extends DataViewSelection = DataViewSelection,
   >
-  extends WithDisposable(ShadowlessElement)
+  extends SignalWatcher(WithDisposable(ShadowlessElement))
   implements DataViewProps<T, Selection>, DataViewExpose
 {
   addRow?(position: InsertToPosition): void;

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/cell-container.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/cell-container.ts
@@ -1,5 +1,6 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { createRef } from 'lit/directives/ref.js';
@@ -14,7 +15,9 @@ import type { DataViewTableColumnManager } from '../table-view-manager.js';
 import { renderUniLit } from '../../../../utils/uni-component/index.js';
 
 @customElement('affine-database-cell-container')
-export class DatabaseCellContainer extends WithDisposable(ShadowlessElement) {
+export class DatabaseCellContainer extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
   private _cell = createRef<DataViewCellLifeCycle>();
 
   static override styles = css`

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/column-header.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/column-header.ts
@@ -5,6 +5,7 @@ import {
   computePosition,
   shift,
 } from '@floating-ui/dom';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { type TemplateResult, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
@@ -21,7 +22,9 @@ import './database-header-column.js';
 import { styles } from './styles.js';
 
 @customElement('affine-database-column-header')
-export class DatabaseColumnHeader extends WithDisposable(ShadowlessElement) {
+export class DatabaseColumnHeader extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
   private _onAddColumn = () => {
     if (this.readonly) return;
     this.tableViewManager.columnAdd('end');
@@ -153,7 +156,9 @@ export class DatabaseColumnHeader extends WithDisposable(ShadowlessElement) {
     return html`
       ${this.renderGroupHeader?.()}
       <div class="affine-database-column-header database-row">
-        <div class="data-view-table-left-bar"></div>
+        ${this.readonly
+          ? nothing
+          : html`<div class="data-view-table-left-bar"></div>`}
         ${repeat(
           this.tableViewManager.columnManagerList,
           column => column.id,

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/database-header-column.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/database-header-column.ts
@@ -1,5 +1,6 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -47,7 +48,9 @@ import {
 } from './vertical-indicator.js';
 
 @customElement('affine-database-header-column')
-export class DatabaseHeaderColumn extends WithDisposable(ShadowlessElement) {
+export class DatabaseHeaderColumn extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
   private _clickColumn = () => {
     if (this.tableViewManager.readonly) {
       return;

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/row.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/row.ts
@@ -1,4 +1,5 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -15,7 +16,7 @@ import { DEFAULT_COLUMN_MIN_WIDTH } from '../consts.js';
 import { openDetail, popRowMenu } from './menu.js';
 
 @customElement('data-view-table-row')
-export class TableRow extends WithDisposable(ShadowlessElement) {
+export class TableRow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
   private _clickDragHandler = () => {
     if (this.view.readonly) {
       return;
@@ -172,21 +173,23 @@ export class TableRow extends WithDisposable(ShadowlessElement) {
   protected override render(): unknown {
     const view = this.view;
     return html`
-      <div class="data-view-table-left-bar">
-        <div
-          class="data-view-table-view-drag-handler"
-          @click=${this._clickDragHandler}
-          style="width: 8px;height: 100%;display:flex;align-items:center;justify-content:center;cursor:grab;"
-        >
-          <div
-            class="show-on-hover-row"
-            style="width: 4px;
+      ${view.readonly
+        ? nothing
+        : html`<div class="data-view-table-left-bar">
+            <div
+              class="data-view-table-view-drag-handler"
+              @click=${this._clickDragHandler}
+              style="width: 8px;height: 100%;display:flex;align-items:center;justify-content:center;cursor:grab;"
+            >
+              <div
+                class="show-on-hover-row"
+                style="width: 4px;
             border-radius: 2px;
             height: 12px;
             background-color: var(--affine-placeholder-color);"
-          ></div>
-        </div>
-      </div>
+              ></div>
+            </div>
+          </div>`}
       ${repeat(
         view.columnManagerList,
         v => v.id,

--- a/packages/blocks/src/database-block/data-view/view/presets/table/controller/selection.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/controller/selection.ts
@@ -684,7 +684,7 @@ export class TableSelectionController implements ReactiveController {
     const dragToFill = this.dragToFillDraggable;
 
     if (!div || !dragToFill) return;
-    if (focus && !isRowSelection) {
+    if (focus && !isRowSelection && !this.host.view.readonly) {
       // Check if row is removed.
       const rows = this.rows(groupKey) ?? [];
       if (rows.length <= focus.rowIndex) return;
@@ -780,7 +780,7 @@ export class TableSelectionController implements ReactiveController {
   ) {
     const div = this.areaSelectionElement;
     if (!div) return;
-    if (!rowSelection && !columnSelection) {
+    if ((!rowSelection && !columnSelection) || this.host.view.readonly) {
       div.style.display = 'none';
       return;
     }

--- a/packages/blocks/src/database-block/data-view/view/presets/table/group.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/group.ts
@@ -1,7 +1,6 @@
-import type { PropertyValues } from 'lit';
-
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
-import { css, html } from 'lit';
+import { SignalWatcher } from '@lit-labs/preact-signals';
+import { type PropertyValues, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -54,7 +53,9 @@ const styles = css`
 `;
 
 @customElement('affine-data-view-table-group')
-export class TableGroup extends WithDisposable(ShadowlessElement) {
+export class TableGroup extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
   private clickAddRow = () => {
     this.view.rowAdd('end', this.group?.key);
     requestAnimationFrame(() => {

--- a/packages/blocks/src/database-block/data-view/widget/views-bar/views.ts
+++ b/packages/blocks/src/database-block/data-view/widget/views-bar/views.ts
@@ -224,6 +224,7 @@ export class DataViewHeaderViews extends WidgetBase {
       }
       return html`<div
         class="database-view-button dv-icon-16 dv-hover"
+        data-testid="database-add-view-button"
         @click="${this._addViewMenu}"
       >
         ${AddCursorIcon}

--- a/packages/blocks/src/database-block/data-view/widget/widget-base.ts
+++ b/packages/blocks/src/database-block/data-view/widget/widget-base.ts
@@ -1,4 +1,5 @@
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { property } from 'lit/decorators.js';
 
 import type { DataSource } from '../common/data-source/base.js';
@@ -8,7 +9,7 @@ import type { DataViewManager } from '../view/data-view-manager.js';
 import type { DataViewWidgetProps } from './types.js';
 
 export class WidgetBase
-  extends WithDisposable(ShadowlessElement)
+  extends SignalWatcher(WithDisposable(ShadowlessElement))
   implements DataViewWidgetProps
 {
   @property({ attribute: false })

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -1,9 +1,8 @@
 import { RangeManager } from '@blocksuite/block-std';
 import { Slot } from '@blocksuite/global/utils';
 import { Slice } from '@blocksuite/store';
-import { css, nothing, unsafeCSS } from 'lit';
+import { css, html, nothing, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { html } from 'lit/static-html.js';
 
 import type { NoteBlockComponent } from '../note-block/index.js';
 import type { AffineInnerModalWidget } from '../root-block/index.js';

--- a/tests/utils/actions/click.ts
+++ b/tests/utils/actions/click.ts
@@ -107,8 +107,8 @@ export async function clickTestOperationsMenuItem(page: Page, name: string) {
   await menuItem.waitFor({ state: 'hidden' }); // wait for animation ended
 }
 
-export async function switchReadonly(page: Page) {
-  await page.evaluate(() => {
+export async function switchReadonly(page: Page, value = true) {
+  await page.evaluate(_value => {
     const defaultPage = document.querySelector(
       'affine-page-root'
     ) as HTMLElement & {
@@ -117,8 +117,8 @@ export async function switchReadonly(page: Page) {
       };
     };
     const doc = defaultPage.doc;
-    doc.awarenessStore.setFlag('readonly', { 'doc:home': true });
-  });
+    doc.awarenessStore.setFlag('readonly', { 'doc:home': _value });
+  }, value);
 }
 
 export async function activeEmbed(page: Page) {


### PR DESCRIPTION
Fix [BS-821](https://linear.app/affine-design/issue/BS-821/playground-%E5%88%87%E6%8D%A2readonly%E5%90%8E%EF%BC%8C%E9%83%A8%E5%88%86block%E4%BB%8D%E5%8F%AF%E4%BB%A5%E8%A2%AB%E7%BC%96%E8%BE%91)

### What changes
- Wrap some database components with `SignalWatcher` to react to the change of `doc.readonly`
- Add e2e tests for readonly mode database

### Before

https://github.com/toeverything/blocksuite/assets/20479050/809837f5-1e1b-41b8-bb8f-60b1921993a6

### After

https://github.com/toeverything/blocksuite/assets/20479050/da4b0c7a-ee0f-4dea-8145-175a9e3f5a63