### PR TITLE
refactor(store): extract sync controller from block

### DIFF
--- a/packages/framework/store/src/__tests__/block.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/block.unit.spec.ts
@@ -7,7 +7,7 @@ import {
   type SchemaToModel,
   defineBlockSchema,
 } from '../schema/index.js';
-import { Block, type YBlock } from '../store/doc/block.js';
+import { Block, type YBlock } from '../store/doc/block/index.js';
 import { DocCollection, IdGeneratorType } from '../store/index.js';
 
 const pageSchema = defineBlockSchema({

--- a/packages/framework/store/src/indexer/base.ts
+++ b/packages/framework/store/src/indexer/base.ts
@@ -3,7 +3,7 @@ import type * as Y from 'yjs';
 import { DisposableGroup, Slot, assertExists } from '@blocksuite/global/utils';
 import { YArrayEvent, YMapEvent, YTextEvent } from 'yjs';
 
-import type { YBlock } from '../store/doc/block.js';
+import type { YBlock } from '../store/doc/block/index.js';
 import type { BlockSuiteDoc } from '../yjs/index.js';
 
 type DocId = string;

--- a/packages/framework/store/src/indexer/search.ts
+++ b/packages/framework/store/src/indexer/search.ts
@@ -9,7 +9,7 @@ import {
 import FlexSearch from 'flexsearch';
 import { Text as YText } from 'yjs';
 
-import type { YBlock } from '../store/doc/block.js';
+import type { YBlock } from '../store/doc/block/index.js';
 import type { YBlocks } from '../store/doc/block-collection.js';
 import type { BlockSuiteDoc } from '../yjs/index.js';
 

--- a/packages/framework/store/src/schema/base.ts
+++ b/packages/framework/store/src/schema/base.ts
@@ -5,7 +5,7 @@ import { type Disposable, Slot } from '@blocksuite/global/utils';
 import { computed, signal } from '@preact/signals-core';
 import { z } from 'zod';
 
-import type { YBlock } from '../store/doc/block.js';
+import type { YBlock } from '../store/doc/block/index.js';
 import type { Doc } from '../store/index.js';
 import type { BaseBlockTransformer } from '../transformer/base.js';
 

--- a/packages/framework/store/src/schema/schema.ts
+++ b/packages/framework/store/src/schema/schema.ts
@@ -7,7 +7,7 @@ import type { BlockSchemaType } from './base.js';
 
 import { SCHEMA_NOT_FOUND_MESSAGE } from '../consts.js';
 import { collectionMigrations, docMigrations } from '../migration/index.js';
-import { Block, type YBlock } from '../store/doc/block.js';
+import { Block, type YBlock } from '../store/doc/block/index.js';
 import { BlockSchema } from './base.js';
 import { MigrationError, SchemaValidateError } from './error.js';
 

--- a/packages/framework/store/src/store/doc/block/index.ts
+++ b/packages/framework/store/src/store/doc/block/index.ts
@@ -1,0 +1,51 @@
+import type { Schema } from '../../../schema/index.js';
+import type { BlockOptions, YBlock } from './types.js';
+
+import { BlockViewType, type Doc } from '../doc.js';
+import { SyncController } from './sync-controller.js';
+
+export * from './types.js';
+
+export class Block {
+  private _syncController: SyncController;
+
+  blockViewType: BlockViewType = BlockViewType.Display;
+
+  constructor(
+    readonly schema: Schema,
+    readonly yBlock: YBlock,
+    readonly doc?: Doc,
+    readonly options: BlockOptions = {}
+  ) {
+    const onChange = !options.onChange
+      ? undefined
+      : (key: string, value: unknown) => {
+          options.onChange?.(this, key, value);
+        };
+    this._syncController = new SyncController(schema, yBlock, doc, onChange);
+  }
+
+  get flavour() {
+    return this._syncController.flavour;
+  }
+
+  get id() {
+    return this._syncController.id;
+  }
+
+  get model() {
+    return this._syncController.model;
+  }
+
+  get pop() {
+    return this._syncController.pop;
+  }
+
+  get stash() {
+    return this._syncController.stash;
+  }
+
+  get version() {
+    return this._syncController.version;
+  }
+}

--- a/packages/framework/store/src/store/doc/block/types.ts
+++ b/packages/framework/store/src/store/doc/block/types.ts
@@ -1,0 +1,14 @@
+import type * as Y from 'yjs';
+
+import type { Block } from './index.js';
+
+export type YBlock = Y.Map<unknown> & {
+  get(prop: 'sys:id'): string;
+  get(prop: 'sys:flavour'): string;
+  get(prop: 'sys:children'): Y.Array<string>;
+  get<T = unknown>(prop: string): T;
+};
+
+export type BlockOptions = {
+  onChange?: (block: Block, key: string, value: unknown) => void;
+};

--- a/packages/framework/store/src/store/doc/doc.ts
+++ b/packages/framework/store/src/store/doc/doc.ts
@@ -2,12 +2,12 @@ import { type Disposable, Slot, assertExists } from '@blocksuite/global/utils';
 import { signal } from '@preact/signals-core';
 
 import type { BlockModel, Schema } from '../../schema/index.js';
-import type { BlockOptions } from './block.js';
+import type { BlockOptions } from './block/index.js';
 import type { BlockCollection, BlockProps } from './block-collection.js';
 import type { DocCRUD } from './crud.js';
 
 import { syncBlockProps } from '../../utils/utils.js';
-import { Block } from './block.js';
+import { Block } from './block/index.js';
 
 export enum BlockViewType {
   Bypass = 'bypass',
@@ -40,7 +40,6 @@ export class Doc {
 
   protected readonly _selector: BlockSelector;
 
-  // @ts-ignore
   readonly slots: BlockCollection['slots'] & {
     /** This is always triggered after `doc.load` is called. */
     ready: Slot;
@@ -73,11 +72,6 @@ export class Doc {
           props: { key: string };
         }
     >;
-  } = {
-    ready: new Slot(),
-    rootAdded: new Slot(),
-    rootDeleted: new Slot(),
-    blockUpdated: new Slot(),
   };
 
   constructor({
@@ -88,6 +82,16 @@ export class Doc {
     readonly,
   }: DocOptions) {
     this._blockCollection = blockCollection;
+
+    this.slots = {
+      ready: new Slot(),
+      rootAdded: new Slot(),
+      rootDeleted: new Slot(),
+      blockUpdated: new Slot(),
+      historyUpdated: this._blockCollection.slots.historyUpdated,
+      yBlockUpdated: this._blockCollection.slots.yBlockUpdated,
+    };
+
     this._crud = crud;
     this._schema = schema;
     this._selector = selector;
@@ -114,12 +118,6 @@ export class Doc {
         }
       }
     );
-
-    this.slots = {
-      ...this.slots,
-      historyUpdated: this._blockCollection.slots.historyUpdated,
-      yBlockUpdated: this._blockCollection.slots.yBlockUpdated,
-    };
   }
 
   private _getSiblings<T>(

--- a/packages/framework/store/src/store/doc/index.ts
+++ b/packages/framework/store/src/store/doc/index.ts
@@ -1,3 +1,3 @@
-export * from './block.js';
+export * from './block/index.js';
 export * from './block-collection.js';
 export * from './doc.js';

--- a/packages/framework/store/src/utils/utils.ts
+++ b/packages/framework/store/src/utils/utils.ts
@@ -5,7 +5,7 @@ import * as Y from 'yjs';
 
 import type { BlockModel } from '../schema/base.js';
 import type { BlockSchema } from '../schema/base.js';
-import type { YBlock } from '../store/doc/block.js';
+import type { YBlock } from '../store/doc/block/index.js';
 import type { BlockProps, YBlocks } from '../store/doc/block-collection.js';
 import type { DocCollection } from '../store/index.js';
 


### PR DESCRIPTION
Extract sync controller from block.

Block will provide features more than create model. It will also provide states and crud API in the future.

This will also make the logic easier to understand.