### PR TITLE
refactor: keydown observer and get query

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -66,10 +66,14 @@ const showSlashMenu = debounce(
       disposables.dispose()
     );
 
-    const slashMenu = new SlashMenu();
+    const inlineEditor = getInlineEditorByModel(
+      context.rootElement.host,
+      context.model
+    );
+    if (!inlineEditor) return;
+    const slashMenu = new SlashMenu(inlineEditor, abortController);
     disposables.add(() => slashMenu.remove());
     slashMenu.context = context;
-    slashMenu.abortController = abortController;
     slashMenu.config = config;
     slashMenu.triggerKey = triggerKey;
 


### PR DESCRIPTION
Fix issue [BS-792](https://linear.app/affine-design/issue/BS-792).

### What Changed?
- Make the `createKeydownObserver` only observe keydown event, not coupled with query parsing logic.
- Use `getQuery` to get the latest query results.