### PR TITLE
fix(edgeless): offsetWidth of edgeless root is zero in Safari

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -129,6 +129,8 @@ export class EdgelessRootBlockComponent extends BlockElement<
     affine-edgeless-root {
       -webkit-user-select: none;
       user-select: none;
+      display: block;
+      height: 100%;
     }
 
     .widgets-container {


### PR DESCRIPTION
Close [BS-767](https://linear.app/affine-design/issue/BS-767/safari%E6%B5%8F%E8%A7%88%E5%99%A8%E4%B8%AD%EF%BC%8Cedgeless-note%E5%9C%A8%E7%99%BD%E6%9D%BF%E4%B8%8A%E4%B8%8D%E6%98%BE%E7%A4%BA)

In Safari, If a custom element does not explicitly set its size, then its `offsetWidth` and `offsetHeight` are 0, which make the following computation error

https://github.com/toeverything/blocksuite/blob/4d01083bbc2a6f179ce28bf4f3f9062e33367a15/packages/blocks/src/root-block/edgeless/utils/viewport.ts#L338-L345

https://github.com/toeverything/blocksuite/blob/4d01083bbc2a6f179ce28bf4f3f9062e33367a15/packages/blocks/src/root-block/edgeless/utils/viewport.ts#L77-L87

PS: This behavior is different from chrome. I think it may be a bug of Safari

### Before

https://github.com/user-attachments/assets/8d4fd257-0be0-498a-8e63-278bc0724ef2

### After

https://github.com/user-attachments/assets/fcff6a06-d351-4ee3-bbbb-8e771bb71070

