### PR TITLE
fix(blocks): improve menu width

### DIFF
--- a/packages/blocks/src/_common/components/toolbar/menu-button.ts
+++ b/packages/blocks/src/_common/components/toolbar/menu-button.ts
@@ -123,7 +123,7 @@ export class EditorMenuContent extends LitElement {
       min-height: 36px;
     }
 
-    ::slotted([slot]) {
+    ::slotted([slot][data-size]) {
       min-width: 146px;
     }
 
@@ -132,7 +132,7 @@ export class EditorMenuContent extends LitElement {
     }
 
     ::slotted([slot][data-size='large']) {
-      min-width: 184px;
+      min-width: 176px;
     }
 
     ::slotted([slot][data-orientation='vertical']) {

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/styles.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/styles.ts
@@ -128,7 +128,8 @@ export const linkPopupStyle = css`
   .affine-link-preview {
     display: flex;
     justify-content: flex-start;
-    width: 140px;
+    min-width: 60px;
+    max-width: 140px;
     padding: var(--1, 0px);
     border-radius: var(--1, 0px);
     opacity: var(--add, 1);

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -475,7 +475,12 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
           </editor-icon-button>
         `}
       >
-        <div slot class="more-actions-container" data-orientation="vertical">
+        <div
+          slot
+          class="more-actions-container"
+          data-size="large"
+          data-orientation="vertical"
+        >
           ${actions}
         </div>
       </editor-menu-button>

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -446,7 +446,9 @@ export function toolbarMoreButton(toolbar: AffineFormatBarWidget) {
         </editor-icon-button>
       `}
     >
-      <div slot data-orientation="vertical">${renderActions(actions)}</div>
+      <div slot data-size="large" data-orientation="vertical">
+        ${renderActions(actions)}
+      </div>
     </editor-menu-button>
   `;
 }

--- a/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
@@ -80,7 +80,7 @@ export class AffineImageToolbar extends LitElement {
             '--packed-height': '4px',
           })}
         >
-          <div slot data-size="small" data-orientation="vertical">
+          <div slot data-size="large" data-orientation="vertical">
             ${MoreMenuRenderer(
               this.blockElement,
               this._popMenuAbortController,


### PR DESCRIPTION
### What's changed!

* Set `min-width` and `max-width` for the link
* Set `min-width` only when `data-size` attribute is turned on
* Unify the minimum width of the more menu

### Before

* <img width="445" alt="Screenshot 2024-07-12 at 20 19 04" src="https://github.com/user-attachments/assets/cc331f56-3285-475d-a121-41d61ca72a1b">

* <img width="283" alt="Screenshot 2024-07-12 at 20 19 59" src="https://github.com/user-attachments/assets/ae6859b7-5aba-485a-a8df-c30a32c25780">

* <img width="507" alt="Screenshot 2024-07-12 at 20 19 19" src="https://github.com/user-attachments/assets/2e787ab0-250a-4ce1-87cc-04e09a59f43c">


### After

* <img width="346" alt="Screenshot 2024-07-12 at 20 17 16" src="https://github.com/user-attachments/assets/f90599ce-1b26-44bf-b268-55eae94f8945">

* <img width="280" alt="Screenshot 2024-07-12 at 20 18 36" src="https://github.com/user-attachments/assets/8ab80906-fe41-4dc2-b383-481d10225d24">

* <img width="337" alt="Screenshot 2024-07-12 at 20 18 17" src="https://github.com/user-attachments/assets/4012cd7c-55bc-4472-94e9-8ea9905c7bf8">
