### PR TITLE
refactor: `BlockElement` -> `BlockComponent`

### DIFF
--- a/packages/blocks/src/_common/components/block-caption.ts
+++ b/packages/blocks/src/_common/components/block-caption.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
@@ -140,7 +140,7 @@ export class BlockCaptionEditor<
   }
 
   @property({ attribute: false })
-  accessor block!: BlockElement<Model> & { isInSurface?: boolean };
+  accessor block!: BlockComponent<Model> & { isInSurface?: boolean };
 
   @state()
   accessor caption: string | null | undefined = undefined;

--- a/packages/blocks/src/_common/components/block-selection.ts
+++ b/packages/blocks/src/_common/components/block-selection.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { SignalWatcher } from '@lit-labs/preact-signals';
 import { LitElement, type PropertyValues, css } from 'lit';
@@ -55,7 +55,7 @@ export class BlockSelection extends SignalWatcher(LitElement) {
   }
 
   @property({ attribute: false })
-  accessor block!: BlockElement;
+  accessor block!: BlockComponent;
 
   @property({ attribute: false })
   accessor borderRadius: number = 5;

--- a/packages/blocks/src/_common/components/captioned-block-component.ts
+++ b/packages/blocks/src/_common/components/captioned-block-component.ts
@@ -1,6 +1,6 @@
 import type { BlockModel } from '@blocksuite/store';
 
-import { BlockElement, type BlockService } from '@blocksuite/block-std';
+import { BlockComponent, type BlockService } from '@blocksuite/block-std';
 import { html, nothing } from 'lit';
 import { query } from 'lit/decorators.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
@@ -11,7 +11,7 @@ export class CaptionedBlockComponent<
   Model extends BlockModel = BlockModel,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
