### PR TITLE
feat(std): multi pointers control support

### DIFF
--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -185,8 +185,14 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<
       })
     );
     // this is required to prevent iframe from capturing pointer events
-    this.handleEvent('pointerMove', ctx => {
-      this._isDragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._isDragging = true;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    this.handleEvent('dragEnd', () => {
+      this._isDragging = false;
       this._showOverlay =
         this._isResizing || this._isDragging || !this._isSelected;
     });

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -85,8 +85,14 @@ export class EmbedFigmaBlockComponent extends EmbedBlockComponent<
       })
     );
     // this is required to prevent iframe from capturing pointer events
-    this.handleEvent('pointerMove', ctx => {
-      this._isDragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._isDragging = true;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    this.handleEvent('dragEnd', () => {
+      this._isDragging = false;
       this._showOverlay =
         this._isResizing || this._isDragging || !this._isSelected;
     });

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -69,8 +69,14 @@ export class EmbedHtmlBlockComponent extends EmbedBlockComponent<
       })
     );
     // this is required to prevent iframe from capturing pointer events
-    this.handleEvent('pointerMove', ctx => {
-      this._isDragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._isDragging = true;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    this.handleEvent('dragEnd', () => {
+      this._isDragging = false;
       this._showOverlay =
         this._isResizing || this._isDragging || !this._isSelected;
     });

--- a/packages/blocks/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-block.ts
@@ -102,8 +102,14 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
       })
     );
     // this is required to prevent iframe from capturing pointer events
-    this.handleEvent('pointerMove', ctx => {
-      this._isDragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._isDragging = true;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    this.handleEvent('dragEnd', () => {
+      this._isDragging = false;
       this._showOverlay =
         this._isResizing || this._isDragging || !this._isSelected;
     });

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -105,8 +105,14 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
       })
     );
     // this is required to prevent iframe from capturing pointer events
-    this.handleEvent('pointerMove', ctx => {
-      this._isDragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._isDragging = true;
+      this._showOverlay =
+        this._isResizing || this._isDragging || !this._isSelected;
+    });
+
+    this.handleEvent('dragEnd', () => {
+      this._isDragging = false;
       this._showOverlay =
         this._isResizing || this._isDragging || !this._isSelected;
     });

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -125,6 +125,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
       user-select: none;
       display: block;
       height: 100%;
+      touch-action: none;
     }
 
     .widgets-container {

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -238,8 +238,6 @@ export class AffineDragHandleWidget extends WidgetComponent<
     }
 
     this._setSelectedBlocks([blocks]);
