### PR TITLE
refactor(presets): remove frame and outline panel register function

### DIFF
--- a/packages/playground/apps/_common/components/custom-frame-panel.ts
+++ b/packages/playground/apps/_common/components/custom-frame-panel.ts
@@ -1,7 +1,6 @@
 import type { AffineEditorContainer } from '@blocksuite/presets';
 
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
-import { registerFramePanelComponents } from '@blocksuite/presets';
 import { css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -23,17 +22,13 @@ export class CustomFramePanel extends WithDisposable(ShadowlessElement) {
   `;
 
   private _renderPanel() {
-    return html`<frame-panel .editor=${this.editor}></frame-panel>`;
+    return html`<affine-frame-panel
+      .editor=${this.editor}
+    ></affine-frame-panel>`;
   }
 
   override connectedCallback(): void {
     super.connectedCallback();
-
-    registerFramePanelComponents(components => {
-      Object.entries(components).forEach(([name, component]) => {
-        customElements.define(name, component);
-      });
-    });
 
     this.disposables.add(
       this.editor.slots.editorModeSwitched.on(() => {

--- a/packages/playground/apps/_common/components/custom-outline-panel.ts
+++ b/packages/playground/apps/_common/components/custom-outline-panel.ts
@@ -1,8 +1,6 @@
+import type { AffineEditorContainer } from '@blocksuite/presets';
+
 import { WithDisposable } from '@blocksuite/block-std';
-import {
-  type AffineEditorContainer,
-  registerOutlinePanelComponents,
-} from '@blocksuite/presets';
 import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -23,20 +21,10 @@ export class CustomOutlinePanel extends WithDisposable(LitElement) {
   `;
 
   private _renderPanel() {
-    return html`<outline-panel
+    return html`<affine-outline-panel
       .editor=${this.editor}
       .fitPadding=${[50, 360, 50, 50]}
-    ></outline-panel>`;
-  }
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-
-    registerOutlinePanelComponents(components => {
-      Object.entries(components).forEach(([name, component]) => {
-        customElements.define(name, component);
-      });
-    });
+    ></affine-outline-panel>`;
   }
 
   override render() {

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -12,7 +12,7 @@ import {
 } from '@blocksuite/blocks';
 import { Bound, DisposableGroup } from '@blocksuite/global/utils';
 import { type PropertyValues, css, html, nothing } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import type {
@@ -80,6 +80,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_PANEL_BODY = 'affine-frame-panel-body';
+
+@customElement(AFFINE_FRAME_PANEL_BODY)
 export class FramePanelBody extends WithDisposable(ShadowlessElement) {
   private _clearDocDisposables = () => {
     this._docDisposables?.dispose();
@@ -244,7 +247,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
       frameItem => [frameItem.frame.id, frameItem.cardIndex].join('-'),
       frameItem => {
         const { frame, frameIndex, cardIndex } = frameItem;
-        return html`<frame-card
+        return html`<affine-frame-card
           data-frame-id=${frame.id}
           .edgeless=${this.edgeless}
           .doc=${this.doc}
@@ -260,7 +263,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
           @select=${this._selectFrame}
           @fitview=${this._fitToElement}
           @drag=${this._drag}
-        ></frame-card>`;
+        ></affine-frame-card>`;
       }
     )}`;
 
@@ -448,6 +451,6 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-panel-body': FramePanelBody;
+    [AFFINE_FRAME_PANEL_BODY]: FramePanelBody;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/card/frame-card-title-editor.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card-title-editor.ts
@@ -1,13 +1,8 @@
-import type {
-  AffineInlineEditor,
-  FrameBlockModel,
-  RichText,
-} from '@blocksuite/blocks';
+import type { FrameBlockModel, RichText } from '@blocksuite/blocks';
 
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
-import { assertExists } from '@blocksuite/global/utils';
 import { css, html } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 const styles = css`
@@ -16,6 +11,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_TITLE_EDITOR = 'affine-frame-card-title-editor';
+
+@customElement(AFFINE_FRAME_TITLE_EDITOR)
 export class FrameCardTitleEditor extends WithDisposable(ShadowlessElement) {
   private _isComposing = false;
 
@@ -31,6 +29,8 @@ export class FrameCardTitleEditor extends WithDisposable(ShadowlessElement) {
   override firstUpdated(): void {
     this.updateComplete
       .then(() => {
+        if (this.inlineEditor === null) return;
+
         this.titleContentElement.style.display = 'none';
 
         this.inlineEditor.selectAll();
@@ -39,38 +39,24 @@ export class FrameCardTitleEditor extends WithDisposable(ShadowlessElement) {
           this.requestUpdate();
         });
 
-        this.disposables.addFromEvent(
-          this.inlineEditorContainer,
-          'blur',
-          () => {
+        const inlineEditorContainer = this.inlineEditor.rootElement;
+
+        this.disposables.addFromEvent(inlineEditorContainer, 'blur', () => {
+          this._unmount();
+        });
+        this.disposables.addFromEvent(inlineEditorContainer, 'click', e => {
+          e.stopPropagation();
+        });
+        this.disposables.addFromEvent(inlineEditorContainer, 'dblclick', e => {
+          e.stopPropagation();
+        });
+
+        this.disposables.addFromEvent(inlineEditorContainer, 'keydown', e => {
+          e.stopPropagation();
+          if (e.key === 'Enter' && !this._isComposing) {
             this._unmount();
           }
-        );
-        this.disposables.addFromEvent(
-          this.inlineEditorContainer,
-          'click',
-          e => {
-            e.stopPropagation();
-          }
-        );
-        this.disposables.addFromEvent(
-          this.inlineEditorContainer,
-          'dblclick',
-          e => {
-            e.stopPropagation();
-          }
-        );
-
-        this.disposables.addFromEvent(
-          this.inlineEditorContainer,
-          'keydown',
-          e => {
-            e.stopPropagation();
-            if (e.key === 'Enter' && !this._isComposing) {
-              this._unmount();
-            }
-          }
-        );
+        });
       })
       .catch(console.error);
   }
@@ -112,13 +98,8 @@ export class FrameCardTitleEditor extends WithDisposable(ShadowlessElement) {
     ></rich-text>`;
   }
 
-  get inlineEditor(): AffineInlineEditor {
-    assertExists(this.richText.inlineEditor);
+  get inlineEditor() {
     return this.richText.inlineEditor;
-  }
-
-  get inlineEditorContainer() {
-    return this.inlineEditor.rootElement;
   }
 
   @property({ attribute: false })
@@ -139,6 +120,6 @@ export class FrameCardTitleEditor extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-card-title-editor': FrameCardTitleEditor;
+    [AFFINE_FRAME_TITLE_EDITOR]: FrameCardTitleEditor;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/card/frame-card-title.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card-title.ts
@@ -4,7 +4,7 @@ import type { Y } from '@blocksuite/store';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import { DisposableGroup } from '@blocksuite/global/utils';
 import { type PropertyValues, css, html } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 
 import { FrameCardTitleEditor } from './frame-card-title-editor.js';
 
@@ -55,6 +55,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_CARD_TITLE = 'affine-frame-card-title';
+
+@customElement(AFFINE_FRAME_CARD_TITLE)
 export class FrameCardTitle extends WithDisposable(ShadowlessElement) {
   private _clearTitleDisposables = () => {
     this._titleDisposables?.dispose();
@@ -144,6 +147,6 @@ export class FrameCardTitle extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-card-title': FrameCardTitle;
+    [AFFINE_FRAME_CARD_TITLE]: FrameCardTitle;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/card/frame-card.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card.ts
@@ -10,7 +10,7 @@ import {
 } from '@blocksuite/blocks';
 import { DisposableGroup } from '@blocksuite/global/utils';
 import { type PropertyValues, css, html, nothing } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import './frame-card-title.js';
@@ -111,6 +111,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_CARD = 'affine-frame-card';
+
+@customElement(AFFINE_FRAME_CARD)
 export class FrameCard extends WithDisposable(ShadowlessElement) {
   private _clearFrameDisposables = () => {
     this._frameDisposables?.dispose();
@@ -228,10 +231,10 @@ export class FrameCard extends WithDisposable(ShadowlessElement) {
     >
       ${this.status === 'dragging'
         ? nothing
-        : html`<frame-card-title
+        : html`<affine-frame-card-title
             .cardIndex=${this.cardIndex}
             .frame=${this.frame}
-          ></frame-card-title>`}
+          ></affine-frame-card-title>`}
       <div
         class="frame-card-body"
         @click=${this._dispatchSelectEvent}
@@ -296,6 +299,6 @@ export class FrameCard extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-card': FrameCard;
+    [AFFINE_FRAME_CARD]: FrameCard;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/frame-panel.ts
+++ b/packages/presets/src/fragments/frame-panel/frame-panel.ts
@@ -3,18 +3,12 @@ import { FramePreview } from '@blocksuite/blocks';
 import { DisposableGroup } from '@blocksuite/global/utils';
 import { baseTheme } from '@toeverything/theme';
 import { type PropertyValues, css, html, unsafeCSS } from 'lit';
-import { property } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import type { AffineEditorContainer } from '../../index.js';
 
 import './body/frame-panel-body.js';
-import { FramePanelBody } from './body/frame-panel-body.js';
-import { FrameCard } from './card/frame-card.js';
-import { FrameCardTitle } from './card/frame-card-title.js';
-import { FrameCardTitleEditor } from './card/frame-card-title-editor.js';
 import './header/frame-panel-header.js';
-import { FramePanelHeader } from './header/frame-panel-header.js';
-import { FramesSettingMenu } from './header/frames-setting-menu.js';
 
 const styles = css`
   frame-panel {
@@ -68,6 +62,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_PANEL = 'affine-frame-panel';
+
+@customElement(AFFINE_FRAME_PANEL)
 export class FramePanel extends WithDisposable(ShadowlessElement) {
   private _editorDisposables: DisposableGroup | null = null;
 
@@ -113,17 +110,17 @@ export class FramePanel extends WithDisposable(ShadowlessElement) {
 
   override render() {
     return html`<div class="frame-panel-container">
-      <frame-panel-header
+      <affine-frame-panel-header
         .edgeless=${this.edgeless}
         .editorHost=${this.host}
-      ></frame-panel-header>
-      <frame-panel-body
+      ></affine-frame-panel-header>
+      <affine-frame-panel-body
         class="frame-panel-body"
         .edgeless=${this.edgeless}
         .doc=${this.doc}
         .editorHost=${this.host}
         .fitPadding=${this.fitPadding}
-      ></frame-panel-body>
+      ></affine-frame-panel-body>
     </div>`;
   }
 
@@ -154,22 +151,6 @@ export class FramePanel extends WithDisposable(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-panel': FramePanel;
+    [AFFINE_FRAME_PANEL]: FramePanel;
   }
-}
-
-const componentsMap = {
-  'frame-panel': FramePanel,
-  'frame-panel-header': FramePanelHeader,
-  'frame-panel-body': FramePanelBody,
-  'frames-setting-menu': FramesSettingMenu,
-  'frame-card': FrameCard,
-  'frame-card-title': FrameCardTitle,
-  'frame-card-title-editor': FrameCardTitleEditor,
-};
-
-export function registerFramePanelComponents(
-  callback: (components: typeof componentsMap) => void
-) {
-  callback(componentsMap);
 }

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -6,7 +6,7 @@ import { WithDisposable } from '@blocksuite/block-std';
 import { createButtonPopper } from '@blocksuite/blocks';
 import { DisposableGroup } from '@blocksuite/global/utils';
 import { LitElement, type PropertyValues, css, html } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 
 import { SettingsIcon, SmallFrameNavigatorIcon } from '../../_common/icons.js';
 import './frames-setting-menu.js';
@@ -99,6 +99,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAME_PANEL_HEADER = 'affine-frame-panel-header';
+
+@customElement(AFFINE_FRAME_PANEL_HEADER)
 export class FramePanelHeader extends WithDisposable(LitElement) {
   private _clearEdgelessDisposables = () => {
     this._edgelessDisposables?.dispose();
@@ -199,10 +202,10 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
         </edgeless-tool-icon-button>
       </div>
       <div class="frames-setting-container">
-        <frames-setting-menu
+        <affine-frames-setting-menu
           .edgeless=${this.edgeless}
           .editorHost=${this.editorHost}
-        ></frames-setting-menu>
+        ></affine-frames-setting-menu>
       </div>
       <div class="presentation-button" @click=${this._enterPresentationMode}>
         ${SmallFrameNavigatorIcon}<span class="presentation-button-label"
@@ -244,6 +247,6 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frame-panel-header': FramePanelHeader;
+    [AFFINE_FRAME_PANEL_HEADER]: FramePanelHeader;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
@@ -3,7 +3,7 @@ import type { EdgelessRootBlockComponent } from '@blocksuite/blocks';
 
 import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, type PropertyValues, css, html } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 const styles = css`
   :host {
@@ -68,6 +68,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_FRAMES_SETTING_MENU = 'affine-frames-setting-menu';
+
+@customElement(AFFINE_FRAMES_SETTING_MENU)
 export class FramesSettingMenu extends WithDisposable(LitElement) {
   private _onBlackBackgroundChange = (checked: boolean) => {
     this.blackBackground = checked;
@@ -214,6 +217,6 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'frames-setting-menu': FramesSettingMenu;
+    [AFFINE_FRAMES_SETTING_MENU]: FramesSettingMenu;
   }
 }

--- a/packages/presets/src/fragments/frame-panel/index.ts
+++ b/packages/presets/src/fragments/frame-panel/index.ts
@@ -1,0 +1,1 @@
+export * from './frame-panel.js';

--- a/packages/presets/src/fragments/index.ts
+++ b/packages/presets/src/fragments/index.ts
@@ -2,11 +2,5 @@ export { BiDirectionalLinkPanel } from './bi-directional-link/bi-directional-lin
 export * from './comment/index.js';
 export * from './doc-meta-tags/doc-meta-tags.js';
 export * from './doc-title/doc-title.js';
-export {
-  FramePanel,
-  registerFramePanelComponents,
-} from './frame-panel/frame-panel.js';
-export {
-  OutlinePanel,
-  registerOutlinePanelComponents,
-} from './outline-panel/outline-panel.js';
+export * from './frame-panel/index.js';
+export * from './outline-panel/index.js';

--- a/packages/presets/src/fragments/outline-panel/body/outline-notice.ts
+++ b/packages/presets/src/fragments/outline-panel/body/outline-notice.ts
@@ -1,6 +1,6 @@
 import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, css, html, nothing } from 'lit';
-import { property } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import { SmallCloseIcon, SortingIcon } from '../../_common/icons.js';
 
@@ -79,6 +79,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_OUTLINE_NOTICE = 'affine-outline-notice';
+
+@customElement(AFFINE_OUTLINE_NOTICE)
 export class OutlineNotice extends WithDisposable(LitElement) {
   static override styles = styles;
 
@@ -129,6 +132,6 @@ export class OutlineNotice extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-notice': OutlineNotice;
+    [AFFINE_OUTLINE_NOTICE]: OutlineNotice;
   }
 }

--- a/packages/presets/src/fragments/outline-panel/card/outline-card.ts
+++ b/packages/presets/src/fragments/outline-panel/card/outline-card.ts
@@ -9,7 +9,7 @@ import {
   on,
   once,
 } from '@blocksuite/blocks';
-import { DisposableGroup, noop } from '@blocksuite/global/utils';
+import { DisposableGroup } from '@blocksuite/global/utils';
 import { SignalWatcher } from '@lit-labs/preact-signals';
 import { baseTheme } from '@toeverything/theme';
 import {
@@ -20,13 +20,11 @@ import {
   nothing,
   unsafeCSS,
 } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import { HiddenIcon, SmallArrowDownIcon } from '../../_common/icons.js';
-import { OutlineBlockPreview } from './outline-preview.js';
-
-noop(OutlineBlockPreview);
+import './outline-preview.js';
 
 export type ReorderEvent = CustomEvent<{
   currentNumber: number;
@@ -219,6 +217,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_OUTLINE_NOTE_CARD = 'affine-outline-note-card';
+
+@customElement(AFFINE_OUTLINE_NOTE_CARD)
 export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
   private _clearNoteDisposables = () => {
     this._noteDisposables?.dispose();
@@ -434,7 +435,7 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
         </div>`}
           <div class="card-content">
             ${children.map(block => {
-              return html`<outline-block-preview
+              return html`<affine-outline-block-preview
                 .block=${block}
                 .showPreviewIcon=${this.showPreviewIcon}
                 .disabledIcon=${this.invisible}
@@ -444,7 +445,7 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
                   if (this.editorMode === 'edgeless' || this.invisible) return;
                   this._dispatchClickBlockEvent(block);
                 }}
-              ></outline-block-preview>`;
+              ></affine-outline-block-preview>`;
             })}
             </div>
           </div>
@@ -498,6 +499,6 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-note-card': OutlineNoteCard;
+    [AFFINE_OUTLINE_NOTE_CARD]: OutlineNoteCard;
   }
 }

--- a/packages/presets/src/fragments/outline-panel/card/outline-preview.ts
+++ b/packages/presets/src/fragments/outline-panel/card/outline-preview.ts
@@ -14,7 +14,7 @@ import { WithDisposable } from '@blocksuite/block-std';
 import { BlocksUtils } from '@blocksuite/blocks';
 import { DisposableGroup, noop } from '@blocksuite/global/utils';
 import { LitElement, css, html, nothing } from 'lit';
-import { property } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import { SmallLinkedDocIcon } from '../../_common/icons.js';
 import { headingKeys, placeholderMap, previewIconMap } from '../config.js';
@@ -140,6 +140,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_OUTLINE_BLOCK_PREVIEW = 'affine-outline-block-preview';
+
+@customElement(AFFINE_OUTLINE_BLOCK_PREVIEW)
 export class OutlineBlockPreview extends WithDisposable(LitElement) {
   private _clearTextDisposables = () => {
     this._textDisposables?.dispose();
@@ -329,6 +332,6 @@ export class OutlineBlockPreview extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-block-preview': OutlineBlockPreview;
+    [AFFINE_OUTLINE_BLOCK_PREVIEW]: OutlineBlockPreview;
   }
 }

--- a/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
+++ b/packages/presets/src/fragments/outline-panel/header/outline-panel-header.ts
@@ -1,7 +1,7 @@
 import { WithDisposable } from '@blocksuite/block-std';
 import { createButtonPopper } from '@blocksuite/blocks';
 import { LitElement, css, html } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 
 import { SettingsIcon, SortingIcon } from '../../_common/icons.js';
 import './outline-setting-menu.js';
@@ -75,6 +75,9 @@ const styles = css`
   }
 `;
 
+export const AFFINE_OUTLINE_PANEL_HEADER = 'affine-outline-panel-header';
+
+@customElement(AFFINE_OUTLINE_PANEL_HEADER)
 export class OutlinePanelHeader extends WithDisposable(LitElement) {
   private _notePreviewSettingMenuPopper: ReturnType<
     typeof createButtonPopper
@@ -129,10 +132,10 @@ export class OutlinePanelHeader extends WithDisposable(LitElement) {
         </edgeless-tool-icon-button>
       </div>
       <div class="note-preview-setting-container">
-        <outline-note-preview-setting-menu
+        <affine-outline-note-preview-setting-menu
           .showPreviewIcon=${this.showPreviewIcon}
           .toggleShowPreviewIcon=${this.toggleShowPreviewIcon}
-        ></outline-note-preview-setting-menu>
+        ></affine-outline-note-preview-setting-menu>
       </div>`;
   }
 
@@ -160,6 +163,6 @@ export class OutlinePanelHeader extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-panel-header': OutlinePanelHeader;
+    [AFFINE_OUTLINE_PANEL_HEADER]: OutlinePanelHeader;
   }
 }

--- a/packages/presets/src/fragments/outline-panel/header/outline-setting-menu.ts
+++ b/packages/presets/src/fragments/outline-panel/header/outline-setting-menu.ts
@@ -1,6 +1,6 @@
 import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, css, html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 const styles = css`
   :host {
@@ -54,6 +54,10 @@ const styles = css`
   }
 `;
 
+export const AFFINE_OUTLINE_NOTE_PREVIEW_SETTING_MENU =
+  'affine-outline-note-preview-setting-menu';
+
+@customElement(AFFINE_OUTLINE_NOTE_PREVIEW_SETTING_MENU)
 export class OutlineNotePreviewSettingMenu extends WithDisposable(LitElement) {
   static override styles = styles;
 
@@ -86,6 +90,6 @@ export class OutlineNotePreviewSettingMenu extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-note-preview-setting-menu': OutlineNotePreviewSettingMenu;
+    [AFFINE_OUTLINE_NOTE_PREVIEW_SETTING_MENU]: OutlineNotePreviewSettingMenu;
   }
 }

--- a/packages/presets/src/fragments/outline-panel/index.ts
+++ b/packages/presets/src/fragments/outline-panel/index.ts
@@ -1,0 +1,1 @@
+export * from './outline-panel.js';

--- a/packages/presets/src/fragments/outline-panel/outline-panel.ts
+++ b/packages/presets/src/fragments/outline-panel/outline-panel.ts
@@ -2,17 +2,14 @@ import { WithDisposable } from '@blocksuite/block-std';
 import { DisposableGroup } from '@blocksuite/global/utils';
 import { baseTheme } from '@toeverything/theme';
 import { LitElement, type PropertyValues, css, html, unsafeCSS } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 import type { AffineEditorContainer } from '../../editors/editor-container.js';
 
-import { OutlineNotice } from './body/outline-notice.js';
-import { OutlinePanelBody } from './body/outline-panel-body.js';
-import { OutlineNoteCard } from './card/outline-card.js';
-import { OutlineBlockPreview } from './card/outline-preview.js';
+import './body/outline-notice.js';
+import './body/outline-panel-body.js';
 import { type OutlineSettingsDataType, outlineSettingsKey } from './config.js';
-import { OutlinePanelHeader } from './header/outline-panel-header.js';
-import { OutlineNotePreviewSettingMenu } from './header/outline-setting-menu.js';
+import './header/outline-panel-header.js';
 
 const styles = css`
   :host {
@@ -57,6 +54,10 @@ const styles = css`
     display: none;
   }
 `;
+
+export const AFFINE_OUTLINE_PANEL = 'affine-outline-panel';
+
+@customElement(AFFINE_OUTLINE_PANEL)
 export class OutlinePanel extends WithDisposable(LitElement) {
   private _editorDisposables: DisposableGroup | null = null;
 
@@ -142,13 +143,13 @@ export class OutlinePanel extends WithDisposable(LitElement) {
   override render() {
     return html`
       <div class="outline-panel-container">
-        <outline-panel-header
+        <affine-outline-panel-header
           .showPreviewIcon=${this._showPreviewIcon}
           .enableNotesSorting=${this._enableNotesSorting}
           .toggleShowPreviewIcon=${this._toggleShowPreviewIcon}
           .toggleNotesSorting=${this._toggleNotesSorting}
-        ></outline-panel-header>
-        <outline-panel-body
+        ></affine-outline-panel-header>
+        <affine-outline-panel-body
           class="outline-panel-body"
           .doc=${this.doc}
           .fitPadding=${this.fitPadding}
@@ -161,12 +162,12 @@ export class OutlinePanel extends WithDisposable(LitElement) {
           .noticeVisible=${this._noticeVisible}
           .setNoticeVisibility=${this._setNoticeVisibility}
         >
-        </outline-panel-body>
-        <outline-notice
+        </affine-outline-panel-body>
+        <affine-outline-notice
           .noticeVisible=${this._noticeVisible}
           .toggleNotesSorting=${this._toggleNotesSorting}
           .setNoticeVisibility=${this._setNoticeVisibility}
-        ></outline-notice>
+        ></affine-outline-notice>
       </div>
     `;
   }
@@ -211,22 +212,6 @@ export class OutlinePanel extends WithDisposable(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'outline-panel': OutlinePanel;
+    [AFFINE_OUTLINE_PANEL]: OutlinePanel;
   }
-}
-
-const componentsMap = {
-  'outline-note-card': OutlineNoteCard,
-  'outline-block-preview': OutlineBlockPreview,
-  'outline-panel': OutlinePanel,
-  'outline-note-preview-setting-menu': OutlineNotePreviewSettingMenu,
-  'outline-panel-body': OutlinePanelBody,
-  'outline-panel-header': OutlinePanelHeader,
-  'outline-notice': OutlineNotice,
-};
-
-export function registerOutlinePanelComponents(
-  callback: (components: typeof componentsMap) => void
-) {
-  callback(componentsMap);
 }

--- a/tests/fragments/frame-panel.spec.ts
+++ b/tests/fragments/frame-panel.spec.ts
@@ -16,7 +16,7 @@ test.describe('frame panel', () => {
   test('should display empty placeholder when no frames', async ({ page }) => {
     await edgelessCommonSetup(page);
     await toggleFramePanel(page);
-    const frameCards = page.locator('frame-card');
+    const frameCards = page.locator('affine-frame-card');
     expect(await frameCards.count()).toBe(0);
 
     const placeholder = page.locator('.no-frame-placeholder');
@@ -46,7 +46,7 @@ test.describe('frame panel', () => {
 
     const frames = page.locator('affine-frame');
     expect(await frames.count()).toBe(2);
-    const frameCards = page.locator('frame-card');
+    const frameCards = page.locator('affine-frame-card');
     expect(await frameCards.count()).toBe(2);
   });
 
@@ -66,7 +66,7 @@ test.describe('frame panel', () => {
 
     const frames = page.locator('affine-frame');
     expect(await frames.count()).toBe(1);
-    const frameCards = page.locator('frame-card');
+    const frameCards = page.locator('affine-frame-card');
     expect(await frameCards.count()).toBe(1);
     const notePortal = page.locator('surface-ref-note-portal');
     expect(await notePortal.count()).toBe(1);
@@ -75,7 +75,7 @@ test.describe('frame panel', () => {
   test('should update panel when frames change', async ({ page }) => {
     await edgelessCommonSetup(page);
     await toggleFramePanel(page);
-    const frameCards = page.locator('frame-card');
+    const frameCards = page.locator('affine-frame-card');
     expect(await frameCards.count()).toBe(0);
 
     await addNote(page, 'hello', 150, 500);


### PR DESCRIPTION
Close: [BS-585](https://linear.app/affine-design/issue/BS-585/更新affine侧lit自定义yuan素的写法)

### What Changes:
- remove `registerXXXComponet` and use `customElement(xxx)` for `affine-frame-panel` and `affine-outline-panel`
- Rename 
  - `frame-panel-xxx` -> `affine-frame-panel-xxx`
  - `outline-panel-xxx` -> `affine-outline-opanel-xxx`