### PR TITLE
fix: paste end with image will lose the focus line text

### DIFF
--- a/tests/clipboard.spec.ts
+++ b/tests/clipboard.spec.ts
@@ -169,7 +169,7 @@ test(
   }
 );
 
-test.skip(
+test(
   scoped`clipboard paste end with image, the cursor should be controlled by up/down keys`,
   async ({ page }) => {
     test.info().annotations.push({
@@ -183,7 +183,7 @@ test.skip(
     // set up clipboard data using html
     const clipData = {
       'text/html': `<p>Lorem Ipsum placeholder text.</p>
-    <figure ><img src='/test-card-1.png' /></figure>
+    <figure ><img src='https://placehold.co/600x400' /></figure>
     `,
     };
     await page.evaluate(
@@ -199,13 +199,16 @@ test.skip(
       },
       { clipData }
     );
+    const str = 'Lorem Ipsum placeholder text.';
     await waitEmbedLoaded(page);
     await assertRichImage(page, 1);
+    await pressEscape(page);
     await pressArrowUp(page, 1);
     await pasteContent(page, clipData);
     await assertRichImage(page, 2);
-    await assertText(page, 'Lorem Ipsum placeholder text.');
+    await assertText(page, str + str);
     await pressArrowDown(page, 1);
+    await pressEscape(page);
     await pasteContent(page, clipData);
     await assertRichImage(page, 3);
     await assertText(page, 'Lorem Ipsum placeholder text.', 1);


### PR DESCRIPTION
``` html
// clipboard data:
<paragraph aaa>
<image>

// paste to: (| is cursor)
<paragraph |bbb>

// before
<paragraph aaa>
<image>

// after
<paragraph aaabbb>
<image>
```