### PR TITLE
feat(store): add signal props for model

### DIFF
--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -73,7 +73,7 @@ export class ParagraphBlockComponent extends BlockComponent<
   }
 
   override renderBlock(): TemplateResult<1> {
-    const { type } = this.model;
+    const { type$ } = this.model;
     const children = html`<div
       class="affine-block-children-container"
       style="padding-left: ${BLOCK_CHILDREN_CONTAINER_PADDING_LEFT}px"
@@ -83,7 +83,7 @@ export class ParagraphBlockComponent extends BlockComponent<
 
     return html`
       <div class="affine-paragraph-block-container">
-        <div class="affine-paragraph-rich-text-wrapper ${type}">
+        <div class="affine-paragraph-rich-text-wrapper ${type$.value}">
           <rich-text
             .yText=${this.model.text.yText}
             .inlineEventSource=${this.topContenteditableElement ?? nothing}

--- a/packages/framework/store/src/__tests__/block.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/block.unit.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest';
+import { computed, effect } from '@preact/signals-core';
+import { describe, expect, test, vi } from 'vitest';
 import * as Y from 'yjs';
 
 import {
@@ -14,6 +15,7 @@ const pageSchema = defineBlockSchema({
   props: internal => ({
     title: internal.Text(),
     count: 0,
+    toggle: false,
     style: {} as Record<string, unknown>,
   }),
   metadata: {
@@ -54,4 +56,143 @@ test('init block without props should add default props', () => {
   expect(yBlock.get('prop:count')).toBe(0);
   expect(model.count).toBe(0);
   expect(model.style).toEqual({});
+});
+
+describe('block model should has signal props', () => {
+  test('atom', () => {
+    const doc = createTestDoc();
+    const yDoc = new Y.Doc();
+    const yBlock = yDoc.getMap('yBlock') as YBlock;
+    yBlock.set('sys:id', '0');
+    yBlock.set('sys:flavour', 'page');
+    yBlock.set('sys:children', new Y.Array());
+
+    const block = new Block(doc.schema, yBlock, doc);
+    const model = block.model as RootModel;
+
+    const isOdd = computed(() => model.count$.value % 2 === 1);
+
+    expect(model.count$.value).toBe(0);
+    expect(isOdd.peek()).toBe(false);
+
+    // set prop
+    model.count = 1;
+    expect(model.count$.value).toBe(1);
+    expect(isOdd.peek()).toBe(true);
+    expect(yBlock.get('prop:count')).toBe(1);
+
+    // set signal
+    model.count$.value = 2;
+    expect(model.count).toBe(2);
+    expect(isOdd.peek()).toBe(false);
+    expect(yBlock.get('prop:count')).toBe(2);
+
+    // set prop
+    yBlock.set('prop:count', 3);
+    expect(model.count).toBe(3);
+    expect(model.count$.value).toBe(3);
+    expect(isOdd.peek()).toBe(true);
+
+    const toggleEffect = vi.fn();
+    effect(() => {
+      toggleEffect(model.toggle$.value);
+    });
+    expect(toggleEffect).toHaveBeenCalledTimes(1);
+    const runToggle = () => {
+      const next = !model.toggle;
+      model.toggle = next;
+      expect(model.toggle$.value).toBe(next);
+    };
+    const times = 10;
+    for (let i = 0; i < times; i++) {
+      runToggle();
+    }
+    expect(toggleEffect).toHaveBeenCalledTimes(times + 1);
+    const runToggleReverse = () => {
+      const next = !model.toggle;
+      model.toggle$.value = next;
+      expect(model.toggle).toBe(next);
+    };
+    for (let i = 0; i < times; i++) {
+      runToggleReverse();
+    }
+    expect(toggleEffect).toHaveBeenCalledTimes(times * 2 + 1);
+  });
+
+  test('nested', () => {
+    const doc = createTestDoc();
+    const yDoc = new Y.Doc();
+    const yBlock = yDoc.getMap('yBlock') as YBlock;
+    yBlock.set('sys:id', '0');
+    yBlock.set('sys:flavour', 'page');
+    yBlock.set('sys:children', new Y.Array());
+
+    const block = new Block(doc.schema, yBlock, doc);
+    const model = block.model as RootModel;
+    expect(model.style).toEqual({});
+
+    model.style = { color: 'red' };
+    expect((yBlock.get('prop:style') as Y.Map<unknown>).toJSON()).toEqual({
+      color: 'red',
+    });
+    expect(model.style$.value).toEqual({ color: 'red' });
+
+    model.style.color = 'yellow';
+    expect((yBlock.get('prop:style') as Y.Map<unknown>).toJSON()).toEqual({
+      color: 'yellow',
+    });
+    expect(model.style$.value).toEqual({ color: 'yellow' });
+
+    model.style$.value = { color: 'blue' };
+    expect(model.style.color).toBe('blue');
+    expect((yBlock.get('prop:style') as Y.Map<unknown>).toJSON()).toEqual({
+      color: 'blue',
+    });
+
+    const map = new Y.Map();
+    map.set('color', 'green');
+    yBlock.set('prop:style', map);
+    expect(model.style.color).toBe('green');
+    expect(model.style$.value).toEqual({ color: 'green' });
+  });
+
+  test('with stash and pop', () => {
+    const doc = createTestDoc();
+    const yDoc = new Y.Doc();
+    const yBlock = yDoc.getMap('yBlock') as YBlock;
+    yBlock.set('sys:id', '0');
+    yBlock.set('sys:flavour', 'page');
+    yBlock.set('sys:children', new Y.Array());
+
+    const block = new Block(doc.schema, yBlock, doc);
+    const model = block.model as RootModel;
+
+    expect(model.count).toBe(0);
+    model.stash('count');
+
+    model.count = 1;
+    expect(model.count$.value).toBe(1);
+    expect(yBlock.get('prop:count')).toBe(0);
+
+    model.count$.value = 2;
+    expect(model.count).toBe(2);
+    expect(yBlock.get('prop:count')).toBe(0);
+
+    model.pop('count');
+    expect(yBlock.get('prop:count')).toBe(2);
+    expect(model.count).toBe(2);
+    expect(model.count$.value).toBe(2);
+
+    model.stash('count');
+    yBlock.set('prop:count', 3);
+    expect(model.count).toBe(3);
+    expect(model.count$.value).toBe(3);
+
+    model.count$.value = 4;
+    expect(yBlock.get('prop:count')).toBe(3);
+    expect(model.count).toBe(4);
+
+    model.pop('count');
+    expect(yBlock.get('prop:count')).toBe(4);
+  });
 });

--- a/packages/framework/store/src/schema/base.ts
+++ b/packages/framework/store/src/schema/base.ts
@@ -1,3 +1,4 @@
+import type { Signal } from '@preact/signals-core';
 import type * as Y from 'yjs';
 
 import { type Disposable, Slot } from '@blocksuite/global/utils';
@@ -151,6 +152,9 @@ export function defineBlockSchema({
   return schema;
 }
 
+type SignaledProps<Props> = Props & {
+  [P in keyof Props & string as `${P}$`]: Signal<Props[P]>;
+};
 /**
  * The MagicProps function is used to append the props to the class.
  * For example:
@@ -173,7 +177,8 @@ const modelLabel = Symbol('model_label');
 // @ts-ignore
 export class BlockModel<
   Props extends object = object,
-> extends MagicProps()<Props> {
+  PropsSignal extends object = SignaledProps<Props>,
+> extends MagicProps()<PropsSignal> {
   private _children = signal<string[]>([]);
 
   private _onCreated: Disposable;


### PR DESCRIPTION
Add signal props for model.

This pr automatically add a signal version property for every prop

```ts
declare const model: BlockModel<{ name: string }>;
assert(typeof model.name$.value === 'string'); // true
 
model.name = 'hello';
assert(model.name$.value === 'hello'); // true
assert(model.yBlock.get('prop:name') === 'hello'); // true

model.name$.value = 'world';
assert(model.name === 'world'); // true
assert(model.yBlock.get('prop:name') === 'world'); // true

model.yBlock.set('prop:name', 'blocksuite');
assert(model.name$.value === 'blocksuite'); // true
```