### PR TITLE
fix(blocks): can click todo list in readonly mode

### DIFF
--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -35,6 +35,8 @@ export class ListBlockComponent extends BlockComponent<
       this._toggleChildren();
       return;
     } else if (this.model.type === 'todo') {
+      if (this.doc.readonly) return;
+
       this.doc.captureSync();
       const checkedPropObj = { checked: !this.model.checked };
       this.doc.updateBlock(this.model, checkedPropObj);

--- a/packages/blocks/src/list-block/styles.ts
+++ b/packages/blocks/src/list-block/styles.ts
@@ -24,6 +24,10 @@ export const listPrefix = css`
     color: var(--affine-icon-color);
   }
 
+  .affine-list-block__todo-prefix.readonly {
+    cursor: default;
+  }
+
   .affine-list-block__todo-prefix > svg {
     width: 20px;
     height: 20px;

--- a/packages/blocks/src/list-block/utils/get-list-icon.ts
+++ b/packages/blocks/src/list-block/utils/get-list-icon.ts
@@ -38,7 +38,7 @@ export function ListIcon(
     case 'todo':
       return html`<div
         contenteditable="false"
-        class="affine-list-block__prefix affine-list-block__todo-prefix"
+        class=${`affine-list-block__prefix affine-list-block__todo-prefix ${model.doc.readonly ? 'readonly' : ''}`}
         @click=${onClick}
       >
         ${model.checked ? checkboxChecked() : checkboxUnchecked()}

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -38,6 +38,28 @@ import {
 } from './utils/asserts.js';
 import { test } from './utils/playwright.js';
 
+const getToggleIcon = (page: Page) => page.locator('.toggle-icon');
+
+async function isToggleIconVisible(toggleIcon: Locator) {
+  const connected = await toggleIcon.isVisible();
+  if (!connected) return false;
+  const element = await toggleIcon.elementHandle();
+  if (!element) return false;
+  const opacity = await element.evaluate(node => {
+    // https://stackoverflow.com/questions/11365296/how-do-i-get-the-opacity-of-an-element-using-javascript
+    return window.getComputedStyle(node).getPropertyValue('opacity');
+  });
+  if (!opacity || typeof opacity !== 'string') {
+    throw new Error('opacity is not a string');
+  }
+  const isVisible = opacity !== '0';
+  return isVisible;
+}
+
+async function assertToggleIconVisible(toggleIcon: Locator, expected = true) {
+  expect(await isToggleIconVisible(toggleIcon)).toBe(expected);
+}
+
 test('add new bulleted list', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);
@@ -52,6 +74,25 @@ test('add new bulleted list', async ({ page }) => {
 
   await assertRichTexts(page, ['aa', 'aa', '']);
   await assertBlockCount(page, 'list', 3);
+});
+
+test('add new todo list', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+
+  await focusRichText(page, 0);
+  await updateBlockType(page, 'affine:list', 'todo');
+  await focusRichText(page, 0);
+
+  await type(page, 'aa');
+  await assertRichTexts(page, ['aa']);
+
+  const checkBox = page.locator('.affine-list-block__prefix');
+  await expect(page.locator('.affine-list--checked')).toHaveCount(0);
+  await checkBox.click();
+  await expect(page.locator('.affine-list--checked')).toHaveCount(1);
+  await checkBox.click();
+  await expect(page.locator('.affine-list--checked')).toHaveCount(0);
 });
 
 test('add new toggle list', async ({ page }) => {
@@ -768,28 +809,6 @@ test('should not convert to a list when pressing space at the second line', asyn
 });
 
 test.describe('toggle list', () => {
-  const getToggleIcon = (page: Page) => page.locator('.toggle-icon');
-
-  async function isToggleIconVisible(toggleIcon: Locator) {
-    const connected = await toggleIcon.isVisible();
-    if (!connected) return false;
-    const element = await toggleIcon.elementHandle();
-    if (!element) return false;
-    const opacity = await element.evaluate(node => {
-      // https://stackoverflow.com/questions/11365296/how-do-i-get-the-opacity-of-an-element-using-javascript
-      return window.getComputedStyle(node).getPropertyValue('opacity');
-    });
-    if (!opacity || typeof opacity !== 'string') {
-      throw new Error('opacity is not a string');
-    }
-    const isVisible = opacity !== '0';
-    return isVisible;
-  }
-
-  async function assertToggleIconVisible(toggleIcon: Locator, expected = true) {
-    expect(await isToggleIconVisible(toggleIcon)).toBe(expected);
-  }
-
   test('click toggle icon should collapsed list', async ({ page }) => {
     await enterPlaygroundRoom(page);
     const { noteId } = await initEmptyParagraphState(page);
@@ -939,7 +958,9 @@ test.describe('toggle list', () => {
     await waitNextFrame(page, 300);
     await assertToggleIconVisible(toggleIcon, false);
   });
+});
 
+test.describe('readonly', () => {
   test('can expand toggle in readonly mode', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyParagraphState(page);
@@ -963,5 +984,30 @@ test.describe('toggle list', () => {
 
     await toggleIcon.click();
     await expect(prefixes).toHaveCount(2);
+  });
+
+  test('can not modify todo list in readonly mode', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    const checkBox = page.locator('.affine-list-block__prefix');
+
+    {
+      await type(page, '[] todo');
+      await switchReadonly(page);
+      await expect(page.locator('.affine-list--checked')).toHaveCount(0);
+      await checkBox.click();
+      await expect(page.locator('.affine-list--checked')).toHaveCount(0);
+    }
+
+    {
+      await switchReadonly(page, false);
+      await checkBox.click();
+      await switchReadonly(page);
+      await expect(page.locator('.affine-list--checked')).toHaveCount(1);
+      await checkBox.click();
+      await expect(page.locator('.affine-list--checked')).toHaveCount(1);
+    }
   });
 });


### PR DESCRIPTION
Fix [BS-821](https://linear.app/affine-design/issue/BS-821/playground-%E5%88%87%E6%8D%A2readonly%E5%90%8E%EF%BC%8C%E9%83%A8%E5%88%86block%E4%BB%8D%E5%8F%AF%E4%BB%A5%E8%A2%AB%E7%BC%96%E8%BE%91)