### PR TITLE
fix(blocks): remove & selector

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/styles.ts
+++ b/packages/blocks/src/_common/components/ai-item/styles.ts
@@ -12,10 +12,10 @@ export const menuItemStyles = css`
     align-self: stretch;
     border-radius: 4px;
     box-sizing: border-box;
-    &:hover {
-      background: var(--affine-hover-color);
-      cursor: pointer;
-    }
+  }
+  .menu-item:hover {
+    background: var(--affine-hover-color);
+    cursor: pointer;
   }
   .item-icon {
     display: flex;

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/number-format-bar.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/column-header/number-format-bar.ts
@@ -55,10 +55,11 @@ export class DatabaseNumberFormatBar extends WithDisposable(LitElement) {
       position: relative;
 
       user-select: none;
-      & svg {
-        width: 16px;
-        height: 16px;
-      }
+    }
+
+    .number-format-toolbar-button svg {
+      width: 16px;
+      height: 16px;
     }
 
     .number-formatting-sample {


### PR DESCRIPTION
Fix [BS-698](https://linear.app/affine-design/issue/BS-698/%E6%94%B9%E6%8E%89and%E9%80%89%E6%8B%A9%E5%99%A8)

Using regex to find & selector.
```
css`(?:[\s\S]|[\n])[^`]*&(?:[\s\S]|[\n])[^`]*`
```

### Regex Explanation by ChatGPT
This regular expression is designed to match a specific pattern in text, commonly used in processing CSS or similar textual data. Let's break down the expression to understand it better:

1. `css``: This part specifies that the regular expression should start matching text with "css`".

2. `(?:[\s\S]|[\n])`: This is a non-capturing group (indicated by `?:`), which matches any single character, including whitespace and newline characters. `[\s\S]` means to match any whitespace or non-whitespace character, essentially matching all characters, while `[\n]` explicitly matches a newline character. The expression here is somewhat redundant since `[\s\S]` already includes the functionality of `\n`.

3. `[^`]*`: This part matches any number of characters that are not the backtick (`). This means it will continue to match until it encounters the next backtick.

*4. `&`: This character must explicitly appear in the matched string.

5. `(?:[\s\S]|[\n])`: Same as point 2, it matches any single character, including newline characters.

6. `[^`]*`: Again, this matches any number of characters that are not backticks, continuing until the next backtick is found.

Overall, this regular expression is looking for a pattern that starts with "css`", followed by any characters (including new lines), contains an ampersand (&), and continues with any characters until the next backtick. This pattern is typically used to parse and manipulate strings in stylesheets or similar contexts where such a pattern might be used to denote specific CSS or styling behaviors.