### PR TITLE
feat: linked menu support configuration

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -7,6 +7,7 @@ import type {
 
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
+import type { RootBlockConfig } from '../index.js';
 import type { EdgelessRootBlockComponent } from './edgeless-root-block.js';
 
 import { RootBlockSchema } from '../root-model.js';
@@ -43,7 +44,13 @@ export type EdgelessRootBlockWidgetName =
   | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET
   | typeof AFFINE_EDGELESS_AUTO_CONNECT_WIDGET;
 
-export const EdgelessRootBlockSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
+export type EdgelessRootBlockSpecType = BlockSpec<
+  EdgelessRootBlockWidgetName,
+  BlockService,
+  RootBlockConfig
+>;
+
+export const EdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
   schema: RootBlockSchema,
   service: EdgelessRootService,
   view: {
@@ -90,7 +97,7 @@ export const EdgelessRootBlockSpec: BlockSpec<EdgelessRootBlockWidgetName> = {
   },
 };
 
-export const PreviewEdgelessRootBlockSpec: BlockSpec = {
+export const PreviewEdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
   schema: RootBlockSchema,
   service: EdgelessRootService,
   view: {

--- a/packages/blocks/src/root-block/index.ts
+++ b/packages/blocks/src/root-block/index.ts
@@ -1,6 +1,7 @@
 import type { EdgelessRootService } from './edgeless/edgeless-root-service.js';
 import type { PageRootService } from './page/page-root-service.js';
 import type { RootBlockModel } from './root-model.js';
+import type { RootBlockConfig } from './types.js';
 
 import './commands/index.js';
 
@@ -28,6 +29,9 @@ declare global {
     }
     interface BlockServices {
       'affine:page': PageRootService | EdgelessRootService;
+    }
+    interface BlockConfigs {
+      'affine:page': RootBlockConfig;
     }
   }
 }

--- a/packages/blocks/src/root-block/page/page-root-spec.ts
+++ b/packages/blocks/src/root-block/page/page-root-spec.ts
@@ -1,6 +1,8 @@
-import type { BlockSpec } from '@blocksuite/block-std';
+import type { BlockService, BlockSpec } from '@blocksuite/block-std';
 
 import { literal, unsafeStatic } from 'lit/static-html.js';
+
+import type { RootBlockConfig } from '../index.js';
 
 import { RootBlockSchema } from '../root-model.js';
 import { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from '../widgets/doc-remote-selection/doc-remote-selection.js';
@@ -28,7 +30,13 @@ export type PageRootBlockWidgetName =
   | typeof AFFINE_DOC_REMOTE_SELECTION_WIDGET
   | typeof AFFINE_VIEWPORT_OVERLAY_WIDGET;
 
-export const PageRootBlockSpec: BlockSpec<PageRootBlockWidgetName> = {
+export type PageRootBlockSpecType = BlockSpec<
+  PageRootBlockWidgetName,
+  BlockService,
+  RootBlockConfig
+>;
+
+export const PageRootBlockSpec: PageRootBlockSpecType = {
   schema: RootBlockSchema,
   service: PageRootService,
   view: {

--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -8,7 +8,10 @@ import type { EDGELESS_ELEMENT_TOOLBAR_WIDGET } from './widgets/element-toolbar/
 import type { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from './widgets/embed-card-toolbar/embed-card-toolbar.js';
 import type { AFFINE_FORMAT_BAR_WIDGET } from './widgets/format-bar/format-bar.js';
 import type { AFFINE_INNER_MODAL_WIDGET } from './widgets/inner-modal/inner-modal.js';
-import type { AFFINE_LINKED_DOC_WIDGET } from './widgets/linked-doc/index.js';
+import type {
+  AFFINE_LINKED_DOC_WIDGET,
+  LinkedWidgetConfig,
+} from './widgets/linked-doc/index.js';
 import type { AFFINE_MODAL_WIDGET } from './widgets/modal/modal.js';
 import type { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from './widgets/page-dragging-area/page-dragging-area.js';
 import type { AFFINE_PIE_MENU_ID_EDGELESS_TOOLS } from './widgets/pie-menu/config.js';
@@ -50,3 +53,7 @@ export type RootBlockComponent =
   | EdgelessRootBlockComponent;
 
 export type PieMenuId = typeof AFFINE_PIE_MENU_ID_EDGELESS_TOOLS;
+
+export interface RootBlockConfig {
+  linkedWidget?: Partial<LinkedWidgetConfig>;
+}

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -32,6 +32,7 @@ export {
 } from './format-bar/format-bar.js';
 export { AffineImageToolbarWidget } from './image-toolbar/index.js';
 export { AffineInnerModalWidget } from './inner-modal/inner-modal.js';
+export { LinkedWidgetUtils } from './linked-doc/config.js';
 export {
   // It's used in the AFFiNE!
   showImportModal,

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -1,11 +1,7 @@
 import type { EditorHost, UIEventStateContext } from '@blocksuite/block-std';
 
 import { WidgetElement } from '@blocksuite/block-std';
-import {
-  DisposableGroup,
-  assertExists,
-  throttle,
-} from '@blocksuite/global/utils';
+import { DisposableGroup, throttle } from '@blocksuite/global/utils';
 import { InlineEditor } from '@blocksuite/inline';
 import { customElement } from 'lit/decorators.js';
 
@@ -19,71 +15,30 @@ import {
 } from '../../../_common/utils/query.js';
 import { getCurrentNativeRange } from '../../../_common/utils/selection.js';
 import { getPopperPosition } from '../../../root-block/utils/position.js';
-import { type LinkedDocOptions, getMenus } from './config.js';
+import { type LinkedMenuGroup, getMenus } from './config.js';
 import { LinkedDocPopover } from './linked-doc-popover.js';
 
-export function showLinkedDocPopover({
-  editorHost,
-  inlineEditor,
-  range,
-  container = document.body,
-  abortController = new AbortController(),
-  options,
-  triggerKey,
-}: {
-  editorHost: EditorHost;
-  inlineEditor: AffineInlineEditor;
-  range: Range;
-  container?: HTMLElement;
-  abortController?: AbortController;
-  options: LinkedDocOptions;
-  triggerKey: string;
-}) {
-  const disposables = new DisposableGroup();
-  abortController.signal.addEventListener('abort', () => disposables.dispose());
-
-  const linkedDoc = new LinkedDocPopover(
-    editorHost,
-    inlineEditor,
-    abortController
-  );
-  linkedDoc.options = options;
-  linkedDoc.triggerKey = triggerKey;
-  // Mount
-  container.append(linkedDoc);
-  disposables.add(() => linkedDoc.remove());
-
-  // Handle position
-  const updatePosition = throttle(() => {
-    const linkedDocElement = linkedDoc.linkedDocElement;
-    assertExists(
-      linkedDocElement,
-      'You should render the linked doc node even if no position'
-    );
-    const position = getPopperPosition(linkedDocElement, range);
-    linkedDoc.updatePosition(position);
-  }, 10);
-  disposables.addFromEvent(window, 'resize', updatePosition);
-  const scrollContainer = getViewportElement(editorHost);
-  if (scrollContainer) {
-    // Note: in edgeless mode, the scroll container is not exist!
-    disposables.addFromEvent(scrollContainer, 'scroll', updatePosition, {
-      passive: true,
-    });
-  }
-
-  // Wait for node to be mounted
-  setTimeout(updatePosition);
-
-  disposables.addFromEvent(window, 'mousedown', (e: Event) => {
-    if (e.target === linkedDoc) return;
-    abortController.abort();
-  });
-
-  return linkedDoc;
-}
-
 export const AFFINE_LINKED_DOC_WIDGET = 'affine-linked-doc-widget';
+
+export interface LinkedWidgetConfig {
+  /**
+   * The first item of the trigger keys will be the primary key
+   * e.g. @, [[
+   */
+  triggerKeys: [string, ...string[]];
+  /**
+   * Convert trigger key to primary key (the first item of the trigger keys)
+   * [[ -> @
+   */
+  convertTriggerKey: boolean;
+  ignoreBlockTypes: (keyof BlockSuite.BlockModels)[];
+  getMenus: (
+    query: string,
+    abort: () => void,
+    editorHost: EditorHost,
+    inlineEditor: AffineInlineEditor
+  ) => Promise<LinkedMenuGroup[]>;
+}
 
 @customElement(AFFINE_LINKED_DOC_WIDGET)
 export class AffineLinkedDocWidget extends WidgetElement {
@@ -113,14 +68,14 @@ export class AffineLinkedDocWidget extends WidgetElement {
       ? leafStart.textContent.slice(0, offsetStart)
       : '';
 
-    const matchedKey = this.options.triggerKeys.find(triggerKey =>
+    const matchedKey = this.config.triggerKeys.find(triggerKey =>
       (prefixText + event.key).endsWith(triggerKey)
     );
     if (!matchedKey) return;
 
-    const primaryTriggerKey = this.options.triggerKeys[0];
+    const primaryTriggerKey = this.config.triggerKeys[0];
     inlineEditor.slots.inlineRangeApply.once(() => {
-      if (this.options.convertTriggerKey && primaryTriggerKey !== matchedKey) {
+      if (this.config.convertTriggerKey && primaryTriggerKey !== matchedKey) {
         // Convert to the primary trigger key
         // e.g. [[ -> @
         const startIdxBeforeMatchKey =
@@ -138,11 +93,11 @@ export class AffineLinkedDocWidget extends WidgetElement {
           length: 0,
         });
         inlineEditor.slots.inlineRangeApply.once(() => {
-          this.showLinkedDoc(inlineEditor, primaryTriggerKey);
+          this.showLinkedDocPopover(inlineEditor, primaryTriggerKey);
         });
         return;
       }
-      this.showLinkedDoc(inlineEditor, matchedKey);
+      this.showLinkedDocPopover(inlineEditor, matchedKey);
     });
   };
 
@@ -162,42 +117,82 @@ export class AffineLinkedDocWidget extends WidgetElement {
       selection.is('text')
     );
     if (!text) return;
+
     const model = this.host.doc.getBlockById(text.blockId);
-    if (!model || matchFlavours(model, this.options.ignoreBlockTypes)) return;
+    if (!model) return;
+
+    if (matchFlavours(model, this.config.ignoreBlockTypes)) {
+      return;
+    }
 
     return getInlineEditorByModel(this.host, model);
   };
 
-  static DEFAULT_OPTIONS: LinkedDocOptions = {
-    /**
-     * The first item of the trigger keys will be the primary key
-     */
-    triggerKeys: ['@', '[[', '【【'],
-    ignoreBlockTypes: ['affine:code'],
-    /**
-     * Convert trigger key to primary key (the first item of the trigger keys)
-     */
-    convertTriggerKey: true,
-    getMenus,
-  };
-
-  options = AffineLinkedDocWidget.DEFAULT_OPTIONS;
-
-  showLinkedDoc = (inlineEditor: AffineInlineEditor, triggerKey: string) => {
+  showLinkedDocPopover = (
+    inlineEditor: AffineInlineEditor,
+    triggerKey: string
+  ) => {
     const curRange = getCurrentNativeRange();
     if (!curRange) return;
-    showLinkedDocPopover({
-      editorHost: this.host,
-      inlineEditor,
-      range: curRange,
-      options: this.options,
+
+    const abortController = new AbortController();
+    const disposables = new DisposableGroup();
+    abortController.signal.addEventListener('abort', () =>
+      disposables.dispose()
+    );
+
+    const linkedDoc = new LinkedDocPopover(
       triggerKey,
+      this.config.getMenus,
+      this.host,
+      inlineEditor,
+      abortController
+    );
+
+    // Mount
+    document.body.append(linkedDoc);
+    disposables.add(() => linkedDoc.remove());
+
+    // Handle position
+    const updatePosition = throttle(() => {
+      const linkedDocElement = linkedDoc.linkedDocElement;
+      if (!linkedDocElement) return;
+      const position = getPopperPosition(linkedDocElement, curRange);
+      linkedDoc.updatePosition(position);
+    }, 10);
+    disposables.addFromEvent(window, 'resize', updatePosition);
+    const scrollContainer = getViewportElement(this.host);
+    if (scrollContainer) {
+      // Note: in edgeless mode, the scroll container is not exist!
+      disposables.addFromEvent(scrollContainer, 'scroll', updatePosition, {
+        passive: true,
+      });
+    }
+
+    // Wait for node to be mounted
+    setTimeout(updatePosition);
+
+    disposables.addFromEvent(window, 'mousedown', (e: Event) => {
+      if (e.target === linkedDoc) return;
+      abortController.abort();
     });
+
+    return linkedDoc;
   };
 
   override connectedCallback() {
     super.connectedCallback();
     this.handleEvent('keyDown', this._onKeyDown);
+  }
+
+  get config(): LinkedWidgetConfig {
+    return {
+      triggerKeys: ['@', '[[', '【【'],
+      ignoreBlockTypes: ['affine:code'],
+      convertTriggerKey: true,
+      getMenus,
+      ...this.std.spec.getConfig(this.flavour)?.linkedWidget,
+    };
   }
 }
 

--- a/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
@@ -43,5 +43,10 @@ export const styles = css`
     background: var(--affine-border-color);
   }
 
+  .group icon-button svg {
+    width: 20px;
+    height: 20px;
+  }
+
   ${scrollbarStyle('.linked-doc-popover .group')}
 `;

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -1,7 +1,6 @@
 import type { BlockModel } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
-import { assertExists } from '@blocksuite/global/utils';
 import { Slice, Text } from '@blocksuite/store';
 
 import type { DataViewBlockComponent } from '../../../data-view-block/index.js';
@@ -173,7 +172,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
                 const codeModel = newModels[0];
                 onModelTextUpdated(rootElement.host, codeModel, richText => {
                   const inlineEditor = richText.inlineEditor;
-                  assertExists(inlineEditor);
+                  if (!inlineEditor) return;
                   inlineEditor.focusEnd();
                 }).catch(console.error);
               }
@@ -218,10 +217,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
               rootElement.host,
               model
             );
-            assertExists(
-              inlineEditor,
-              "Can't set style mark! Inline editor not found"
-            );
+            if (!inlineEditor) return;
             inlineEditor.setMarks({
               [id]: true,
             });
@@ -261,7 +257,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         const linkedDocWidgetEle =
           rootElement.widgetElements['affine-linked-doc-widget'];
         if (!linkedDocWidgetEle) return false;
-        if (!('showLinkedDoc' in linkedDocWidgetEle)) {
+        if (!('showLinkedDocPopover' in linkedDocWidgetEle)) {
           console.warn(
             'You may not have correctly implemented the linkedDoc widget! "showLinkedDoc(model)" method not found on widget'
           );
@@ -272,17 +268,17 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       action: ({ model, rootElement }) => {
         const triggerKey = '@';
         insertContent(rootElement.host, model, triggerKey);
-        assertExists(model.doc.root);
+        if (!model.doc.root) return;
         const widgetEle =
           rootElement.widgetElements['affine-linked-doc-widget'];
-        assertExists(widgetEle);
+        if (!widgetEle) return;
         // We have checked the existence of showLinkedDoc method in the showWhen
         const linkedDocWidget = widgetEle as AffineLinkedDocWidget;
         // Wait for range to be updated
         setTimeout(() => {
           const inlineEditor = getInlineEditorByModel(rootElement.host, model);
-          assertExists(inlineEditor);
-          linkedDocWidget.showLinkedDoc(inlineEditor, triggerKey);
+          if (!inlineEditor) return;
+          linkedDocWidget.showLinkedDocPopover(inlineEditor, triggerKey);
         });
       },
     },
@@ -351,7 +347,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
 
         const attachmentService =
           rootElement.host.spec.getService('affine:attachment');
-        assertExists(attachmentService);
+        if (!attachmentService) return;
         const maxFileSize = attachmentService.maxFileSize;
 
         await addSiblingAttachmentBlocks(
@@ -642,7 +638,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
 
       action: ({ model, rootElement }) => {
         const parent = rootElement.doc.getParent(model);
-        assertExists(parent);
+        if (!parent) return;
         const index = parent.children.indexOf(model);
         const id = rootElement.doc.addBlock(
           'affine:data-view',

--- a/packages/blocks/src/specs/group/edgeless.ts
+++ b/packages/blocks/src/specs/group/edgeless.ts
@@ -3,6 +3,7 @@ import { FrameBlockSpec } from '../../frame-block/frame-spec.js';
 import { EdgelessRootBlockSpec } from '../../root-block/edgeless/edgeless-root-spec.js';
 import { EdgelessSurfaceBlockSpec } from '../../surface-block/surface-spec.js';
 import { EdgelessSurfaceRefBlockSpec } from '../../surface-ref-block/surface-ref-spec.js';
+export type { EdgelessRootBlockSpecType } from '../../root-block/edgeless/edgeless-root-spec.js';
 
 export {
   EdgelessRootBlockSpec,

--- a/packages/blocks/src/specs/group/page.ts
+++ b/packages/blocks/src/specs/group/page.ts
@@ -1,5 +1,6 @@
 import { PageRootBlockSpec } from '../../root-block/page/page-root-spec.js';
 import { PageSurfaceBlockSpec } from '../../surface-block/surface-spec.js';
 import { PageSurfaceRefBlockSpec } from '../../surface-ref-block/surface-ref-spec.js';
+export type { PageRootBlockSpecType } from '../../root-block/page/page-root-spec.js';
 
 export { PageRootBlockSpec, PageSurfaceBlockSpec, PageSurfaceRefBlockSpec };

--- a/packages/framework/block-std/src/spec/spec-store.ts
+++ b/packages/framework/block-std/src/spec/spec-store.ts
@@ -81,6 +81,19 @@ export class SpecStore {
     this.slots.afterApply.emit();
   }
 
+  getConfig<Key extends BlockSuite.ConfigKeys>(
+    flavour: string
+  ): BlockSuite.BlockConfigs[Key] | null;
+
+  getConfig(flavour: string) {
+    const spec = this._specs.get(flavour);
+    if (!spec) {
+      return null;
+    }
+
+    return spec.config;
+  }
+
   getService<Key extends BlockSuite.ServiceKeys>(
     flavour: Key
   ): BlockSuite.BlockServices[Key];
@@ -127,7 +140,9 @@ export class SpecStore {
 declare global {
   namespace BlockSuite {
     interface BlockServices {}
+    interface BlockConfigs {}
 
     type ServiceKeys = string & keyof BlockServices;
+    type ConfigKeys = string & keyof BlockConfigs;
   }
 }

--- a/packages/framework/block-std/src/spec/type.ts
+++ b/packages/framework/block-std/src/spec/type.ts
@@ -14,9 +14,11 @@ export interface BlockView<WidgetNames extends string = string> {
 export interface BlockSpec<
   WidgetNames extends string = string,
   Service extends BlockService = BlockService,
+  BlockConfig = object,
 > {
   schema: BlockSchemaType;
-  service?: BlockServiceConstructor<Service>;
   view: BlockView<WidgetNames>;
+  config?: BlockConfig;
+  service?: BlockServiceConstructor<Service>;
   setup?: (slots: BlockSpecSlots, disposableGroup: DisposableGroup) => void;
 }


### PR DESCRIPTION
Close issue [BS-863](https://linear.app/affine-design/issue/BS-863).
Related PR in [AFFiNE](https://github.com/toeverything/AFFiNE/pull/7554).

### What changed?
- Add `config` field to `BlockSpec` to allows personalized block customization.
```typescript
interface BlockSpec {
  schema: BlockSchemaType;
  view: BlockView<WidgetNames>;
  config?: BlockConfig;
}
// get config by falvour
this.std.spec.getConfig(this.flavour)
```

- Add `linkedWidget` config in `RootBlockSpec`
- Refactor `linked-doc-popover` to support customization

### What's next?
- `getMenus` returns an observable array
- Add `commands` field to `BlockSpec` and encapsulated `insertLinkedNode` into a command
- Refactor `linked-doc-popover` to adapt to more scenarios