-
-    return true;
   };
 
   private _createDragPreview = (

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -56,11 +56,11 @@ export class AffineFormatBarWidget extends WidgetComponent {
   private _calculatePlacement() {
     const rootComponent = this.block;
 
-    this.handleEvent('pointerMove', ctx => {
-      this._dragging = ctx.get('pointerState').dragging;
+    this.handleEvent('dragStart', () => {
+      this._dragging = true;
     });
 
-    this.handleEvent('pointerUp', () => {
+    this.handleEvent('dragEnd', () => {
       this._dragging = false;
     });
 

--- a/packages/framework/block-std/src/event/control/pointer.ts
+++ b/packages/framework/block-std/src/event/control/pointer.ts
@@ -1,40 +1,194 @@
 import type { UIEventDispatcher } from '../dispatcher.js';
 
 import { UIEventState, UIEventStateContext } from '../base.js';
+import { MultiPointerEventState } from '../state/index.js';
 import { PointerEventState } from '../state/index.js';
 import { EventScopeSourceType, EventSourceState } from '../state/source.js';
 import { isFarEnough } from '../utils.js';
 
-export class PointerControl {
+type PointerId = typeof PointerEvent.prototype.pointerId;
+
+function createContext(
+  event: Event,
+  state: PointerEventState | MultiPointerEventState
+) {
+  return UIEventStateContext.from(
+    new UIEventState(event),
+    new EventSourceState({
+      event,
+      sourceType: EventScopeSourceType.Target,
+    }),
+    state
+  );
+}
+
+abstract class PointerControllerBase {
+  constructor(protected _dispatcher: UIEventDispatcher) {}
+
+  protected get _rect() {
+    return this._dispatcher.host.getBoundingClientRect();
+  }
+
+  abstract listen(): void;
+}
+
+class PointerEventForward extends PointerControllerBase {
   private _down = (event: PointerEvent) => {
+    const { pointerId } = event;
+
+    const pointerState = new PointerEventState({
+      event,
+      rect: this._rect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    this._startStates.set(pointerId, pointerState);
+    this._lastStates.set(pointerId, pointerState);
+    this._dispatcher.run('pointerDown', createContext(event, pointerState));
+  };
+
+  private _lastStates = new Map<PointerId, PointerEventState>();
+
+  private _move = (event: PointerEvent) => {
+    const { pointerId } = event;
+
+    const start = this._startStates.get(pointerId) ?? null;
+    const last = this._lastStates.get(pointerId) ?? null;
+
+    const state = new PointerEventState({
+      event,
+      rect: this._rect,
+      startX: start?.x ?? -Infinity,
+      startY: start?.y ?? -Infinity,
+      last,
+    });
+    this._lastStates.set(pointerId, state);
+
+    this._dispatcher.run('pointerMove', createContext(event, state));
+  };
+
+  private _startStates = new Map<PointerId, PointerEventState>();
+
+  private _upOrOut = (up: boolean) => (event: PointerEvent) => {
+    const { pointerId } = event;
+
+    const start = this._startStates.get(pointerId) ?? null;
+    const last = this._lastStates.get(pointerId) ?? null;
+
+    const state = new PointerEventState({
+      event,
+      rect: this._rect,
+      startX: start?.x ?? -Infinity,
+      startY: start?.y ?? -Infinity,
+      last,
+    });
+
+    this._startStates.delete(pointerId);
+    this._lastStates.delete(pointerId);
+
+    this._dispatcher.run(
+      up ? 'pointerUp' : 'pointerOut',
+      createContext(event, state)
+    );
+  };
+
+  listen() {
+    const { host, disposables } = this._dispatcher;
+    disposables.addFromEvent(host, 'pointerdown', this._down);
+    disposables.addFromEvent(host, 'pointermove', this._move);
+    disposables.addFromEvent(host, 'pointerup', this._upOrOut(true));
+    disposables.addFromEvent(host, 'pointerout', this._upOrOut(false));
+  }
+}
+
+class ClickController extends PointerControllerBase {
+  private _down = (event: PointerEvent) => {
+    // disable for secondary pointer
+    if (event.isPrimary === false) return;
+
     if (
-      this._lastPointerDownEvent &&
-      event.timeStamp - this._lastPointerDownEvent.timeStamp < 500 &&
-      !isFarEnough(event, this._lastPointerDownEvent)
+      this._downPointerState &&
+      event.pointerId === this._downPointerState.raw.pointerId &&
+      event.timeStamp - this._downPointerState.raw.timeStamp < 500 &&
+      !isFarEnough(event, this._downPointerState.raw)
     ) {
       this._pointerDownCount++;
     } else {
       this._pointerDownCount = 1;
     }
 
-    const pointerEventState = new PointerEventState({
+    this._downPointerState = new PointerEventState({
       event,
       rect: this._rect,
-      startX: this._startX,
-      startY: this._startY,
+      startX: -Infinity,
+      startY: -Infinity,
       last: null,
     });
+  };
 
-    this._startX = pointerEventState.point.x;
-    this._startY = pointerEventState.point.y;
-    this._startDragState = pointerEventState;
-    this._lastDragState = pointerEventState;
-    this._lastPointerDownEvent = event;
+  private _downPointerState: PointerEventState | null = null;
 
-    this._dispatcher.run(
-      'pointerDown',
-      this._createContext(event, pointerEventState)
-    );
+  private _pointerDownCount = 0;
+
+  private _up = (event: PointerEvent) => {
+    if (!this._downPointerState) return;
+
+    if (isFarEnough(this._downPointerState.raw, event)) {
+      this._pointerDownCount = 0;
+      this._downPointerState = null;
+      return;
+    }
+
+    const state = new PointerEventState({
+      event,
+      rect: this._rect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    const context = createContext(event, state);
+
+    const run = () => {
+      this._dispatcher.run('pointerUp', context);
+      this._dispatcher.run('click', context);
+      if (this._pointerDownCount === 2) {
+        this._dispatcher.run('doubleClick', context);
+      }
+      if (this._pointerDownCount === 3) {
+        this._dispatcher.run('tripleClick', context);
+      }
+    };
+
+    run();
+  };
+
+  listen() {
+    const { host, disposables } = this._dispatcher;
+
+    disposables.addFromEvent(host, 'pointerdown', this._down);
+    disposables.addFromEvent(host, 'pointerup', this._up);
+  }
+}
+
+class DragController extends PointerControllerBase {
+  private _down = (event: PointerEvent) => {
+    if (!event.isPrimary) {
+      if (this._dragging && this._lastPointerState) {
+        this._up(this._lastPointerState.raw);
+      }
+      this._reset();
+      return;
+    }
+
+    const pointerState = new PointerEventState({
+      event,
+      rect: this._rect,
+      startX: -Infinity,
+      startY: -Infinity,
+      last: null,
+    });
+    this._startPointerState = pointerState;
 
     this._dispatcher.disposables.addFromEvent(
       document,
@@ -46,51 +200,94 @@ export class PointerControl {
 
   private _dragging = false;
 
-  private _lastDragState: PointerEventState | null = null;
-
-  private _lastPointerDownEvent: PointerEvent | null = null;
+  private _lastPointerState: PointerEventState | null = null;
 
   private _move = (event: PointerEvent) => {
-    const last = this._lastDragState;
+    if (
+      this._startPointerState === null ||
+      this._startPointerState.raw.pointerId !== event.pointerId
+    )
+      return;
+
+    const start = this._startPointerState;
+    const last = this._lastPointerState ?? start;
+
     const state = new PointerEventState({
       event,
       rect: this._rect,
-      startX: this._startX,
-      startY: this._startY,
+      startX: start.x,
+      startY: start.y,
       last,
     });
-    this._lastDragState = state;
 
-    if (!this._startDragState) {
-      return;
-    }
+    this._lastPointerState = state;
 
-    if (!this._dragging && isFarEnough(this._startDragState.raw, state.raw)) {
+    if (!this._dragging && isFarEnough(event, this._startPointerState.raw)) {
       this._dragging = true;
-      this._dispatcher.run(
-        'dragStart',
-        this._createContext(event, this._startDragState)
-      );
+      this._dispatcher.run('dragStart', createContext(event, start));
     }
 
     if (this._dragging) {
-      this._dispatcher.run('dragMove', this._createContext(event, state));
+      this._dispatcher.run('dragMove', createContext(event, state));
     }
   };
 
-  private _moveOn = (event: PointerEvent) => {
+  private _reset = () => {
+    this._dragging = false;
+    this._startPointerState = null;
+    this._lastPointerState = null;
+
+    document.removeEventListener('pointermove', this._move);
+    document.removeEventListener('pointerup', this._up);
+  };
+
+  private _startPointerState: PointerEventState | null = null;
+
+  private _up = (event: PointerEvent) => {
+    if (
+      !this._startPointerState ||
+      this._startPointerState.raw.pointerId !== event.pointerId
+    )
+      return;
+
+    const start = this._startPointerState;
+    const last = this._lastPointerState;
+
     const state = new PointerEventState({
       event,
       rect: this._rect,
-      startX: this._startX,
-      startY: this._startY,
-      last: this._lastDragState,
+      startX: start.x,
+      startY: start.y,
+      last,
     });
 
-    this._dispatcher.run('pointerMove', this._createContext(event, state));
+    if (this._dragging) {
+      this._dispatcher.run('dragEnd', createContext(event, state));
+    }
+
+    this._reset();
   };
 
-  private _out = (event: PointerEvent) => {
+  listen() {
+    const { host, disposables } = this._dispatcher;
+    disposables.addFromEvent(host, 'pointerdown', this._down);
+  }
+}
+
+class PinchController extends PointerControllerBase {
+  private _down = (event: PointerEvent) => {
+    // Another pointer down
+    if (
+      this._startPointerStates.primary !== null &&
+      this._startPointerStates.secondary !== null
+    ) {
+      this._reset();
+    }
+
+    if (this._startPointerStates.primary === null && !event.isPrimary) {
+      return;
+    }
+
     const state = new PointerEventState({
       event,
       rect: this._rect,
@@ -99,88 +296,133 @@ export class PointerControl {
       last: null,
     });
 
-    this._dispatcher.run('pointerOut', this._createContext(event, state));
+    if (event.isPrimary) {
+      this._startPointerStates.primary = state;
+    } else {
+      this._startPointerStates.secondary = state;
+    }
   };
 
-  private _pointerDownCount = 0;
-
-  private _reset = () => {
-    this._startX = -Infinity;
-    this._startY = -Infinity;
-    this._lastDragState = null;
-    this._dragging = false;
+  private _lastPointerStates: {
+    primary: PointerEventState | null;
+    secondary: PointerEventState | null;
+  } = {
+    primary: null,
+    secondary: null,
   };
 
-  private _startDragState: PointerEventState | null = null;
+  private _move = (event: PointerEvent) => {
+    if (
+      this._startPointerStates.primary === null ||
+      this._startPointerStates.secondary === null
+    ) {
+      return;
+    }
 
-  private _startX = -Infinity;
+    const { pointerId } = event;
 
-  private _startY = -Infinity;
+    const start1 =
+      this._startPointerStates.primary.raw.pointerId === pointerId
+        ? this._startPointerStates.primary
+        : this._startPointerStates.secondary;
 
-  private _up = (event: PointerEvent) => {
-    const pointerEventState = new PointerEventState({
+    const last1 =
+      (this._lastPointerStates.primary?.raw.pointerId === pointerId
+        ? this._lastPointerStates.primary
+        : this._lastPointerStates.secondary) ?? start1;
+
+    if (!isFarEnough(last1.raw, event)) return;
+
+    const state1 = new PointerEventState({
       event,
       rect: this._rect,
-      startX: this._startX,
-      startY: this._startY,
-      last: this._lastDragState,
+      startX: start1.x,
+      startY: start1.y,
+      last: last1,
     });
-    const context = this._createContext(event, pointerEventState);
 
-    const run = () => {
-      if (this._dragging) {
-        this._dispatcher.run('dragEnd', context);
-        return;
-      }
-      this._dispatcher.run('click', context);
-      if (this._pointerDownCount === 2) {
-        this._dispatcher.run('doubleClick', context);
-      }
-      if (this._pointerDownCount === 3) {
-        this._dispatcher.run('tripleClick', context);
-      }
+    const start2 =
+      this._startPointerStates.primary.raw.pointerId !== pointerId
+        ? this._startPointerStates.primary
+        : this._startPointerStates.secondary;
+
+    const last2 =
+      (this._lastPointerStates.primary?.raw.pointerId !== pointerId
+        ? this._lastPointerStates.primary
+        : this._lastPointerStates.secondary) ?? start2;
+
+    const state2 = new PointerEventState({
+      event: last2.raw,
+      rect: this._rect,
+      startX: start2.x,
+      startY: start2.y,
+      last: last2,
+    });
+
+    const multiPointerState = new MultiPointerEventState(event, [
+      state1,
+      state2,
+    ]);
+
+    this._lastPointerStates = {
+      primary: state1.raw.isPrimary ? state1 : state2,
+      secondary: state1.raw.isPrimary ? state2 : state1,
     };
 
-    run();
-    this._dispatcher.run('pointerUp', context);
-
-    this._reset();
-    document.removeEventListener('pointermove', this._move);
-    document.removeEventListener('pointerup', this._up);
+    this._dispatcher.run('pinch', createContext(event, multiPointerState));
   };
 
-  constructor(private _dispatcher: UIEventDispatcher) {}
+  private _reset = () => {
+    this._startPointerStates = {
+      primary: null,
+      secondary: null,
+    };
+    this._lastPointerStates = {
+      primary: null,
+      secondary: null,
+    };
+  };
 
-  private _createContext(event: Event, pointerState: PointerEventState) {
-    return UIEventStateContext.from(
-      new UIEventState(event),
-      new EventSourceState({
-        event,
-        sourceType: EventScopeSourceType.Target,
-      }),
-      pointerState
-    );
+  private _startPointerStates: {
+    primary: PointerEventState | null;
+    secondary: PointerEventState | null;
+  } = {
+    primary: null,
+    secondary: null,
+  };
+
+  private _upOrOut = (event: PointerEvent) => {
+    const { pointerId } = event;
+    if (
+      pointerId === this._startPointerStates.primary?.raw.pointerId ||
+      pointerId === this._startPointerStates.secondary?.raw.pointerId
+    ) {
+      this._reset();
+    }
+  };
+
+  override listen(): void {
+    const { host, disposables } = this._dispatcher;
+    disposables.addFromEvent(host, 'pointerdown', this._down);
+    disposables.addFromEvent(host, 'pointermove', this._move);
+    disposables.addFromEvent(host, 'pointerup', this._upOrOut);
+    disposables.addFromEvent(host, 'pointerout', this._upOrOut);
   }
+}
 
-  private get _rect() {
-    return this._dispatcher.host.getBoundingClientRect();
+export class PointerControl {
+  private controllers: PointerControllerBase[];
+
+  constructor(_dispatcher: UIEventDispatcher) {
+    this.controllers = [
+      new PointerEventForward(_dispatcher),
+      new ClickController(_dispatcher),
+      new DragController(_dispatcher),
+      new PinchController(_dispatcher),
+    ];
   }
 
   listen() {
-    this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.host,
-      'pointerdown',
-      this._down
-    );
-    this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.host,
-      'pointermove',
-      this._moveOn
-    );
-    this._dispatcher.disposables.addFromEvent(
-      this._dispatcher.host,
-      'pointerout',
-      this._out
-    );
+    this.controllers.forEach(controller => controller.listen());
   }
 }

--- a/packages/framework/block-std/src/event/dispatcher.ts
+++ b/packages/framework/block-std/src/event/dispatcher.ts
@@ -42,6 +42,8 @@ const eventNames = [
   'dragMove',
   'dragEnd',
 
+  'pinch',
+
   'keyDown',
   'keyUp',
 

--- a/packages/framework/block-std/src/event/state/pointer.ts
+++ b/packages/framework/block-std/src/event/state/pointer.ts
@@ -17,8 +17,6 @@ export class PointerEventState extends UIEventState {
 
   delta: Point;
 
-  dragging: boolean;
-
   keys: {
     shift: boolean;
     cmd: boolean;
@@ -54,7 +52,6 @@ export class PointerEventState extends UIEventState {
       alt: event.altKey,
     };
     this.button = last?.button || event.button;
-    this.dragging = !!last;
     this.pressure = event.pressure;
   }
 
@@ -67,8 +64,20 @@ export class PointerEventState extends UIEventState {
   }
 }
 
+export class MultiPointerEventState extends UIEventState {
+  pointers: PointerEventState[];
+
+  override type = 'multiPointerState';
+
+  constructor(event: PointerEvent, pointers: PointerEventState[]) {
+    super(event);
+    this.pointers = pointers;
+  }
+}
+
 declare global {
   interface BlockSuiteUIEventState {
     pointerState: PointerEventState;
+    multiPointerState: MultiPointerEventState;
   }
 }

--- a/packages/presets/src/__tests__/utils/common.ts
+++ b/packages/presets/src/__tests__/utils/common.ts
@@ -21,6 +21,7 @@ export function click(target: HTMLElement, position: { x: number; y: number }) {
       clientX,
       clientY,
       bubbles: true,
+      isPrimary: true,
     })
   );
   target.dispatchEvent(
@@ -28,6 +29,7 @@ export function click(target: HTMLElement, position: { x: number; y: number }) {
       clientX,
       clientY,
       bubbles: true,
+      isPrimary: true,
     })
   );
   target.dispatchEvent(
@@ -46,7 +48,8 @@ export function click(target: HTMLElement, position: { x: number; y: number }) {
  */
 export function pointerdown(
   target: HTMLElement,
-  position: { x: number; y: number }
+  position: { x: number; y: number },
+  isPrimary = true
 ) {
   const element = target.getBoundingClientRect();
   const clientX = element.x + position.x;
@@ -57,6 +60,7 @@ export function pointerdown(
       clientX,
       clientY,
       bubbles: true,
+      isPrimary,
     })
   );
 }
@@ -68,7 +72,8 @@ export function pointerdown(
  */
 export function pointerup(
   target: HTMLElement,
-  position: { x: number; y: number }
+  position: { x: number; y: number },
+  isPrimary = true
 ) {
   const element = target.getBoundingClientRect();
   const clientX = element.x + position.x;
@@ -79,6 +84,7 @@ export function pointerup(
       clientX,
       clientY,
       bubbles: true,
+      isPrimary,
     })
   );
 }
@@ -90,7 +96,8 @@ export function pointerup(
  */
 export function pointermove(
   target: HTMLElement,
-  position: { x: number; y: number }
+  position: { x: number; y: number },
+  isPrimary = true
 ) {
   const element = target.getBoundingClientRect();
   const clientX = element.x + position.x;
@@ -101,6 +108,7 @@ export function pointermove(
       clientX,
       clientY,
       bubbles: true,
+      isPrimary,
     })
   );
 }
@@ -128,4 +136,41 @@ export function drag(
 
   pointermove(target, end);
   pointerup(target, end);
+}
+
+export function pinch(
+  target: Element,
+  start1: { x: number; y: number },
+  start2: { x: number; y: number },
+  end1: { x: number; y: number },
+  end2: { x: number; y: number },
+  step: number = 5
+) {
+  pointerdown(target as HTMLElement, start1, true);
+  pointerdown(target as HTMLElement, start2, false);
+  pointermove(target as HTMLElement, start1, true);
+  pointermove(target as HTMLElement, start2, false);
+
+  if (step !== 0) {
+    const xStep1 = (end1.x - start1.x) / step;
+    const yStep1 = (end1.y - start1.y) / step;
+    const xStep2 = (end2.x - start2.x) / step;
+    const yStep2 = (end2.y - start2.y) / step;
+
+    for (const [i] of Array.from({ length: step }).entries()) {
+      pointermove(target as HTMLElement, {
+        x: start1.x + xStep1 * (i + 1),
+        y: start1.y + yStep1 * (i + 1),
+      });
+      pointermove(target as HTMLElement, {
+        x: start2.x + xStep2 * (i + 1),
+        y: start2.y + yStep2 * (i + 1),
+      });
+    }
+  }
+
+  pointermove(target as HTMLElement, end1, true);
+  pointermove(target as HTMLElement, end2, false);
+  pointerup(target as HTMLElement, end1, true);
+  pointerup(target as HTMLElement, end2, false);
 }


### PR DESCRIPTION
This PR enables multi-pointer event support. The previous implementation did not consider multi-pointer inputs, such as those from touchscreen devices, which resulted in discontinuous pointer inputs.

## What Changes:
### Refactoring of `PointerControl`
- **Decoupled Custom Pointer Event Creation Logic**: The logic for creating pointer-based custom events has been decoupled from the previous implementation in the `PointerControl` class. This change involves the separation into different controllers:
  - `PointerEventForward`: Forward `pointerXXX` events.
  - `ClickController`: Manages `xxxClick` events.
  - `DragController`: Manages `dragXXX` events.
  - `PinchController` *(new)*: Manages `pinch` events.
- **Support for Multiple Pointers**:
  - Enhanced the handling of previous events to support multiple pointers.
  - Introduced a new class `MultiPointerEventState` to manage multi-pointer inputs:

    ```typescript
    export class MultiPointerEventState extends UIEventState {
      pointers: PointerEventState[];
      // ...
    }
    ```

The previous implementation was limited to single-pointer interactions, which led to discontinuous dragging on devices supporting multi-pointer inputs, such as touchscreens. For a better understanding of the issue, refer to the following video:

https://github.com/user-attachments/assets/0888733e-cf25-48d4-8b43-8b2d97afe9cf

### Misc
- **Improved Touch Interaction**: Added `touch-action: none` in the edgeless editor to prevent default native touch gestures, such as:
  - Pinching to zoom the entire page.
  - Swiping to navigate back.
- **Refined Dragging Logic**: Refactored some of the dragging detection logic from `pointerXXX` to `dragXXX`.
- **Testing Enhancements**: Introduced a `pinch` test utils function to facilitate testing of the new pinch functionality.
``` ts
// blocksuite/packages/presets/src/__tests__/utils/common.ts
export function pinch(
  target: Element,
  start1: { x: number; y: number },
  start2: { x: number; y: number },
  end1: { x: number; y: number },
  end2: { x: number; y: number },
  step: number = 5
) 
```