-> extends BlockElement<Model, Service, WidgetName> {
+> extends BlockComponent<Model, Service, WidgetName> {
   constructor() {
     super();
     this.addRenderer(this._renderWithWidget);

--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -3,7 +3,7 @@ import { Slice } from '@blocksuite/store';
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { EmbedToolbarBlockElement } from './type.js';
+import type { EmbedToolbarBlockComponent } from './type.js';
 
 import {
   isEmbedLinkedDocBlock,
@@ -215,7 +215,7 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
   accessor abortController!: AbortController;
 
   @property({ attribute: false })
-  accessor block!: EmbedToolbarBlockElement;
+  accessor block!: EmbedToolbarBlockComponent;
 }
 
 declare global {

--- a/packages/blocks/src/_common/components/embed-card/modal/embed-card-caption-edit-modal.ts
+++ b/packages/blocks/src/_common/components/embed-card/modal/embed-card-caption-edit-modal.ts
@@ -1,3 +1,5 @@
+import type { BlockModel } from '@blocksuite/store';
+
 import {
   type BlockComponent,
   ShadowlessElement,
@@ -20,7 +22,7 @@ export class EmbedCardEditCaptionEditModal extends WithDisposable(
   }
 
   private get _model() {
-    return this.block.model;
+    return this.block.model as BlockModel<{ caption: string }>;
   }
 
   private _onKeydown(e: KeyboardEvent) {

--- a/packages/blocks/src/_common/components/embed-card/modal/embed-card-caption-edit-modal.ts
+++ b/packages/blocks/src/_common/components/embed-card/modal/embed-card-caption-edit-modal.ts
@@ -1,9 +1,11 @@
-import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import {
+  type BlockComponent,
+  ShadowlessElement,
+  WithDisposable,
+} from '@blocksuite/block-std';
 import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-
-import type { BlockComponent } from '../../../utils/query.js';
 
 import { embedCardModalStyles } from './styles.js';
 

--- a/packages/blocks/src/_common/components/embed-card/type.ts
+++ b/packages/blocks/src/_common/components/embed-card/type.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import type { BookmarkBlockModel } from '../../../bookmark-block/bookmark-model.js';
 import type { EmbedFigmaModel } from '../../../embed-figma-block/embed-figma-model.js';
@@ -18,7 +18,7 @@ import { EmbedLoomBlockComponent } from '../../../embed-loom-block/embed-loom-bl
 import { EmbedSyncedDocBlockComponent } from '../../../embed-synced-doc-block/embed-synced-doc-block.js';
 import { EmbedYoutubeBlockComponent } from '../../../embed-youtube-block/embed-youtube-block.js';
 
-export type EmbedToolbarBlockElement =
+export type EmbedToolbarBlockComponent =
   | BookmarkBlockComponent
   | EmbedGithubBlockComponent
   | EmbedYoutubeBlockComponent
@@ -36,9 +36,9 @@ export type EmbedToolbarModel =
   | EmbedSyncedDocModel
   | EmbedLoomModel;
 
-export function isEmbedCardBlockElement(
-  block: BlockElement
-): block is EmbedToolbarBlockElement {
+export function isEmbedCardBlockComponent(
+  block: BlockComponent
+): block is EmbedToolbarBlockComponent {
   return (
     block instanceof BookmarkBlockComponent ||
     block instanceof EmbedGithubBlockComponent ||

--- a/packages/blocks/src/_common/components/file-drop-manager.ts
+++ b/packages/blocks/src/_common/components/file-drop-manager.ts
@@ -11,7 +11,7 @@ import type { DragIndicator } from './drag-indicator.js';
 import {
   type DropResult,
   calcDropTarget,
-  getClosestBlockElementByPoint,
+  getClosestBlockComponentByPoint,
   getModelByBlockComponent,
   isInsidePageEditor,
   matchFlavours,
@@ -87,7 +87,7 @@ export class FileDropManager {
 
     const { clientX, clientY } = event;
     const point = new Point(clientX, clientY);
-    const element = getClosestBlockElementByPoint(point.clone());
+    const element = getClosestBlockComponentByPoint(point.clone());
 
     let result: DropResult | null = null;
     if (element) {

--- a/packages/blocks/src/_common/components/peekable.ts
+++ b/packages/blocks/src/_common/components/peekable.ts
@@ -1,5 +1,5 @@
 import type {
-  BlockElement,
+  BlockComponent,
   BlockStdScope,
   Command,
   DisposableClass,
@@ -57,7 +57,7 @@ export interface PeekViewService {
    * @param template Optional template to render in the peek view modal. If not given, the peek view service will render the content.
    * @returns A promise that resolves when the peek view is closed.
    */
-  peek<Element extends BlockElement>(
+  peek<Element extends BlockComponent>(
     target: Element,
     template?: TemplateResult
   ): Promise<void>;
@@ -189,7 +189,7 @@ export const peekSelectedBlockCommand: Command<'selectedBlocks'> = (
 declare global {
   namespace BlockSuite {
     interface CommandContext {
-      selectedPeekableBlocks?: BlockElement[];
+      selectedPeekableBlocks?: BlockComponent[];
     }
 
     interface Commands {

--- a/packages/blocks/src/_common/components/rich-text/markdown/block.ts
+++ b/packages/blocks/src/_common/components/rich-text/markdown/block.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists, isEqual } from '@blocksuite/global/utils';
 import {
@@ -22,7 +22,7 @@ import {
 } from './utils.js';
 
 export function tryConvertBlock(
-  element: BlockElement,
+  element: BlockComponent,
   inline: AffineInlineEditor,
   prefixText: string,
   range: { index: number; length: number }

--- a/packages/blocks/src/_common/components/rich-text/markdown/utils.ts
+++ b/packages/blocks/src/_common/components/rich-text/markdown/utils.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import type { ListType } from '../../../../list-block/index.js';
 
@@ -8,7 +8,7 @@ import {
   matchFlavours,
 } from '../../../../_common/utils/index.js';
 
-function addSpace(element: BlockElement, index: number) {
+function addSpace(element: BlockComponent, index: number) {
   element.model.text?.insert(' ', index);
   const currentText = element.selection.find('text');
   element.selection.setGroup('note', [
@@ -24,7 +24,7 @@ function addSpace(element: BlockElement, index: number) {
 }
 
 export function convertToList(
-  element: BlockElement,
+  element: BlockComponent,
   listType: ListType,
   prefix: string,
   otherProperties?: Record<string, unknown>
@@ -59,7 +59,7 @@ export function convertToList(
 }
 
 export function convertToParagraph(
-  element: BlockElement,
+  element: BlockComponent,
   type: 'text' | 'quote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
   prefix: string
 ): boolean {
@@ -108,7 +108,7 @@ export function convertToParagraph(
 }
 
 export function convertToDivider(
-  element: BlockElement,
+  element: BlockComponent,
   prefix: string
 ): boolean {
   const { doc, model } = element;

--- a/packages/blocks/src/_common/configs/move-block.ts
+++ b/packages/blocks/src/_common/configs/move-block.ts
@@ -1,42 +1,42 @@
 import type { BlockSelection } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 
-const getSelection = (blockComponent: BlockElement) =>
+const getSelection = (blockComponent: BlockComponent) =>
   blockComponent.host.selection;
 
-function getBlockSelectionBySide(blockElement: BlockElement, tail: boolean) {
-  const selection = getSelection(blockElement);
+function getBlockSelectionBySide(block: BlockComponent, tail: boolean) {
+  const selection = getSelection(block);
   const selections = selection.filter('block');
   const sel = selections.at(tail ? -1 : 0) as BlockSelection | undefined;
   return sel ?? null;
 }
 
-function getTextSelection(blockElement: BlockElement) {
-  const selection = getSelection(blockElement);
+function getTextSelection(block: BlockComponent) {
+  const selection = getSelection(block);
   return selection.find('text');
 }
 
-const pathToBlock = (blockElement: BlockElement, blockId: string) =>
-  blockElement.host.view.getBlock(blockId);
+const pathToBlock = (block: BlockComponent, blockId: string) =>
+  block.host.view.getBlock(blockId);
 
 interface MoveBlockConfig {
   name: string;
   hotkey: string[];
-  action: (blockElement: BlockElement) => void;
+  action: (block: BlockComponent) => void;
 }
 
 export const moveBlockConfigs: MoveBlockConfig[] = [
   {
     name: 'Move Up',
     hotkey: ['Mod-Alt-ArrowUp', 'Mod-Shift-ArrowUp'],
-    action: blockElement => {
-      const doc = blockElement.doc;
-      const textSelection = getTextSelection(blockElement);
+    action: block => {
+      const doc = block.doc;
+      const textSelection = getTextSelection(block);
       if (textSelection) {
         const currentModel = pathToBlock(
-          blockElement,
+          block,
           textSelection.from.blockId
         )?.model;
         if (!currentModel) return;
@@ -44,30 +44,27 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
         const previousSiblingModel = doc.getPrev(currentModel);
         if (!previousSiblingModel) return;
 
-        const parentModel = blockElement.doc.getParent(previousSiblingModel);
+        const parentModel = block.doc.getParent(previousSiblingModel);
         if (!parentModel) return;
 
-        blockElement.doc.moveBlocks(
+        block.doc.moveBlocks(
           [currentModel],
           parentModel,
           previousSiblingModel,
           true
         );
-        blockElement.updateComplete
+        block.updateComplete
           .then(() => {
-            const rangeManager = blockElement.host.rangeManager;
+            const rangeManager = block.host.rangeManager;
             assertExists(rangeManager);
             rangeManager.syncTextSelectionToRange(textSelection);
           })
           .catch(console.error);
         return true;
       }
-      const blockSelection = getBlockSelectionBySide(blockElement, true);
+      const blockSelection = getBlockSelectionBySide(block, true);
       if (blockSelection) {
-        const currentModel = pathToBlock(
-          blockElement,
-          blockSelection.blockId
-        )?.model;
+        const currentModel = pathToBlock(block, blockSelection.blockId)?.model;
         if (!currentModel) return;
 
         const previousSiblingModel = doc.getPrev(currentModel);
@@ -90,12 +87,12 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
   {
     name: 'Move Down',
     hotkey: ['Mod-Alt-ArrowDown', 'Mod-Shift-ArrowDown'],
-    action: blockElement => {
-      const doc = blockElement.doc;
-      const textSelection = getTextSelection(blockElement);
+    action: block => {
+      const doc = block.doc;
+      const textSelection = getTextSelection(block);
       if (textSelection) {
         const currentModel = pathToBlock(
-          blockElement,
+          block,
           textSelection.from.blockId
         )?.model;
         if (!currentModel) return;
@@ -107,22 +104,19 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
         if (!parentModel) return;
 
         doc.moveBlocks([currentModel], parentModel, nextSiblingModel, false);
-        blockElement.updateComplete
+        block.updateComplete
           .then(() => {
             // `textSelection` will not change so we need wo sync it manually
-            const rangeManager = blockElement.host.rangeManager;
+            const rangeManager = block.host.rangeManager;
             assertExists(rangeManager);
             rangeManager.syncTextSelectionToRange(textSelection);
           })
           .catch(console.error);
         return true;
       }
-      const blockSelection = getBlockSelectionBySide(blockElement, true);
+      const blockSelection = getBlockSelectionBySide(block, true);
       if (blockSelection) {
-        const currentModel = pathToBlock(
-          blockElement,
-          blockSelection.blockId
-        )?.model;
+        const currentModel = pathToBlock(block, blockSelection.blockId)?.model;
         if (!currentModel) return;
 
         const nextSiblingModel = doc.getNext(currentModel);

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -30,7 +30,7 @@ import {
 } from '../utils/index.js';
 import { styles } from './styles.js';
 
-export class EmbedBlockElement<
+export class EmbedBlockComponent<
   Model extends
     BlockModel<EdgelessSelectableProps> = BlockModel<EdgelessSelectableProps>,
   Service extends BlockService = BlockService,

--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -11,7 +11,7 @@ import type { EdgelessRootBlockComponent } from '../../root-block/edgeless/edgel
 import type { RootBlockModel } from '../../root-block/index.js';
 
 import {
-  blockElementGetter,
+  blockComponentGetter,
   getBlockComponentByModel,
   getRootByEditorHost,
   isInsidePageEditor,
@@ -386,7 +386,8 @@ export class ExportManager {
       return this.edgelessToCanvas(
         edgeless.surface.renderer,
         bound,
-        (model: BlockModel) => blockElementGetter(model, this.editorHost.view),
+        (model: BlockModel) =>
+          blockComponentGetter(model, this.editorHost.view),
         edgeless
       );
     }
@@ -396,7 +397,7 @@ export class ExportManager {
   async edgelessToCanvas(
     surfaceRenderer: Renderer,
     bound: IBound,
-    blockElementGetter: (model: BlockModel) => Element | null = () => null,
+    blockComponentGetter: (model: BlockModel) => Element | null = () => null,
     edgeless?: EdgelessRootBlockComponent,
     nodes?: EdgelessBlockModel[],
     surfaces?: BlockSuite.SurfaceElementModelType[],
@@ -467,14 +468,16 @@ export class ExportManager {
           blockBound.h
         );
       }
-      let blockElement = blockElementGetter(block)?.parentElement;
+      let blockComponent = blockComponentGetter(block)?.parentElement;
       if (matchFlavours(block, ['affine:note'])) {
-        blockElement = blockElement?.closest('.edgeless-block-portal-note');
+        blockComponent = blockComponent?.closest('.edgeless-block-portal-note');
       }
 
-      if (blockElement) {
+      if (blockComponent) {
         const blockBound = xywhArrayToObject(block);
-        const canvasData = await this._html2canvas(blockElement as HTMLElement);
+        const canvasData = await this._html2canvas(
+          blockComponent as HTMLElement
+        );
         ctx.drawImage(
           canvasData,
           blockBound.x - bound.x + 50,
@@ -490,7 +493,7 @@ export class ExportManager {
 
         for (let i = 0; i < blocksInsideFrame.length; i++) {
           const element = blocksInsideFrame[i];
-          const htmlElement = blockElementGetter(element);
+          const htmlElement = blockComponentGetter(element);
           const blockBound = xywhArrayToObject(element);
           const canvasData = await html2canvas(htmlElement as HTMLElement);
 

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/affine-link.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
@@ -25,7 +25,7 @@ export class AffineLink extends ShadowlessElement {
   private _whenHover = new HoverController(
     this,
     ({ abortController }) => {
-      if (this.blockElement.doc.readonly) {
+      if (this.block.doc.readonly) {
         return null;
       }
 
@@ -108,12 +108,12 @@ export class AffineLink extends ShadowlessElement {
     ></a>`;
   }
 
-  get blockElement() {
-    const blockElement = this.inlineEditor.rootElement.closest<BlockElement>(
+  get block() {
+    const block = this.inlineEditor.rootElement.closest<BlockComponent>(
       `[${BLOCK_ID_ATTR}]`
     );
-    assertExists(blockElement);
-    return blockElement;
+    assertExists(block);
+    return block;
   }
 
   get inlineEditor() {
@@ -146,7 +146,7 @@ export class AffineLink extends ShadowlessElement {
   // Please also note that when readonly mode active,
   // this workaround is not necessary and links work normally.
   get std() {
-    const std = this.blockElement.std;
+    const std = this.block.std;
     assertExists(std);
     return std;
   }

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { InlineRange } from '@blocksuite/inline/types';
 
 import { WithDisposable } from '@blocksuite/block-std';
@@ -238,24 +238,24 @@ export class LinkPopup extends WithDisposable(LitElement) {
       targetFlavour = this._embedOptions.flavour;
     }
 
-    const blockElement = this.blockElement;
-    if (!blockElement) return;
+    const block = this.block;
+    if (!block) return;
     const url = this.currentLink;
     const title = this.currentText;
     const props = {
       url,
       title: title === url ? '' : title,
     };
-    const doc = blockElement.doc;
-    const parent = doc.getParent(blockElement.model);
+    const doc = block.doc;
+    const parent = doc.getParent(block.model);
     assertExists(parent);
-    const index = parent.children.indexOf(blockElement.model);
+    const index = parent.children.indexOf(block.model);
     doc.addBlock(targetFlavour as never, props, parent, index + 1);
 
     const totalTextLength = this.inlineEditor.yTextLength;
     const inlineTextLength = this.targetInlineRange.length;
     if (totalTextLength === inlineTextLength) {
-      doc.deleteBlock(blockElement.model);
+      doc.deleteBlock(block.model);
     } else {
       this.inlineEditor.formatText(this.targetInlineRange, { link: null });
     }
@@ -271,19 +271,19 @@ export class LinkPopup extends WithDisposable(LitElement) {
     const { flavour } = this._embedOptions;
     const url = this.currentLink;
 
-    const blockElement = this.blockElement;
-    if (!blockElement) return;
-    const doc = blockElement.doc;
-    const parent = doc.getParent(blockElement.model);
+    const block = this.block;
+    if (!block) return;
+    const doc = block.doc;
+    const parent = doc.getParent(block.model);
     assertExists(parent);
-    const index = parent.children.indexOf(blockElement.model);
+    const index = parent.children.indexOf(block.model);
 
     doc.addBlock(flavour as never, { url }, parent, index + 1);
 
     const totalTextLength = this.inlineEditor.yTextLength;
     const inlineTextLength = this.targetInlineRange.length;
     if (totalTextLength === inlineTextLength) {
-      doc.deleteBlock(blockElement.model);
+      doc.deleteBlock(block.model);
     } else {
       this.inlineEditor.formatText(this.targetInlineRange, { link: null });
     }
@@ -299,10 +299,10 @@ export class LinkPopup extends WithDisposable(LitElement) {
   }
 
   private get _isBookmarkAllowed() {
-    const blockElement = this.blockElement;
-    if (!blockElement) return false;
-    const schema = blockElement.doc.schema;
-    const parent = blockElement.doc.getParent(blockElement.model);
+    const block = this.block;
+    if (!block) return false;
+    const schema = block.doc.schema;
+    const parent = block.doc.getParent(block.model);
     if (!parent) return false;
     const bookmarkSchema = schema.flavourSchemaMap.get('affine:bookmark');
     if (!bookmarkSchema) return false;
@@ -566,14 +566,12 @@ export class LinkPopup extends WithDisposable(LitElement) {
       .catch(console.error);
   }
 
-  get blockElement() {
-    const blockElement = this.inlineEditor.rootElement.closest<BlockElement>(
+  get block() {
+    const block = this.inlineEditor.rootElement.closest<BlockComponent>(
       `[${BLOCK_ID_ATTR}]`
     );
-    if (!blockElement) {
-      return null;
-    }
-    return blockElement;
+    if (!block) return null;
+    return block;
   }
 
   get currentLink() {
@@ -590,11 +588,11 @@ export class LinkPopup extends WithDisposable(LitElement) {
   }
 
   get host() {
-    return this.blockElement?.host;
+    return this.block?.host;
   }
 
   get std() {
-    return this.blockElement?.std;
+    return this.block?.std;
   }
 
   @property({ attribute: false })

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { Slot } from '@blocksuite/global/utils';
 import type { Doc, DocMeta } from '@blocksuite/store';
 
@@ -235,12 +235,12 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     this._updateRefMeta(doc);
   }
 
-  get blockElement() {
-    const blockElement = this.inlineEditor.rootElement.closest<BlockElement>(
+  get block() {
+    const block = this.inlineEditor.rootElement.closest<BlockComponent>(
       `[${BLOCK_ID_ATTR}]`
     );
-    assertExists(blockElement);
-    return blockElement;
+    assertExists(block);
+    return block;
   }
 
   get customContent() {
@@ -276,7 +276,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
   }
 
   get std() {
-    const std = this.blockElement.std;
+    const std = this.block.std;
     assertExists(std);
     return std;
   }

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { InlineRange } from '@blocksuite/inline';
 
 import { WithDisposable } from '@blocksuite/block-std';
@@ -41,12 +41,12 @@ export class ReferencePopup extends WithDisposable(LitElement) {
   static override styles = styles;
 
   private _convertToCardView() {
-    const blockElement = this.blockElement;
-    const doc = blockElement.host.doc;
-    const parent = doc.getParent(blockElement.model);
+    const block = this.block;
+    const doc = block.host.doc;
+    const parent = doc.getParent(block.model);
     assertExists(parent);
 
-    const index = parent.children.indexOf(blockElement.model);
+    const index = parent.children.indexOf(block.model);
     const docId = this.referenceDocId;
     doc.addBlock(
       'affine:embed-linked-doc',
@@ -58,7 +58,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     const totalTextLength = this.inlineEditor.yTextLength;
     const inlineTextLength = this.targetInlineRange.length;
     if (totalTextLength === inlineTextLength) {
-      doc.deleteBlock(blockElement.model);
+      doc.deleteBlock(block.model);
     } else {
       this.inlineEditor.insertText(this.targetInlineRange, this.docTitle);
     }
@@ -67,12 +67,12 @@ export class ReferencePopup extends WithDisposable(LitElement) {
   }
 
   private _convertToEmbedView() {
-    const blockElement = this.blockElement;
-    const doc = blockElement.host.doc;
-    const parent = doc.getParent(blockElement.model);
+    const block = this.block;
+    const doc = block.host.doc;
+    const parent = doc.getParent(block.model);
     assertExists(parent);
 
-    const index = parent.children.indexOf(blockElement.model);
+    const index = parent.children.indexOf(block.model);
     const docId = this.referenceDocId;
     doc.addBlock(
       'affine:embed-synced-doc',
@@ -84,7 +84,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     const totalTextLength = this.inlineEditor.yTextLength;
     const inlineTextLength = this.targetInlineRange.length;
     if (totalTextLength === inlineTextLength) {
-      doc.deleteBlock(blockElement.model);
+      doc.deleteBlock(block.model);
     } else {
       this.inlineEditor.insertText(this.targetInlineRange, this.docTitle);
     }
@@ -101,17 +101,17 @@ export class ReferencePopup extends WithDisposable(LitElement) {
 
   get _embedViewButtonDisabled() {
     if (
-      this.blockElement.doc.readonly ||
+      this.block.doc.readonly ||
       isInsideBlockByFlavour(
-        this.blockElement.doc,
-        this.blockElement.model,
+        this.block.doc,
+        this.block.model,
         'affine:edgeless-text'
       )
     ) {
       return true;
     }
     return (
-      !!this.blockElement.closest('affine-embed-synced-doc-block') ||
+      !!this.block.closest('affine-embed-synced-doc-block') ||
       this.referenceDocId === this.doc.id
     );
   }
@@ -136,11 +136,11 @@ export class ReferencePopup extends WithDisposable(LitElement) {
 
   private _openDoc() {
     const refDocId = this.referenceDocId;
-    const blockElement = this.blockElement;
-    if (refDocId === blockElement.doc.id) return;
+    const block = this.block;
+    if (refDocId === block.doc.id) return;
 
     const rootElement = this.std.view.viewFromPath('block', [
-      blockElement.doc.root?.id ?? '',
+      block.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
     assertExists(rootElement);
 
@@ -276,15 +276,13 @@ export class ReferencePopup extends WithDisposable(LitElement) {
       return;
     }
 
-    const parent = this.blockElement.host.doc.getParent(
-      this.blockElement.model
-    );
+    const parent = this.block.host.doc.getParent(this.block.model);
     assertExists(parent);
 
     this.disposables.add(
       effect(() => {
         const children = parent.children;
-        if (children.includes(this.blockElement.model)) return;
+        if (children.includes(this.block.model)) return;
         this.abortController.abort();
       })
     );
@@ -353,16 +351,16 @@ export class ReferencePopup extends WithDisposable(LitElement) {
       .catch(console.error);
   }
 
-  get blockElement() {
-    const blockElement = this.inlineEditor.rootElement.closest<BlockElement>(
+  get block() {
+    const block = this.inlineEditor.rootElement.closest<BlockComponent>(
       `[${BLOCK_ID_ATTR}]`
     );
-    assertExists(blockElement);
-    return blockElement;
+    assertExists(block);
+    return block;
   }
 
   get doc() {
-    const doc = this.blockElement.doc;
+    const doc = this.block.doc;
     assertExists(doc);
     return doc;
   }
@@ -375,7 +373,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
   }
 
   get std() {
-    const std = this.blockElement.std;
+    const std = this.block.std;
     assertExists(std);
     return std;
   }

--- a/packages/blocks/src/_common/types.ts
+++ b/packages/blocks/src/_common/types.ts
@@ -1,3 +1,4 @@
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { Slot } from '@blocksuite/global/utils';
 import type { Point } from '@blocksuite/global/utils';
 import type { BlockModel, Doc } from '@blocksuite/store';
@@ -8,7 +9,6 @@ import type {
   GroupElementModel,
 } from '../surface-block/index.js';
 import type { RefNodeSlots } from './inline/presets/nodes/reference-node/reference-node.js';
-import type { BlockComponent } from './utils/query.js';
 
 export type SelectionPosition = 'start' | 'end' | Point;
 

--- a/packages/blocks/src/_common/utils/drag-and-drop.ts
+++ b/packages/blocks/src/_common/utils/drag-and-drop.ts
@@ -1,3 +1,4 @@
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { Point } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
@@ -7,12 +8,11 @@ import type { EditingState } from '../types.js';
 
 import { matchFlavours } from './model.js';
 import {
-  type BlockComponent,
   DropFlags,
-  getClosestBlockElementByElement,
+  getClosestBlockComponentByElement,
   getDropRectByPoint,
   getModelByBlockComponent,
-  getRectByBlockElement,
+  getRectByBlockComponent,
 } from './query.js';
 import { Rect } from './rect.js';
 
@@ -55,9 +55,9 @@ export function calcDropTarget(
   }
 
   if (!shouldAppendToDatabase && !matchFlavours(model, ['affine:database'])) {
-    const databaseBlockElement = element.closest('affine-database');
-    if (databaseBlockElement) {
-      element = databaseBlockElement;
+    const databaseBlockComponent = element.closest('affine-database');
+    if (databaseBlockComponent) {
+      element = databaseBlockComponent;
       model = getModelByBlockComponent(element);
     }
   }
@@ -125,7 +125,7 @@ export function calcDropTarget(
       ) {
         type = 'none';
       } else {
-        prevRect = getRectByBlockElement(prev);
+        prevRect = getRectByBlockComponent(prev);
       }
     } else {
       prev = element.parentElement?.previousElementSibling;
@@ -149,13 +149,13 @@ export function calcDropTarget(
         next = null;
       }
     } else {
-      next = getClosestBlockElementByElement(
+      next = getClosestBlockComponentByElement(
         element.parentElement
       )?.nextElementSibling;
     }
 
     if (next) {
-      nextRect = getRectByBlockElement(next);
+      nextRect = getRectByBlockComponent(next);
       offsetY = (nextRect.top - domRect.bottom) / 2;
     }
   }

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -1,5 +1,5 @@
 import type {
-  BlockElement,
+  BlockComponent,
   EditorHost,
   ViewStore,
 } from '@blocksuite/block-std';
@@ -30,10 +30,6 @@ const ATTR_SELECTOR = `[${ATTR}]`;
 // h1.margin-top = 8px + 24px = 32px;
 const MAX_SPACE = 32;
 const STEPS = MAX_SPACE / 2 / 2;
-
-// Fix use unknown type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type BlockComponent = BlockElement<any>;
 
 interface ContainerBlock {
   model?: BlockModel;
@@ -175,7 +171,7 @@ export function buildPath(model: BlockModel | null): string[] {
   return path;
 }
 
-export function blockElementGetter(model: BlockModel, view: ViewStore) {
+export function blockComponentGetter(model: BlockModel, view: ViewStore) {
   if (matchFlavours(model, ['affine:image', 'affine:frame'])) {
     let current: BlockModel | null = model;
     const path: string[] = [];
@@ -494,7 +490,7 @@ function isEdgelessChildImage({ classList }: Element) {
  * ############### block
  * ```
  */
-export function getClosestBlockElementByPoint(
+export function getClosestBlockComponentByPoint(
   point: Point,
   state: {
     rect?: Rect;
@@ -542,7 +538,7 @@ export function getClosestBlockElementByPoint(
   }
 
   // find block element
-  element = findBlockElement(
+  element = findBlockComponent(
     document.elementsFromPoint(point.x, point.y),
     container
   );
@@ -567,7 +563,7 @@ export function getClosestBlockElementByPoint(
       }
     } else {
       // Indented paragraphs or list
-      bounds = getRectByBlockElement(element);
+      bounds = getRectByBlockComponent(element);
       childBounds = element
         .querySelector('.affine-block-children-container')
         ?.firstElementChild?.getBoundingClientRect();
@@ -594,13 +590,13 @@ export function getClosestBlockElementByPoint(
     n *= -1;
 
     // find block element
-    element = findBlockElement(
+    element = findBlockComponent(
       document.elementsFromPoint(point.x, point.y),
       container
     );
 
     if (element) {
-      bounds = getRectByBlockElement(element);
+      bounds = getRectByBlockComponent(element);
       diff = bounds.bottom - point.y;
       if (diff >= 0 && diff <= STEPS * 2) {
         return element;
@@ -622,7 +618,7 @@ export function getClosestBlockElementByPoint(
  * @param container container which the blocks can be found inside
  * @param point position
  */
-export function findClosestBlockElement(
+export function findClosestBlockComponent(
   container: BlockComponent,
   point: Point,
   selector: string
@@ -660,7 +656,7 @@ export function findClosestBlockElement(
 /**
  * Returns the closest block element by element that does not contain the page element and note element.
  */
-export function getClosestBlockElementByElement(
+export function getClosestBlockComponentByElement(
   element: Element | null
 ): BlockComponent | null {
   if (!element) return null;
@@ -698,7 +694,7 @@ export function getModelByBlockComponent(component: Element) {
  * https://github.com/toeverything/blocksuite/issues/902
  * https://github.com/toeverything/blocksuite/pull/1121
  */
-export function getRectByBlockElement(element: Element | BlockComponent) {
+export function getRectByBlockComponent(element: Element | BlockComponent) {
   if (isDatabase(element)) return element.getBoundingClientRect();
   return (element.firstElementChild ?? element).getBoundingClientRect();
 }
@@ -707,7 +703,7 @@ export function getRectByBlockElement(element: Element | BlockComponent) {
  * Returns block elements excluding their subtrees.
  * Only keep block elements of same level.
  */
-export function getBlockElementsExcludeSubtrees(
+export function getBlockComponentsExcludeSubtrees(
   elements: Element[] | BlockComponent[]
 ) {
   if (elements.length <= 1) return elements;
@@ -727,7 +723,7 @@ export function getBlockElementsExcludeSubtrees(
  * Find block element from an `Element[]`.
  * In Chrome/Safari, `document.elementsFromPoint` does not include `affine-image`.
  */
-function findBlockElement(elements: Element[], parent?: Element) {
+function findBlockComponent(elements: Element[], parent?: Element) {
   const len = elements.length;
   let element = null;
   let i = 0;
@@ -742,7 +738,7 @@ function findBlockElement(elements: Element[], parent?: Element) {
       if (i < len && hasBlockId(element) && isBlock(element)) {
         return elements[i];
       }
-      return getClosestBlockElementByElement(element);
+      return getClosestBlockComponentByElement(element);
     }
   }
   return null;
@@ -822,7 +818,7 @@ export function getDropRectByPoint(
   flag: DropFlags;
 } {
   const result = {
-    rect: getRectByBlockElement(element),
+    rect: getRectByBlockComponent(element),
     flag: DropFlags.Normal,
   };
 

--- a/packages/blocks/src/code-block/clipboard/index.ts
+++ b/packages/blocks/src/code-block/clipboard/index.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { Clipboard, type UIEventHandler } from '@blocksuite/block-std';
 import { DisposableGroup, assertExists } from '@blocksuite/global/utils';
@@ -26,7 +26,7 @@ export class CodeClipboardController {
     });
   };
 
-  host: BlockElement;
+  host: BlockComponent;
 
   onPagePaste: UIEventHandler = ctx => {
     const e = ctx.get('clipboardState').raw;
@@ -70,7 +70,7 @@ export class CodeClipboardController {
     return true;
   };
 
-  constructor(host: BlockElement) {
+  constructor(host: BlockComponent) {
     this.host = host;
   }
 

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { BundledLanguage, Highlighter } from 'shiki';
 
 import { getInlineRangeProvider } from '@blocksuite/block-std';
@@ -417,7 +417,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
 
   override get topContenteditableElement() {
     if (this.rootElement instanceof EdgelessRootBlockComponent) {
-      const el = this.closest<BlockElement>(NOTE_SELECTOR);
+      const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
     return this.rootElement;

--- a/packages/blocks/src/database-block/widgets/expand/table-full-screen-modal.ts
+++ b/packages/blocks/src/database-block/widgets/expand/table-full-screen-modal.ts
@@ -1,4 +1,4 @@
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { customElement, property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
@@ -11,7 +11,7 @@ import {
 import { fullScreenStyles } from './styles.js';
 
 @customElement('affine-database-table-view-full-screen')
-export class DatabaseTableViewFullScreen extends BlockElement<DatabaseBlockModel> {
+export class DatabaseTableViewFullScreen extends BlockComponent<DatabaseBlockModel> {
   _renderView = () => {
     /* eslint-disable lit/binding-positions, lit/no-invalid-html */
     return html`

--- a/packages/blocks/src/edgeless-text/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-block.ts
@@ -1,6 +1,6 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
-import { EdgelessBlockElement } from '@blocksuite/block-std';
+import { EdgelessBlockComponent } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import { type PropertyValueMap, css, html } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
@@ -26,7 +26,7 @@ export const EDGELESS_TEXT_BLOCK_MIN_WIDTH = 50;
 export const EDGELESS_TEXT_BLOCK_MIN_HEIGHT = 50;
 
 @customElement('affine-edgeless-text')
-export class EdgelessTextBlockComponent extends EdgelessBlockElement<
+export class EdgelessTextBlockComponent extends EdgelessBlockComponent<
   EdgelessRootService,
   EdgelessTextBlockModel,
   EdgelessTextBlockService
@@ -149,7 +149,7 @@ export class EdgelessTextBlockComponent extends EdgelessBlockElement<
 
     const { disposables, rootService } = this;
     const edgelessSelection = rootService.selection;
-    const selectedRect = this.parentBlockElement.selectedRect;
+    const selectedRect = this.parentBlock.selectedRect;
 
     disposables.add(
       selectedRect.slots.dragStart
@@ -322,7 +322,7 @@ export class EdgelessTextBlockComponent extends EdgelessBlockElement<
 
   tryFocusEnd() {
     const paragraphOrLists = Array.from(
-      this.querySelectorAll<BlockElement>('affine-paragraph, affine-list')
+      this.querySelectorAll<BlockComponent>('affine-paragraph, affine-list')
     );
     const last = paragraphOrLists.at(-1);
     if (last) {
@@ -347,8 +347,8 @@ export class EdgelessTextBlockComponent extends EdgelessBlockElement<
     );
   }
 
-  override get parentBlockElement() {
-    return super.parentBlockElement as EdgelessRootBlockComponent;
+  override get parentBlock() {
+    return super.parentBlock as EdgelessRootBlockComponent;
   }
 
   @state()

--- a/packages/blocks/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/blocks/src/embed-figma-block/embed-figma-block.ts
@@ -7,12 +7,12 @@ import type { EmbedFigmaModel } from './embed-figma-model.js';
 import type { EmbedFigmaBlockService } from './embed-figma-service.js';
 
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
 import { FigmaIcon, styles } from './styles.js';
 
 @customElement('affine-embed-figma-block')
-export class EmbedFigmaBlockComponent extends EmbedBlockElement<
+export class EmbedFigmaBlockComponent extends EmbedBlockComponent<
   EmbedFigmaModel,
   EmbedFigmaBlockService
 > {

--- a/packages/blocks/src/embed-github-block/embed-github-block.ts
+++ b/packages/blocks/src/embed-github-block/embed-github-block.ts
@@ -8,7 +8,7 @@ import type { EmbedGithubStyles } from './embed-github-model.js';
 import type { EmbedGithubBlockService } from './embed-github-service.js';
 
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
 import { getEmbedCardIcons } from '../_common/utils/url.js';
 import { type EmbedGithubModel, githubUrlRegex } from './embed-github-model.js';
@@ -20,7 +20,7 @@ import {
 } from './utils.js';
 
 @customElement('affine-embed-github-block')
-export class EmbedGithubBlockComponent extends EmbedBlockElement<
+export class EmbedGithubBlockComponent extends EmbedBlockComponent<
   EmbedGithubModel,
   EmbedGithubBlockService
 > {

--- a/packages/blocks/src/embed-html-block/embed-html-block.ts
+++ b/packages/blocks/src/embed-html-block/embed-html-block.ts
@@ -8,12 +8,12 @@ import type { EmbedHtmlModel, EmbedHtmlStyles } from './embed-html-model.js';
 import type { EmbedHtmlBlockService } from './embed-html-service.js';
 
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/index.js';
 import './components/fullscreen-toolbar.js';
 import { HtmlIcon, styles } from './styles.js';
 
 @customElement('affine-embed-html-block')
-export class EmbedHtmlBlockComponent extends EmbedBlockElement<
+export class EmbedHtmlBlockComponent extends EmbedBlockComponent<
   EmbedHtmlModel,
   EmbedHtmlBlockService
 > {

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -17,7 +17,7 @@ import type { EmbedLinkedDocBlockService } from './embed-linked-doc-service.js';
 
 import { Peekable, isPeekable } from '../_common/components/peekable.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/index.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/index.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
 import { renderLinkedDocInCard } from '../_common/utils/render-linked-doc.js';
 import { SyncedDocErrorIcon } from '../embed-synced-doc-block/styles.js';
@@ -28,7 +28,7 @@ import { getEmbedLinkedDocIcons } from './utils.js';
 @Peekable({
   enableOn: ({ doc }: EmbedLinkedDocBlockComponent) => !doc.readonly,
 })
-export class EmbedLinkedDocBlockComponent extends EmbedBlockElement<
+export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<
   EmbedLinkedDocModel,
   EmbedLinkedDocBlockService
 > {

--- a/packages/blocks/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/blocks/src/embed-loom-block/embed-loom-block.ts
@@ -6,7 +6,7 @@ import type { EmbedLoomStyles } from './embed-loom-model.js';
 import type { EmbedLoomBlockService } from './embed-loom-service.js';
 
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
 import { getEmbedCardIcons } from '../_common/utils/url.js';
 import { type EmbedLoomModel, loomUrlRegex } from './embed-loom-model.js';
@@ -14,7 +14,7 @@ import { LoomIcon, styles } from './styles.js';
 import { refreshEmbedLoomUrlData } from './utils.js';
 
 @customElement('affine-embed-loom-block')
-export class EmbedLoomBlockComponent extends EmbedBlockElement<
+export class EmbedLoomBlockComponent extends EmbedBlockComponent<
   EmbedLoomModel,
   EmbedLoomBlockService
 > {

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -24,7 +24,7 @@ import type { EmbedSyncedDocBlockService } from './embed-synced-doc-service.js';
 
 import { Peekable } from '../_common/components/peekable.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { EmbedEdgelessIcon, EmbedPageIcon } from '../_common/icons/text.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
 import { type DocMode, NoteDisplayMode } from '../_common/types.js';
@@ -39,7 +39,7 @@ import { blockStyles } from './styles.js';
 @Peekable({
   enableOn: ({ doc }: EmbedSyncedDocBlockComponent) => !doc.readonly,
 })
-export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
+export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
   EmbedSyncedDocModel,
   EmbedSyncedDocBlockService
 > {
@@ -89,9 +89,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockElement<
     };
 
     const observer = new ResizeObserver(fitToContent);
-    const blockElement = this.embedBlock;
+    const block = this.embedBlock;
 
-    observer.observe(blockElement);
+    observer.observe(block);
 
     this._disposables.add(() => {
       observer.disconnect();

--- a/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/blocks/src/embed-youtube-block/embed-youtube-block.ts
@@ -6,7 +6,7 @@ import type { EmbedYoutubeStyles } from './embed-youtube-model.js';
 import type { EmbedYoutubeBlockService } from './embed-youtube-service.js';
 
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
-import { EmbedBlockElement } from '../_common/embed-block-helper/embed-block-element.js';
+import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { OpenIcon } from '../_common/icons/text.js';
 import { getEmbedCardIcons } from '../_common/utils/url.js';
 import {
@@ -17,7 +17,7 @@ import { YoutubeIcon, styles } from './styles.js';
 import { refreshEmbedYoutubeUrlData } from './utils.js';
 
 @customElement('affine-embed-youtube-block')
-export class EmbedYoutubeBlockComponent extends EmbedBlockElement<
+export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
   EmbedYoutubeModel,
   EmbedYoutubeBlockService
 > {

--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -1,7 +1,7 @@
 import type { Doc } from '@blocksuite/store';
 
 import {
-  EdgelessBlockElement,
+  EdgelessBlockComponent,
   ShadowlessElement,
   WithDisposable,
 } from '@blocksuite/block-std';
@@ -241,7 +241,7 @@ export class EdgelessFrameTitle extends WithDisposable(ShadowlessElement) {
 }
 
 @customElement('affine-frame')
-export class FrameBlockComponent extends EdgelessBlockElement<
+export class FrameBlockComponent extends EdgelessBlockComponent<
   EdgelessRootService,
   FrameBlockModel
 > {

--- a/packages/blocks/src/image-block/image-resize-manager.ts
+++ b/packages/blocks/src/image-block/image-resize-manager.ts
@@ -1,9 +1,8 @@
-import type { PointerEventState } from '@blocksuite/block-std';
+import type { BlockComponent, PointerEventState } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 
 import {
-  type BlockComponent,
   getClosestBlockComponentByElement,
   getModelByElement,
   isEdgelessPage,

--- a/packages/blocks/src/image-block/image-resize-manager.ts
+++ b/packages/blocks/src/image-block/image-resize-manager.ts
@@ -4,7 +4,7 @@ import { assertExists } from '@blocksuite/global/utils';
 
 import {
   type BlockComponent,
-  getClosestBlockElementByElement,
+  getClosestBlockComponentByElement,
   getModelByElement,
   isEdgelessPage,
 } from '../_common/utils/query.js';
@@ -70,7 +70,7 @@ export class ImageResizeManager {
 
   onStart(e: PointerEventState) {
     const eventTarget = e.raw.target as HTMLElement;
-    this._activeComponent = getClosestBlockElementByElement(
+    this._activeComponent = getClosestBlockComponentByElement(
       eventTarget
     ) as BlockComponent;
 

--- a/packages/blocks/src/image-block/utils.ts
+++ b/packages/blocks/src/image-block/utils.ts
@@ -215,8 +215,8 @@ function convertToPng(blob: Blob): Promise<Blob | null> {
   });
 }
 
-export async function copyImageBlob(blockElement: ImageBlockComponent) {
-  const { host, model } = blockElement;
+export async function copyImageBlob(block: ImageBlockComponent) {
+  const { host, model } = block;
   let blob = await getImageBlob(model);
   if (!blob) {
     console.error('Failed to get image blob');

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -40,7 +40,7 @@ export {
 } from './_common/components/index.js';
 export { type NavigatorMode } from './_common/edgeless/frame/consts.js';
 export {
-  EmbedBlockElement,
+  EmbedBlockComponent,
   createEmbedBlockSchema,
   defineEmbedModel,
 } from './_common/embed-block-helper/index.js';

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { InlineRangeProvider } from '@blocksuite/inline';
 
 import { getInlineRangeProvider } from '@blocksuite/block-std';
@@ -183,7 +183,7 @@ export class ListBlockComponent extends CaptionedBlockComponent<
 
   override get topContenteditableElement() {
     if (this.rootElement instanceof EdgelessRootBlockComponent) {
-      const el = this.closest<BlockElement>(NOTE_SELECTOR);
+      const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
     return this.rootElement;

--- a/packages/blocks/src/note-block/commands/index.ts
+++ b/packages/blocks/src/note-block/commands/index.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 export * from './block-type.js';
 export * from './select-block.js';
@@ -8,9 +8,9 @@ export * from './text-style.js';
 declare global {
   namespace BlockSuite {
     interface CommandContext {
-      focusBlock?: BlockElement | null;
+      focusBlock?: BlockComponent | null;
 
-      anchorBlock?: BlockElement | null;
+      anchorBlock?: BlockComponent | null;
     }
   }
 }

--- a/packages/blocks/src/note-block/commands/utils.ts
+++ b/packages/blocks/src/note-block/commands/utils.ts
@@ -4,7 +4,7 @@ import type {
   CommandKeyToData,
   InitCommandCtx,
 } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 import {
@@ -103,7 +103,7 @@ function getCombinedFormatFromInlineEditors(
 }
 
 function getSelectedInlineEditors(
-  blocks: BlockElement[],
+  blocks: BlockComponent[],
   filter: (
     inlineRoot: InlineRootElement<AffineTextAttributes>
   ) => InlineEditor<AffineTextAttributes> | []
@@ -205,10 +205,10 @@ function handleCurrentSelection<
           return range.intersectsNode(el);
         })
         .filter(el => {
-          const blockElement = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
-          if (blockElement) {
+          const block = el.closest<BlockComponent>(`[${BLOCK_ID_ATTR}]`);
+          if (block) {
             return FORMAT_NATIVE_SUPPORT_FLAVOURS.includes(
-              blockElement.model.flavour as BlockSuite.Flavour
+              block.model.flavour as BlockSuite.Flavour
             );
           }
           return false;

--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -4,7 +4,7 @@ import type {
   UIEventHandler,
   UIEventStateContext,
 } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 import { assertExists } from '@blocksuite/global/utils';
@@ -103,7 +103,7 @@ export class KeymapController implements ReactiveController {
     });
   };
 
-  private _focusBlock: BlockElement | null = null;
+  private _focusBlock: BlockComponent | null = null;
 
   private _onArrowDown = (ctx: UIEventStateContext) => {
     const event = ctx.get('defaultState').event;
@@ -522,9 +522,9 @@ export class KeymapController implements ReactiveController {
     this._bindMoveBlockHotKey();
   };
 
-  host: ReactiveControllerHost & BlockElement;
+  host: ReactiveControllerHost & BlockComponent;
 
-  constructor(host: ReactiveControllerHost & BlockElement) {
+  constructor(host: ReactiveControllerHost & BlockComponent) {
     (this.host = host).addController(this);
   }
 

--- a/packages/blocks/src/note-block/note-block.ts
+++ b/packages/blocks/src/note-block/note-block.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -9,7 +9,7 @@ import type { NoteBlockService } from './note-service.js';
 import { KeymapController } from './keymap-controller.js';
 
 @customElement('affine-note')
-export class NoteBlockComponent extends BlockElement<
+export class NoteBlockComponent extends BlockComponent<
   NoteBlockModel,
   NoteBlockService
 > {

--- a/packages/blocks/src/note-block/note-edgeless-block.ts
+++ b/packages/blocks/src/note-block/note-edgeless-block.ts
@@ -1,10 +1,10 @@
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import {
   ShadowlessElement,
   WithDisposable,
-  toEdgelessBlockElement,
+  toEdgelessBlockComponent,
 } from '@blocksuite/block-std';
 import { Point } from '@blocksuite/global/utils';
 import { Bound, almostEqual, clamp } from '@blocksuite/global/utils';
@@ -21,7 +21,7 @@ import { DEFAULT_NOTE_BACKGROUND_COLOR } from '../_common/edgeless/note/consts.j
 import { MoreIndicatorIcon } from '../_common/icons/edgeless.js';
 import { NoteDisplayMode } from '../_common/types.js';
 import { matchFlavours } from '../_common/utils/model.js';
-import { getClosestBlockElementByPoint } from '../_common/utils/query.js';
+import { getClosestBlockComponentByPoint } from '../_common/utils/query.js';
 import { handleNativeRangeAtPoint } from '../_common/utils/selection.js';
 import { StrokeStyle } from '../surface-block/consts.js';
 import { NoteBlockComponent } from './note-block.js';
@@ -101,7 +101,7 @@ export class EdgelessNoteMask extends WithDisposable(ShadowlessElement) {
 const ACTIVE_NOTE_EXTRA_PADDING = 20;
 
 @customElement('affine-edgeless-note')
-export class EdgelessNoteBlockComponent extends toEdgelessBlockElement(
+export class EdgelessNoteBlockComponent extends toEdgelessBlockComponent(
   NoteBlockComponent
 ) {
   static override styles = css`
@@ -251,9 +251,9 @@ export class EdgelessNoteBlockComponent extends toEdgelessBlockElement(
   }
 
   private _tryAddParagraph(x: number, y: number) {
-    const nearest = getClosestBlockElementByPoint(
+    const nearest = getClosestBlockComponentByPoint(
       new Point(x, y)
-    ) as BlockElement | null;
+    ) as BlockComponent | null;
     if (!nearest) return;
 
     const nearestBBox = nearest.getBoundingClientRect();

--- a/packages/blocks/src/note-block/utils.ts
+++ b/packages/blocks/src/note-block/utils.ts
@@ -1,7 +1,6 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 export const ensureBlockInContainer = (
-  blockElement: BlockElement,
-  containerElement: BlockElement
-) =>
-  containerElement.contains(blockElement) && blockElement !== containerElement;
+  block: BlockComponent,
+  containerElement: BlockComponent
+) => containerElement.contains(block) && block !== containerElement;

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { InlineRangeProvider } from '@blocksuite/inline';
 
 import { getInlineRangeProvider } from '@blocksuite/block-std';
@@ -152,7 +152,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<
 
   override get topContenteditableElement() {
     if (this.rootElement instanceof EdgelessRootBlockComponent) {
-      const el = this.closest<BlockElement>(NOTE_SELECTOR);
+      const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
     return this.rootElement;

--- a/packages/blocks/src/root-block/clipboard/index.ts
+++ b/packages/blocks/src/root-block/clipboard/index.ts
@@ -1,5 +1,5 @@
 import type { UIEventHandler } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { BlockSnapshot, Doc } from '@blocksuite/store';
 
 import { DisposableGroup, assertExists } from '@blocksuite/global/utils';
@@ -80,7 +80,7 @@ export class PageClipboard {
     });
   };
 
-  host: BlockElement;
+  host: BlockComponent;
 
   onBlockSnapshotPaste = (
     snapshot: BlockSnapshot,
@@ -163,7 +163,7 @@ export class PageClipboard {
       .run();
   };
 
-  constructor(host: BlockElement) {
+  constructor(host: BlockComponent) {
     this.host = host;
   }
 

--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -1,5 +1,5 @@
 import type {
-  BlockElement,
+  BlockComponent,
   EditorHost,
   TextRangePoint,
   TextSelection,
@@ -55,7 +55,7 @@ class PointState {
     return block;
   };
 
-  readonly block: BlockElement;
+  readonly block: BlockComponent;
 
   readonly model: BlockModel;
 
@@ -291,7 +291,7 @@ class PasteTr {
 
     host.updateComplete
       .then(() => {
-        const target = this.std.host.querySelector<BlockElement>(
+        const target = this.std.host.querySelector<BlockComponent>(
           `[${host.blockIdAttr}="${cursorModel.id}"]`
         );
         if (!target) {

--- a/packages/blocks/src/root-block/commands/block-crud/get-block-index.ts
+++ b/packages/blocks/src/root-block/commands/block-crud/get-block-index.ts
@@ -1,5 +1,5 @@
 import type { Command } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 
@@ -22,13 +22,13 @@ export const getBlockIndexCommand: Command<
   const parent = ctx.std.view.getBlock(parentModel.id);
   if (!parent) return;
 
-  const index = parent.childBlockElements.findIndex(x => {
+  const index = parent.childBlocks.findIndex(x => {
     return x.blockId === path;
   });
 
   next({
     blockIndex: index,
-    parentBlock: parent as BlockElement,
+    parentBlock: parent as BlockComponent,
   });
 };
 
@@ -36,7 +36,7 @@ declare global {
   namespace BlockSuite {
     interface CommandContext {
       blockIndex?: number;
-      parentBlock?: BlockElement;
+      parentBlock?: BlockComponent;
     }
 
     interface Commands {

--- a/packages/blocks/src/root-block/commands/block-crud/get-next-block.ts
+++ b/packages/blocks/src/root-block/commands/block-crud/get-next-block.ts
@@ -1,11 +1,11 @@
 import type { Command } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 
-function getNext(std: BlockSuite.Std, blockElement: BlockElement) {
+function getNext(std: BlockSuite.Std, block: BlockComponent) {
   const view = std.view;
-  const next = std.doc.getNext(blockElement.model);
+  const next = std.doc.getNext(block.model);
   if (!next) return null;
   return view.getBlock(next.id);
 }
@@ -15,9 +15,9 @@ function getNextBlock(std: BlockSuite.Std, path: string) {
   const focusBlock = view.getBlock(path);
   if (!focusBlock) return null;
 
-  let next: BlockElement | null = null;
-  if (focusBlock.childBlockElements[0]) {
-    next = focusBlock.childBlockElements[0];
+  let next: BlockComponent | null = null;
+  if (focusBlock.childBlocks[0]) {
+    next = focusBlock.childBlocks[0];
   }
 
   if (!next) {
@@ -54,7 +54,7 @@ export const getNextBlockCommand: Command<
 declare global {
   namespace BlockSuite {
     interface CommandContext {
-      nextBlock?: BlockElement;
+      nextBlock?: BlockComponent;
     }
 
     interface Commands {

--- a/packages/blocks/src/root-block/commands/block-crud/get-prev-block.ts
+++ b/packages/blocks/src/root-block/commands/block-crud/get-prev-block.ts
@@ -1,13 +1,13 @@
 import type { Command } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { assertExists } from '@blocksuite/global/utils';
 
 function getPrevSibling(std: BlockSuite.Std, path: string) {
   const view = std.view;
-  const blockElement = view.getBlock(path);
-  if (!blockElement) return null;
-  const prev = std.doc.getPrev(blockElement.model);
+  const block = view.getBlock(path);
+  if (!block) return null;
+  const prev = std.doc.getPrev(block.model);
   if (!prev) return null;
   return view.getBlock(prev.id);
 }
@@ -15,7 +15,7 @@ function getPrevSibling(std: BlockSuite.Std, path: string) {
 function getPrevBlock(std: BlockSuite.Std, path: string) {
   const view = std.view;
 
-  const prev: BlockElement | null = getPrevSibling(std, path);
+  const prev: BlockComponent | null = getPrevSibling(std, path);
 
   if (!prev) {
     return null;
@@ -54,7 +54,7 @@ export const getPrevBlockCommand: Command<
 declare global {
   namespace BlockSuite {
     interface CommandContext {
-      prevBlock?: BlockElement;
+      prevBlock?: BlockComponent;
     }
 
     interface Commands {

--- a/packages/blocks/src/root-block/commands/text-crud/delete-text.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/delete-text.ts
@@ -24,7 +24,7 @@ export const deleteTextCommand: Command<
 
   const range = host.rangeManager.textSelectionToRange(textSelection);
   if (!range) return;
-  const selectedElements = host.rangeManager.getSelectedBlockElementsByRange(
+  const selectedElements = host.rangeManager.getSelectedBlockComponentsByRange(
     range,
     {
       mode: 'flat',

--- a/packages/blocks/src/root-block/commands/text-crud/format-native.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/format-native.ts
@@ -1,5 +1,5 @@
 import type { Command } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { INLINE_ROOT_ATTR, type InlineRootElement } from '@blocksuite/inline';
 
@@ -33,10 +33,10 @@ export const formatNativeCommand: Command<
   )
     .filter(el => range?.intersectsNode(el))
     .filter(el => {
-      const blockElement = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
-      if (blockElement) {
+      const block = el.closest<BlockComponent>(`[${BLOCK_ID_ATTR}]`);
+      if (block) {
         return FORMAT_NATIVE_SUPPORT_FLAVOURS.includes(
-          blockElement.model.flavour as BlockSuite.Flavour
+          block.model.flavour as BlockSuite.Flavour
         );
       }
       return false;

--- a/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
@@ -16,7 +16,7 @@ import type {
 import { SmallScissorsIcon } from '../../../../_common/icons/edgeless.js';
 import {
   buildPath,
-  getRectByBlockElement,
+  getRectByBlockComponent,
 } from '../../../../_common/utils/index.js';
 import { DEFAULT_NOTE_HEIGHT } from '../../utils/consts.js';
 import { isNoteBlock } from '../../utils/query.js';
@@ -110,7 +110,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
     return this.edgeless.host;
   }
 
-  get _noteBlockElement() {
+  get _noteBlock() {
     if (!this._editorHost) return null;
     const noteBlock = this._editorHost.view.viewFromPath(
       'block',
@@ -190,7 +190,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
   }
 
   private _updateDivingLineAndBlockIds() {
-    if (!this._anchorNote || !this._noteBlockElement) {
+    if (!this._anchorNote || !this._noteBlock) {
       this._divingLinePositions = [];
       this._noteBlockIds = [];
       return;
@@ -198,7 +198,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
 
     const divingLinePositions: Point[] = [];
     const noteBlockIds: string[] = [];
-    const noteRect = this._noteBlockElement.getBoundingClientRect();
+    const noteRect = this._noteBlock.getBoundingClientRect();
     const noteTop = noteRect.top;
     const noteBottom = noteRect.bottom;
 
@@ -350,10 +350,10 @@ export class NoteSlicer extends WithDisposable(LitElement) {
 
     this._updateDivingLineAndBlockIds();
 
-    const noteBlockElement = this._noteBlockElement;
-    if (!noteBlockElement || !this._divingLinePositions.length) return nothing;
+    const noteBlock = this._noteBlock;
+    if (!noteBlock || !this._divingLinePositions.length) return nothing;
 
-    const rect = getRectByBlockElement(noteBlockElement);
+    const rect = getRectByBlockComponent(noteBlock);
     const width = rect.width;
     const buttonPosition = this._divingLinePositions[this._activeSlicerIndex];
 

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -36,7 +36,7 @@ import {
 import { matchFlavours } from '../../../_common/utils/index.js';
 import { groupBy } from '../../../_common/utils/iterable.js';
 import {
-  blockElementGetter,
+  blockComponentGetter,
   getRootByEditorHost,
   isInsidePageEditor,
 } from '../../../_common/utils/query.js';
@@ -894,7 +894,7 @@ export class EdgelessClipboardController extends PageClipboard {
       block: BlockSuite.EdgelessBlockModelType,
       isInFrame = false
     ) => {
-      let blockElement = blockElementGetter(
+      let blockComponent = blockComponentGetter(
         block,
         this.std.view
       )?.parentElement;
@@ -902,14 +902,14 @@ export class EdgelessClipboardController extends PageClipboard {
         'affine:',
         '.edgeless-block-portal-'
       );
-      blockElement = blockElement?.closest(blockPortalSelector);
-      if (!blockElement) {
+      blockComponent = blockComponent?.closest(blockPortalSelector);
+      if (!blockComponent) {
         throw new Error('Could not find edgeless block portal.');
       }
 
       const blockBound = Bound.deserialize(block.xywh);
       const canvasData = await html2canvas(
-        blockElement as HTMLElement,
+        blockComponent as HTMLElement,
         html2canvasOption
       );
       ctx.drawImage(

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -690,12 +690,12 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
             if (selected.children.length === 0) {
               this._addEmptyParagraphBlock(selected);
             } else {
-              const blockElement = this._edgeless.host.view.viewFromPath(
+              const block = this._edgeless.host.view.viewFromPath(
                 'block',
                 buildPath(selected)
               );
-              if (blockElement) {
-                const rect = blockElement
+              if (block) {
+                const rect = block
                   .querySelector('.affine-block-children-container')!
                   .getBoundingClientRect();
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -2,7 +2,7 @@ import type { SurfaceSelection } from '@blocksuite/block-std';
 import type { IBound, IPoint, IVec } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { IS_WINDOWS } from '@blocksuite/global/env';
 import { serializeXYWH } from '@blocksuite/global/utils';
 import { Point } from '@blocksuite/global/utils';
@@ -94,7 +94,7 @@ export interface EdgelessViewport {
 }
 
 @customElement('affine-edgeless-root')
-export class EdgelessRootBlockComponent extends BlockElement<
+export class EdgelessRootBlockComponent extends BlockComponent<
   RootBlockModel,
   EdgelessRootService,
   EdgelessRootBlockWidgetName

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -1,5 +1,5 @@
 import type {
-  BlockElement,
+  BlockComponent,
   BlockService,
   BlockSpec,
   BlockSpecSlots,
@@ -102,7 +102,7 @@ export const PreviewEdgelessRootBlockSpec: BlockSpec = {
         component,
         service,
       }: {
-        component: BlockElement;
+        component: BlockComponent;
         service: BlockService;
       }) => {
         // Does not allow the edgeless to display toolbar.

--- a/packages/blocks/src/root-block/edgeless/utils/note-resize-observer.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/note-resize-observer.ts
@@ -23,8 +23,8 @@ export class NoteResizeObserver {
   private _onResize = (entries: ResizeObserverEntry[]) => {
     const resizedNotes = new Map<string, [DOMRectReadOnly, DOMRectReadOnly?]>();
     entries.forEach(entry => {
-      const blockElement = entry.target.closest(`[${BLOCK_ID_ATTR}]`);
-      const id = blockElement?.getAttribute(BLOCK_ID_ATTR);
+      const blockComponent = entry.target.closest(`[${BLOCK_ID_ATTR}]`);
+      const id = blockComponent?.getAttribute(BLOCK_ID_ATTR);
       if (!id) return;
       const lastRect = this._lastRects.get(id);
       if (
@@ -74,14 +74,9 @@ export class NoteResizeObserver {
       const blockId = model.id;
       unCachedKeys.delete(blockId);
 
-      const blockElement = editorHost.view.viewFromPath(
-        'block',
-        buildPath(model)
-      );
+      const block = editorHost.view.viewFromPath('block', buildPath(model));
 
-      const container = blockElement?.querySelector(
-        '.affine-note-block-container'
-      );
+      const container = block?.querySelector('.affine-note-block-container');
 
       const cachedElement = this._cachedElements.get(blockId);
       if (cachedElement) {

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -1,5 +1,5 @@
 import type { BlockSelection } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import { IS_MAC, IS_WINDOWS } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
@@ -43,7 +43,7 @@ export class PageKeyboardManager {
     });
   };
 
-  constructor(public rootElement: BlockElement) {
+  constructor(public rootElement: BlockComponent) {
     this.rootElement.bindHotKey(
       {
         'Mod-z': ctx => {

--- a/packages/blocks/src/root-block/page/page-root-block.ts
+++ b/packages/blocks/src/root-block/page/page-root-block.ts
@@ -1,7 +1,7 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 import type { BlockModel, Text } from '@blocksuite/store';
 
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { css, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -48,7 +48,7 @@ function testClickOnBlankArea(
 }
 
 @customElement('affine-page-root')
-export class PageRootBlockComponent extends BlockElement<
+export class PageRootBlockComponent extends BlockComponent<
   RootBlockModel,
   PageRootService,
   PageRootBlockWidgetName

--- a/packages/blocks/src/root-block/preview/preview-root-block.ts
+++ b/packages/blocks/src/root-block/preview/preview-root-block.ts
@@ -1,10 +1,10 @@
 // import { PageRootBlockComponent } from '../page/page-root-block.js';
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('affine-preview-root')
-export class PreviewRootBlockComponent extends BlockElement {
+export class PreviewRootBlockComponent extends BlockComponent {
   static override styles = css`
     affine-preview-root {
       display: block;

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -1,4 +1,4 @@
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import { BlockService } from '@blocksuite/block-std';
@@ -411,7 +411,7 @@ export class RootService extends BlockService<RootBlockModel> {
   }
 
   get selectedBlocks() {
-    let result: BlockElement[] = [];
+    let result: BlockComponent[] = [];
     this.std.command
       .chain()
       .tryAll(chain => [

--- a/packages/blocks/src/root-block/utils/callback.ts
+++ b/packages/blocks/src/root-block/utils/callback.ts
@@ -1,4 +1,4 @@
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import { assertExists } from '@blocksuite/global/utils';
@@ -35,7 +35,7 @@ export async function onModelTextUpdated(
 export async function onModelElementUpdated(
   editorHost: EditorHost,
   model: BlockModel,
-  callback: (blockElement: BlockElement) => void
+  callback: (block: BlockComponent) => void
 ) {
   const page = model.doc;
   assertExists(page.root);

--- a/packages/blocks/src/root-block/utils/guard.ts
+++ b/packages/blocks/src/root-block/utils/guard.ts
@@ -1,12 +1,12 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 
 import type { RootBlockComponent } from '../types.js';
 
 export function isRootElement(
-  blockElement: BlockElement
-): blockElement is RootBlockComponent {
+  block: BlockComponent
+): block is RootBlockComponent {
   return (
-    blockElement.tagName === 'AFFINE-PAGE-ROOT' ||
-    blockElement.tagName === 'AFFINE-EDGELESS-ROOT'
+    block.tagName === 'AFFINE-PAGE-ROOT' ||
+    block.tagName === 'AFFINE-EDGELESS-ROOT'
   );
 }

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -402,14 +402,14 @@ export class AffineAIPanelWidget extends WidgetElement {
       this._onDocumentClick
     );
     this.disposables.add(
-      this.blockElement.host.event.add('pointerDown', evtState =>
+      this.block.host.event.add('pointerDown', evtState =>
         this._onDocumentClick(
           evtState.get('pointerState').event as PointerEvent
         )
       )
     );
     this.disposables.add(
-      this.blockElement.host.event.add('click', () => {
+      this.block.host.event.add('click', () => {
         return this.state !== 'hidden' ? true : false;
       })
     );

--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -25,7 +25,7 @@ export class LanguageListButton extends LitElement {
   private _abortController?: AbortController;
 
   private _clickLangBtn = () => {
-    if (this.blockElement.doc.readonly) return;
+    if (this.blockComponent.doc.readonly) return;
     if (this._abortController) {
       // Close the language list if it's already opened.
       this._abortController.abort();
@@ -49,7 +49,7 @@ export class LanguageListButton extends LitElement {
     const options: FilterableListOptions = {
       placeholder: 'Search for a language',
       onSelect: item => {
-        this.blockElement.setLang(item.name);
+        this.blockComponent.setLang(item.name);
         this._updateLanguage();
       },
       active: item => item.name === this._currentLanguage.id,
@@ -62,7 +62,7 @@ export class LanguageListButton extends LitElement {
         getLanguagePriority(a.name as BundledLanguage) -
         getLanguagePriority(b.name as BundledLanguage),
       referenceElement: this._langButton,
-      container: this.blockElement.host,
+      container: this.blockComponent.host,
       abortController: this._abortController,
       // stacking-context(editor-host)
       portalStyles: {
@@ -98,7 +98,7 @@ export class LanguageListButton extends LitElement {
 
   private _updateLanguage() {
     this._currentLanguage =
-      getStandardLanguage(this.blockElement.model.language) ??
+      getStandardLanguage(this.blockComponent.model.language) ??
       PLAIN_TEXT_LANG_INFO;
   }
 
@@ -115,10 +115,10 @@ export class LanguageListButton extends LitElement {
       text=${this._currentLanguage.name ?? this._currentLanguage.id}
       height="24px"
       @click=${this._clickLangBtn}
-      ?disabled=${this.blockElement.doc.readonly}
+      ?disabled=${this.blockComponent.doc.readonly}
     >
       <span slot="suffix">
-        ${!this.blockElement.doc.readonly ? ArrowDownIcon : nothing}
+        ${!this.blockComponent.doc.readonly ? ArrowDownIcon : nothing}
       </span>
     </icon-button> `;
   }
@@ -130,7 +130,7 @@ export class LanguageListButton extends LitElement {
   private accessor _langButton!: HTMLElement;
 
   @property({ attribute: false })
-  accessor blockElement!: CodeBlockComponent;
+  accessor blockComponent!: CodeBlockComponent;
 
   @property({ attribute: false })
   accessor onActiveStatusChange: (active: boolean) => void = noop;

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -28,7 +28,7 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
 
       return {
         template: html`<language-list-button
-          .blockElement=${this.blockElement}
+          .blockComponent=${this.block}
           .onActiveStatusChange=${async (active: boolean) => {
             this._isActivated = active;
             if (!active) {
@@ -48,9 +48,9 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
         portalStyles: {
           zIndex: 'var(--affine-z-index-popover)',
         },
-        container: this.blockElement,
+        container: this.block,
         computePosition: {
-          referenceElement: this.blockElement,
+          referenceElement: this.block,
           placement: 'left-start',
           middleware: [offset({ mainAxis: -5, crossAxis: 5 })],
           autoUpdate: true,
@@ -79,7 +79,7 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
     const hasMultipleBlockSelections =
       blockSelections.length > 1 ||
       (blockSelections.length === 1 &&
-        blockSelections[0].blockId !== this.blockElement.blockId);
+        blockSelections[0].blockId !== this.block.blockId);
 
     if (hasMultipleBlockSelections) {
       return false;
@@ -90,7 +90,7 @@ export class AffineCodeLanguageListWidget extends WidgetElement<
 
   override connectedCallback() {
     super.connectedCallback();
-    this._hoverController.setReference(this.blockElement);
+    this._hoverController.setReference(this.block);
     this._hoverController.onAbort = () => {
       // If the language list is opened, don't close it.
       if (this._isActivated) return;

--- a/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/components/code-toolbar.ts
@@ -85,7 +85,7 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
         >
           <div slot data-size="small" data-orientation="vertical">
             ${MoreMenuRenderer(
-              this.blockElement,
+              this.blockComponent,
               this._popMenuAbortController,
               this.moreItems
             )}
@@ -96,7 +96,7 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
       portalStyles: {
         zIndex: 'var(--affine-z-index-popover)',
       },
-      container: this.blockElement.host,
+      container: this.blockComponent.host,
       computePosition: {
         referenceElement: this._moreButton,
         placement: 'bottom-start',
@@ -117,7 +117,7 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
   override render() {
     const items = CodeToolbarItemRenderer(
       this.items,
-      this.blockElement,
+      this.blockComponent,
       this.closeCurrentMenu
     );
 
@@ -131,7 +131,7 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
           .tooltip=${'More'}
           .tooltipOffset=${4}
           .showTooltip=${!this._moreMenuOpen}
-          ?disabled=${this.blockElement.readonly}
+          ?disabled=${this.blockComponent.readonly}
           @click=${() => this._toggleMoreMenu()}
         >
           ${MoreVerticalIcon}
@@ -147,7 +147,7 @@ export class AffineCodeToolbar extends WithDisposable(LitElement) {
   private accessor _moreMenuOpen = false;
 
   @property({ attribute: false })
-  accessor blockElement!: CodeBlockComponent;
+  accessor blockComponent!: CodeBlockComponent;
 
   @property({ attribute: false })
   accessor items!: CodeToolbarItem[];

--- a/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/config.ts
@@ -28,7 +28,7 @@ export const defaultItems: CodeToolbarItem[] = [
     name: 'caption',
     icon: CaptionIcon,
     tooltip: 'Caption',
-    showWhen: blockElement => !blockElement.doc.readonly,
+    showWhen: block => !block.doc.readonly,
     action: (codeBlock, onClick) => {
       codeBlock.captionEditor?.show();
       onClick?.();

--- a/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
@@ -27,7 +27,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
     this._hoverController = new HoverController(
       this,
       ({ abortController }) => {
-        const codeBlock = this.blockElement;
+        const codeBlock = this.block;
         const selection = this.host.selection;
 
         const textSelection = selection.find('text');
@@ -49,7 +49,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
 
         return {
           template: html`<affine-code-toolbar
-            .blockElement=${codeBlock}
+            .blockComponent=${codeBlock}
             .abortController=${abortController}
             .items=${this.items}
             .moreItems=${this.moreItems}
@@ -60,7 +60,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
               }
             }}
           ></affine-code-toolbar>`,
-          container: this.blockElement,
+          container: this.block,
           // stacking-context(editor-host)
           portalStyles: {
             zIndex: 'var(--affine-z-index-popover)',
@@ -86,7 +86,7 @@ export class AffineCodeToolbarWidget extends WidgetElement<
       { allowMultiple: true }
     );
 
-    const codeBlock = this.blockElement;
+    const codeBlock = this.block;
     this._hoverController.setReference(codeBlock);
     this._hoverController.onAbort = () => {
       // If the more menu is opened, don't close it.

--- a/packages/blocks/src/root-block/widgets/code-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/utils.ts
@@ -61,13 +61,13 @@ export function CodeToolbarItemRenderer(
 }
 
 export function MoreMenuRenderer(
-  blockElement: CodeBlockComponent,
+  block: CodeBlockComponent,
   abortController: AbortController,
   config: CodeToolbarMoreItem[]
 ) {
   return config
     .filter(item => {
-      return item.type === 'divider' || item.showWhen(blockElement);
+      return item.type === 'divider' || item.showWhen(block);
     })
     .map(item => {
       let template: TemplateResult | null = null;
@@ -76,11 +76,11 @@ export function MoreMenuRenderer(
           const moreItem = item as MoreItem;
           const name =
             moreItem.name instanceof Function
-              ? moreItem.name(blockElement)
+              ? moreItem.name(block)
               : moreItem.name;
           const icon =
             moreItem.icon instanceof Function
-              ? moreItem.icon(blockElement)
+              ? moreItem.icon(block)
               : moreItem.icon;
           const buttonClass = `menu-item ${name.toLocaleLowerCase().split(' ').join('-')}`;
           template = html`
@@ -88,7 +88,7 @@ export function MoreMenuRenderer(
               class=${buttonClass}
               @click=${(e: MouseEvent) => {
                 e.stopPropagation();
-                moreItem.action(blockElement, abortController);
+                moreItem.action(block, abortController);
               }}
             >
               ${icon} ${name}

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -65,7 +65,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }
 
   private _getCursorRect(selections: BaseSelection[]): SelectionRect | null {
-    if (!isRootElement(this.blockElement)) {
+    if (!isRootElement(this.block)) {
       console.error('remote selection widget must be used in page component');
       return null;
     }
@@ -120,9 +120,9 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
     } else if (blockSelections.length > 0) {
       const lastBlockSelection = blockSelections[blockSelections.length - 1];
 
-      const blockElement = this.host.view.getBlock(lastBlockSelection.blockId);
-      if (blockElement) {
-        const rect = blockElement.getBoundingClientRect();
+      const block = this.host.view.getBlock(lastBlockSelection.blockId);
+      if (block) {
+        const rect = block.getBoundingClientRect();
         return {
           width: 2,
           height: rect.height,
@@ -141,7 +141,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }
 
   private _getSelectionRect(selections: BaseSelection[]): SelectionRect[] {
-    if (!isRootElement(this.blockElement)) {
+    if (!isRootElement(this.block)) {
       console.error('remote selection widget must be used in page component');
       return [];
     }
@@ -181,9 +181,9 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
       }
     } else if (blockSelections.length > 0) {
       return blockSelections.flatMap(blockSelection => {
-        const blockElement = this.host.view.getBlock(blockSelection.blockId);
-        if (blockElement) {
-          const rect = blockElement.getBoundingClientRect();
+        const block = this.host.view.getBlock(blockSelection.blockId);
+        if (block) {
+          const rect = block.getBoundingClientRect();
           return {
             width: rect.width,
             height: rect.height,

--- a/packages/blocks/src/root-block/widgets/drag-handle/config.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/config.ts
@@ -1,5 +1,5 @@
 import type { PointerEventState } from '@blocksuite/block-std';
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { Disposable } from '@blocksuite/global/utils';
 import type { Point } from '@blocksuite/global/utils';
 
@@ -36,7 +36,7 @@ export type DropResult = {
 export type OnDragStartProps = {
   state: PointerEventState;
   startDragging: (
-    blockElements: BlockElement[],
+    blocks: BlockComponent[],
     state: PointerEventState,
     dragPreview?: HTMLElement,
     dragPreviewOffset?: Point
@@ -48,7 +48,7 @@ export type OnDragStartProps = {
 
 export type OnDragEndProps = {
   state: PointerEventState;
-  draggingElements: BlockElement[];
+  draggingElements: BlockComponent[];
   dropBlockId: string;
   dropType: DropType | null;
   dragPreview: DragPreview;
@@ -62,7 +62,7 @@ export type DragHandleOption = {
   onDragStart?: (props: OnDragStartProps) => boolean;
   onDragMove?: (
     state: PointerEventState,
-    draggingElements?: BlockElement[]
+    draggingElements?: BlockComponent[]
   ) => boolean;
   onDragEnd?: (props: OnDragEndProps) => boolean;
 };

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { IVec } from '@blocksuite/global/utils';
 
 import {
@@ -31,7 +31,7 @@ import type { DragHandleOption, DropResult, DropType } from './config.js';
 
 import {
   Rect,
-  getBlockElementsExcludeSubtrees,
+  getBlockComponentsExcludeSubtrees,
   getCurrentNativeRange,
   getModelByBlockComponent,
   isInsideEdgelessEditor,
@@ -94,10 +94,10 @@ export class AffineDragHandleWidget extends WidgetElement<
   private _anchorModelDisposables: DisposableGroup | null = null;
 
   private _calculatePreviewOffset = (
-    blockElements: BlockElement[],
+    blocks: BlockComponent[],
     state: PointerEventState
   ) => {
-    const { top, left } = blockElements[0].getBoundingClientRect();
+    const { top, left } = blocks[0].getBoundingClientRect();
     const previewOffset = new Point(state.raw.x - left, state.raw.y - top);
     return previewOffset;
   };
@@ -142,7 +142,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     return selector;
   };
 
-  private _canEditing = (noteBlock: BlockElement) => {
+  private _canEditing = (noteBlock: BlockComponent) => {
     if (noteBlock.doc.id !== this.doc.id) return false;
 
     if (isInsidePageEditor(this.host)) return true;
@@ -230,20 +230,20 @@ export class AffineDragHandleWidget extends WidgetElement<
     }
 
     // Should select the block if current block is not selected
-    const blockElement = this.anchorBlockElement;
-    if (!blockElement) return;
+    const blocks = this.anchorBlockComponent;
+    if (!blocks) return;
 
     if (selectedBlocks.length > 1) {
       this._showDragHandleOnHoverBlock(this._anchorBlockPath);
     }
 
-    this._setSelectedBlocks([blockElement]);
+    this._setSelectedBlocks([blocks]);
 
     return true;
   };
 
   private _createDragPreview = (
-    blockElements: BlockElement[],
+    blocks: BlockComponent[],
     state: PointerEventState,
     dragPreviewEl?: HTMLElement,
     dragPreviewOffset?: Point
@@ -254,13 +254,11 @@ export class AffineDragHandleWidget extends WidgetElement<
       dragPreview.append(dragPreviewEl);
     } else {
       let width = 0;
-      blockElements.forEach(element => {
+      blocks.forEach(element => {
         width = Math.max(width, element.getBoundingClientRect().width);
       });
 
-      const selectedIds = blockElements.map(
-        blockElement => blockElement.model.id
-      );
+      const selectedIds = blocks.map(block => block.model.id);
 
       const selector = this._calculateSelector(selectedIds);
 
@@ -272,7 +270,7 @@ export class AffineDragHandleWidget extends WidgetElement<
         previewSpec.value
       );
 
-      const offset = this._calculatePreviewOffset(blockElements, state);
+      const offset = this._calculatePreviewOffset(blocks, state);
       const posX = state.raw.x - offset.x;
       const posY = state.raw.y - offset.y;
       const altKey = state.raw.altKey;
@@ -405,28 +403,28 @@ export class AffineDragHandleWidget extends WidgetElement<
     return this._onDragStart(state);
   };
 
-  private _getBlockElementFromViewStore = (path: string) => {
+  private _getBlockComponentFromViewStore = (path: string) => {
     return this.host.view.getBlock(path);
   };
 
-  private _getDraggingAreaRect = (blockElement: BlockElement): Rect => {
+  private _getDraggingAreaRect = (block: BlockComponent): Rect => {
     // When hover block is in selected blocks, should show hover rect on the selected blocks
     // Top: the top of the first selected block
     // Left: the left of the first selected block
     // Right: the largest right of the selected blocks
     // Bottom: the bottom of the last selected block
-    let { left, top, right, bottom } = blockElement.getBoundingClientRect();
+    let { left, top, right, bottom } = block.getBoundingClientRect();
 
-    const blockElements = this._getHoveredBlocks();
+    const blocks = this._getHoveredBlocks();
 
-    blockElements.forEach(blockElement => {
-      left = Math.min(left, blockElement.getBoundingClientRect().left);
-      top = Math.min(top, blockElement.getBoundingClientRect().top);
-      right = Math.max(right, blockElement.getBoundingClientRect().right);
-      bottom = Math.max(bottom, blockElement.getBoundingClientRect().bottom);
+    blocks.forEach(block => {
+      left = Math.min(left, block.getBoundingClientRect().left);
+      top = Math.min(top, block.getBoundingClientRect().top);
+      right = Math.max(right, block.getBoundingClientRect().right);
+      bottom = Math.max(bottom, block.getBoundingClientRect().bottom);
     });
 
-    const offsetLeft = getDragHandleLeftPadding(blockElements);
+    const offsetLeft = getDragHandleLeftPadding(blocks);
 
     const offsetParentRect =
       this.dragHandleContainerOffsetParent.getBoundingClientRect();
@@ -457,23 +455,19 @@ export class AffineDragHandleWidget extends WidgetElement<
    */
   private _getDropResult = (state: PointerEventState): DropResult | null => {
     const point = new Point(state.raw.x, state.raw.y);
-    const closestBlockElement = getClosestBlockByPoint(
+    const closestBlock = getClosestBlockByPoint(
       this.host,
       this.rootElement,
       point
     );
-    if (!closestBlockElement) {
-      return null;
-    }
+    if (!closestBlock) return null;
 
-    const blockId = closestBlockElement.model.id;
-    const blockPath = closestBlockElement.path;
-    const model = closestBlockElement.model;
+    const blockId = closestBlock.model.id;
+    const blockPath = closestBlock.path;
+    const model = closestBlock.model;
 
     const isDatabase = matchFlavours(model, ['affine:database']);
-    if (isDatabase) {
-      return null;
-    }
+    if (isDatabase) return null;
 
     // note block can only be dropped into another note block
     // prevent note block from being dropped into other blocks
@@ -482,9 +476,9 @@ export class AffineDragHandleWidget extends WidgetElement<
       matchFlavours(this.draggingElements[0].model, ['affine:note']);
 
     if (isDraggedElementNote) {
-      const parent = this.std.doc.getParent(closestBlockElement.model);
+      const parent = this.std.doc.getParent(closestBlock.model);
       if (!parent) return null;
-      const parentElement = this._getBlockElementFromViewStore(parent.id);
+      const parentElement = this._getBlockComponentFromViewStore(parent.id);
       if (!parentElement) return null;
       if (!matchFlavours(parentElement.model, ['affine:note'])) return null;
     }
@@ -494,7 +488,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     // nor a child-block of any dragging elements
     if (
       containBlock(
-        this.draggingElements.map(blockElement => blockElement.model.id),
+        this.draggingElements.map(block => block.model.id),
         blockId
       ) ||
       containChildBlock(this.draggingElements, blockPath)
@@ -508,7 +502,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     const result = calcDropTarget(
       point,
       model,
-      closestBlockElement,
+      closestBlock,
       this.draggingElements,
       this.scale * this.cumulativeParentScale,
       isDraggedElementNote === false
@@ -530,49 +524,46 @@ export class AffineDragHandleWidget extends WidgetElement<
     return dropIndicator;
   };
 
-  private _getHoveredBlocks = (): BlockElement[] => {
+  private _getHoveredBlocks = (): BlockComponent[] => {
     if (!this._isHoverDragHandleVisible || !this._anchorBlockPath) return [];
 
-    const hoverBlock = this.anchorBlockElement;
+    const hoverBlock = this.anchorBlockComponent;
     if (!hoverBlock) return [];
 
     const selections = this.selectedBlocks;
-    let blockElements: BlockElement[] = [];
+    let blocks: BlockComponent[] = [];
 
     // When current selection is TextSelection, should cover all the blocks in native range
     if (selections.length > 0 && includeTextSelection(selections)) {
       const range = getCurrentNativeRange();
       if (!range) return [];
       if (!this._rangeManager) return [];
-      blockElements = this._rangeManager.getSelectedBlockElementsByRange(
-        range,
-        {
-          match: el => el.model.role === 'content',
-          mode: 'highest',
-        }
-      );
+      blocks = this._rangeManager.getSelectedBlockComponentsByRange(range, {
+        match: el => el.model.role === 'content',
+        mode: 'highest',
+      });
     } else {
-      blockElements = this.selectedBlocks
-        .map(block => this._getBlockElementFromViewStore(block.blockId))
-        .filter((block): block is BlockElement => !!block);
+      blocks = this.selectedBlocks
+        .map(block => this._getBlockComponentFromViewStore(block.blockId))
+        .filter((block): block is BlockComponent => !!block);
     }
 
     if (
       containBlock(
-        blockElements.map(block => PathFinder.id(block.path)),
+        blocks.map(block => PathFinder.id(block.path)),
         this._anchorBlockPath
       )
     ) {
-      return blockElements;
+      return blocks;
     }
 
     return [hoverBlock];
   };
 
   // Need to consider block padding and scale
-  private _getTopWithBlockElement = (blockElement: BlockElement) => {
-    const computedStyle = getComputedStyle(blockElement);
-    const { top } = blockElement.getBoundingClientRect();
+  private _getTopWithBlockComponent = (block: BlockComponent) => {
+    const computedStyle = getComputedStyle(block);
+    const { top } = block.getBoundingClientRect();
     const paddingTop = parseInt(computedStyle.paddingTop) * this.scale;
     return (
       (top +
@@ -648,8 +639,8 @@ export class AffineDragHandleWidget extends WidgetElement<
     }
   };
 
-  /** Check if given blockElement is selected */
-  private _isBlockSelected = (block?: BlockElement) => {
+  /** Check if given block component is selected */
+  private _isBlockSelected = (block?: BlockComponent) => {
     if (!block) return false;
     return this.selectedBlocks.some(
       selection => selection.blockId === block.model.id
@@ -678,7 +669,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
   private _lastHoveredBlockPath: string | null = null;
 
-  private _lastShowedBlock: { path: string; el: BlockElement } | null = null;
+  private _lastShowedBlock: { path: string; el: BlockComponent } | null = null;
 
   private _onDragEnd = (state: PointerEventState) => {
     const targetBlockId = this.dropBlockId;
@@ -695,7 +686,7 @@ export class AffineDragHandleWidget extends WidgetElement<
         target.classList.contains('edgeless-container');
       if (!isTargetEdgelessContainer) return false;
 
-      const selectedBlocks = getBlockElementsExcludeSubtrees(draggingElements)
+      const selectedBlocks = getBlockComponentsExcludeSubtrees(draggingElements)
         .map(element => getModelByBlockComponent(element))
         .filter((x): x is BlockModel => !!x);
       if (selectedBlocks.length === 0) return false;
@@ -757,7 +748,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       return false;
     }
 
-    const selectedBlocks = getBlockElementsExcludeSubtrees(draggingElements)
+    const selectedBlocks = getBlockComponentsExcludeSubtrees(draggingElements)
       .map(element => getModelByBlockComponent(element))
       .filter((x): x is BlockModel => !!x);
     if (!selectedBlocks.length) {
@@ -810,7 +801,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       if (!parent) return;
       // Need to update selection when moving blocks successfully
       // Because the block path may be changed after moving
-      const parentElement = this._getBlockElementFromViewStore(parent.id);
+      const parentElement = this._getBlockComponentFromViewStore(parent.id);
       if (parentElement) {
         const newSelectedBlocks = selectedBlocks.map(block => {
           return this.std.view.getBlock(block.id);
@@ -818,7 +809,7 @@ export class AffineDragHandleWidget extends WidgetElement<
         if (!newSelectedBlocks) return;
 
         const noteId = getNoteId(parentElement);
-        this._setSelectedBlocks(newSelectedBlocks as BlockElement[], noteId);
+        this._setSelectedBlocks(newSelectedBlocks as BlockComponent[], noteId);
       }
     }, 0);
 
@@ -828,10 +819,10 @@ export class AffineDragHandleWidget extends WidgetElement<
   private _onDragHandlePointerDown = () => {
     if (!this._isHoverDragHandleVisible || !this._anchorBlockPath) return;
 
-    const blockElement = this.anchorBlockElement;
-    if (!blockElement) return;
+    const block = this.anchorBlockComponent;
+    if (!block) return;
 
-    this._dragHoverRect = this._getDraggingAreaRect(blockElement) ?? null;
+    this._dragHoverRect = this._getDraggingAreaRect(block) ?? null;
   };
 
   private _onDragHandlePointerEnter = () => {
@@ -840,8 +831,8 @@ export class AffineDragHandleWidget extends WidgetElement<
     if (!container || !grabber) return;
 
     if (this._isHoverDragHandleVisible && this._anchorBlockPath) {
-      const blockElement = this.anchorBlockElement;
-      if (!blockElement) return;
+      const block = this.anchorBlockComponent;
+      if (!block) return;
 
       const padding = DRAG_HANDLE_CONTAINER_PADDING * this.scale;
       container.style.paddingTop = `${padding}px`;
@@ -912,8 +903,8 @@ export class AffineDragHandleWidget extends WidgetElement<
     )
       return;
     // Get current hover block element by path
-    const hoverBlockElement = this.anchorBlockElement;
-    if (!hoverBlockElement) return false;
+    const hoverBlock = this.anchorBlockComponent;
+    if (!hoverBlock) return false;
 
     let selections = this.selectedBlocks;
 
@@ -927,12 +918,14 @@ export class AffineDragHandleWidget extends WidgetElement<
         this._rangeManager
       ) {
         const range = nativeSelection.getRangeAt(0);
-        const blockElements =
-          this._rangeManager.getSelectedBlockElementsByRange(range, {
+        const blocks = this._rangeManager.getSelectedBlockComponentsByRange(
+          range,
+          {
             match: el => el.model.role === 'content',
             mode: 'highest',
-          });
-        this._setSelectedBlocks(blockElements);
+          }
+        );
+        this._setSelectedBlocks(blocks);
         selections = this.selectedBlocks;
       }
     }
@@ -947,27 +940,27 @@ export class AffineDragHandleWidget extends WidgetElement<
         this._anchorBlockId
       )
     ) {
-      const blockElement = this.anchorBlockElement;
-      if (blockElement) {
-        this._setSelectedBlocks([blockElement]);
+      const block = this.anchorBlockComponent;
+      if (block) {
+        this._setSelectedBlocks([block]);
       }
     }
 
-    const blockElements = this.selectedBlocks
+    const blocks = this.selectedBlocks
       .map(selection => {
-        return this._getBlockElementFromViewStore(selection.blockId);
+        return this._getBlockComponentFromViewStore(selection.blockId);
       })
-      .filter((element): element is BlockElement<BlockModel> => !!element);
+      .filter((element): element is BlockComponent<BlockModel> => !!element);
 
     // This could be skip if we can ensure that all selected blocks are on the same level
     // Which means not selecting parent block and child block at the same time
-    const blockElementsExcludingChildren = getBlockElementsExcludeSubtrees(
-      blockElements
-    ) as BlockElement[];
+    const blocksExcludingChildren = getBlockComponentsExcludeSubtrees(
+      blocks
+    ) as BlockComponent[];
 
-    if (blockElementsExcludingChildren.length === 0) return false;
+    if (blocksExcludingChildren.length === 0) return false;
 
-    this._startDragging(blockElementsExcludingChildren, state);
+    this._startDragging(blocksExcludingChildren, state);
     this._hide();
     return true;
   };
@@ -980,24 +973,24 @@ export class AffineDragHandleWidget extends WidgetElement<
     if (this._isTopLevelDragHandleVisible) return;
 
     const point = new Point(state.raw.x, state.raw.y);
-    const closestBlockElement = getClosestBlockByPoint(
+    const closestBlock = getClosestBlockByPoint(
       this.host,
       this.rootElement,
       point
     );
-    if (!closestBlockElement) {
+    if (!closestBlock) {
       this._anchorBlockId = '';
       this._anchorBlockPath = null;
       return;
     }
 
-    const blockId = closestBlockElement.getAttribute(this.host.blockIdAttr);
+    const blockId = closestBlock.getAttribute(this.host.blockIdAttr);
     if (!blockId) return;
 
     this._anchorBlockId = blockId;
-    this._anchorBlockPath = closestBlockElement.blockId;
+    this._anchorBlockPath = closestBlock.blockId;
 
-    if (insideDatabaseTable(closestBlockElement) || this.doc.readonly) {
+    if (insideDatabaseTable(closestBlock) || this.doc.readonly) {
       this._hide();
       return;
     }
@@ -1084,24 +1077,21 @@ export class AffineDragHandleWidget extends WidgetElement<
     if (this.dropIndicator) this.dropIndicator.rect = null;
   };
 
-  private _setSelectedBlocks = (
-    blockElements: BlockElement[],
-    noteId?: string
-  ) => {
+  private _setSelectedBlocks = (blocks: BlockComponent[], noteId?: string) => {
     const { selection } = this.host;
-    const selections = blockElements.map(blockElement =>
+    const selections = blocks.map(block =>
       selection.create('block', {
-        blockId: blockElement.blockId,
+        blockId: block.blockId,
       })
     );
 
     // When current page is edgeless page
     // We need to remain surface selection and set editing as true
     if (isInsideEdgelessEditor(this.host)) {
-      const surfaceElementId = noteId ? noteId : getNoteId(blockElements[0]);
+      const surfaceElementId = noteId ? noteId : getNoteId(blocks[0]);
       const surfaceSelection = selection.create(
         'surface',
-        blockElements[0]!.blockId,
+        blocks[0]!.blockId,
         [surfaceElementId],
         true
       );
@@ -1114,8 +1104,8 @@ export class AffineDragHandleWidget extends WidgetElement<
 
   // Multiple blocks: drag handle should show on the vertical middle of all blocks
   private _showDragHandleOnHoverBlock = (blockPath: string) => {
-    const blockElement = this._getBlockElementFromViewStore(blockPath);
-    if (!blockElement) return;
+    const block = this._getBlockComponentFromViewStore(blockPath);
+    if (!block) return;
 
     const container = this._dragHandleContainer;
     const grabber = this._dragHandleGrabber;
@@ -1123,17 +1113,17 @@ export class AffineDragHandleWidget extends WidgetElement<
 
     this._isHoverDragHandleVisible = true;
 
-    const draggingAreaRect = this._getDraggingAreaRect(blockElement);
+    const draggingAreaRect = this._getDraggingAreaRect(block);
 
     // Some blocks have padding, should consider padding when calculating position
 
-    const containerHeight = getDragHandleContainerHeight(blockElement.model);
+    const containerHeight = getDragHandleContainerHeight(block.model);
 
     // Ad-hoc solution for list with toggle icon
-    updateDragHandleClassName([blockElement]);
+    updateDragHandleClassName([block]);
     // End of ad-hoc solution
 
-    const posTop = this._getTopWithBlockElement(blockElement);
+    const posTop = this._getTopWithBlockComponent(block);
 
     const rowPaddingY =
       ((containerHeight - DRAG_HANDLE_GRABBER_HEIGHT) / 2) *
@@ -1160,10 +1150,10 @@ export class AffineDragHandleWidget extends WidgetElement<
       container.style.height = `${draggingAreaRect.height}px`;
     };
 
-    if (isBlockPathEqual(blockElement.blockId, this._lastShowedBlock?.path)) {
+    if (isBlockPathEqual(block.blockId, this._lastShowedBlock?.path)) {
       applyStyle(true);
     } else if (this.selectedBlocks.length) {
-      if (this._isBlockSelected(blockElement))
+      if (this._isBlockSelected(block))
         applyStyle(
           this._isDragHandleHovered &&
             this._isBlockSelected(this._lastShowedBlock?.el)
@@ -1180,11 +1170,11 @@ export class AffineDragHandleWidget extends WidgetElement<
       DRAG_HANDLE_GRABBER_BORDER_RADIUS * this.scale * this.noteScale
     }px`;
 
-    this._handleAnchorModelDisposables(blockElement.model);
-    if (!isBlockPathEqual(blockElement.blockId, this._lastShowedBlock?.path)) {
+    this._handleAnchorModelDisposables(block.model);
+    if (!isBlockPathEqual(block.blockId, this._lastShowedBlock?.path)) {
       this._lastShowedBlock = {
-        path: blockElement.blockId,
-        el: blockElement,
+        path: block.blockId,
+        el: block,
       };
     }
   };
@@ -1195,12 +1185,10 @@ export class AffineDragHandleWidget extends WidgetElement<
     await edgelessRoot.surface.updateComplete;
 
     if (!this._anchorBlockPath) return;
-    const blockElement = this.anchorBlockElement;
-    if (!blockElement) return;
+    const block = this.anchorBlockComponent;
+    if (!block) return;
 
-    const edgelessElement = edgelessRoot.service.getElementById(
-      blockElement.model.id
-    );
+    const edgelessElement = edgelessRoot.service.getElementById(block.model.id);
     if (!edgelessElement) return;
 
     const container = this._dragHandleContainer;
@@ -1238,29 +1226,29 @@ export class AffineDragHandleWidget extends WidgetElement<
       DRAG_HANDLE_GRABBER_BORDER_RADIUS * this.scale
     }px`;
 
-    this._handleAnchorModelDisposables(blockElement.model);
+    this._handleAnchorModelDisposables(block.model);
 
     this._isTopLevelDragHandleVisible = true;
   };
 
   private _startDragging = (
-    blockElements: BlockElement[],
+    blocks: BlockComponent[],
     state: PointerEventState,
     dragPreviewEl?: HTMLElement,
     dragPreviewOffset?: Point
   ) => {
-    if (!blockElements.length) {
+    if (!blocks.length) {
       return;
     }
 
-    this.draggingElements = blockElements;
+    this.draggingElements = blocks;
 
     if (this.dragPreview) {
       this._removeDragPreview();
     }
 
     this.dragPreview = this._createDragPreview(
-      blockElements,
+      blocks,
       state,
       dragPreviewEl,
       dragPreviewOffset
@@ -1448,7 +1436,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
   dragging = false;
 
-  draggingElements: BlockElement[] = [];
+  draggingElements: BlockComponent[] = [];
 
   dropBlockId = '';
 
@@ -1662,9 +1650,9 @@ export class AffineDragHandleWidget extends WidgetElement<
     `;
   }
 
-  get anchorBlockElement(): BlockElement | null {
+  get anchorBlockComponent(): BlockComponent | null {
     if (!this._anchorBlockPath) return null;
-    return this._getBlockElementFromViewStore(this._anchorBlockPath);
+    return this._getBlockComponentFromViewStore(this._anchorBlockPath);
   }
 
   get anchorEdgelessElement(): EdgelessBlockModel | null {
@@ -1679,9 +1667,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   get rootElement() {
-    return this.blockElement as
-      | PageRootBlockComponent
-      | EdgelessRootBlockComponent;
+    return this.block as PageRootBlockComponent | EdgelessRootBlockComponent;
   }
 
   get selectedBlocks() {

--- a/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
@@ -1,4 +1,4 @@
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import {
@@ -16,15 +16,14 @@ import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-bl
 import { BLOCK_CHILDREN_CONTAINER_PADDING_LEFT } from '../../../_common/consts.js';
 import { getBlockProps } from '../../../_common/utils/block-props.js';
 import {
-  type BlockComponent,
   type EmbedCardStyle,
   Rect,
-  findClosestBlockElement,
-  getClosestBlockElementByElement,
-  getClosestBlockElementByPoint,
+  findClosestBlockComponent,
+  getClosestBlockComponentByElement,
+  getClosestBlockComponentByPoint,
   getDropRectByPoint,
   getHoveringNote,
-  getRectByBlockElement,
+  getRectByBlockComponent,
   isInsidePageEditor,
   matchFlavours,
 } from '../../../_common/utils/index.js';
@@ -70,11 +69,11 @@ export const getDragHandleContainerHeight = (model: BlockModel) => {
 
 // To check if the block is a child block of the selected blocks
 export const containChildBlock = (
-  blockElements: BlockElement[],
+  blocks: BlockComponent[],
   childPath: string[]
 ) => {
-  return blockElements.some(blockElement => {
-    const path = blockElement.path;
+  return blocks.some(block => {
+    const path = block.path;
     return PathFinder.includes(childPath, path);
   });
 };
@@ -97,10 +96,10 @@ export const captureEventTarget = (target: EventTarget | null) => {
     : null;
 };
 
-export const getNoteId = (blockElement: BlockElement) => {
-  let element = blockElement;
+export const getNoteId = (block: BlockComponent) => {
+  let element = block;
   while (element && element.flavour !== 'affine:note') {
-    element = element.parentBlockElement;
+    element = element.parentBlock;
   }
 
   return element.model.id;
@@ -160,7 +159,7 @@ export const getClosestNoteBlock = (
   point: Point
 ) => {
   return isInsidePageEditor(editorHost)
-    ? findClosestBlockElement(rootElement, point, 'affine-note')
+    ? findClosestBlockComponent(rootElement, point, 'affine-note')
     : getHoveringNote(point)?.closest('affine-edgeless-note');
 };
 
@@ -176,36 +175,30 @@ export const getClosestBlockByPoint = (
 
   const noteRect = Rect.fromDOM(closestNoteBlock);
 
-  const blockElement = getClosestBlockElementByPoint(point, {
+  const block = getClosestBlockComponentByPoint(point, {
     container: closestNoteBlock,
     rect: noteRect,
-  }) as BlockElement | null;
+  }) as BlockComponent | null;
 
   const blockSelector =
     '.affine-note-block-container > .affine-block-children-container > [data-block-id]';
 
-  const closestBlockElement = (
-    blockElement &&
-    PathFinder.includes(
-      blockElement.path,
-      (closestNoteBlock as BlockElement).path
-    )
-      ? blockElement
-      : findClosestBlockElement(
-          closestNoteBlock as BlockElement,
+  const closestBlock = (
+    block &&
+    PathFinder.includes(block.path, (closestNoteBlock as BlockComponent).path)
+      ? block
+      : findClosestBlockComponent(
+          closestNoteBlock as BlockComponent,
           point.clone(),
           blockSelector
         )
-  ) as BlockElement;
+  ) as BlockComponent;
 
-  if (
-    !closestBlockElement ||
-    !!closestBlockElement.closest('.surface-ref-note-portal')
-  ) {
+  if (!closestBlock || !!closestBlock.closest('.surface-ref-note-portal')) {
     return null;
   }
 
-  return closestBlockElement;
+  return closestBlock;
 };
 
 export function calcDropTarget(
@@ -243,7 +236,7 @@ export function calcDropTarget(
       ) {
         type = 'none';
       } else {
-        prevRect = getRectByBlockElement(prev);
+        prevRect = getRectByBlockComponent(prev);
       }
     } else {
       prev = element.parentElement?.previousElementSibling;
@@ -260,7 +253,7 @@ export function calcDropTarget(
     // To drop in, the position must after the target first
     // If drop in target has children, we can use insert before or after of that children
     // to achieve the same effect.
-    const hasChild = (element as BlockComponent).childBlockElements.length;
+    const hasChild = (element as BlockComponent).childBlocks.length;
     if (
       allowSublist &&
       matchFlavours(model, ['affine:list']) &&
@@ -284,13 +277,13 @@ export function calcDropTarget(
         next = null;
       }
     } else {
-      next = getClosestBlockElementByElement(
+      next = getClosestBlockComponentByElement(
         element.parentElement
       )?.nextElementSibling;
     }
 
     if (next) {
-      nextRect = getRectByBlockElement(next);
+      nextRect = getRectByBlockComponent(next);
       offsetY = (nextRect.top - domRect.bottom) / 2;
     }
   }
@@ -322,21 +315,19 @@ export const getDropResult = (
 ): DropResult | null => {
   let dropIndicator = null;
   const point = new Point(event.x, event.y);
-  const closestBlockElement = getClosestBlockElementByPoint(
-    point
-  ) as BlockElement;
-  if (!closestBlockElement) {
+  const closestBlock = getClosestBlockComponentByPoint(point) as BlockComponent;
+  if (!closestBlock) {
     return dropIndicator;
   }
 
-  const model = closestBlockElement.model;
+  const model = closestBlock.model;
 
   const isDatabase = matchFlavours(model, ['affine:database']);
   if (isDatabase) {
     return dropIndicator;
   }
 
-  const result = calcDropTarget(point, model, closestBlockElement, [], scale);
+  const result = calcDropTarget(point, model, closestBlock, [], scale);
   if (result) {
     dropIndicator = result;
   }
@@ -344,11 +335,11 @@ export const getDropResult = (
   return dropIndicator;
 };
 
-export function getDragHandleLeftPadding(blockElements: BlockElement[]) {
-  const hasToggleList = blockElements.some(
-    blockElement =>
-      matchFlavours(blockElement.model, ['affine:list']) &&
-      blockElement.model.children.length > 0
+export function getDragHandleLeftPadding(blocks: BlockComponent[]) {
+  const hasToggleList = blocks.some(
+    block =>
+      matchFlavours(block.model, ['affine:list']) &&
+      block.model.children.length > 0
   );
   const offsetLeft = hasToggleList
     ? DRAG_HANDLE_CONTAINER_OFFSET_LEFT_LIST
@@ -356,12 +347,12 @@ export function getDragHandleLeftPadding(blockElements: BlockElement[]) {
   return offsetLeft;
 }
 
-let previousEle: BlockElement[] = [];
-export function updateDragHandleClassName(blockElements: BlockElement[] = []) {
+let previousEle: BlockComponent[] = [];
+export function updateDragHandleClassName(blocks: BlockComponent[] = []) {
   const className = 'with-drag-handle';
-  previousEle.forEach(blockElement => blockElement.classList.remove(className));
-  previousEle = blockElements;
-  blockElements.forEach(blockElement => blockElement.classList.add(className));
+  previousEle.forEach(block => block.classList.remove(className));
+  previousEle = blocks;
+  blocks.forEach(block => block.classList.add(className));
 }
 
 export function getDuplicateBlocks(blocks: BlockModel[]) {
@@ -381,7 +372,7 @@ export function convertDragPreviewDocToEdgeless({
   noteScale,
   state,
 }: OnDragEndProps & {
-  blockComponent: BlockElement;
+  blockComponent: BlockComponent;
   cssSelector: string;
   width?: number;
   height?: number;
@@ -469,7 +460,7 @@ export function convertDragPreviewEdgelessToDoc({
   state,
   style,
 }: OnDragEndProps & {
-  blockComponent: BlockElement;
+  blockComponent: BlockComponent;
   style?: EmbedCardStyle;
 }): boolean {
   const doc = blockComponent.doc;

--- a/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
@@ -356,7 +356,7 @@ export class EdgelessAutoConnectWidget extends WidgetElement<
   }
 
   private _initLabels() {
-    const { service } = this.blockElement;
+    const { service } = this.block;
     const surfaceRefs = service.doc
       .getBlocksByFlavour('affine:surface-ref')
       .map(block => block.model) as SurfaceRefBlockModel[];
@@ -415,7 +415,7 @@ export class EdgelessAutoConnectWidget extends WidgetElement<
 
       this._edgelessOnlyNotesSet = edgelessOnlyNotesSet;
       this._pageVisibleElementsMap = pageVisibleBlocks;
-    }, this.blockElement);
+    }, this.block);
 
     this._disposables.add(
       service.selection.slots.updated.on(() => {

--- a/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
@@ -140,7 +140,7 @@ export class EdgelessCopilotWidget extends WidgetElement<
           return;
         }
 
-        const off = this.blockElement.dispatcher.add('pointerDown', ctx => {
+        const off = this.block.dispatcher.add('pointerDown', ctx => {
           const e = ctx.get('pointerState').raw;
           const aiPanel = this.host.view.getWidget(
             AFFINE_AI_PANEL_WIDGET,
@@ -250,7 +250,7 @@ export class EdgelessCopilotWidget extends WidgetElement<
   }
 
   get edgeless() {
-    return this.blockElement;
+    return this.block;
   }
 
   get selectionModelRect() {

--- a/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
@@ -55,7 +55,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<
   };
 
   private _updateRemoteRects = () => {
-    const { selection, blockElement } = this;
+    const { selection, block } = this;
     const remoteSelectionsMap = selection.remoteSurfaceSelectionsMap;
     const remoteRects: EdgelessRemoteSelectionWidget['_remoteRects'] =
       new Map();
@@ -65,7 +65,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<
         if (selection.elements.length === 0) return;
 
         const elements = selection.elements
-          .map(id => blockElement.service.getElementById(id))
+          .map(id => block.service.getElementById(id))
           .filter(element => element) as BlockSuite.EdgelessModelType[];
         const rect = getSelectedRect(elements);
 
@@ -252,7 +252,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetElement<
   }
 
   get edgeless() {
-    return this.blockElement;
+    return this.block;
   }
 
   get selection() {

--- a/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/index.ts
@@ -77,7 +77,7 @@ export class AffineEdgelessZoomToolbarWidget extends WidgetElement<
   }
 
   get edgeless() {
-    return this.blockElement;
+    return this.block;
   }
 
   @state()

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-attachment-button.ts
@@ -30,8 +30,8 @@ import '../../edgeless/components/panel/card-style-panel.js';
 @customElement('edgeless-change-attachment-button')
 export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
   private _download = () => {
-    if (!this._blockElement) return;
-    downloadAttachmentBlob(this._blockElement);
+    if (!this._block) return;
+    downloadAttachmentBlob(this._block);
   };
 
   private _setCardStyle = (style: EmbedCardStyle) => {
@@ -43,10 +43,10 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
   };
 
   private _showCaption = () => {
-    this._blockElement?.captionEditor?.show();
+    this._block?.captionEditor?.show();
   };
 
-  private get _blockElement() {
+  private get _block() {
     const blockSelection =
       this.edgeless.service.selection.surfaceSelections.filter(sel =>
         sel.elements.includes(this.model.id)
@@ -55,12 +55,12 @@ export class EdgelessChangeAttachmentButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const blockElement = this.std.view.getBlock(
+    const block = this.std.view.getBlock(
       blockSelection[0].blockId
     ) as AttachmentBlockComponent | null;
-    assertExists(blockElement);
+    assertExists(block);
 
-    return blockElement;
+    return block;
   }
 
   private get _doc() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -80,7 +80,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const block = this._blockElement;
+    const block = this._blockComponent;
     if (block && 'convertToCard' in block) {
       block.convertToCard();
       return;
@@ -130,7 +130,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const block = this._blockElement;
+    const block = this._blockComponent;
     if (block && 'convertToEmbed' in block) {
       block.convertToEmbed();
       return;
@@ -198,12 +198,12 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
   };
 
   private _open = () => {
-    this._blockElement?.open();
+    this._blockComponent?.open();
   };
 
   private _peek = () => {
-    if (!this._blockElement) return;
-    peek(this._blockElement);
+    if (!this._blockComponent) return;
+    peek(this._blockComponent);
   };
 
   static override styles = css`
@@ -240,7 +240,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     }
   `;
 
-  private get _blockElement() {
+  private get _blockComponent() {
     const blockSelection =
       this.edgeless.service.selection.surfaceSelections.filter(sel =>
         sel.elements.includes(this.model.id)
@@ -249,7 +249,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const blockElement = this.std.view.getBlock(blockSelection[0].blockId) as
+    const blockComponent = this.std.view.getBlock(blockSelection[0].blockId) as
       | BookmarkBlockComponent
       | EmbedGithubBlockComponent
       | EmbedYoutubeBlockComponent
@@ -259,13 +259,13 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
       | EmbedLoomBlockComponent
       | null;
 
-    if (!blockElement) return;
+    if (!blockComponent) return;
 
-    return blockElement;
+    return blockComponent;
   }
 
   private get _canConvertToEmbedView() {
-    const block = this._blockElement;
+    const block = this._blockComponent;
 
     // synced doc entry controlled by awareness flag
     if (!!block && isEmbedLinkedDocBlock(block.model)) {
@@ -314,7 +314,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     }
     return (
       isEmbedLinkedDocBlock(this.model) &&
-      (!!this._blockElement?.closest('affine-embed-synced-doc-block') ||
+      (!!this._blockComponent?.closest('affine-embed-synced-doc-block') ||
         this.model.pageId === this._doc.id)
     );
   }
@@ -398,7 +398,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
 
     // open in new tab
 
-    if (this._blockElement && isPeekable(this._blockElement)) {
+    if (this._blockComponent && isPeekable(this._blockComponent)) {
       buttons.push({
         name: 'Open in center peek',
         icon: CenterPeekIcon,
@@ -477,7 +477,7 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
   }
 
   private _showCaption() {
-    this._blockElement?.captionEditor?.show();
+    this._blockComponent?.captionEditor?.show();
   }
 
   private _viewMenuButton() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-image-button.ts
@@ -14,15 +14,15 @@ import { downloadImageBlob } from '../../../image-block/utils.js';
 @customElement('edgeless-change-image-button')
 export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
   private _download = () => {
-    if (!this._blockElement) return;
-    downloadImageBlob(this._blockElement).catch(console.error);
+    if (!this._blockComponent) return;
+    downloadImageBlob(this._blockComponent).catch(console.error);
   };
 
   private _showCaption = () => {
-    this._blockElement?.captionEditor?.show();
+    this._blockComponent?.captionEditor?.show();
   };
 
-  private get _blockElement() {
+  private get _blockComponent() {
     const blockSelection =
       this.edgeless.service.selection.surfaceSelections.filter(sel =>
         sel.elements.includes(this.model.id)
@@ -31,11 +31,11 @@ export class EdgelessChangeImageButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const blockElement = this.edgeless.std.view.getBlock(
+    const block = this.edgeless.std.view.getBlock(
       blockSelection[0].blockId
     ) as ImageBlockComponent | null;
 
-    return blockElement;
+    return block;
   }
 
   private get _doc() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -379,7 +379,7 @@ export class EdgelessElementToolbarWidget extends WidgetElement<
   }
 
   get edgeless() {
-    return this.blockElement as EdgelessRootBlockComponent;
+    return this.block as EdgelessRootBlockComponent;
   }
 
   get selection() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-button.ts
@@ -210,9 +210,9 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
 
   private _reload = (selections: SurfaceSelection[]) => {
     selections.forEach(sel => {
-      const blockElement = this.view.getBlock(sel.blockId);
-      if (!!blockElement && this._refreshable(blockElement.model)) {
-        (blockElement as RefreshableBlockComponent).refreshData();
+      const block = this.view.getBlock(sel.blockId);
+      if (!!block && this._refreshable(block.model)) {
+        (block as RefreshableBlockComponent).refreshData();
       }
     });
   };
@@ -288,16 +288,16 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
         break;
       case 'open':
         if (
-          this._blockElement &&
-          'open' in this._blockElement &&
-          typeof this._blockElement.open === 'function'
+          this._block &&
+          'open' in this._block &&
+          typeof this._block.open === 'function'
         ) {
-          this._blockElement.open();
+          this._block.open();
         }
         break;
       case 'center-peek':
-        if (this._blockElement && isPeekable(this._blockElement)) {
-          peek(this._blockElement);
+        if (this._block && isPeekable(this._block)) {
+          peek(this._block);
         }
         break;
     }
@@ -378,7 +378,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
     ];
   }
 
-  private get _blockElement() {
+  private get _block() {
     const blockSelection = this.edgeless.service.selection.surfaceSelections;
     if (
       blockSelection.length !== 1 ||
@@ -387,12 +387,10 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       return;
     }
 
-    const blockElement = this.view.getBlock(blockSelection[0].blockId);
-    if (!blockElement) {
-      return;
-    }
+    const block = this.view.getBlock(blockSelection[0].blockId);
+    if (!block) return;
 
-    return blockElement;
+    return block;
   }
 
   private _refreshable(ele: BlockModel) {
@@ -439,11 +437,7 @@ export class EdgelessMoreButton extends WithDisposable(LitElement) {
       });
     }
 
-    if (
-      isSingleSelect &&
-      this._blockElement &&
-      isPeekable(this._blockElement)
-    ) {
+    if (isSingleSelect && this._block && isPeekable(this._block)) {
       result.push(CENTER_PEEK_ACTION);
     }
 

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -19,9 +19,9 @@ import '../../../_common/components/button.js';
 import { toggleEmbedCardCaptionEditModal } from '../../../_common/components/embed-card/modal/embed-card-caption-edit-modal.js';
 import { toggleEmbedCardEditModal } from '../../../_common/components/embed-card/modal/embed-card-edit-modal.js';
 import {
-  type EmbedToolbarBlockElement,
+  type EmbedToolbarBlockComponent,
   type EmbedToolbarModel,
-  isEmbedCardBlockElement,
+  isEmbedCardBlockComponent,
 } from '../../../_common/components/embed-card/type.js';
 import { isPeekable, peek } from '../../../_common/components/index.js';
 import { toast } from '../../../_common/components/toast.js';
@@ -76,7 +76,7 @@ export class EmbedCardToolbar extends WidgetElement<
 
   private _embedOptions: EmbedOptions | null = null;
 
-  private _focusBlock: EmbedToolbarBlockElement | null = null;
+  private _focusBlock: EmbedToolbarBlockComponent | null = null;
 
   private _resetAbortController = () => {
     this._abortController.abort();
@@ -661,12 +661,12 @@ export class EmbedCardToolbar extends WidgetElement<
         }
 
         const block = this.std.view.getBlock(blockSelections[0].blockId);
-        if (!block || !isEmbedCardBlockElement(block)) {
+        if (!block || !isEmbedCardBlockComponent(block)) {
           this._hide();
           return;
         }
 
-        this._focusBlock = block as EmbedToolbarBlockElement;
+        this._focusBlock = block as EmbedToolbarBlockComponent;
         this._show();
       })
     );

--- a/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
@@ -60,23 +60,22 @@ export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
     return null;
   }
 
-  const selectedBlockElements = formatBar.selectedBlockElements;
+  const selectedBlocks = formatBar.selectedBlocks;
   // only support model with text
-  if (selectedBlockElements.some(el => !el.model.text)) {
+  if (selectedBlocks.some(el => !el.model.text)) {
     return null;
   }
 
   const paragraphIcon =
-    selectedBlockElements.length < 1
+    selectedBlocks.length < 1
       ? textConversionConfigs[0].icon
       : textConversionConfigs.find(
           ({ flavour, type }) =>
-            selectedBlockElements[0].flavour === flavour &&
-            (selectedBlockElements[0].model as ParagraphBlockModel).type ===
-              type
+            selectedBlocks[0].flavour === flavour &&
+            (selectedBlocks[0].model as ParagraphBlockModel).type === type
         )?.icon ?? textConversionConfigs[0].icon;
 
-  const rootElement = formatBar.blockElement;
+  const rootElement = formatBar.block;
   if (!isRootElement(rootElement)) {
     console.error('paragraph button host is not a page component');
     return null;

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -1,6 +1,6 @@
 import type {
   BaseSelection,
-  BlockElement,
+  BlockComponent,
   CursorSelection,
 } from '@blocksuite/block-std';
 
@@ -54,7 +54,7 @@ export class AffineFormatBarWidget extends WidgetElement {
   static override styles = formatBarStyle;
 
   private _calculatePlacement() {
-    const rootElement = this.blockElement;
+    const rootElement = this.block;
 
     this.handleEvent('pointerMove', ctx => {
       this._dragging = ctx.get('pointerState').dragging;
@@ -76,9 +76,9 @@ export class AffineFormatBarWidget extends WidgetElement {
           }
           targetRect = range.getBoundingClientRect();
         } else if (this.displayType === 'block') {
-          const blockElement = this._selectedBlockElements[0];
-          if (!blockElement) return;
-          targetRect = blockElement.getBoundingClientRect();
+          const block = this._selectedBlocks[0];
+          if (!block) return;
+          targetRect = block.getBoundingClientRect();
         } else {
           return;
         }
@@ -142,7 +142,7 @@ export class AffineFormatBarWidget extends WidgetElement {
                   const { selectedBlocks } = ctx;
                   assertExists(selectedBlocks);
 
-                  this._selectedBlockElements = selectedBlocks;
+                  this._selectedBlocks = selectedBlocks;
                 })
                 .run();
 
@@ -158,11 +158,11 @@ export class AffineFormatBarWidget extends WidgetElement {
             const selectedBlocks = blockSelections
               .map(selection => {
                 const path = selection.blockId;
-                return this.blockElement.host.view.getBlock(path);
+                return this.block.host.view.getBlock(path);
               })
-              .filter((el): el is BlockElement => !!el);
+              .filter((el): el is BlockComponent => !!el);
 
-            this._selectedBlockElements = selectedBlocks;
+            this._selectedBlocks = selectedBlocks;
             return;
           }
 
@@ -250,12 +250,12 @@ export class AffineFormatBarWidget extends WidgetElement {
     };
 
     const getReferenceElementFromBlock = () => {
-      const firstBlockElement = this._selectedBlockElements[0];
-      let rect = firstBlockElement?.getBoundingClientRect();
+      const firstBlock = this._selectedBlocks[0];
+      let rect = firstBlock?.getBoundingClientRect();
 
       if (!rect) return;
 
-      this._selectedBlockElements.forEach(el => {
+      this._selectedBlocks.forEach(el => {
         const elRect = el.getBoundingClientRect();
         if (elRect.top < rect.top) {
           rect = new DOMRect(rect.left, elRect.top, rect.width, rect.bottom);
@@ -273,7 +273,7 @@ export class AffineFormatBarWidget extends WidgetElement {
       return {
         getBoundingClientRect: () => rect,
         getClientRects: () =>
-          this._selectedBlockElements.map(el => el.getBoundingClientRect()),
+          this._selectedBlocks.map(el => el.getBoundingClientRect()),
       };
     };
 
@@ -322,16 +322,13 @@ export class AffineFormatBarWidget extends WidgetElement {
 
     if (
       this.displayType === 'block' &&
-      this._selectedBlockElements?.[0]?.flavour === 'affine:surface-ref'
+      this._selectedBlocks?.[0]?.flavour === 'affine:surface-ref'
     ) {
       return false;
     }
 
-    if (
-      this.displayType === 'block' &&
-      this._selectedBlockElements.length === 1
-    ) {
-      const selectedBlock = this._selectedBlockElements[0];
+    if (this.displayType === 'block' && this._selectedBlocks.length === 1) {
+      const selectedBlock = this._selectedBlocks[0];
       if (
         !matchFlavours(selectedBlock.model, [
           'affine:paragraph',
@@ -349,12 +346,9 @@ export class AffineFormatBarWidget extends WidgetElement {
     }
 
     // if the selection is on an embed (ex. linked page), we should not display the format bar
-    if (
-      this.displayType === 'text' &&
-      this._selectedBlockElements.length === 1
-    ) {
+    if (this.displayType === 'text' && this._selectedBlocks.length === 1) {
       const isEmbed = () => {
-        const [element] = this._selectedBlockElements;
+        const [element] = this._selectedBlocks;
         const richText = element.querySelector<RichText>('rich-text');
         const inline = richText?.inlineEditor;
         if (!richText || !inline) {
@@ -487,7 +481,7 @@ export class AffineFormatBarWidget extends WidgetElement {
     super.connectedCallback();
     this._abortController = new AbortController();
 
-    const rootElement = this.blockElement;
+    const rootElement = this.block;
     assertExists(rootElement);
     const widgets = rootElement.widgets;
 
@@ -536,7 +530,7 @@ export class AffineFormatBarWidget extends WidgetElement {
 
   reset() {
     this._displayType = 'none';
-    this._selectedBlockElements = [];
+    this._selectedBlocks = [];
   }
 
   override updated() {
@@ -561,8 +555,8 @@ export class AffineFormatBarWidget extends WidgetElement {
     return sl.getRangeAt(0);
   }
 
-  get selectedBlockElements() {
-    return this._selectedBlockElements;
+  get selectedBlocks() {
+    return this._selectedBlocks;
   }
 
   @state()
@@ -572,7 +566,7 @@ export class AffineFormatBarWidget extends WidgetElement {
   private accessor _dragging = false;
 
   @state()
-  private accessor _selectedBlockElements: BlockElement[] = [];
+  private accessor _selectedBlocks: BlockComponent[] = [];
 
   @state()
   accessor configItems: FormatBarConfigItem[] = [];

--- a/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
@@ -40,7 +40,7 @@ export class AffineImageToolbar extends LitElement {
 
   get _items() {
     return ConfigRenderer(
-      this.blockElement,
+      this.blockComponent,
       this.abortController,
       this.config,
       this.closeCurrentMenu
@@ -82,14 +82,14 @@ export class AffineImageToolbar extends LitElement {
         >
           <div slot data-size="large" data-orientation="vertical">
             ${MoreMenuRenderer(
-              this.blockElement,
+              this.blockComponent,
               this._popMenuAbortController,
               this.moreMenuConfig
             )}
           </div>
         </editor-menu-content>
       `,
-      container: this.blockElement.host,
+      container: this.blockComponent.host,
       // stacking-context(editor-host)
       portalStyles: {
         zIndex: 'var(--affine-z-index-popover)',
@@ -140,7 +140,7 @@ export class AffineImageToolbar extends LitElement {
   accessor abortController!: AbortController;
 
   @property({ attribute: false })
-  accessor blockElement!: ImageBlockComponent;
+  accessor blockComponent!: ImageBlockComponent;
 
   @property({ attribute: false })
   accessor config!: ImageConfigItem[];

--- a/packages/blocks/src/root-block/widgets/image-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/config.ts
@@ -17,12 +17,9 @@ export const commonConfig: ImageConfigItem[] = [
     icon: DownloadIcon,
     tooltip: 'Download',
     showWhen: () => true,
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
       abortController.abort();
-      blockElement.download();
+      block.download();
     },
     type: 'common',
   },
@@ -30,13 +27,10 @@ export const commonConfig: ImageConfigItem[] = [
     name: 'caption',
     icon: CaptionIcon,
     tooltip: 'Caption',
-    showWhen: blockElement => !blockElement.doc.readonly,
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
+    showWhen: block => !block.doc.readonly,
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
       abortController.abort();
-      blockElement.captionEditor?.show();
+      block.captionEditor?.show();
     },
     type: 'common',
   },
@@ -47,18 +41,15 @@ export const moreMenuConfig: MoreMenuConfigItem[] = [
     name: 'Turn into card view',
     icon: BookmarkIcon,
     tooltip: 'Turn into Card view',
-    showWhen: blockElement => {
-      const doc = blockElement.doc;
+    showWhen: block => {
+      const doc = block.doc;
       const supportAttachment =
         doc.schema.flavourSchemaMap.has('affine:attachment');
       const readonly = doc.readonly;
-      return supportAttachment && !readonly && !!blockElement.blob;
+      return supportAttachment && !readonly && !!block.blob;
     },
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
-      blockElement.convertToCardView();
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
+      block.convertToCardView();
       abortController.abort();
     },
     type: 'more',
@@ -68,11 +59,8 @@ export const moreMenuConfig: MoreMenuConfigItem[] = [
     icon: CopyIcon,
     tooltip: 'Copy',
     showWhen: () => true,
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
-      blockElement.copy();
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
+      block.copy();
       abortController.abort();
     },
     type: 'more',
@@ -81,30 +69,24 @@ export const moreMenuConfig: MoreMenuConfigItem[] = [
     name: 'Duplicate',
     icon: DuplicateIcon,
     tooltip: 'Duplicate',
-    showWhen: blockElement => !blockElement.doc.readonly,
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
-      duplicate(blockElement, abortController);
+    showWhen: block => !block.doc.readonly,
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
+      duplicate(block, abortController);
     },
     type: 'more',
   },
   {
     type: 'divider',
-    showWhen: blockElement => !blockElement.doc.readonly,
+    showWhen: block => !block.doc.readonly,
   },
   {
     name: 'Delete',
     icon: DeleteIcon,
     tooltip: 'Delete',
-    showWhen: blockElement => !blockElement.doc.readonly,
-    action: (
-      blockElement: ImageBlockComponent,
-      abortController: AbortController
-    ) => {
+    showWhen: block => !block.doc.readonly,
+    action: (block: ImageBlockComponent, abortController: AbortController) => {
       abortController.abort();
-      blockElement.doc.deleteBlock(blockElement.model);
+      block.doc.deleteBlock(block.model);
     },
     type: 'more',
   },

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -28,7 +28,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
     this._hoverController = new HoverController(
       this,
       ({ abortController }) => {
-        const imageBlock = this.blockElement;
+        const imageBlock = this.block;
         const selection = this.host.selection;
 
         const textSelection = selection.find('text');
@@ -55,7 +55,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
 
         return {
           template: html`<affine-image-toolbar
-            .blockElement=${imageBlock}
+            .blockComponent=${imageBlock}
             .abortController=${abortController}
             .config=${this.config}
             .moreMenuConfig=${this.moreMenuConfig}
@@ -66,7 +66,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
               }
             }}
           ></affine-image-toolbar>`,
-          container: this.blockElement,
+          container: this.block,
           computePosition: {
             referenceElement: imageContainer,
             placement: 'right-start',
@@ -88,7 +88,7 @@ export class AffineImageToolbarWidget extends WidgetElement<
       { allowMultiple: true }
     );
 
-    const imageBlock = this.blockElement;
+    const imageBlock = this.block;
     this._hoverController.setReference(imageBlock);
     this._hoverController.onAbort = () => {
       // If the more menu is opened, don't close it.

--- a/packages/blocks/src/root-block/widgets/image-toolbar/type.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/type.ts
@@ -6,9 +6,9 @@ export type DefaultItemConfig = {
   name: string;
   icon: TemplateResult;
   tooltip: string;
-  showWhen: (blockElement: ImageBlockComponent) => boolean;
+  showWhen: (block: ImageBlockComponent) => boolean;
   action: (
-    blockElement: ImageBlockComponent,
+    block: ImageBlockComponent,
     abortController: AbortController,
     onClick?: () => void
   ) => void;
@@ -24,13 +24,13 @@ export type MoreItem = DefaultItemConfig & {
 
 export type DividerItem = {
   type: 'divider';
-  showWhen: (blockElement: ImageBlockComponent) => boolean;
+  showWhen: (block: ImageBlockComponent) => boolean;
 };
 
 export type CustomItem = {
-  showWhen: (blockElement: ImageBlockComponent) => boolean;
+  showWhen: (block: ImageBlockComponent) => boolean;
   render: (
-    blockElement: ImageBlockComponent,
+    block: ImageBlockComponent,
     onClick?: () => void
   ) => TemplateResult | null;
   type: 'custom';

--- a/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/utils.ts
@@ -18,14 +18,14 @@ import { getBlockProps } from '../../../_common/utils/block-props.js';
 import { isInsidePageEditor } from '../../../_common/utils/query.js';
 
 export function ConfigRenderer(
-  blockElement: ImageBlockComponent,
+  block: ImageBlockComponent,
   abortController: AbortController,
   config: ImageConfigItem[],
   onClick?: () => void
 ) {
   return config
     .filter(item => {
-      return item.showWhen(blockElement);
+      return item.showWhen(block);
     })
     .map(item => {
       let template: TemplateResult | null = null;
@@ -38,7 +38,7 @@ export function ConfigRenderer(
               class=${buttonClass}
               .tooltip=${defaultItem.tooltip}
               .tooltipOffset=${4}
-              @click=${() => defaultItem.action(blockElement, abortController)}
+              @click=${() => defaultItem.action(block, abortController)}
             >
               ${defaultItem.icon}
             </editor-icon-button>
@@ -47,7 +47,7 @@ export function ConfigRenderer(
         }
         case 'custom': {
           const customItem = item as CustomItem;
-          template = customItem.render(blockElement, onClick);
+          template = customItem.render(block, onClick);
           break;
         }
         default:
@@ -61,13 +61,13 @@ export function ConfigRenderer(
 }
 
 export function MoreMenuRenderer(
-  blockElement: ImageBlockComponent,
+  block: ImageBlockComponent,
   abortController: AbortController,
   config: MoreMenuConfigItem[]
 ) {
   return config
     .filter(item => {
-      return item.showWhen(blockElement);
+      return item.showWhen(block);
     })
     .map(item => {
       let template: TemplateResult | null = null;
@@ -80,7 +80,7 @@ export function MoreMenuRenderer(
               class=${buttonClass}
               @click=${(e: MouseEvent) => {
                 e.stopPropagation();
-                moreItem.action(blockElement, abortController);
+                moreItem.action(block, abortController);
               }}
             >
               ${moreItem.icon} ${moreItem.name}
@@ -107,10 +107,10 @@ export function MoreMenuRenderer(
 }
 
 export function duplicate(
-  blockElement: ImageBlockComponent,
+  block: ImageBlockComponent,
   abortController?: AbortController
 ) {
-  const model = blockElement.model;
+  const model = block.model;
   const blockProps = getBlockProps(model);
   const { width, height, xywh, rotate, zIndex, ...duplicateProps } = blockProps;
 
@@ -127,7 +127,7 @@ export function duplicate(
   );
   abortController?.abort();
 
-  const editorHost = blockElement.host;
+  const editorHost = block.host;
   editorHost.updateComplete
     .then(() => {
       const { selection } = editorHost;

--- a/packages/blocks/src/root-block/widgets/page-dragging-area/page-dragging-area.ts
+++ b/packages/blocks/src/root-block/widgets/page-dragging-area/page-dragging-area.ts
@@ -1,6 +1,6 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 
-import { BlockElement, WidgetElement } from '@blocksuite/block-std';
+import { BlockComponent, WidgetElement } from '@blocksuite/block-std';
 import { assertInstanceOf } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -21,7 +21,7 @@ type Rect = {
 };
 
 type BlockInfo = {
-  element: BlockElement;
+  element: BlockComponent;
   rect: Rect;
 };
 
@@ -127,11 +127,11 @@ export class AffinePageDraggingAreaWidget extends WidgetElement<
     }
     const { scrollLeft, scrollTop } = this._viewport;
 
-    const getAllNodeFromTree = (): BlockElement[] => {
-      const blockElement: BlockElement[] = [];
+    const getAllNodeFromTree = (): BlockComponent[] => {
+      const blocks: BlockComponent[] = [];
       this.host.view.walkThrough(node => {
         const view = node;
-        if (!(view instanceof BlockElement)) {
+        if (!(view instanceof BlockComponent)) {
           return true;
         }
         if (
@@ -140,11 +140,11 @@ export class AffinePageDraggingAreaWidget extends WidgetElement<
             view.model.flavour
           )
         ) {
-          blockElement.push(view);
+          blocks.push(view);
         }
         return;
       });
-      return blockElement;
+      return blocks;
     };
 
     const elements = getAllNodeFromTree();
@@ -184,13 +184,13 @@ export class AffinePageDraggingAreaWidget extends WidgetElement<
   }
 
   private get _viewport() {
-    const rootElement = this.blockElement;
+    const rootElement = this.block;
     if (!rootElement) return;
     return rootElement.viewport;
   }
 
   private get scrollContainer() {
-    return getScrollContainer(this.blockElement);
+    return getScrollContainer(this.block);
   }
 
   override connectedCallback() {
@@ -352,7 +352,7 @@ function filterBlockInfosByParent(
   const targetBlock = parentInfos.element;
   let results = [parentInfos];
   if (targetBlock.childElementCount > 0) {
-    const childBlockInfos = targetBlock.childBlockElements
+    const childBlockInfos = targetBlock.childBlocks
       .map(el =>
         filteredBlockInfos.find(
           blockInfo => blockInfo.element.model.id === el.model.id
@@ -433,7 +433,7 @@ function getSelectingBlockPaths(blockInfos: BlockInfo[], userRect: Rect) {
 function isDragArea(e: PointerEventState) {
   const el = e.raw.target;
   assertInstanceOf(el, Element);
-  const block = el.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
+  const block = el.closest<BlockComponent>(`[${BLOCK_ID_ATTR}]`);
   return block && matchFlavours(block.model, ['affine:page', 'affine:note']);
 }
 

--- a/packages/blocks/src/root-block/widgets/pie-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/index.ts
@@ -148,7 +148,7 @@ export class AffinePieMenuWidget extends WidgetElement {
   }
 
   get rootElement(): EdgelessRootBlockComponent {
-    const rootElement = this.blockElement;
+    const rootElement = this.block;
     if (rootElement instanceof EdgelessRootBlockComponent) {
       return rootElement;
     }

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -126,7 +126,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
     if (!inlineEditor) return;
 
     inlineEditor.slots.inlineRangeApply.once(() => {
-      const rootElement = this.blockElement;
+      const rootElement = this.block;
       if (!isRootElement(rootElement)) {
         console.error('SlashMenuWidget should be used in RootBlock');
         return;

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -34,7 +34,7 @@ export class AffineSurfaceRefToolbar extends WidgetElement<
   private _hoverController = new HoverController(
     this,
     ({ abortController }) => {
-      const surfaceRefBlock = this.blockElement;
+      const surfaceRefBlock = this.block;
       const selection = this.host.selection;
 
       const textSelection = selection.find('text');
@@ -56,12 +56,12 @@ export class AffineSurfaceRefToolbar extends WidgetElement<
 
       return {
         template: SurfaceRefToolbarOptions({
-          blockElement: this.blockElement,
-          model: this.blockElement.model,
+          block: this.block,
+          model: this.block.model,
           abortController,
         }),
         computePosition: {
-          referenceElement: this.blockElement,
+          referenceElement: this.block,
           placement: 'top-start',
           middleware: [
             offset({
@@ -86,7 +86,7 @@ export class AffineSurfaceRefToolbar extends WidgetElement<
   override connectedCallback() {
     super.connectedCallback();
 
-    this._hoverController.setReference(this.blockElement);
+    this._hoverController.setReference(this.block);
   }
 }
 
@@ -97,13 +97,13 @@ declare global {
 }
 
 function SurfaceRefToolbarOptions(options: {
-  blockElement: SurfaceRefBlockComponent;
+  block: SurfaceRefBlockComponent;
   model: SurfaceRefBlockModel;
   abortController: AbortController;
 }) {
-  const { blockElement, model, abortController } = options;
+  const { block, model, abortController } = options;
   const readonly = model.doc.readonly;
-  const hasValidReference = !!blockElement.referenceModel;
+  const hasValidReference = !!block.referenceModel;
 
   return html`
     <style>
@@ -151,7 +151,7 @@ function SurfaceRefToolbarOptions(options: {
         class="view-in-edgeless-button"
         text="View in Edgeless"
         width="fit-content"
-        @click=${() => blockElement.viewInEdgeless()}
+        @click=${() => block.viewInEdgeless()}
         >${EdgelessModeIcon}
       </icon-button>
 
@@ -168,7 +168,7 @@ function SurfaceRefToolbarOptions(options: {
         ?hidden=${readonly}
         @click=${() => {
           abortController.abort();
-          blockElement.captionElement.show();
+          block.captionElement.show();
         }}
       >
         ${CaptionIcon}
@@ -180,15 +180,15 @@ function SurfaceRefToolbarOptions(options: {
         size="32px"
         ?hidden=${!hasValidReference}
         @click=${() => {
-          const referencedModel = blockElement.referenceModel;
+          const referencedModel = block.referenceModel;
 
           if (!referencedModel) return;
 
-          edgelessToBlob(blockElement.host, {
-            surfaceRefBlock: blockElement,
-            surfaceRenderer: blockElement.surfaceRenderer,
+          edgelessToBlob(block.host, {
+            surfaceRefBlock: block,
+            surfaceRenderer: block.surfaceRenderer,
             edgelessElement: referencedModel,
-            blockContainer: blockElement.portal,
+            blockContainer: block.portal,
           })
             .then(blob => {
               const fileName =
@@ -208,12 +208,12 @@ function SurfaceRefToolbarOptions(options: {
         <affine-tooltip tip-position="top">Download</affine-tooltip>
       </icon-button>
 
-      ${isPeekable(blockElement)
+      ${isPeekable(block)
         ? html`<icon-button
             size="32px"
             ?hidden=${!hasValidReference}
             @click=${() => {
-              peek(blockElement);
+              peek(block);
             }}
           >
             ${CenterPeekIcon}
@@ -227,18 +227,18 @@ function SurfaceRefToolbarOptions(options: {
         size="32px"
         ?hidden=${!hasValidReference}
         @click=${() => {
-          edgelessToBlob(blockElement.host, {
-            surfaceRefBlock: blockElement,
-            surfaceRenderer: blockElement.surfaceRenderer,
+          edgelessToBlob(block.host, {
+            surfaceRefBlock: block,
+            surfaceRenderer: block.surfaceRenderer,
             edgelessElement:
-              blockElement.referenceModel as BlockSuite.EdgelessModelType,
-            blockContainer: blockElement.portal,
+              block.referenceModel as BlockSuite.EdgelessModelType,
+            blockContainer: block.portal,
           })
             .then(blob => {
               return writeImageBlobToClipboard(blob);
             })
             .then(() => {
-              toast(blockElement.host, 'Copied image to clipboard');
+              toast(block.host, 'Copied image to clipboard');
             })
             .catch(err => {
               console.error(err);

--- a/packages/blocks/src/surface-block/mini-mindmap/mindmap-root-block.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/mindmap-root-block.ts
@@ -1,11 +1,11 @@
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import type { RootBlockModel } from '../../root-block/root-model.js';
 
 @customElement('mini-mindmap-root-block')
-export class MindmapRootBlock extends BlockElement<RootBlockModel> {
+export class MindmapRootBlock extends BlockComponent<RootBlockModel> {
   override render() {
     return html`
       <style>

--- a/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
@@ -1,6 +1,6 @@
 import type { Bound } from '@blocksuite/global/utils';
 
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 
@@ -15,7 +15,7 @@ import { Renderer } from '../canvas-renderer/renderer.js';
 import { LayerManager } from '../managers/layer-manager.js';
 
 @customElement('mini-mindmap-surface-block')
-export class MindmapSurfaceBlock extends BlockElement<SurfaceBlockModel> {
+export class MindmapSurfaceBlock extends BlockComponent<SurfaceBlockModel> {
   private _layer!: LayerManager;
 
   private _renderer!: Renderer;

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -1,4 +1,4 @@
-import { BlockElement, RangeManager } from '@blocksuite/block-std';
+import { BlockComponent, RangeManager } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import { css, html, nothing } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
@@ -17,7 +17,7 @@ import { ConnectorElementModel } from './element-model/index.js';
 import { ConnectionOverlay } from './managers/connector-manager.js';
 
 @customElement('affine-surface')
-export class SurfaceBlockComponent extends BlockElement<
+export class SurfaceBlockComponent extends BlockComponent<
   SurfaceBlockModel,
   SurfaceBlockService
 > {
@@ -246,7 +246,7 @@ export class SurfaceBlockComponent extends BlockElement<
   }
 
   get edgeless() {
-    return this.parentBlockElement as EdgelessRootBlockComponent;
+    return this.parentBlock as EdgelessRootBlockComponent;
   }
 
   get renderer() {

--- a/packages/blocks/src/surface-ref-block/portal/note.ts
+++ b/packages/blocks/src/surface-ref-block/portal/note.ts
@@ -131,16 +131,14 @@ export class SurfaceRefNotePortal extends WithDisposable(ShadowlessElement) {
       const editableElements = Array.from<HTMLDivElement>(
         this.querySelectorAll('[contenteditable]')
       );
-      const blockElements = Array.from(
-        this.querySelectorAll(`[data-block-id]`)
-      );
+      const blocks = Array.from(this.querySelectorAll(`[data-block-id]`));
 
       editableElements.forEach(element => {
         if (element.contentEditable === 'true')
           element.contentEditable = 'false';
       });
 
-      blockElements.forEach(element => {
+      blocks.forEach(element => {
         element.setAttribute(RangeManager.rangeQueryExcludeAttr, 'true');
       });
     }, 500);

--- a/packages/blocks/src/surface-ref-block/surface-ref-block-edgeless.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block-edgeless.ts
@@ -1,11 +1,11 @@
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import type { SurfaceRefBlockModel } from './surface-ref-model.js';
 
 @customElement('affine-edgeless-surface-ref')
-export class EdgelessSurfaceRefBlockComponent extends BlockElement<SurfaceRefBlockModel> {
+export class EdgelessSurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockModel> {
   override render() {
     return nothing;
   }

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -1,5 +1,5 @@
 import { PathFinder } from '@blocksuite/block-std';
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { deserializeXYWH } from '@blocksuite/global/utils';
 import { Bound } from '@blocksuite/global/utils';
 import { type Disposable, assertExists, noop } from '@blocksuite/global/utils';
@@ -56,7 +56,7 @@ type RefElementModel = BlockSuite.SurfaceElementModelType | FrameBlockModel;
 
 @customElement('affine-surface-ref')
 @Peekable()
-export class SurfaceRefBlockComponent extends BlockElement<
+export class SurfaceRefBlockComponent extends BlockComponent<
   SurfaceRefBlockModel,
   SurfaceRefBlockService
 > {
@@ -481,7 +481,7 @@ export class SurfaceRefBlockComponent extends BlockElement<
     return (
       this.isConnected &&
       this.parentElement &&
-      !this.parentBlockElement.closest('affine-surface-ref')
+      !this.parentBlock.closest('affine-surface-ref')
     );
   }
 

--- a/packages/docs/guide/block-view.md
+++ b/packages/docs/guide/block-view.md
@@ -6,11 +6,11 @@ By default, we provide a [lit](https://lit.dev/) renderer called `@blocksuite/li
 
 ## Web Component Block View
 
-We provide a `BlockElement` class to help building a lit-based block view.
+We provide a `BlockComponent` class to help building a lit-based block view.
 
 ```ts
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
-import { BlockElement } from '@blocksuite/lit';
+import { BlockComponent } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -24,7 +24,7 @@ const myBlockSchema = defineBlockSchema({
 type MyBlockModel = SchemaToModel<typeof myBlockSchema>;
 
 @customElements('my-block')
-class MyBlockView extends BlockElement<MyBlockModel> {
+class MyBlockView extends BlockComponent<MyBlockModel> {
   override render() {
     return html`
       <div>
@@ -41,7 +41,7 @@ A block can have children, and we can render them by using `renderModelChildren`
 
 ```ts
 @customElements('my-block')
-class MyBlockView extends BlockElement<MyBlockModel> {
+class MyBlockView extends BlockComponent<MyBlockModel> {
   override render() {
     return html`
       <div>
@@ -59,7 +59,7 @@ It's easy to get and set props in a block view.
 
 ```ts
 @customElements('my-block')
-class MyBlockView extends BlockElement<MyBlockModel> {
+class MyBlockView extends BlockComponent<MyBlockModel> {
   private _onClick = () => {
     this.doc.updateBlock(this.model, {
       count: this.model.count + 1,
@@ -82,7 +82,7 @@ It's also possible to watch prop changes to create something like `computed prop
 
 ```ts
 @customElements('my-block')
-class MyBlockView extends BlockElement<MyBlockModel> {
+class MyBlockView extends BlockComponent<MyBlockModel> {
   private _yen = '0¥';
 
   override connectedCallback() {

--- a/packages/docs/guide/block-widgets.md
+++ b/packages/docs/guide/block-widgets.md
@@ -28,7 +28,7 @@ class MyWidgetView extends WidgetElement<MyBlockView> {
 ## Get Host Block
 
 Widget is always related to a block called host block.
-And we can get the host block by using `blockElement` property.
+And we can get the host block by using `BlockComponent` property.
 
 For example, if you have a `code block` for displaying code examples, and you want to display a `language picker` widget to let users change the language of the code block. The widget could be defined in this manner:
 
@@ -38,9 +38,9 @@ import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElements('my-widget')
-class CodeLanguagePicker extends WidgetElement<CodeBlockElement> {
+class CodeLanguagePicker extends WidgetElement<CodeBlockComponent> {
   private _onChange = e => {
-    this.doc.updateBlock(this.blockElement.model, {
+    this.doc.updateBlock(this.blockComponent.model, {
       language: e.target.value,
     });
   };

--- a/packages/docs/guide/event.md
+++ b/packages/docs/guide/event.md
@@ -8,7 +8,7 @@ For UI events such as `click` in editor, there is an underlying event dispatcher
 
 ```ts
 @customElements('my-block')
-class MyBlockView extends BlockElement<MyBlockModel> {
+class MyBlockView extends BlockComponent<MyBlockModel> {
   private _handleClick = () => {
     //...
   };
@@ -25,7 +25,7 @@ class MyBlockView extends BlockElement<MyBlockModel> {
 All events on dispatcher are bound to the root element of the block view to make it possible to bubble events to the parent block view.
 
 ```ts
-class ChildView extends BlockElement<MyBlockModel> {
+class ChildView extends BlockComponent<MyBlockModel> {
   private _handleClick = () => {
     console.log('click1');
   };
@@ -36,7 +36,7 @@ class ChildView extends BlockElement<MyBlockModel> {
   }
 }
 
-class ParentView extends BlockElement<MyBlockModel> {
+class ParentView extends BlockComponent<MyBlockModel> {
   private _handleClick = () => {
     console.log('click2');
   };
@@ -58,7 +58,7 @@ click2
 You may want to stop the event from bubbling to the parent block view. You can simply return `true` in the event handler:
 
 ```ts
-class ChildView extends BlockElement<MyBlockModel> {
+class ChildView extends BlockComponent<MyBlockModel> {
   private _handleClick = () => {
     console.log('click1');
     return true;
@@ -89,7 +89,7 @@ We also provide two more scopes to subscribe to make it possible to handle event
 The flavour scope will subscribe to events triggered by the block view and other blocks with the same flavour.
 
 ```ts
-class MyBlock extends BlockElement<MyBlockModel> {
+class MyBlock extends BlockComponent<MyBlockModel> {
   override connectedCallback() {
     super.connectedCallback();
     this.handleEvent('click', this._handleClick, { flavour: true });
@@ -102,7 +102,7 @@ class MyBlock extends BlockElement<MyBlockModel> {
 The global scope will subscribe to events triggered by the block view and all other blocks.
 
 ```ts
-class MyBlock extends BlockElement<MyBlockModel> {
+class MyBlock extends BlockComponent<MyBlockModel> {
   override connectedCallback() {
     super.connectedCallback();
     this.handleEvent('click', this._handleClick, { global: true });
@@ -126,7 +126,7 @@ For characters that are created by holding shift, the `Shift-` prefix is implied
 You can use `Mod-` as a shorthand for `Cmd-` on Mac and `Ctrl-` on other platforms.
 
 ```ts
-class MyBlock extends BlockElement<MyBlockModel> {
+class MyBlock extends BlockComponent<MyBlockModel> {
   override connectedCallback() {
     super.connectedCallback();
     this.bindHotkey({

--- a/packages/docs/guide/working-with-block-tree.md
+++ b/packages/docs/guide/working-with-block-tree.md
@@ -175,7 +175,7 @@ As an example, the following code more specifically shows how the two getters `s
 
 ```ts
 import { BlockService } from '@blocksuite/block-std';
-import type { BlockElement } from '@blocksuite/lit';
+import type { BlockComponent } from '@blocksuite/lit';
 import type { RootBlockModel } from './root-model.js';
 
 export class RootService extends BlockService<RootBlockModel> {
@@ -183,7 +183,7 @@ export class RootService extends BlockService<RootBlockModel> {
 
   // A plain getter in service
   get selectedBlocks() {
-    let result: BlockElement[] = [];
+    let result: BlockComponent[] = [];
     // Here we are using something new...
     // Introducing commands!
     this.std.command
@@ -285,13 +285,13 @@ export class EmbedGithubModel extends defineEmbedModel<{
 Then based on this model, a lit-based UI component for the block can be defined:
 
 ```ts
-import { EmbedBlockElement } from '@blocksuite/blocks';
+import { EmbedBlockComponent } from '@blocksuite/blocks';
 import type { EmbedGithubBlockModel } from './embed-github-model.js';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElement('affine-embed-github-block')
-export class EmbedGithubBlock extends EmbedBlockElement<EmbedGithubModel> {
+export class EmbedGithubBlock extends EmbedBlockComponent<EmbedGithubModel> {
   // styles...
 
   override render() {

--- a/packages/framework/block-std/src/event/control/range.ts
+++ b/packages/framework/block-std/src/event/control/range.ts
@@ -1,4 +1,4 @@
-import type { BlockElement } from '../../view/index.js';
+import type { BlockComponent } from '../../view/index.js';
 import type {
   EventName,
   EventScope,
@@ -63,7 +63,7 @@ export class RangeControl {
   constructor(private _dispatcher: UIEventDispatcher) {}
 
   private _buildEventScopeByNativeRange(name: EventName, range: Range) {
-    const blocks = this._findBlockElementPath(range);
+    const blocks = this._findBlockComponentPath(range);
     const paths = blocks
       .map(blockView => {
         return blockView;
@@ -96,14 +96,14 @@ export class RangeControl {
     );
   }
 
-  private _findBlockElementPath(range: Range): string[][] {
+  private _findBlockComponentPath(range: Range): string[][] {
     const start = range.startContainer;
     const end = range.endContainer;
     const ancestor = range.commonAncestorContainer;
     const getBlockView = (node: Node) => {
       const el = node instanceof Element ? node : node.parentElement;
       // TODO(mirone/#6534): find a better way to get block element from a node
-      return el?.closest<BlockElement>('[data-block-id]');
+      return el?.closest<BlockComponent>('[data-block-id]');
     };
     if (ancestor.nodeType === Node.TEXT_NODE) {
       const leaf = getBlockView(ancestor);

--- a/packages/framework/block-std/src/event/dispatcher.ts
+++ b/packages/framework/block-std/src/event/dispatcher.ts
@@ -3,7 +3,7 @@ import type { BlockModel } from '@blocksuite/store';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { DisposableGroup, Slot } from '@blocksuite/global/utils';
 
-import type { BlockElement } from '../view/index.js';
+import type { BlockComponent } from '../view/index.js';
 
 import { PathFinder } from '../utils/index.js';
 import {
@@ -218,7 +218,7 @@ export class UIEventDispatcher {
 
     // TODO(mirone/#6534): find a better way to get block element from a node
     const el = target instanceof Element ? target : target.parentElement;
-    const block = el?.closest<BlockElement>('[data-block-id]');
+    const block = el?.closest<BlockComponent>('[data-block-id]');
 
     const path = block?.path;
     if (!path) {

--- a/packages/framework/block-std/src/spec/slots.ts
+++ b/packages/framework/block-std/src/spec/slots.ts
@@ -1,13 +1,13 @@
 import { Slot } from '@blocksuite/global/utils';
 
 import type { BlockService } from '../service/index.js';
-import type { BlockElement, WidgetElement } from '../view/index.js';
+import type { BlockComponent, WidgetElement } from '../view/index.js';
 
 export type BlockSpecSlots<Service extends BlockService = BlockService> = {
   mounted: Slot<{ service: Service }>;
   unmounted: Slot<{ service: Service }>;
-  viewConnected: Slot<{ component: BlockElement; service: Service }>;
-  viewDisconnected: Slot<{ component: BlockElement; service: Service }>;
+  viewConnected: Slot<{ component: BlockComponent; service: Service }>;
+  viewDisconnected: Slot<{ component: BlockComponent; service: Service }>;
   widgetConnected: Slot<{ component: WidgetElement; service: Service }>;
   widgetDisconnected: Slot<{
     component: WidgetElement;

--- a/packages/framework/block-std/src/view/element/block-component.ts
+++ b/packages/framework/block-std/src/view/element/block-component.ts
@@ -22,7 +22,7 @@ import { ShadowlessElement } from './shadowless-element.js';
 export const modelContext = createContext<BlockModel>('model');
 export const serviceContext = createContext<BlockService>('service');
 
-export class BlockElement<
+export class BlockComponent<
   Model extends BlockModel = BlockModel,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
@@ -147,7 +147,7 @@ export class BlockElement<
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const result = await super.getUpdateComplete();
-    await Promise.all(this.childBlockElements.map(el => el.updateComplete));
+    await Promise.all(this.childBlocks.map(el => el.updateComplete));
     return result;
   }
 
@@ -216,13 +216,13 @@ export class BlockElement<
     return this.dataset.blockId as string;
   }
 
-  get childBlockElements() {
+  get childBlocks() {
     const childModels = this.model.children;
     return childModels
       .map(child => {
         return this.std.view.getBlock(child.id);
       })
-      .filter((x): x is BlockElement => !!x);
+      .filter((x): x is BlockComponent => !!x);
   }
 
   get flavour(): string {
@@ -261,13 +261,13 @@ export class BlockElement<
     return model;
   }
 
-  get parentBlockElement(): BlockElement {
+  get parentBlock(): BlockComponent {
     const el = this.parentElement;
     // TODO(mirone/#6534): find a better way to get block element from a node
-    return el?.closest('[data-block-id]') as BlockElement;
+    return el?.closest('[data-block-id]') as BlockComponent;
   }
 
-  get rootElement(): BlockElement | null {
+  get rootElement(): BlockComponent | null {
     const rootId = this.doc.root?.id;
     if (!rootId) {
       return null;
@@ -297,7 +297,7 @@ export class BlockElement<
     return service;
   }
 
-  get topContenteditableElement(): BlockElement | null {
+  get topContenteditableElement(): BlockComponent | null {
     return this.rootElement;
   }
 

--- a/packages/framework/block-std/src/view/element/edgeless-block-component.ts
+++ b/packages/framework/block-std/src/view/element/edgeless-block-component.ts
@@ -6,16 +6,16 @@ import { nothing } from 'lit';
 
 import type { BlockService } from '../../service/index.js';
 
-import { BlockElement } from './block-element.js';
+import { BlockComponent } from './block-component.js';
 
 export const edgelessElementSymbol = Symbol('edgelessElement');
 
-export abstract class EdgelessBlockElement<
+export abstract class EdgelessBlockComponent<
   EdgelessRootService extends BlockService = BlockService,
   Model extends BlockModel = BlockModel,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
-> extends BlockElement<Model, Service, WidgetName> {
+> extends BlockComponent<Model, Service, WidgetName> {
   [edgelessElementSymbol] = true;
 
   override connectedCallback(): void {
@@ -76,12 +76,12 @@ export abstract class EdgelessBlockElement<
 }
 
 // @ts-ignore
-export function toEdgelessBlockElement<
+export function toEdgelessBlockComponent<
   EdgelessRootService extends BlockService,
   Model extends BlockModel,
   Service extends BlockService,
   WidgetName extends string,
-  B extends typeof BlockElement<Model, Service, WidgetName>,
+  B extends typeof BlockComponent<Model, Service, WidgetName>,
 >(CustomBlock: B) {
   // @ts-ignore
   return class extends CustomBlock {
@@ -164,6 +164,6 @@ export function toEdgelessBlockElement<
     new (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...args: any[]
-    ): EdgelessBlockElement<EdgelessRootService>;
+    ): EdgelessBlockComponent<EdgelessRootService>;
   };
 }

--- a/packages/framework/block-std/src/view/element/index.ts
+++ b/packages/framework/block-std/src/view/element/index.ts
@@ -1,5 +1,5 @@
-export * from './block-element.js';
-export * from './edgeless-block-element.js';
+export * from './block-component.js';
+export * from './edgeless-block-component.js';
 export * from './lit-host.js';
 export * from './shadowless-element.js';
 export * from './widget-element.js';

--- a/packages/framework/block-std/src/view/element/widget-element.ts
+++ b/packages/framework/block-std/src/view/element/widget-element.ts
@@ -10,15 +10,15 @@ import type { BlockService } from '../../service/index.js';
 
 import { WithDisposable } from '../utils/with-disposable.js';
 import {
-  type BlockElement,
+  type BlockComponent,
   modelContext,
   serviceContext,
-} from './block-element.js';
+} from './block-component.js';
 import { docContext, stdContext } from './lit-host.js';
 
 export class WidgetElement<
   Model extends BlockModel = BlockModel,
-  B extends BlockElement = BlockElement,
+  B extends BlockComponent = BlockComponent,
   S extends BlockService = BlockService,
 > extends SignalWatcher(WithDisposable(LitElement)) {
   handleEvent = (
@@ -71,7 +71,7 @@ export class WidgetElement<
     return null;
   }
 
-  get blockElement() {
+  get block() {
     return this.std.view.getBlock(this.model.id) as B;
   }
 

--- a/packages/framework/block-std/src/view/utils/inline-range-provider.ts
+++ b/packages/framework/block-std/src/view/utils/inline-range-provider.ts
@@ -7,10 +7,10 @@ import {
 } from '@blocksuite/inline';
 
 import type { TextSelection } from '../../selection/index.js';
-import type { BlockElement } from '../element/block-element.js';
+import type { BlockComponent } from '../element/block-component.js';
 
 export const getInlineRangeProvider: (
-  element: BlockElement
+  element: BlockComponent
 ) => InlineRangeProvider | null = element => {
   const editorHost = element.host;
   const selectionManager = editorHost.selection;
@@ -32,8 +32,8 @@ export const getInlineRangeProvider: (
       const inlineRoot = startElement?.closest(`[${INLINE_ROOT_ATTR}]`);
       if (!inlineRoot) return false;
 
-      const blockElement = startElement?.closest(`[${editorHost.blockIdAttr}]`);
-      if (!blockElement || blockElement !== element) return false;
+      const block = startElement?.closest(`[${editorHost.blockIdAttr}]`);
+      if (!block || block !== element) return false;
     } else {
       if (!range.intersectsNode(element)) return false;
     }

--- a/packages/framework/block-std/src/view/utils/range-binding.ts
+++ b/packages/framework/block-std/src/view/utils/range-binding.ts
@@ -2,7 +2,7 @@ import { assertExists, throttle } from '@blocksuite/global/utils';
 
 import type { BaseSelection, TextSelection } from '../../selection/index.js';
 
-import { BlockElement } from '../element/block-element.js';
+import { BlockComponent } from '../element/block-component.js';
 import { RangeManager } from './range-manager.js';
 
 /**
@@ -25,7 +25,7 @@ export class RangeBinding {
     const range = this.rangeManager.value;
     if (!range) return;
 
-    const blocks = this.rangeManager.getSelectedBlockElementsByRange(range, {
+    const blocks = this.rangeManager.getSelectedBlockComponentsByRange(range, {
       mode: 'flat',
     });
 
@@ -89,10 +89,10 @@ export class RangeBinding {
     const range = this.rangeManager.value;
     if (!range) return;
 
-    const blocks = this.rangeManager.getSelectedBlockElementsByRange(range, {
+    const blocks = this.rangeManager.getSelectedBlockComponentsByRange(range, {
       mode: 'flat',
     });
-    const highestBlocks = this.rangeManager.getSelectedBlockElementsByRange(
+    const highestBlocks = this.rangeManager.getSelectedBlockComponentsByRange(
       range,
       {
         mode: 'highest',
@@ -111,12 +111,12 @@ export class RangeBinding {
     this._compositionStartCallback = async event => {
       this.isComposing = false;
 
-      const parents: BlockElement[] = [];
+      const parents: BlockComponent[] = [];
       for (const highestBlock of highestBlocks) {
         const parentModel = this.host.doc.getParent(highestBlock.blockId);
         if (!parentModel) continue;
         const parent = this.host.view.getBlock(parentModel.id);
-        if (!(parent instanceof BlockElement) || parents.includes(parent))
+        if (!(parent instanceof BlockComponent) || parents.includes(parent))
           continue;
 
         // Restore the DOM structure damaged by the composition
@@ -204,7 +204,7 @@ export class RangeBinding {
         ? range.commonAncestorContainer
         : range.commonAncestorContainer.parentElement;
     if (!el) return;
-    const block = el.closest<BlockElement>(`[${this.host.blockIdAttr}]`);
+    const block = el.closest<BlockComponent>(`[${this.host.blockIdAttr}]`);
     if (block?.getAttribute(RangeManager.rangeSyncExcludeAttr) === 'true')
       return;
 

--- a/packages/framework/block-std/src/view/utils/range-manager.ts
+++ b/packages/framework/block-std/src/view/utils/range-manager.ts
@@ -3,7 +3,7 @@ import type { TextSelection } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { INLINE_ROOT_ATTR, type InlineRootElement } from '@blocksuite/inline';
 
-import type { BlockElement } from '../element/block-element.js';
+import type { BlockComponent } from '../element/block-component.js';
 import type { EditorHost } from '../element/lit-host.js';
 
 import { RangeBinding } from './range-binding.js';
@@ -13,7 +13,7 @@ import { RangeBinding } from './range-binding.js';
  */
 export class RangeManager {
   /**
-   * Used to exclude certain elements when using `getSelectedBlockElementsByRange`.
+   * Used to exclude certain elements when using `getSelectedBlockComponentsByRange`.
    */
   static rangeQueryExcludeAttr = 'data-range-query-exclude';
 
@@ -49,7 +49,7 @@ export class RangeManager {
   getClosestBlock(node: Node) {
     const el = node instanceof Element ? node : node.parentElement;
     if (!el) return null;
-    const block = el.closest<BlockElement>(`[${this.host.blockIdAttr}]`);
+    const block = el.closest<BlockComponent>(`[${this.host.blockIdAttr}]`);
     if (!block) return null;
     if (this._isRangeSyncExcluded(block)) return null;
     return block;
@@ -80,16 +80,16 @@ export class RangeManager {
    *
    * match function will be evaluated before filtering using mode
    */
-  getSelectedBlockElementsByRange(
+  getSelectedBlockComponentsByRange(
     range: Range,
     options: {
-      match?: (el: BlockElement) => boolean;
+      match?: (el: BlockComponent) => boolean;
       mode?: 'all' | 'flat' | 'highest';
     } = {}
-  ): BlockElement[] {
+  ): BlockComponent[] {
     const { mode = 'all', match = () => true } = options;
 
-    let result = Array.from<BlockElement>(
+    let result = Array.from<BlockComponent>(
       this.host.querySelectorAll(
         `[${this.host.blockIdAttr}]:not([${RangeManager.rangeQueryExcludeAttr}="true"])`
       )

--- a/packages/framework/block-std/src/view/view-store.ts
+++ b/packages/framework/block-std/src/view/view-store.ts
@@ -2,10 +2,10 @@ import type { BlockModel } from '@blocksuite/store';
 
 import { assertExists } from '@blocksuite/global/utils';
 
-import type { BlockElement, WidgetElement } from './element/index.js';
+import type { BlockComponent, WidgetElement } from './element/index.js';
 
 export class ViewStore {
-  private readonly _blockMap = new Map<string, BlockElement>();
+  private readonly _blockMap = new Map<string, BlockComponent>();
 
   private readonly _widgetMap = new Map<string, WidgetElement>();
 
@@ -19,7 +19,7 @@ export class ViewStore {
     return path.reverse();
   };
 
-  deleteBlock = (node: BlockElement) => {
+  deleteBlock = (node: BlockComponent) => {
     this._blockMap.delete(node.id);
   };
 
@@ -29,7 +29,7 @@ export class ViewStore {
     this._widgetMap.delete(widgetIndex);
   };
 
-  fromPath = (path: string | undefined | null): BlockElement | null => {
+  fromPath = (path: string | undefined | null): BlockComponent | null => {
     const id = path ?? this.std.doc.root?.id;
     if (!id) {
       return null;
@@ -37,7 +37,7 @@ export class ViewStore {
     return this._blockMap.get(id) ?? null;
   };
 
-  getBlock = (id: string): BlockElement | null => {
+  getBlock = (id: string): BlockComponent | null => {
     return this._blockMap.get(id) ?? null;
   };
 
@@ -49,7 +49,7 @@ export class ViewStore {
     return this._widgetMap.get(widgetIndex) ?? null;
   };
 
-  setBlock = (node: BlockElement) => {
+  setBlock = (node: BlockComponent) => {
     this._blockMap.set(node.model.id, node);
   };
 
@@ -61,9 +61,9 @@ export class ViewStore {
 
   walkThrough = (
     fn: (
-      nodeView: BlockElement,
+      nodeView: BlockComponent,
       index: number,
-      parent: BlockElement
+      parent: BlockComponent
     ) => undefined | null | true,
     path?: string | undefined | null
   ) => {
@@ -71,7 +71,7 @@ export class ViewStore {
     assertExists(tree, `Invalid path to get node in view: ${path}`);
 
     const iterate =
-      (parent: BlockElement) => (node: BlockElement, index: number) => {
+      (parent: BlockComponent) => (node: BlockComponent, index: number) => {
         const result = fn(node, index, parent);
         if (result === true) {
           return;
@@ -102,14 +102,14 @@ export class ViewStore {
     this._widgetMap.clear();
   }
 
-  viewFromPath(type: 'block', path: string[]): null | BlockElement;
+  viewFromPath(type: 'block', path: string[]): null | BlockComponent;
 
   viewFromPath(type: 'widget', path: string[]): null | WidgetElement;
 
   viewFromPath(
     type: 'block' | 'widget',
     path: string[]
-  ): null | BlockElement | WidgetElement {
+  ): null | BlockComponent | WidgetElement {
     if (type === 'block') {
       return this.fromPath(path[path.length - 1]);
     }

--- a/packages/playground/apps/starter/data/heavy-whiteboard.ts
+++ b/packages/playground/apps/starter/data/heavy-whiteboard.ts
@@ -27,7 +27,7 @@ export const heavyWhiteboard: InitFn = (
       title: new Text(),
     });
 
-    const surfaceBlockElements: Record<string, unknown> = {};
+    const surfaceBlocks: Record<string, unknown> = {};
 
     let i = 0;
 
@@ -36,7 +36,7 @@ export const heavyWhiteboard: InitFn = (
       const x = Math.random() * count * 2;
       const y = Math.random() * count * 2;
       const id = nanoid();
-      surfaceBlockElements[id] = native2Y(
+      surfaceBlocks[id] = native2Y(
         {
           id,
           index: 'a0',
@@ -61,9 +61,9 @@ export const heavyWhiteboard: InitFn = (
     doc.addBlock(
       'affine:surface',
       {
-        elements: new Boxed(
-          native2Y(surfaceBlockElements, { deep: false })
-        ) as Boxed<Y.Map<Y.Map<unknown>>>,
+        elements: new Boxed(native2Y(surfaceBlocks, { deep: false })) as Boxed<
+          Y.Map<Y.Map<unknown>>
+        >,
       },
       rootId
     );

--- a/packages/presets/src/__tests__/edgeless/layer.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/layer.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import type { BlockElement } from '@blocksuite/block-std';
+import type { BlockComponent } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import {
@@ -259,22 +259,22 @@ test('blocks should rerender when their z-index changed', async () => {
       index: service.layer.generateIndex('affine:note'),
     }),
   ];
-  const assertBlockElementsContent = () => {
-    const blockElements = Array.from(
+  const assertBlocksContent = () => {
+    const blocks = Array.from(
       document.querySelectorAll(
         'affine-edgeless-root .edgeless-layer > [data-block-id]'
       )
     );
 
-    expect(blockElements.length).toBe(5);
+    expect(blocks.length).toBe(5);
 
-    blockElements.forEach(element => {
+    blocks.forEach(element => {
       expect(element.children.length).toBeGreaterThan(0);
     });
   };
 
   await wait();
-  assertBlockElementsContent();
+  assertBlocksContent();
 
   service.addElement('shape', {
     shapeType: 'rect',
@@ -285,7 +285,7 @@ test('blocks should rerender when their z-index changed', async () => {
   });
 
   await wait();
-  assertBlockElementsContent();
+  assertBlocksContent();
 });
 
 describe('layer reorder functionality', () => {
@@ -524,7 +524,7 @@ test('the actual rendering z-index should satisfy the logic order of their index
   const edgeless = getDocRootBlock(doc, editor, 'edgeless');
   const blocks = Array.from(
     edgeless.querySelectorAll('.edgeless-layer > [data-block-id]')
-  ) as BlockElement[];
+  ) as BlockComponent[];
 
   expect(blocks.length).toBe(indexes.length + 1);
 

--- a/packages/presets/src/ai/entries/code-toolbar/setup-code-toolbar.ts
+++ b/packages/presets/src/ai/entries/code-toolbar/setup-code-toolbar.ts
@@ -22,7 +22,7 @@ export function setupCodeToolbarEntry(codeToolbar: AffineCodeToolbarWidget) {
   const onAskAIClick = () => {
     const { host } = codeToolbar;
     const { selection } = host;
-    const imageBlock = codeToolbar.blockElement;
+    const imageBlock = codeToolbar.block;
     selection.setGroup('note', [
       selection.create('block', { blockId: imageBlock.blockId }),
     ]);

--- a/packages/presets/src/ai/entries/image-toolbar/setup-image-toolbar.ts
+++ b/packages/presets/src/ai/entries/image-toolbar/setup-image-toolbar.ts
@@ -21,7 +21,7 @@ export function setupImageToolbarEntry(imageToolbar: AffineImageToolbarWidget) {
   const onAskAIClick = () => {
     const { host } = imageToolbar;
     const { selection } = host;
-    const imageBlock = imageToolbar.blockElement;
+    const imageBlock = imageToolbar.block;
     selection.setGroup('note', [
       selection.create('image', { blockId: imageBlock.blockId }),
     ]);

--- a/packages/presets/src/ai/utils/edgeless.ts
+++ b/packages/presets/src/ai/utils/edgeless.ts
@@ -1,4 +1,4 @@
-import type { BlockElement, EditorHost } from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type {
   EdgelessCopilotWidget,
   EdgelessRootService,
@@ -62,8 +62,8 @@ export function getEdgelessCopilotWidget(
   return copilotWidget;
 }
 
-export function findNoteBlockModel(blockElement: BlockElement) {
-  let curBlock = blockElement;
+export function findNoteBlockModel(block: BlockComponent) {
+  let curBlock = block;
   while (curBlock) {
     if (matchFlavours(curBlock.model, ['affine:note'])) {
       return curBlock.model;
@@ -71,7 +71,7 @@ export function findNoteBlockModel(blockElement: BlockElement) {
     if (matchFlavours(curBlock.model, ['affine:page', 'affine:surface'])) {
       return null;
     }
-    curBlock = curBlock.parentBlockElement;
+    curBlock = curBlock.parentBlock;
   }
   return null;
 }

--- a/packages/presets/src/ai/utils/editor-actions.ts
+++ b/packages/presets/src/ai/utils/editor-actions.ts
@@ -1,5 +1,5 @@
 import type {
-  BlockElement,
+  BlockComponent,
   EditorHost,
   TextSelection,
 } from '@blocksuite/block-std';
@@ -14,10 +14,10 @@ import {
   markdownToSnapshot,
 } from './markdown-utils.js';
 
-const getNoteId = (blockElement: BlockElement) => {
-  let element = blockElement;
+const getNoteId = (block: BlockComponent) => {
+  let element = block;
   while (element && element.flavour !== 'affine:note') {
-    element = element.parentBlockElement;
+    element = element.parentBlock;
   }
 
   return element.model.id;
@@ -25,7 +25,7 @@ const getNoteId = (blockElement: BlockElement) => {
 
 const setBlockSelection = (
   host: EditorHost,
-  parent: BlockElement,
+  parent: BlockComponent,
   models: BlockModel[]
 ) => {
   const selections = models
@@ -51,10 +51,10 @@ const setBlockSelection = (
 export const insert = async (
   host: EditorHost,
   content: string,
-  selectBlock: BlockElement,
+  selectBlock: BlockComponent,
   below: boolean = true
 ) => {
-  const blockParent = selectBlock.parentBlockElement;
+  const blockParent = selectBlock.parentBlock;
   const index = blockParent.model.children.findIndex(
     model => model.id === selectBlock.model.id
   );
@@ -73,7 +73,7 @@ export const insert = async (
 export const insertBelow = async (
   host: EditorHost,
   content: string,
-  selectBlock: BlockElement
+  selectBlock: BlockComponent
 ) => {
   await insert(host, content, selectBlock, true);
 };
@@ -81,7 +81,7 @@ export const insertBelow = async (
 export const insertAbove = async (
   host: EditorHost,
   content: string,
-  selectBlock: BlockElement
+  selectBlock: BlockComponent
 ) => {
   await insert(host, content, selectBlock, false);
 };
@@ -89,11 +89,11 @@ export const insertAbove = async (
 export const replace = async (
   host: EditorHost,
   content: string,
-  firstBlock: BlockElement,
+  firstBlock: BlockComponent,
   selectedModels: BlockModel[],
   textSelection?: TextSelection
 ) => {
-  const firstBlockParent = firstBlock.parentBlockElement;
+  const firstBlockParent = firstBlock.parentBlock;
   const firstIndex = firstBlockParent.model.children.findIndex(
     model => model.id === firstBlock.model.id
   );

--- a/packages/presets/src/blocks/ai-chat-block/ai-chat-block.ts
+++ b/packages/presets/src/blocks/ai-chat-block/ai-chat-block.ts
@@ -1,4 +1,4 @@
-import { BlockElement } from '@blocksuite/block-std';
+import { BlockComponent } from '@blocksuite/block-std';
 import { Peekable } from '@blocksuite/blocks';
 import { computed } from '@lit-labs/preact-signals';
 import { html } from 'lit';
@@ -16,7 +16,7 @@ import { ChatMessagesSchema } from './types.js';
 @Peekable({
   enableOn: ({ doc }: AIChatBlockComponent) => !doc.readonly,
 })
-export class AIChatBlockComponent extends BlockElement<AIChatBlockModel> {
+export class AIChatBlockComponent extends BlockComponent<AIChatBlockModel> {
   // Deserialize messages from JSON string and verify the type using zod
   private _deserializeChatMessages = computed(() => {
     const messages = this.model.messages$.value;

--- a/packages/presets/src/blocks/ai-chat-block/ai-chat-edgeless-block.ts
+++ b/packages/presets/src/blocks/ai-chat-block/ai-chat-edgeless-block.ts
@@ -1,4 +1,4 @@
-import { toEdgelessBlockElement } from '@blocksuite/block-std';
+import { toEdgelessBlockComponent } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -7,7 +7,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { AIChatBlockComponent } from './ai-chat-block.js';
 
 @customElement('affine-edgeless-ai-chat')
-export class EdgelessAIChatBlockComponent extends toEdgelessBlockElement(
+export class EdgelessAIChatBlockComponent extends toEdgelessBlockComponent(
   AIChatBlockComponent
 ) {
   rootServiceFlavour!: 'affine:page';

--- a/packages/presets/src/fragments/outline-panel/body/outline-panel-body.ts
+++ b/packages/presets/src/fragments/outline-panel/body/outline-panel-body.ts
@@ -399,17 +399,17 @@ export class OutlinePanelBody extends WithDisposable(LitElement) {
 
     const { blockPath } = e.detail;
     const path = [rootElement.model.id, ...blockPath];
-    const blockElement = this.editorHost.view.viewFromPath('block', path);
-    if (!blockElement) return;
+    const block = this.editorHost.view.viewFromPath('block', path);
+    if (!block) return;
 
-    blockElement.scrollIntoView({
+    block.scrollIntoView({
       behavior: 'instant',
       block: 'center',
       inline: 'center',
     });
 
     requestAnimationFrame(() => {
-      const blockRect = blockElement.getBoundingClientRect();
+      const blockRect = block.getBoundingClientRect();
       const { top, left, width, height } = blockRect;
       assertExists(rootElement.viewport, 'viewport should exist');
       const {

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import type {
-  BlockElement,
+  BlockComponent,
   EditorHost,
 } from '@block-std/view/element/index.js';
 import type { CssVariableName } from '@blocks/_common/theme/css-variables.js';
@@ -382,12 +382,12 @@ export async function assertRichTextModelType(
       const editorHost =
         document.querySelectorAll('editor-host')[currentEditorIndex];
       const richText = editorHost.querySelectorAll('rich-text')[index];
-      const blockElement = richText.closest<BlockElement>(`[${BLOCK_ID_ATTR}]`);
+      const block = richText.closest<BlockComponent>(`[${BLOCK_ID_ATTR}]`);
 
-      if (!blockElement) {
-        throw new Error('blockElement is undefined');
+      if (!block) {
+        throw new Error('block component is undefined');
       }
-      return (blockElement.model as BlockModel<{ type: string }>).type;
+      return (block.model as BlockModel<{ type: string }>).type;
     },
     { index, BLOCK_ID_ATTR, currentEditorIndex }
   );
@@ -515,7 +515,7 @@ export async function assertBlockType(
 ) {
   const actual = await page.evaluate(
     ({ id }) => {
-      const element = document.querySelector<BlockElement>(
+      const element = document.querySelector<BlockComponent>(
         `[data-block-id="${id}"]`
       );
 
@@ -539,7 +539,7 @@ export async function assertBlockFlavour(
 ) {
   const actual = await page.evaluate(
     ({ id }) => {
-      const element = document.querySelector<BlockElement>(
+      const element = document.querySelector<BlockComponent>(
         `[data-block-id="${id}"]`
       );
 
@@ -562,7 +562,7 @@ export async function assertBlockTextContent(
 ) {
   const actual = await page.evaluate(
     ({ id }) => {
-      const element = document.querySelector<BlockElement>(
+      const element = document.querySelector<BlockComponent>(
         `[data-block-id="${id}"]`
       );
 


### PR DESCRIPTION
This continues after #7714, which preserves the `BlockElement` naming for edgeless element concept.
