### PR TITLE
refactor(std): add block-std/edgeless scope

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-block-model.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-block-model.ts
@@ -1,1 +1,1 @@
-export { EdgelessBlockModel } from '@blocksuite/block-std';
+export { EdgelessBlockModel } from '@blocksuite/block-std/edgeless';

--- a/packages/blocks/src/surface-block/element-model/base.ts
+++ b/packages/blocks/src/surface-block/element-model/base.ts
@@ -1,8 +1,8 @@
+import type { EditorHost } from '@blocksuite/block-std';
 import type {
-  EditorHost,
   IEdgelessElement,
   IHitTestOptions,
-} from '@blocksuite/block-std';
+} from '@blocksuite/block-std/edgeless';
 import type { IVec, SerializedXYWH, XYWH } from '@blocksuite/global/utils';
 import type { Y } from '@blocksuite/store';
 
@@ -34,7 +34,7 @@ import {
   yfield,
 } from './decorators.js';
 
-export type { IHitTestOptions } from '@blocksuite/block-std';
+export type { IHitTestOptions } from '@blocksuite/block-std/edgeless';
 
 export type ModelToProps<
   T extends SurfaceElementModel,

--- a/packages/framework/block-std/package.json
+++ b/packages/framework/block-std/package.json
@@ -35,7 +35,8 @@
     "@blocksuite/store": "workspace:*"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./edgeless": "./src/edgeless/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -43,8 +44,14 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "types": "./dist/index.d.ts",
         "module": "./dist/index.js",
         "import": "./dist/index.js"
+      },
+      "./edgeless": {
+        "types": "./dist/edgeless/index.d.ts",
+        "module": "./dist/edgeless/index.js",
+        "import": "./dist/edgeless/index.js"
       }
     }
   },

--- a/packages/framework/block-std/src/index.ts
+++ b/packages/framework/block-std/src/index.ts
@@ -1,6 +1,5 @@
 export * from './clipboard/index.js';
 export * from './command/index.js';
-export * from './edgeless/index.js';
 export * from './event/index.js';
 export * from './scope/index.js';
 export * from './selection/index.js';

--- a/packages/presets/src/blocks/ai-chat-block/ai-chat-model.ts
+++ b/packages/presets/src/blocks/ai-chat-block/ai-chat-model.ts
@@ -1,6 +1,6 @@
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
-import { selectable } from '@blocksuite/block-std';
+import { selectable } from '@blocksuite/block-std/edgeless';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 type AIChatProps = {


### PR DESCRIPTION
Edgeless related entities should be exported under the `block-std/edgeless` scope.