### PR TITLE
refactor: switch to `widgetComponent` and `rootComponent`

### DIFF
--- a/packages/blocks/src/_common/components/rich-text/keymap/container.ts
+++ b/packages/blocks/src/_common/components/rich-text/keymap/container.ts
@@ -236,10 +236,10 @@ export const bindContainerHotkey = (block: BlockComponent) => {
     'Mod-Backspace': ctx => {
       if (!(block.selected?.is('block') || block.selected?.is('text'))) return;
 
-      const rootElement = block.closest<RootBlockComponent>(
+      const rootComponent = block.closest<RootBlockComponent>(
         'affine-page-root,affine-edgeless-root'
       );
-      if (!rootElement) return;
+      if (!rootComponent) return;
 
       {
         const [_, context] = std.command
@@ -277,10 +277,10 @@ export const bindContainerHotkey = (block: BlockComponent) => {
     'Shift-Tab': ctx => {
       if (!(block.selected?.is('block') || block.selected?.is('text'))) return;
 
-      const rootElement = block.closest<RootBlockComponent>(
+      const rootComponent = block.closest<RootBlockComponent>(
         'affine-page-root,affine-edgeless-root'
       );
-      if (!rootElement) return;
+      if (!rootComponent) return;
 
       {
         const [_, context] = std.command

--- a/packages/blocks/src/_common/components/toast.ts
+++ b/packages/blocks/src/_common/components/toast.ts
@@ -39,9 +39,9 @@ const createToastContainer = (editorHost: EditorHost) => {
   `;
   const template = html`<div class="toast-container" style="${styles}"></div>`;
   const element = htmlToElement<HTMLDivElement>(template);
-  const rootElement = getRootByEditorHost(editorHost);
-  assertExists(rootElement);
-  const viewportElement = rootElement.viewportElement;
+  const rootComponent = getRootByEditorHost(editorHost);
+  assertExists(rootComponent);
+  const viewportElement = rootComponent.viewportElement;
   viewportElement?.append(element);
   return element;
 };

--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -131,13 +131,15 @@ export class ExportManager {
           reject(e);
         }
         const rootModel = this.doc.root;
-        const rootElement = this.doc.root
+        const rootComponent = this.doc.root
           ? getBlockComponentByModel(this.editorHost, rootModel)
           : null;
-        const imageCard = rootElement?.querySelector('affine-image-block-card');
+        const imageCard = rootComponent?.querySelector(
+          'affine-image-block-card'
+        );
         const isReady =
           !imageCard || imageCard.getAttribute('imageState') === '0';
-        if (rootElement && isReady) {
+        if (rootComponent && isReady) {
           clearInterval(checkReactRender);
           resolve(true);
         }
@@ -179,15 +181,15 @@ export class ExportManager {
     const pathname = location.pathname;
     const editorMode = isInsidePageEditor(this.editorHost);
 
-    const rootElement = getRootByEditorHost(this.editorHost);
-    assertExists(rootElement);
-    const viewportElement = rootElement.viewportElement;
+    const rootComponent = getRootByEditorHost(this.editorHost);
+    assertExists(rootComponent);
+    const viewportElement = rootComponent.viewportElement;
     assertExists(viewportElement);
     const pageContainer = viewportElement.querySelector(
       '.affine-page-root-block-container'
     );
     const rect = pageContainer?.getBoundingClientRect();
-    const { viewport } = rootElement;
+    const { viewport } = rootComponent;
     assertExists(viewport);
     const pageWidth = rect?.width;
     const pageLeft = rect?.left ?? 0;
@@ -410,9 +412,9 @@ export class ExportManager {
 
     const pathname = location.pathname;
     const editorMode = isInsidePageEditor(this.editorHost);
-    const rootElement = getRootByEditorHost(this.editorHost);
-    assertExists(rootElement);
-    const viewportElement = rootElement.viewportElement;
+    const rootComponent = getRootByEditorHost(this.editorHost);
+    assertExists(rootComponent);
+    const viewportElement = rootComponent.viewportElement;
     assertExists(viewportElement);
     const containerComputedStyle = window.getComputedStyle(viewportElement);
 
@@ -420,7 +422,7 @@ export class ExportManager {
       this._html2canvas(element, {
         backgroundColor: containerComputedStyle.backgroundColor,
       });
-    const container = rootElement.querySelector(
+    const container = rootComponent.querySelector(
       '.affine-block-children-container'
     );
 

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-node.ts
@@ -145,9 +145,9 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     const targetDocId = refMeta.id;
     const rootModel = model.doc.root;
     assertExists(rootModel);
-    const rootElement = getRootByElement(this) as RootBlockComponent;
-    assertExists(rootElement);
-    rootElement.slots.docLinkClicked.emit({ docId: targetDocId });
+    const rootComponent = getRootByElement(this) as RootBlockComponent;
+    assertExists(rootComponent);
+    rootComponent.slots.docLinkClicked.emit({ docId: targetDocId });
   }
 
   override connectedCallback() {

--- a/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/reference-node/reference-popup.ts
@@ -139,12 +139,12 @@ export class ReferencePopup extends WithDisposable(LitElement) {
     const block = this.block;
     if (refDocId === block.doc.id) return;
 
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       block.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
+    assertExists(rootComponent);
 
-    rootElement.slots.docLinkClicked.emit({ docId: refDocId });
+    rootComponent.slots.docLinkClicked.emit({ docId: refDocId });
   }
 
   private _openMenuButton() {

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -265,13 +265,16 @@ export function getViewportElement(editorHost: EditorHost) {
     console.error('Failed to get root doc');
     return null;
   }
-  const rootElement = editorHost.view.viewFromPath('block', [doc.root.id]);
+  const rootComponent = editorHost.view.viewFromPath('block', [doc.root.id]);
 
-  if (!rootElement || rootElement.closest('affine-page-root') !== rootElement) {
+  if (
+    !rootComponent ||
+    rootComponent.closest('affine-page-root') !== rootComponent
+  ) {
     console.error('Failed to get viewport element!');
     return null;
   }
-  return (rootElement as PageRootBlockComponent).viewportElement;
+  return (rootComponent as PageRootBlockComponent).viewportElement;
 }
 
 /**
@@ -308,12 +311,12 @@ export async function asyncGetBlockComponentByModel(
   model: BlockModel
 ): Promise<BlockComponent | null> {
   assertExists(model.doc.root);
-  const rootElement = getRootByEditorHost(editorHost);
-  if (!rootElement) return null;
-  await rootElement.updateComplete;
+  const rootComponent = getRootByEditorHost(editorHost);
+  if (!rootComponent) return null;
+  await rootComponent.updateComplete;
 
   if (model.id === model.doc.root.id) {
-    return rootElement;
+    return rootComponent;
   }
 
   return editorHost.view.getBlock(model.id);

--- a/packages/blocks/src/attachment-block/attachment-service.ts
+++ b/packages/blocks/src/attachment-block/attachment-service.ts
@@ -150,7 +150,7 @@ export class AttachmentBlockService extends BlockService<AttachmentBlockModel> {
           place
         );
       } else if (isInsideEdgelessEditor(this.host as EditorHost)) {
-        const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+        const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
         point = edgelessRoot.service.viewport.toViewCoordFromClientCoord(point);
         await edgelessRoot.addAttachments(attachmentFiles, point);
 
@@ -186,14 +186,14 @@ export class AttachmentBlockService extends BlockService<AttachmentBlockModel> {
     );
   }
 
-  get rootElement(): RootBlockComponent {
+  get rootComponent(): RootBlockComponent {
     const rootModel = this.doc.root;
     assertExists(rootModel);
 
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       rootModel.id,
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
-    return rootElement;
+    assertExists(rootComponent);
+    return rootComponent;
   }
 }

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -416,11 +416,11 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
   }
 
   override get topContenteditableElement() {
-    if (this.rootElement instanceof EdgelessRootBlockComponent) {
+    if (this.rootComponent instanceof EdgelessRootBlockComponent) {
       const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
-    return this.rootElement;
+    return this.rootComponent;
   }
 
   @query('rich-text')

--- a/packages/blocks/src/data-view-block/data-view-block.ts
+++ b/packages/blocks/src/data-view-block/data-view-block.ts
@@ -282,17 +282,17 @@ export class DataViewBlockComponent extends CaptionedBlockComponent<DataViewBloc
   }
 
   get innerModalWidget() {
-    return this.rootElement?.widgetElements[
+    return this.rootComponent?.widgetComponents[
       AFFINE_INNER_MODAL_WIDGET
     ] as AffineInnerModalWidget;
   }
 
   override get topContenteditableElement() {
-    if (this.rootElement instanceof EdgelessRootBlockComponent) {
+    if (this.rootComponent instanceof EdgelessRootBlockComponent) {
       const note = this.closest<NoteBlockComponent>('affine-note');
       return note;
     }
-    return this.rootElement;
+    return this.rootComponent;
   }
 
   get view() {

--- a/packages/blocks/src/database-block/data-view/column/presets/link/cell-renderer.ts
+++ b/packages/blocks/src/database-block/data-view/column/presets/link/cell-renderer.ts
@@ -113,12 +113,12 @@ export class LinkCell extends BaseCellRenderer<string> {
     if (!rootId) {
       return;
     }
-    const rootElement = std?.view.viewFromPath('block', [
+    const rootComponent = std?.view.viewFromPath('block', [
       rootId,
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
+    assertExists(rootComponent);
 
-    rootElement.slots.docLinkClicked.emit({ docId: this.docId });
+    rootComponent.slots.docLinkClicked.emit({ docId: this.docId });
   };
 
   override render() {

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/column-stats-cell.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/column-stats-cell.ts
@@ -68,9 +68,9 @@ export class DatabaseColumnStatsCell extends WithDisposable(LitElement) {
   };
 
   openMenu = (ev: MouseEvent) => {
-    const rootElement = getRootByElement(this);
+    const rootComponent = getRootByElement(this);
     popColStatOperationMenu(
-      rootElement,
+      rootComponent,
       ev.target as HTMLElement,
       this.column,
       this.getColumnType(),

--- a/packages/blocks/src/database-block/data-view/view/presets/table/components/menu.ts
+++ b/packages/blocks/src/database-block/data-view/view/presets/table/components/menu.ts
@@ -133,7 +133,7 @@ export const popRowMenu = (
 };
 
 export const popColStatOperationMenu = (
-  _rootElement: RootBlockComponent | null,
+  _rootComponent: RootBlockComponent | null,
   elem: HTMLElement,
   _column: DataViewColumnManager,
   calcType: ColumnDataType,

--- a/packages/blocks/src/database-block/database-block.ts
+++ b/packages/blocks/src/database-block/database-block.ts
@@ -400,17 +400,17 @@ export class DatabaseBlockComponent extends CaptionedBlockComponent<
   }
 
   get innerModalWidget() {
-    return this.rootElement!.widgetElements[
+    return this.rootComponent!.widgetComponents[
       AFFINE_INNER_MODAL_WIDGET
     ] as AffineInnerModalWidget;
   }
 
   override get topContenteditableElement() {
-    if (this.rootElement instanceof EdgelessRootBlockComponent) {
+    if (this.rootComponent instanceof EdgelessRootBlockComponent) {
       const note = this.closest<NoteBlockComponent>(NOTE_SELECTOR);
       return note;
     }
-    return this.rootElement;
+    return this.rootComponent;
   }
 
   get view() {

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -186,12 +186,12 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<
     const linkedDocId = this.model.pageId;
     if (linkedDocId === this.doc.id) return;
 
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       this.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
+    assertExists(rootComponent);
 
-    rootElement.slots.docLinkClicked.emit({ docId: linkedDocId });
+    rootComponent.slots.docLinkClicked.emit({ docId: linkedDocId });
   };
 
   refreshData = () => {

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -310,12 +310,12 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
     const syncedDocId = this.model.pageId;
     if (syncedDocId === this.doc.id) return;
 
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       this.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
+    assertExists(rootComponent);
 
-    rootElement.slots.docLinkClicked.emit({ docId: syncedDocId });
+    rootComponent.slots.docLinkClicked.emit({ docId: syncedDocId });
   };
 
   refreshData = () => {

--- a/packages/blocks/src/image-block/image-resize-manager.ts
+++ b/packages/blocks/src/image-block/image-resize-manager.ts
@@ -73,9 +73,9 @@ export class ImageResizeManager {
       eventTarget
     ) as BlockComponent;
 
-    const rootElement = getClosestRootBlockComponent(this._activeComponent);
-    if (rootElement && isEdgelessPage(rootElement)) {
-      this._zoom = rootElement.service.viewport.zoom;
+    const rootComponent = getClosestRootBlockComponent(this._activeComponent);
+    if (rootComponent && isEdgelessPage(rootComponent)) {
+      this._zoom = rootComponent.service.viewport.zoom;
     } else {
       this._zoom = 1;
     }

--- a/packages/blocks/src/image-block/image-service.ts
+++ b/packages/blocks/src/image-block/image-service.ts
@@ -133,7 +133,7 @@ export class ImageBlockService extends BlockService<ImageBlockModel> {
           place
         );
       } else if (isInsideEdgelessEditor(this.host as EditorHost)) {
-        const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+        const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
         point = edgelessRoot.service.viewport.toViewCoordFromClientCoord(point);
         await edgelessRoot.addImages(imageFiles, point);
 
@@ -168,14 +168,14 @@ export class ImageBlockService extends BlockService<ImageBlockModel> {
     );
   }
 
-  get rootElement(): RootBlockComponent {
+  get rootComponent(): RootBlockComponent {
     const rootModel = this.doc.root;
     assertExists(rootModel);
 
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       rootModel.id,
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
-    return rootElement;
+    assertExists(rootComponent);
+    return rootComponent;
   }
 }

--- a/packages/blocks/src/list-block/list-block.ts
+++ b/packages/blocks/src/list-block/list-block.ts
@@ -182,11 +182,11 @@ export class ListBlockComponent extends CaptionedBlockComponent<
   }
 
   override get topContenteditableElement() {
-    if (this.rootElement instanceof EdgelessRootBlockComponent) {
+    if (this.rootComponent instanceof EdgelessRootBlockComponent) {
       const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
-    return this.rootElement;
+    return this.rootComponent;
   }
 
   @state()

--- a/packages/blocks/src/paragraph-block/paragraph-block.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-block.ts
@@ -151,11 +151,11 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<
   }
 
   override get topContenteditableElement() {
-    if (this.rootElement instanceof EdgelessRootBlockComponent) {
+    if (this.rootComponent instanceof EdgelessRootBlockComponent) {
       const el = this.closest<BlockComponent>(NOTE_SELECTOR);
       return el;
     }
-    return this.rootElement;
+    return this.rootComponent;
   }
 
   @query('rich-text')

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -830,10 +830,10 @@ export class EdgelessClipboardController extends PageClipboard {
     const pathname = location.pathname;
     const editorMode = isInsidePageEditor(host);
 
-    const rootElement = getRootByEditorHost(host);
-    assertExists(rootElement);
+    const rootComponent = getRootByEditorHost(host);
+    assertExists(rootComponent);
 
-    const container = rootElement.querySelector(
+    const container = rootComponent.querySelector(
       '.affine-block-children-container'
     );
     if (!container) return;

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -41,33 +41,33 @@ import {
 } from './utils/text.js';
 
 export class EdgelessPageKeyboardManager extends PageKeyboardManager {
-  constructor(override rootElement: EdgelessRootBlockComponent) {
-    super(rootElement);
-    this.rootElement.bindHotKey(
+  constructor(override rootComponent: EdgelessRootBlockComponent) {
+    super(rootComponent);
+    this.rootComponent.bindHotKey(
       {
         v: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'default',
           });
         },
         t: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'text',
           });
         },
         c: () => {
           const mode = ConnectorMode.Curve;
-          rootElement.service.editPropsStore.recordLastProps('connector', {
+          rootComponent.service.editPropsStore.recordLastProps('connector', {
             mode,
           });
-          this._setEdgelessTool(rootElement, { type: 'connector', mode });
+          this._setEdgelessTool(rootComponent, { type: 'connector', mode });
         },
         l: () => {
-          if (!rootElement.doc.awarenessStore.getFlag('enable_lasso_tool')) {
+          if (!rootComponent.doc.awarenessStore.getFlag('enable_lasso_tool')) {
             return;
           }
           // select the current lasso mode
-          const edgeless = rootElement;
+          const edgeless = rootComponent;
           const lassoController = edgeless.tools.controllers['lasso'];
           const tool: EdgelessTool = {
             type: 'lasso',
@@ -80,11 +80,11 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this._setEdgelessTool(edgeless, tool);
         },
         'Shift-l': () => {
-          if (!rootElement.doc.awarenessStore.getFlag('enable_lasso_tool')) {
+          if (!rootComponent.doc.awarenessStore.getFlag('enable_lasso_tool')) {
             return;
           }
           // toggle between lasso modes
-          const edgeless = rootElement;
+          const edgeless = rootComponent;
           const cur = edgeless.edgelessTool;
           const tool: EdgelessTool = {
             type: 'lasso',
@@ -98,13 +98,13 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this._setEdgelessTool(edgeless, tool);
         },
         h: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'pan',
             panning: false,
           });
         },
         n: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'affine:note',
             childFlavour: DEFAULT_NOTE_CHILD_FLAVOUR,
             childType: DEFAULT_NOTE_CHILD_TYPE,
@@ -112,18 +112,18 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           });
         },
         p: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'brush',
           });
         },
         e: () => {
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'eraser',
           });
         },
         k: () => {
-          if (this.rootElement.service.locked) return;
-          const { selection } = rootElement.service;
+          if (this.rootComponent.service.locked) return;
+          const { selection } = rootComponent.service;
 
           if (
             selection.selectedElements.length === 1 &&
@@ -132,42 +132,47 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
               'affine:note',
             ])
           ) {
-            rootElement.slots.toggleNoteSlicer.emit();
+            rootComponent.slots.toggleNoteSlicer.emit();
           }
         },
         f: () => {
-          if (this.rootElement.service.locked) return;
+          if (this.rootComponent.service.locked) return;
           if (
-            this.rootElement.service.selection.selectedElements.length !== 0 &&
-            !this.rootElement.service.selection.editing
+            this.rootComponent.service.selection.selectedElements.length !==
+              0 &&
+            !this.rootComponent.service.selection.editing
           ) {
-            const frame = rootElement.service.frame.createFrameOnSelected();
+            const frame = rootComponent.service.frame.createFrameOnSelected();
             if (!frame) return;
-            rootElement.service.telemetryService?.track('CanvasElementAdded', {
-              control: 'shortcut',
-              page: 'whiteboard editor',
-              module: 'toolbar',
-              segment: 'toolbar',
-              type: 'frame',
-            });
-            rootElement.surface.fitToViewport(Bound.deserialize(frame.xywh));
-          } else if (!this.rootElement.service.selection.editing) {
-            this._setEdgelessTool(rootElement, { type: 'frame' });
+            rootComponent.service.telemetryService?.track(
+              'CanvasElementAdded',
+              {
+                control: 'shortcut',
+                page: 'whiteboard editor',
+                module: 'toolbar',
+                segment: 'toolbar',
+                type: 'frame',
+              }
+            );
+            rootComponent.surface.fitToViewport(Bound.deserialize(frame.xywh));
+          } else if (!this.rootComponent.service.selection.editing) {
+            this._setEdgelessTool(rootComponent, { type: 'frame' });
           }
         },
         '-': () => {
-          if (this.rootElement.service.locked) return;
-          const { selectedElements: elements } = rootElement.service.selection;
+          if (this.rootComponent.service.locked) return;
+          const { selectedElements: elements } =
+            rootComponent.service.selection;
           if (
-            !rootElement.service.selection.editing &&
+            !rootComponent.service.selection.editing &&
             elements.length === 1 &&
             isNoteBlock(elements[0])
           ) {
-            rootElement.slots.toggleNoteSlicer.emit();
+            rootComponent.slots.toggleNoteSlicer.emit();
           }
         },
         '@': () => {
-          const std = this.rootElement.std;
+          const std = this.rootComponent.std;
           if (
             std.selection.getGroup('note').length > 0 ||
             // eslint-disable-next-line unicorn/prefer-array-some
@@ -184,7 +189,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           insertedLinkType
             ?.then(type => {
               if (type) {
-                rootElement.service.telemetryService?.track(
+                rootComponent.service.telemetryService?.track(
                   'CanvasElementAdded',
                   {
                     control: 'shortcut',
@@ -195,7 +200,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                   }
                 );
                 if (type.isNewDoc) {
-                  rootElement.service.telemetryService?.track('DocCreated', {
+                  rootComponent.service.telemetryService?.track('DocCreated', {
                     control: 'shortcut',
                     page: 'whiteboard editor',
                     segment: 'whiteboard',
@@ -207,65 +212,67 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             .catch(console.error);
         },
         'Shift-s': () => {
-          if (this.rootElement.service.locked) return;
+          if (this.rootComponent.service.locked) return;
           if (
-            this.rootElement.service.selection.editing ||
+            this.rootComponent.service.selection.editing ||
             !(
-              rootElement.tools.currentController instanceof ShapeToolController
+              rootComponent.tools.currentController instanceof
+              ShapeToolController
             )
           ) {
             return;
           }
 
-          const attr = rootElement.service.editPropsStore.getLastProps('shape');
+          const attr =
+            rootComponent.service.editPropsStore.getLastProps('shape');
 
           const nextShapeType = getNextShapeType(
             attr.radius > 0 && attr.shapeType === ShapeType.Rect
               ? 'roundedRect'
               : attr.shapeType
           );
-          this._setEdgelessTool(rootElement, {
+          this._setEdgelessTool(rootComponent, {
             type: 'shape',
             shapeType:
               nextShapeType === 'roundedRect' ? ShapeType.Rect : nextShapeType,
           });
 
-          updateShapeProps(nextShapeType, rootElement);
+          updateShapeProps(nextShapeType, rootComponent);
 
-          const controller = rootElement.tools
+          const controller = rootComponent.tools
             .currentController as ShapeToolController;
           controller.createOverlay();
         },
         'Mod-g': ctx => {
-          if (this.rootElement.service.locked) return;
+          if (this.rootComponent.service.locked) return;
           if (
-            this.rootElement.service.selection.selectedElements.length > 1 &&
-            !this.rootElement.service.selection.editing
+            this.rootComponent.service.selection.selectedElements.length > 1 &&
+            !this.rootComponent.service.selection.editing
           ) {
             ctx.get('keyboardState').event.preventDefault();
-            rootElement.service.createGroupFromSelected();
+            rootComponent.service.createGroupFromSelected();
           }
         },
         'Shift-Mod-g': ctx => {
-          if (this.rootElement.service.locked) return;
-          const { selection } = this.rootElement.service;
+          if (this.rootComponent.service.locked) return;
+          const { selection } = this.rootComponent.service;
           if (
             selection.selectedElements.length === 1 &&
             selection.firstElement instanceof GroupElementModel
           ) {
             ctx.get('keyboardState').event.preventDefault();
-            rootElement.service.ungroup(selection.firstElement);
+            rootComponent.service.ungroup(selection.firstElement);
           }
         },
         'Mod-a': ctx => {
-          if (this.rootElement.service.locked) return;
-          if (this.rootElement.service.selection.editing) {
+          if (this.rootComponent.service.locked) return;
+          if (this.rootComponent.service.selection.editing) {
             return;
           }
 
           ctx.get('defaultState').event.preventDefault();
-          const { service } = this.rootElement;
-          this.rootElement.service.selection.set({
+          const { service } = this.rootComponent;
+          this.rootComponent.service.selection.set({
             elements: [
               ...service.blocks
                 .filter(block => block.group === null)
@@ -279,19 +286,19 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
         'Mod-1': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.rootElement.service.setZoomByAction('fit');
+          this.rootComponent.service.setZoomByAction('fit');
         },
         'Mod--': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.rootElement.service.setZoomByAction('out');
+          this.rootComponent.service.setZoomByAction('out');
         },
         'Mod-0': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.rootElement.service.setZoomByAction('reset');
+          this.rootComponent.service.setZoomByAction('reset');
         },
         'Mod-=': ctx => {
           ctx.get('defaultState').event.preventDefault();
-          this.rootElement.service.setZoomByAction('in');
+          this.rootComponent.service.setZoomByAction('in');
         },
         Backspace: () => {
           this._delete();
@@ -304,7 +311,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this._delete();
         },
         Escape: () => {
-          const { currentController } = this.rootElement.tools;
+          const { currentController } = this.rootComponent.tools;
           if (
             currentController instanceof LassoToolController &&
             currentController.isSelecting
@@ -315,8 +322,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             currentController.abort();
           }
 
-          if (!this.rootElement.service.selection.empty) {
-            rootElement.selection.clear();
+          if (!this.rootComponent.service.selection.empty) {
+            rootComponent.selection.clear();
           }
         },
 
@@ -353,7 +360,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
 
         Enter: () => {
-          const { service } = rootElement;
+          const { service } = rootComponent;
           const selection = service.selection;
           const elements = selection.selectedElements;
           const onlyOne = elements.length === 1;
@@ -368,7 +375,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                 editing: true,
               });
               requestAnimationFrame(() => {
-                mountConnectorLabelEditor(element, rootElement);
+                mountConnectorLabelEditor(element, rootComponent);
               });
               return;
             }
@@ -378,7 +385,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                 elements: [id],
                 editing: true,
               });
-              const textBlock = rootElement.host.view.getBlock(id);
+              const textBlock = rootComponent.host.view.getBlock(id);
               if (textBlock instanceof EdgelessTextBlockComponent) {
                 textBlock.tryFocusEnd();
               }
@@ -398,7 +405,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           const target = service.getElementById(id) as ShapeElementModel;
 
           requestAnimationFrame(() => {
-            mountShapeTextEditor(target, rootElement);
+            mountShapeTextEditor(target, rootComponent);
 
             if (isElementOutsideViewport(service.viewport, target, [20, 20])) {
               const { elementBound } = target;
@@ -411,7 +418,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           });
         },
         Tab: () => {
-          const { service } = rootElement;
+          const { service } = rootComponent;
           const selection = service.selection;
           const elements = selection.selectedElements;
 
@@ -425,7 +432,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           const target = service.getElementById(id) as ShapeElementModel;
 
           requestAnimationFrame(() => {
-            mountShapeTextEditor(target, rootElement);
+            mountShapeTextEditor(target, rootComponent);
 
             if (isElementOutsideViewport(service.viewport, target, [20, 20])) {
               const { elementBound } = target;
@@ -448,7 +455,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   }
 
   private _bindShiftKey() {
-    this.rootElement.handleEvent(
+    this.rootComponent.handleEvent(
       'keyDown',
       ctx => {
         const event = ctx.get('defaultState').event;
@@ -458,7 +465,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
       },
       { global: true }
     );
-    this.rootElement.handleEvent(
+    this.rootComponent.handleEvent(
       'keyUp',
       ctx => {
         const event = ctx.get('defaultState').event;
@@ -473,7 +480,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   }
 
   private _bindToggleHand() {
-    this.rootElement.handleEvent(
+    this.rootComponent.handleEvent(
       'keyDown',
       ctx => {
         const event = ctx.get('keyboardState').raw;
@@ -483,7 +490,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
       },
       { global: true }
     );
-    this.rootElement.handleEvent(
+    this.rootComponent.handleEvent(
       'keyUp',
       ctx => {
         const event = ctx.get('keyboardState').raw;
@@ -496,7 +503,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   }
 
   private _delete() {
-    const edgeless = this.rootElement;
+    const edgeless = this.rootComponent;
 
     if (edgeless.service.locked) return;
     if (edgeless.service.selection.editing) {
@@ -515,7 +522,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   }
 
   private _move(key: string, shift = false) {
-    const edgeless = this.rootElement;
+    const edgeless = this.rootComponent;
 
     if (edgeless.service.locked) return;
     if (edgeless.service.selection.editing) return;
@@ -633,7 +640,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
   }
 
   private _shift(event: KeyboardEvent) {
-    const edgeless = this.rootElement;
+    const edgeless = this.rootComponent;
 
     if (event.repeat) return;
 
@@ -652,7 +659,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
     Call this function with a check for !event.repeat to consider only the first keydown (not repeat). This way, you can use onPressSpaceBar in a tool to determine if the space bar is pressed or not.
   */
 
-    const edgeless = this.rootElement;
+    const edgeless = this.rootComponent;
     const selection = edgeless.service.selection;
     const currentTool = edgeless.edgelessTool;
     const type = currentTool.type;

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -43,8 +43,8 @@ export class PageKeyboardManager {
     });
   };
 
-  constructor(public rootElement: BlockComponent) {
-    this.rootElement.bindHotKey(
+  constructor(public rootComponent: BlockComponent) {
+    this.rootComponent.bindHotKey(
       {
         'Mod-z': ctx => {
           ctx.get('defaultState').event.preventDefault();
@@ -85,8 +85,8 @@ export class PageKeyboardManager {
   }
 
   private _createEmbedBlock() {
-    const rootElement = this.rootElement;
-    const [_, ctx] = this.rootElement.std.command
+    const rootComponent = this.rootComponent;
+    const [_, ctx] = this.rootComponent.std.command
       .chain()
       .getSelectedModels({
         types: ['block'],
@@ -103,20 +103,20 @@ export class PageKeyboardManager {
       return;
     }
 
-    const doc = rootElement.host.doc;
+    const doc = rootComponent.host.doc;
     const autofill = getTitleFromSelectedModels(selectedModels);
-    void promptDocTitle(rootElement.host, autofill).then(title => {
+    void promptDocTitle(rootComponent.host, autofill).then(title => {
       if (title === null) return;
       const linkedDoc = convertSelectedBlocksToLinkedDoc(
         doc,
         selectedModels,
         title
       );
-      const linkedDocService = rootElement.host.spec.getService(
+      const linkedDocService = rootComponent.host.spec.getService(
         'affine:embed-linked-doc'
       );
       linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
-      notifyDocCreated(rootElement.host, doc);
+      notifyDocCreated(rootComponent.host, doc);
     });
   }
 
@@ -134,7 +134,7 @@ export class PageKeyboardManager {
   }
 
   private get _doc() {
-    return this.rootElement.doc;
+    return this.rootComponent.doc;
   }
 
   private _replaceBlocksBySelection(
@@ -144,7 +144,7 @@ export class PageKeyboardManager {
   ) {
     const current = selections[0];
     const first = this._doc.getBlockById(current.blockId);
-    const firstElement = this.rootElement.host.view.getBlock(current.blockId);
+    const firstElement = this.rootComponent.host.view.getBlock(current.blockId);
 
     assertExists(first, `Cannot find block ${current.blockId}`);
     assertExists(firstElement, `Cannot find block view ${current.blockId}`);
@@ -169,6 +169,6 @@ export class PageKeyboardManager {
   }
 
   private get _selection() {
-    return this.rootElement.host.selection;
+    return this.rootComponent.host.selection;
   }
 }

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -433,11 +433,11 @@ export class RootService extends BlockService<RootBlockModel> {
   }
 
   get viewportElement() {
-    const rootElement = this.std.view.viewFromPath('block', [
+    const rootComponent = this.std.view.viewFromPath('block', [
       this.std.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
-    assertExists(rootElement);
-    const viewportElement = rootElement.viewportElement as HTMLElement | null;
+    assertExists(rootComponent);
+    const viewportElement = rootComponent.viewportElement as HTMLElement | null;
     assertExists(viewportElement);
     return viewportElement;
   }

--- a/packages/blocks/src/root-block/utils/callback.ts
+++ b/packages/blocks/src/root-block/utils/callback.ts
@@ -40,9 +40,9 @@ export async function onModelElementUpdated(
   const page = model.doc;
   assertExists(page.root);
 
-  const rootElement = editorHost.view.viewFromPath('block', [page.root.id]);
-  if (!rootElement) return;
-  await rootElement.updateComplete;
+  const rootComponent = editorHost.view.viewFromPath('block', [page.root.id]);
+  if (!rootComponent) return;
+  await rootComponent.updateComplete;
 
   const element = editorHost.view.viewFromPath('block', buildPath(model));
   if (element) callback(element);

--- a/packages/blocks/src/root-block/utils/guard.ts
+++ b/packages/blocks/src/root-block/utils/guard.ts
@@ -2,7 +2,7 @@ import type { BlockComponent } from '@blocksuite/block-std';
 
 import type { RootBlockComponent } from '../types.js';
 
-export function isRootElement(
+export function isRootComponent(
   block: BlockComponent
 ): block is RootBlockComponent {
   return (

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -1,6 +1,6 @@
 import type { BaseSelection } from '@blocksuite/block-std';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import {
   type ComputePositionConfig,
@@ -33,7 +33,7 @@ import './components/index.js';
 export const AFFINE_AI_PANEL_WIDGET = 'affine-ai-panel-widget';
 
 @customElement(AFFINE_AI_PANEL_WIDGET)
-export class AffineAIPanelWidget extends WidgetElement {
+export class AffineAIPanelWidget extends WidgetComponent {
   private _abortController = new AbortController();
 
   private _answer: string | null = null;

--- a/packages/blocks/src/root-block/widgets/code-language-list/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { sleep } from '@blocksuite/global/utils';
 import { offset } from '@floating-ui/dom';
 import { computed } from '@lit-labs/preact-signals';
@@ -15,7 +15,7 @@ export const AFFINE_CODE_LANGUAGE_LIST_WIDGET =
   'affine-code-language-list-widget';
 
 @customElement(AFFINE_CODE_LANGUAGE_LIST_WIDGET)
-export class AffineCodeLanguageListWidget extends WidgetElement<
+export class AffineCodeLanguageListWidget extends WidgetComponent<
   CodeBlockModel,
   CodeBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/code-toolbar/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { limitShift, shift } from '@floating-ui/dom';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -14,7 +14,7 @@ import { defaultItems, defaultMoreItems } from './config.js';
 
 export const AFFINE_CODE_TOOLBAR_WIDGET = 'affine-code-toolbar-widget';
 @customElement(AFFINE_CODE_TOOLBAR_WIDGET)
-export class AffineCodeToolbarWidget extends WidgetElement<
+export class AffineCodeToolbarWidget extends WidgetComponent<
   CodeBlockModel,
   CodeBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -5,7 +5,7 @@ import {
   BlockSelection,
   TextSelection,
 } from '@blocksuite/block-std';
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { computed } from '@lit-labs/preact-signals';
 import { css, html, nothing } from 'lit';
@@ -13,7 +13,7 @@ import { customElement } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { RemoteColorManager } from '../../../root-block/remote-color-manager/remote-color-manager.js';
-import { isRootElement } from '../../../root-block/utils/guard.js';
+import { isRootComponent } from '../../../root-block/utils/guard.js';
 import { cursorStyle, filterCoveringRects, selectionStyle } from './utils.js';
 
 export interface SelectionRect {
@@ -27,7 +27,7 @@ export const AFFINE_DOC_REMOTE_SELECTION_WIDGET =
   'affine-doc-remote-selection-widget';
 
 @customElement(AFFINE_DOC_REMOTE_SELECTION_WIDGET)
-export class AffineDocRemoteSelectionWidget extends WidgetElement {
+export class AffineDocRemoteSelectionWidget extends WidgetComponent {
   private _abortController = new AbortController();
 
   private _remoteColorManager: RemoteColorManager | null = null;
@@ -65,7 +65,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }
 
   private _getCursorRect(selections: BaseSelection[]): SelectionRect | null {
-    if (!isRootElement(this.block)) {
+    if (!isRootComponent(this.block)) {
       console.error('remote selection widget must be used in page component');
       return null;
     }
@@ -141,7 +141,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetElement {
   }
 
   private _getSelectionRect(selections: BaseSelection[]): SelectionRect[] {
-    if (!isRootElement(this.block)) {
+    if (!isRootComponent(this.block)) {
       console.error('remote selection widget must be used in page component');
       return [];
     }

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -5,7 +5,7 @@ import {
   PathFinder,
   type PointerEventState,
   type UIEventHandler,
-  WidgetElement,
+  WidgetComponent,
 } from '@blocksuite/block-std';
 import { Point } from '@blocksuite/global/utils';
 import { Bound } from '@blocksuite/global/utils';
@@ -83,7 +83,7 @@ import {
 export const AFFINE_DRAG_HANDLE_WIDGET = 'affine-drag-handle-widget';
 
 @customElement(AFFINE_DRAG_HANDLE_WIDGET)
-export class AffineDragHandleWidget extends WidgetElement<
+export class AffineDragHandleWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent | PageRootBlockComponent
 > {
@@ -146,7 +146,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     if (noteBlock.doc.id !== this.doc.id) return false;
 
     if (isInsidePageEditor(this.host)) return true;
-    const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+    const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
 
     const noteBlockId = noteBlock.path[noteBlock.path.length - 1];
     return (
@@ -169,7 +169,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       return;
     }
 
-    const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+    const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
     const editing = edgelessRoot.service.selection.editing;
     const selectedElements = edgelessRoot.service.selection.selectedElements;
     if (editing || selectedElements.length !== 1) {
@@ -287,14 +287,14 @@ export class AffineDragHandleWidget extends WidgetElement<
 
       dragPreview.style.opacity = altKey ? '1' : '0.5';
     }
-    this.rootElement.append(dragPreview);
+    this.rootComponent.append(dragPreview);
     return dragPreview;
   };
 
   private _createDropIndicator = () => {
     if (!this.dropIndicator) {
       this.dropIndicator = new DropIndicator();
-      this.rootElement.append(this.dropIndicator);
+      this.rootComponent.append(this.dropIndicator);
     }
   };
 
@@ -457,7 +457,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     const point = new Point(state.raw.x, state.raw.y);
     const closestBlock = getClosestBlockByPoint(
       this.host,
-      this.rootElement,
+      this.rootComponent,
       point
     );
     if (!closestBlock) return null;
@@ -697,7 +697,7 @@ export class AffineDragHandleWidget extends WidgetElement<
       });
       if (isSurfaceComponent) return true;
 
-      const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+      const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
 
       const { left: viewportLeft, top: viewportTop } = edgelessRoot.viewport;
 
@@ -975,7 +975,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     const point = new Point(state.raw.x, state.raw.y);
     const closestBlock = getClosestBlockByPoint(
       this.host,
-      this.rootElement,
+      this.rootComponent,
       point
     );
     if (!closestBlock) {
@@ -1181,7 +1181,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
   private _showDragHandleOnTopLevelBlocks = async () => {
     if (isInsidePageEditor(this.host)) return;
-    const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+    const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
     await edgelessRoot.surface.updateComplete;
 
     if (!this._anchorBlockPath) return;
@@ -1282,7 +1282,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
     const closestNoteBlock = getClosestNoteBlock(
       this.host,
-      this.rootElement,
+      this.rootComponent,
       point
     ) as NoteBlockComponent | null;
 
@@ -1354,7 +1354,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     const point = new Point(state.raw.x, state.raw.y);
     const closestNoteBlock = getClosestNoteBlock(
       this.host,
-      this.rootElement,
+      this.rootComponent,
       point
     );
     if (
@@ -1368,7 +1368,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     }
 
     this.lastDragPointerState = state;
-    if (this.rootElement instanceof PageRootBlockComponent) {
+    if (this.rootComponent instanceof PageRootBlockComponent) {
       if (!shouldAutoScroll) return;
 
       const result = autoScroll(this.scrollContainer, state.raw.y);
@@ -1467,7 +1467,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     edgelessElement: EdgelessBlockModel
   ): Rect | null {
     if (isInsidePageEditor(this.host)) return null;
-    const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+    const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
 
     const rect = getSelectedRect([edgelessElement]);
     let [left, top] = edgelessRoot.service.viewport.toViewCoord(
@@ -1499,7 +1499,7 @@ export class AffineDragHandleWidget extends WidgetElement<
   }
 
   private get scrollContainer() {
-    return getScrollContainer(this.rootElement!);
+    return getScrollContainer(this.rootComponent!);
   }
 
   override connectedCallback() {
@@ -1564,7 +1564,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     if (isInsidePageEditor(this.host)) {
       this._disposables.add(this.doc.slots.blockUpdated.on(() => this._hide()));
 
-      const pageRoot = this.rootElement as PageRootBlockComponent;
+      const pageRoot = this.rootComponent as PageRootBlockComponent;
       this._disposables.add(
         pageRoot.slots.viewportUpdated.on(() => {
           this._hide();
@@ -1580,7 +1580,7 @@ export class AffineDragHandleWidget extends WidgetElement<
         this._updateDropIndicatorOnScroll
       );
     } else if (isInsideEdgelessEditor(this.host)) {
-      const edgelessRoot = this.rootElement as EdgelessRootBlockComponent;
+      const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
 
       this._disposables.add(
         edgelessRoot.slots.edgelessToolUpdated.on(
@@ -1657,7 +1657,7 @@ export class AffineDragHandleWidget extends WidgetElement<
 
   get anchorEdgelessElement(): EdgelessBlockModel | null {
     if (isInsidePageEditor(this.host) || !this._anchorBlockId) return null;
-    const { service } = this.rootElement as EdgelessRootBlockComponent;
+    const { service } = this.rootComponent as EdgelessRootBlockComponent;
     const edgelessElement = service.getElementById(this._anchorBlockId);
     return isTopLevelBlock(edgelessElement) ? edgelessElement : null;
   }
@@ -1666,7 +1666,7 @@ export class AffineDragHandleWidget extends WidgetElement<
     return AffineDragHandleWidget.staticOptionRunner;
   }
 
-  get rootElement() {
+  get rootComponent() {
     return this.block as PageRootBlockComponent | EdgelessRootBlockComponent;
   }
 

--- a/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
@@ -155,20 +155,24 @@ export const isOutOfNoteBlock = (
 
 export const getClosestNoteBlock = (
   editorHost: EditorHost,
-  rootElement: BlockComponent,
+  rootComponent: BlockComponent,
   point: Point
 ) => {
   return isInsidePageEditor(editorHost)
-    ? findClosestBlockComponent(rootElement, point, 'affine-note')
+    ? findClosestBlockComponent(rootComponent, point, 'affine-note')
     : getHoveringNote(point)?.closest('affine-edgeless-note');
 };
 
 export const getClosestBlockByPoint = (
   editorHost: EditorHost,
-  rootElement: BlockComponent,
+  rootComponent: BlockComponent,
   point: Point
 ) => {
-  const closestNoteBlock = getClosestNoteBlock(editorHost, rootElement, point);
+  const closestNoteBlock = getClosestNoteBlock(
+    editorHost,
+    rootComponent,
+    point
+  );
   if (!closestNoteBlock || closestNoteBlock.closest('.affine-surface-ref')) {
     return null;
   }

--- a/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import { type TemplateResult, css, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -105,7 +105,7 @@ export const AFFINE_EDGELESS_AUTO_CONNECT_WIDGET =
   'affine-edgeless-auto-connect-widget';
 
 @customElement(AFFINE_EDGELESS_AUTO_CONNECT_WIDGET)
-export class EdgelessAutoConnectWidget extends WidgetElement<
+export class EdgelessAutoConnectWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent,
   EdgelessRootService

--- a/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-copilot/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import {
   autoUpdate,
@@ -29,7 +29,7 @@ import { EdgelessCopilotPanel } from '../edgeless-copilot-panel/index.js';
 export const AFFINE_EDGELESS_COPILOT_WIDGET = 'affine-edgeless-copilot-widget';
 
 @customElement(AFFINE_EDGELESS_COPILOT_WIDGET)
-export class EdgelessCopilotWidget extends WidgetElement<
+export class EdgelessCopilotWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-remote-selection/index.ts
@@ -1,6 +1,6 @@
 import type { UserInfo } from '@blocksuite/store';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -23,7 +23,7 @@ export const AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET =
   'affine-edgeless-remote-selection-widget';
 
 @customElement(AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET)
-export class EdgelessRemoteSelectionWidget extends WidgetElement<
+export class EdgelessRemoteSelectionWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-zoom-toolbar/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { css, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
@@ -12,7 +12,7 @@ export const AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET =
   'affine-edgeless-zoom-toolbar-widget';
 
 @customElement(AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET)
-export class AffineEdgelessZoomToolbarWidget extends WidgetElement<
+export class AffineEdgelessZoomToolbarWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { type TemplateResult, css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { join } from 'lit/directives/join.js';
@@ -101,7 +101,7 @@ export const EDGELESS_ELEMENT_TOOLBAR_WIDGET =
   'edgeless-element-toolbar-widget';
 
 @customElement(EDGELESS_ELEMENT_TOOLBAR_WIDGET)
-export class EdgelessElementToolbarWidget extends WidgetElement<
+export class EdgelessElementToolbarWidget extends WidgetComponent<
   RootBlockModel,
   EdgelessRootBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlockModel, DocCollection, Slice } from '@blocksuite/store';
 import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
@@ -68,7 +68,7 @@ import { embedCardToolbarStyle } from './styles.js';
 export const AFFINE_EMBED_CARD_TOOLBAR_WIDGET = 'affine-embed-card-toolbar';
 
 @customElement(AFFINE_EMBED_CARD_TOOLBAR_WIDGET)
-export class EmbedCardToolbar extends WidgetElement<
+export class EmbedCardToolbar extends WidgetComponent<
   RootBlockModel,
   RootBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/components/paragraph-button.ts
@@ -15,7 +15,7 @@ import '../../../../_common/components/toolbar/icon-button.js';
 import '../../../../_common/components/toolbar/menu-button.js';
 import { textConversionConfigs } from '../../../../_common/configs/text-conversion.js';
 import { ArrowDownIcon } from '../../../../_common/icons/index.js';
-import { isRootElement } from '../../../../root-block/utils/guard.js';
+import { isRootComponent } from '../../../../root-block/utils/guard.js';
 
 interface ParagraphPanelProps {
   host: EditorHost;
@@ -75,8 +75,8 @@ export const ParagraphButton = (formatBar: AffineFormatBarWidget) => {
             (selectedBlocks[0].model as ParagraphBlockModel).type === type
         )?.icon ?? textConversionConfigs[0].icon;
 
-  const rootElement = formatBar.block;
-  if (!isRootElement(rootElement)) {
+  const rootComponent = formatBar.block;
+  if (!isRootComponent(rootComponent)) {
     console.error('paragraph button host is not a page component');
     return null;
   }

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -4,7 +4,7 @@ import type {
   CursorSelection,
 } from '@blocksuite/block-std';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { DisposableGroup, assertExists } from '@blocksuite/global/utils';
 import {
   type Placement,
@@ -28,7 +28,7 @@ import {
 import '../../../_common/components/toolbar/toolbar.js';
 import { matchFlavours } from '../../../_common/utils/model.js';
 import { isFormatSupported } from '../../../note-block/commands/utils.js';
-import { isRootElement } from '../../../root-block/utils/guard.js';
+import { isRootComponent } from '../../../root-block/utils/guard.js';
 import { ConfigRenderer } from './components/config-renderer.js';
 import {
   type FormatBarConfigItem,
@@ -42,7 +42,7 @@ import { formatBarStyle } from './styles.js';
 export const AFFINE_FORMAT_BAR_WIDGET = 'affine-format-bar-widget';
 
 @customElement(AFFINE_FORMAT_BAR_WIDGET)
-export class AffineFormatBarWidget extends WidgetElement {
+export class AffineFormatBarWidget extends WidgetComponent {
   private _abortController = new AbortController();
 
   private _floatDisposables: DisposableGroup | null = null;
@@ -54,7 +54,7 @@ export class AffineFormatBarWidget extends WidgetElement {
   static override styles = formatBarStyle;
 
   private _calculatePlacement() {
-    const rootElement = this.block;
+    const rootComponent = this.block;
 
     this.handleEvent('pointerMove', ctx => {
       this._dragging = ctx.get('pointerState').dragging;
@@ -102,11 +102,11 @@ export class AffineFormatBarWidget extends WidgetElement {
     this.disposables.add(
       this._selectionManager.slots.changed.on(() => {
         const update = async () => {
-          const textSelection = rootElement.selection.find('text');
-          const blockSelections = rootElement.selection.filter('block');
+          const textSelection = rootComponent.selection.find('text');
+          const blockSelections = rootComponent.selection.filter('block');
 
           // Should not re-render format bar when only cursor selection changed in edgeless
-          const cursorSelection = rootElement.selection.find('cursor');
+          const cursorSelection = rootComponent.selection.find('cursor');
           if (cursorSelection) {
             if (!this._lastCursor) {
               this._lastCursor = cursorSelection;
@@ -130,7 +130,7 @@ export class AffineFormatBarWidget extends WidgetElement {
               block.model.role === 'content'
             ) {
               this._displayType = 'text';
-              assertExists(rootElement.host.rangeManager);
+              assertExists(rootComponent.host.rangeManager);
 
               this.host.std.command
                 .chain()
@@ -481,9 +481,9 @@ export class AffineFormatBarWidget extends WidgetElement {
     super.connectedCallback();
     this._abortController = new AbortController();
 
-    const rootElement = this.block;
-    assertExists(rootElement);
-    const widgets = rootElement.widgets;
+    const rootComponent = this.block;
+    assertExists(rootComponent);
+    const widgets = rootComponent.widgets;
 
     // check if the host use the format bar widget
     if (!Object.hasOwn(widgets, AFFINE_FORMAT_BAR_WIDGET)) {
@@ -491,9 +491,9 @@ export class AffineFormatBarWidget extends WidgetElement {
     }
 
     // check if format bar widget support the host
-    if (!isRootElement(rootElement)) {
+    if (!isRootComponent(rootComponent)) {
       console.error(
-        `format bar not support rootElement: ${rootElement.constructor.name} but its widgets has format bar`
+        `format bar not support rootComponent: ${rootComponent.constructor.name} but its widgets has format bar`
       );
       return;
     }

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { limitShift, shift } from '@floating-ui/dom';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -15,7 +15,7 @@ import { commonConfig, moreMenuConfig } from './config.js';
 export const AFFINE_IMAGE_TOOLBAR_WIDGET = 'affine-image-toolbar-widget';
 
 @customElement(AFFINE_IMAGE_TOOLBAR_WIDGET)
-export class AffineImageToolbarWidget extends WidgetElement<
+export class AffineImageToolbarWidget extends WidgetComponent<
   ImageBlockModel,
   ImageBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/inner-modal/inner-modal.ts
+++ b/packages/blocks/src/root-block/widgets/inner-modal/inner-modal.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import {
   type FloatingElement,
   type ReferenceElement,
@@ -12,7 +12,7 @@ import { customElement } from 'lit/decorators.js';
 export const AFFINE_INNER_MODAL_WIDGET = 'affine-inner-modal-widget';
 
 @customElement(AFFINE_INNER_MODAL_WIDGET)
-export class AffineInnerModalWidget extends WidgetElement {
+export class AffineInnerModalWidget extends WidgetComponent {
   private _getTarget?: () => ReferenceElement;
 
   open(

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -1,6 +1,6 @@
 import type { EditorHost, UIEventStateContext } from '@blocksuite/block-std';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import {
   DisposableGroup,
   assertExists,
@@ -86,7 +86,7 @@ export function showLinkedDocPopover({
 export const AFFINE_LINKED_DOC_WIDGET = 'affine-linked-doc-widget';
 
 @customElement(AFFINE_LINKED_DOC_WIDGET)
-export class AffineLinkedDocWidget extends WidgetElement {
+export class AffineLinkedDocWidget extends WidgetComponent {
   private _onKeyDown = (ctx: UIEventStateContext) => {
     const eventState = ctx.get('keyboardState');
     const event = eventState.raw;

--- a/packages/blocks/src/root-block/widgets/modal/modal.ts
+++ b/packages/blocks/src/root-block/widgets/modal/modal.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -7,7 +7,7 @@ import { createCustomModal } from './custom-modal.js';
 export const AFFINE_MODAL_WIDGET = 'affine-modal-widget';
 
 @customElement(AFFINE_MODAL_WIDGET)
-export class AffineModalWidget extends WidgetElement {
+export class AffineModalWidget extends WidgetComponent {
   open(options: Parameters<typeof createCustomModal>[0]) {
     return createCustomModal(options, this.ownerDocument.body);
   }

--- a/packages/blocks/src/root-block/widgets/page-dragging-area/page-dragging-area.ts
+++ b/packages/blocks/src/root-block/widgets/page-dragging-area/page-dragging-area.ts
@@ -1,6 +1,6 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 
-import { BlockComponent, WidgetElement } from '@blocksuite/block-std';
+import { BlockComponent, WidgetComponent } from '@blocksuite/block-std';
 import { assertInstanceOf } from '@blocksuite/global/utils';
 import { html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -29,7 +29,7 @@ export const AFFINE_PAGE_DRAGGING_AREA_WIDGET =
   'affine-page-dragging-area-widget';
 
 @customElement(AFFINE_PAGE_DRAGGING_AREA_WIDGET)
-export class AffinePageDraggingAreaWidget extends WidgetElement<
+export class AffinePageDraggingAreaWidget extends WidgetComponent<
   RootBlockModel,
   PageRootBlockComponent
 > {
@@ -184,9 +184,9 @@ export class AffinePageDraggingAreaWidget extends WidgetElement<
   }
 
   private get _viewport() {
-    const rootElement = this.block;
-    if (!rootElement) return;
-    return rootElement.viewport;
+    const rootComponent = this.block;
+    if (!rootComponent) return;
+    return rootComponent.viewport;
   }
 
   private get scrollContainer() {

--- a/packages/blocks/src/root-block/widgets/pie-menu/base.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/base.ts
@@ -16,7 +16,7 @@ export interface PieMenuSchema {
 
   trigger: (props: {
     keyEvent: KeyboardEvent;
-    rootElement: EdgelessRootBlockComponent;
+    rootComponent: EdgelessRootBlockComponent;
   }) => boolean;
 }
 
@@ -45,9 +45,9 @@ export interface PieRootNodeModel extends PieBaseNodeModel {
 }
 
 export type PieMenuContext = {
-  rootElement: EdgelessRootBlockComponent;
+  rootComponent: EdgelessRootBlockComponent;
   menu: PieMenu;
-  widgetElement: AffinePieMenuWidget;
+  widgetComponent: AffinePieMenuWidget;
   node: PieNode;
 };
 export type ActionFunction = (ctx: PieMenuContext) => void;

--- a/packages/blocks/src/root-block/widgets/pie-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/config.ts
@@ -61,9 +61,9 @@ const pie = new PieMenuBuilder({
   id: AFFINE_PIE_MENU_ID_EDGELESS_TOOLS,
   label: 'Tools',
   icon: ToolsIcon,
-  trigger: ({ keyEvent: ev, rootElement }) => {
+  trigger: ({ keyEvent: ev, rootComponent }) => {
     if (isControlledKeyboardEvent(ev)) return false;
-    const isEditing = rootElement.service.selection.editing;
+    const isEditing = rootComponent.service.selection.editing;
 
     return ev.key === 'q' && !isEditing;
   },
@@ -77,8 +77,8 @@ pie.expandableCommand({
     pie.colorPicker({
       label: 'Pen Color',
       active: getActiveConnectorStrokeColor,
-      onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-        rootElement.service.editPropsStore.recordLastProps('brush', {
+      onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+        rootComponent.service.editPropsStore.recordLastProps('brush', {
           color: color as LastProps['brush']['color'],
         });
       },
@@ -125,15 +125,15 @@ pie.command({
 pie.command({
   label: 'Reset Zoom',
   icon: ViewBarIcon,
-  action: ({ rootElement }) => {
-    rootElement.service.zoomToFit();
+  action: ({ rootComponent }) => {
+    rootComponent.service.zoomToFit();
   },
 });
 
 pie.command({
   label: 'Present',
-  icon: ({ rootElement }) => {
-    const { type } = rootElement.edgelessTool;
+  icon: ({ rootComponent }) => {
+    const { type } = rootComponent.edgelessTool;
     if (type === 'frameNavigator') {
       return html`
         <span
@@ -148,10 +148,10 @@ pie.command({
 
     return FrameNavigatorIcon;
   },
-  action: ({ rootElement }) => {
-    const { type } = rootElement.edgelessTool;
+  action: ({ rootComponent }) => {
+    const { type } = rootComponent.edgelessTool;
     if (type === 'frameNavigator') {
-      rootElement.tools.setEdgelessTool({ type: 'default' });
+      rootComponent.tools.setEdgelessTool({ type: 'default' });
 
       if (document.fullscreenElement) {
         document.exitFullscreen().catch(console.error);
@@ -160,7 +160,7 @@ pie.command({
       return;
     }
 
-    rootElement.tools.setEdgelessTool({
+    rootComponent.tools.setEdgelessTool({
       type: 'frameNavigator',
       mode: 'fit',
     });
@@ -169,8 +169,8 @@ pie.command({
 // Connector submenu
 pie.beginSubmenu({
   label: 'Connector',
-  icon: ({ rootElement }) => {
-    const tool = rootElement.edgelessTool;
+  icon: ({ rootComponent }) => {
+    const tool = rootComponent.edgelessTool;
 
     if (tool.type === 'connector') {
       switch (tool.mode) {
@@ -216,8 +216,8 @@ pie.command({
 pie.colorPicker({
   label: 'Line Color',
   active: getActiveConnectorStrokeColor,
-  onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.recordLastProps('connector', {
+  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+    rootComponent.service.editPropsStore.recordLastProps('connector', {
       stroke: color as LastProps['connector']['stroke'],
     });
   },
@@ -262,59 +262,59 @@ const shapes = [
 shapes.forEach(shape => {
   pie.command({
     label: shape.label,
-    icon: ({ rootElement }) => {
+    icon: ({ rootComponent }) => {
       const attributes =
-        rootElement.service.editPropsStore.getLastProps('shape');
+        rootComponent.service.editPropsStore.getLastProps('shape');
       return shape.icon(attributes.shapeStyle);
     },
 
-    action: ({ rootElement }) => {
-      rootElement.service.tool.setEdgelessTool({
+    action: ({ rootComponent }) => {
+      rootComponent.service.tool.setEdgelessTool({
         type: 'shape',
         shapeType: shape.type,
       });
-      rootElement.service.editPropsStore.recordLastProps('shape', {
+      rootComponent.service.editPropsStore.recordLastProps('shape', {
         shapeType: shape.type,
       });
-      updateShapeOverlay(rootElement);
+      updateShapeOverlay(rootComponent);
     },
   });
 });
 
 pie.command({
   label: 'Toggle Style',
-  icon: ({ rootElement }) => {
+  icon: ({ rootComponent }) => {
     const { shapeStyle } =
-      rootElement.service.editPropsStore.getLastProps('shape');
+      rootComponent.service.editPropsStore.getLastProps('shape');
     return shapeStyle === ShapeStyle.General
       ? ScribbledStyleIcon
       : GeneralStyleIcon;
   },
 
-  action: ({ rootElement }) => {
+  action: ({ rootComponent }) => {
     const { shapeStyle } =
-      rootElement.service.editPropsStore.getLastProps('shape');
+      rootComponent.service.editPropsStore.getLastProps('shape');
     const toggleType =
       shapeStyle === ShapeStyle.General
         ? ShapeStyle.Scribbled
         : ShapeStyle.General;
 
-    rootElement.service.editPropsStore.recordLastProps('shape', {
+    rootComponent.service.editPropsStore.recordLastProps('shape', {
       shapeStyle: toggleType,
     });
 
-    updateShapeOverlay(rootElement);
+    updateShapeOverlay(rootComponent);
   },
 });
 
 pie.colorPicker({
   label: 'Fill',
   active: getActiveShapeColor('fill'),
-  onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.recordLastProps('shape', {
+  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+    rootComponent.service.editPropsStore.recordLastProps('shape', {
       fillColor: color as LastProps['shape']['fillColor'],
     });
-    updateShapeOverlay(rootElement);
+    updateShapeOverlay(rootComponent);
   },
   colors: FILL_COLORS.map(color => ({ color })),
 });
@@ -323,11 +323,11 @@ pie.colorPicker({
   label: 'Stroke',
   hollow: true,
   active: getActiveShapeColor('stroke'),
-  onChange: (color: CssVariableName, { rootElement }: PieMenuContext) => {
-    rootElement.service.editPropsStore.recordLastProps('shape', {
+  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+    rootComponent.service.editPropsStore.recordLastProps('shape', {
       strokeColor: color as LastProps['shape']['strokeColor'],
     });
-    updateShapeOverlay(rootElement);
+    updateShapeOverlay(rootComponent);
   },
   colors: STROKE_COLORS.map(color => ({ color, name: 'Color' })),
 });

--- a/packages/blocks/src/root-block/widgets/pie-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/index.ts
@@ -1,7 +1,7 @@
 import type { UIEventStateContext } from '@blocksuite/block-std';
 import type { IVec } from '@blocksuite/global/utils';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { noop } from '@blocksuite/global/utils';
 import { nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -25,7 +25,7 @@ noop(PieNodeChild);
 export const AFFINE_PIE_MENU_WIDGET = 'affine-pie-menu-widget';
 
 @customElement(AFFINE_PIE_MENU_WIDGET)
-export class AffinePieMenuWidget extends WidgetElement {
+export class AffinePieMenuWidget extends WidgetComponent {
   private _handleCursorPos = (ctx: UIEventStateContext) => {
     const ev = ctx.get('pointerState');
     const { x, y } = ev.point;
@@ -37,7 +37,7 @@ export class AffinePieMenuWidget extends WidgetElement {
     const ev = ctx.get('keyboardState');
     const { trigger } = this.currentMenu.schema;
 
-    if (trigger({ keyEvent: ev.raw, rootElement: this.rootElement })) {
+    if (trigger({ keyEvent: ev.raw, rootComponent: this.rootComponent })) {
       clearTimeout(this.selectOnTrigRelease.timeout);
       if (this.selectOnTrigRelease.allow) {
         this.currentMenu.selectHovered();
@@ -61,7 +61,7 @@ export class AffinePieMenuWidget extends WidgetElement {
     const menu = this._createMenu(schema, {
       x,
       y,
-      widgetElement: this,
+      widgetComponent: this,
     });
     this.currentMenu = menu;
 
@@ -77,19 +77,19 @@ export class AffinePieMenuWidget extends WidgetElement {
     {
       x,
       y,
-      widgetElement,
+      widgetComponent,
     }: {
       x: number;
       y: number;
-      widgetElement: AffinePieMenuWidget;
+      widgetComponent: AffinePieMenuWidget;
     }
   ) {
     const menu = new PieMenu();
     menu.id = schema.id;
     menu.schema = schema;
     menu.position = [x, y];
-    menu.rootElement = widgetElement.rootElement;
-    menu.widgetElement = widgetElement;
+    menu.rootComponent = widgetComponent.rootComponent;
+    menu.widgetComponent = widgetComponent;
     menu.abortController.signal.addEventListener(
       'abort',
       this._onMenuClose.bind(this)
@@ -99,7 +99,7 @@ export class AffinePieMenuWidget extends WidgetElement {
   }
 
   private _initPie() {
-    PieManager.setup({ rootElement: this.rootElement });
+    PieManager.setup({ rootComponent: this.rootComponent });
 
     this._disposables.add(
       PieManager.slots.open.on(this._attachMenu.bind(this))
@@ -147,10 +147,10 @@ export class AffinePieMenuWidget extends WidgetElement {
     return !!this.currentMenu;
   }
 
-  get rootElement(): EdgelessRootBlockComponent {
-    const rootElement = this.block;
-    if (rootElement instanceof EdgelessRootBlockComponent) {
-      return rootElement;
+  get rootComponent(): EdgelessRootBlockComponent {
+    const rootComponent = this.block;
+    if (rootComponent instanceof EdgelessRootBlockComponent) {
+      return rootComponent;
     }
     throw new Error('AffinePieMenuWidget is only supported in edgeless');
   }

--- a/packages/blocks/src/root-block/widgets/pie-menu/menu.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/menu.ts
@@ -134,7 +134,7 @@ export class PieMenu extends WithDisposable(LitElement) {
 
   private _setupEvents() {
     this._disposables.addFromEvent(
-      this.widgetElement,
+      this.widgetComponent,
       'pointermove',
       this._handlePointerMove
     );
@@ -283,11 +283,11 @@ export class PieMenu extends WithDisposable(LitElement) {
   accessor position!: IVec;
 
   @property({ attribute: false })
-  accessor rootElement!: EdgelessRootBlockComponent;
+  accessor rootComponent!: EdgelessRootBlockComponent;
 
   @property({ attribute: false })
   accessor schema!: PieMenuSchema;
 
   @property({ attribute: false })
-  accessor widgetElement!: AffinePieMenuWidget;
+  accessor widgetComponent!: AffinePieMenuWidget;
 }

--- a/packages/blocks/src/root-block/widgets/pie-menu/node.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/node.ts
@@ -120,9 +120,9 @@ export class PieNode extends WithDisposable(LitElement) {
     if (isRootNode(schema)) return;
 
     const ctx = {
-      rootElement: this.menu.rootElement,
+      rootComponent: this.menu.rootComponent,
       menu: this.menu,
-      widgetElement: this.menu.widgetElement,
+      widgetComponent: this.menu.widgetComponent,
       node: this,
     };
 
@@ -139,8 +139,13 @@ export class PieNode extends WithDisposable(LitElement) {
     const icon = this.model.icon;
     if (typeof icon === 'function') {
       const { menu } = this;
-      const { rootElement, widgetElement } = menu;
-      return icon({ rootElement, menu, widgetElement, node: this });
+      const { rootComponent, widgetComponent } = menu;
+      return icon({
+        rootComponent,
+        menu,
+        widgetComponent,
+        node: this,
+      });
     }
     return icon;
   }

--- a/packages/blocks/src/root-block/widgets/pie-menu/pie-manager.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/pie-manager.ts
@@ -61,16 +61,16 @@ export class PieManager {
     this.registeredSchemas[id] = schema;
   }
 
-  private static _setupTriggers(rootElement: EdgelessRootBlockComponent) {
+  private static _setupTriggers(rootComponent: EdgelessRootBlockComponent) {
     Object.values(this.registeredSchemas).forEach(schema => {
       const { trigger } = schema;
 
-      rootElement.handleEvent(
+      rootComponent.handleEvent(
         'keyDown',
         ctx => {
           const ev = ctx.get('keyboardState');
 
-          if (trigger({ keyEvent: ev.raw, rootElement }) && !ev.raw.repeat) {
+          if (trigger({ keyEvent: ev.raw, rootComponent }) && !ev.raw.repeat) {
             this.open(schema.id);
           }
         },
@@ -95,8 +95,12 @@ export class PieManager {
     return this.schemas.delete(schema);
   }
 
-  static setup({ rootElement }: { rootElement: EdgelessRootBlockComponent }) {
+  static setup({
+    rootComponent,
+  }: {
+    rootComponent: EdgelessRootBlockComponent;
+  }) {
     this.schemas.forEach(schema => this._register(schema));
-    this._setupTriggers(rootElement);
+    this._setupTriggers(rootComponent);
   }
 }

--- a/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
@@ -16,17 +16,17 @@ import type {
 import { ShapeToolController } from '../../edgeless/controllers/tools/shape-tool.js';
 import { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
-export function updateShapeOverlay(rootElement: EdgelessRootBlockComponent) {
-  const controller = rootElement.tools.currentController;
+export function updateShapeOverlay(rootComponent: EdgelessRootBlockComponent) {
+  const controller = rootComponent.tools.currentController;
   if (controller instanceof ShapeToolController) {
     controller.createOverlay();
   }
 }
 
 export function getActiveShapeColor(type: 'fill' | 'stroke') {
-  return ({ rootElement }: PieMenuContext) => {
-    if (rootElement instanceof EdgelessRootBlockComponent) {
-      const props = rootElement.service.editPropsStore.getLastProps('shape');
+  return ({ rootComponent }: PieMenuContext) => {
+    if (rootComponent instanceof EdgelessRootBlockComponent) {
+      const props = rootComponent.service.editPropsStore.getLastProps('shape');
       if (type == 'fill') return props.fillColor;
       else return props.strokeColor;
     }
@@ -34,17 +34,20 @@ export function getActiveShapeColor(type: 'fill' | 'stroke') {
   };
 }
 
-export function getActiveConnectorStrokeColor({ rootElement }: PieMenuContext) {
-  if (rootElement instanceof EdgelessRootBlockComponent) {
-    const props = rootElement.service.editPropsStore.getLastProps('connector');
+export function getActiveConnectorStrokeColor({
+  rootComponent,
+}: PieMenuContext) {
+  if (rootComponent instanceof EdgelessRootBlockComponent) {
+    const props =
+      rootComponent.service.editPropsStore.getLastProps('connector');
     return props.stroke;
   }
   return '';
 }
 
 export function setEdgelessToolAction(tool: EdgelessTool): ActionFunction {
-  return ({ rootElement }) => {
-    rootElement.service.tool.setEdgelessTool(tool);
+  return ({ rootComponent }) => {
+    rootComponent.service.tool.setEdgelessTool(tool);
   };
 }
 

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -118,7 +118,7 @@ export type SlashMenuItemGenerator = (
 ) => (SlashMenuGroupDivider | SlashMenuActionItem | SlashSubMenu)[];
 
 export type SlashMenuContext = {
-  rootElement: RootBlockComponent;
+  rootComponent: RootBlockComponent;
   model: BlockModel;
 };
 
@@ -150,9 +150,9 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         showWhen: ({ model }) =>
           model.doc.schema.flavourSchemaMap.has(config.flavour) &&
           !insideDatabase(model),
-        action: ({ rootElement }) => {
+        action: ({ rootComponent }) => {
           const { flavour, type } = config;
-          rootElement.host.std.command
+          rootComponent.host.std.command
             .chain()
             .updateBlockType({
               flavour,
@@ -171,7 +171,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
                   return false;
                 }
                 const codeModel = newModels[0];
-                onModelTextUpdated(rootElement.host, codeModel, richText => {
+                onModelTextUpdated(rootComponent.host, codeModel, richText => {
                   const inlineEditor = richText.inlineEditor;
                   assertExists(inlineEditor);
                   inlineEditor.focusEnd();
@@ -208,14 +208,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         name,
         icon,
         tooltip: slashMenuToolTips[name],
-        action: ({ rootElement, model }) => {
+        action: ({ rootComponent, model }) => {
           if (!model.text) {
             return;
           }
           const len = model.text.length;
           if (!len) {
             const inlineEditor = getInlineEditorByModel(
-              rootElement.host,
+              rootComponent.host,
               model
             );
             assertExists(
@@ -241,9 +241,9 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       description: 'Start a new document.',
       icon: NewDocIcon,
       tooltip: slashMenuToolTips['New Doc'],
-      action: ({ rootElement, model }) => {
-        const newDoc = createDefaultDoc(rootElement.doc.collection);
-        insertContent(rootElement.host, model, REFERENCE_NODE, {
+      action: ({ rootComponent, model }) => {
+        const newDoc = createDefaultDoc(rootComponent.doc.collection);
+        insertContent(rootComponent.host, model, REFERENCE_NODE, {
           reference: {
             type: 'LinkedPage',
             pageId: newDoc.id,
@@ -257,9 +257,9 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: LinkedDocIcon,
       tooltip: slashMenuToolTips['Linked Doc'],
       alias: ['dual link'],
-      showWhen: ({ rootElement }) => {
+      showWhen: ({ rootComponent }) => {
         const linkedDocWidgetEle =
-          rootElement.widgetElements['affine-linked-doc-widget'];
+          rootComponent.widgetComponents['affine-linked-doc-widget'];
         if (!linkedDocWidgetEle) return false;
         if (!('showLinkedDoc' in linkedDocWidgetEle)) {
           console.warn(
@@ -269,18 +269,21 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         }
         return true;
       },
-      action: ({ model, rootElement }) => {
+      action: ({ model, rootComponent }) => {
         const triggerKey = '@';
-        insertContent(rootElement.host, model, triggerKey);
+        insertContent(rootComponent.host, model, triggerKey);
         assertExists(model.doc.root);
         const widgetEle =
-          rootElement.widgetElements['affine-linked-doc-widget'];
+          rootComponent.widgetComponents['affine-linked-doc-widget'];
         assertExists(widgetEle);
         // We have checked the existence of showLinkedDoc method in the showWhen
         const linkedDocWidget = widgetEle as AffineLinkedDocWidget;
         // Wait for range to be updated
         setTimeout(() => {
-          const inlineEditor = getInlineEditorByModel(rootElement.host, model);
+          const inlineEditor = getInlineEditorByModel(
+            rootComponent.host,
+            model
+          );
           assertExists(inlineEditor);
           linkedDocWidget.showLinkedDoc(inlineEditor, triggerKey);
         });
@@ -297,8 +300,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:image') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parent = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parent = rootComponent.doc.getParent(model);
         if (!parent) {
           return;
         }
@@ -306,10 +309,15 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         const imageFiles = await getImageFilesFromLocal();
         if (!imageFiles.length) return;
 
-        const imageService = rootElement.host.spec.getService('affine:image');
+        const imageService = rootComponent.host.spec.getService('affine:image');
         const maxFileSize = imageService.maxFileSize;
 
-        addSiblingImageBlock(rootElement.host, imageFiles, maxFileSize, model);
+        addSiblingImageBlock(
+          rootComponent.host,
+          imageFiles,
+          maxFileSize,
+          model
+        );
         tryRemoveEmptyLine(model);
       },
     },
@@ -321,14 +329,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:bookmark') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parentModel = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
           return;
         }
         const index = parentModel.children.indexOf(model) + 1;
         await toggleEmbedCardCreateModal(
-          rootElement.host,
+          rootComponent.host,
           'Links',
           'The added link will be displayed as a card view.',
           { mode: 'page', parentModel, index }
@@ -345,17 +353,17 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:attachment') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
+      action: async ({ rootComponent, model }) => {
         const file = await openFileOrFiles();
         if (!file) return;
 
         const attachmentService =
-          rootElement.host.spec.getService('affine:attachment');
+          rootComponent.host.spec.getService('affine:attachment');
         assertExists(attachmentService);
         const maxFileSize = attachmentService.maxFileSize;
 
         await addSiblingAttachmentBlocks(
-          rootElement.host,
+          rootComponent.host,
           [file],
           maxFileSize,
           model
@@ -371,14 +379,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:embed-youtube') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parentModel = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
           return;
         }
         const index = parentModel.children.indexOf(model) + 1;
         await toggleEmbedCardCreateModal(
-          rootElement.host,
+          rootComponent.host,
           'YouTube',
           'The added YouTube video link will be displayed as an embed view.',
           { mode: 'page', parentModel, index }
@@ -394,14 +402,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:embed-github') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parentModel = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
           return;
         }
         const index = parentModel.children.indexOf(model) + 1;
         await toggleEmbedCardCreateModal(
-          rootElement.host,
+          rootComponent.host,
           'GitHub',
           'The added GitHub issue or pull request link will be displayed as a card view.',
           { mode: 'page', parentModel, index }
@@ -419,14 +427,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:embed-figma') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parentModel = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
           return;
         }
         const index = parentModel.children.indexOf(model) + 1;
         await toggleEmbedCardCreateModal(
-          rootElement.host,
+          rootComponent.host,
           'Figma',
           'The added Figma link will be displayed as an embed view.',
           { mode: 'page', parentModel, index }
@@ -441,14 +449,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:embed-loom') &&
         !insideDatabase(model),
-      action: async ({ rootElement, model }) => {
-        const parentModel = rootElement.doc.getParent(model);
+      action: async ({ rootComponent, model }) => {
+        const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
           return;
         }
         const index = parentModel.children.indexOf(model) + 1;
         await toggleEmbedCardCreateModal(
-          rootElement.host,
+          rootComponent.host,
           'Loom',
           'The added Loom video link will be displayed as an embed view.',
           { mode: 'page', parentModel, index }
@@ -462,8 +470,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
     // TODO-slash: Group & Frame explorer
 
     // ---------------------------------------------------------
-    ({ model, rootElement }) => {
-      const { doc } = rootElement;
+    ({ model, rootComponent }) => {
+      const { doc } = rootComponent;
 
       const surfaceModel = getSurfaceBlock(doc);
       const noteModel = doc.getParent(model);
@@ -510,7 +518,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         name: 'Group: ' + element.get('title'),
         icon: GroupingIcon,
         action: () => {
-          const { doc } = rootElement;
+          const { doc } = rootComponent;
           const noteModel = doc.getParent(model) as NoteBlockModel;
           const insertIdx = noteModel.children.indexOf(model);
           const surfaceRefProps = {
@@ -563,8 +571,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
           icon: TodayIcon,
           tooltip: slashMenuToolTips['Today'],
           description: formatDate(now),
-          action: ({ rootElement, model }) => {
-            insertContent(rootElement.host, model, formatDate(now));
+          action: ({ rootComponent, model }) => {
+            insertContent(rootComponent.host, model, formatDate(now));
           },
         },
         {
@@ -572,10 +580,10 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
           icon: TomorrowIcon,
           tooltip: slashMenuToolTips['Tomorrow'],
           description: formatDate(tomorrow),
-          action: ({ rootElement, model }) => {
+          action: ({ rootComponent, model }) => {
             const tomorrow = new Date();
             tomorrow.setDate(tomorrow.getDate() + 1);
-            insertContent(rootElement.host, model, formatDate(tomorrow));
+            insertContent(rootComponent.host, model, formatDate(tomorrow));
           },
         },
         {
@@ -583,10 +591,10 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
           icon: YesterdayIcon,
           tooltip: slashMenuToolTips['Yesterday'],
           description: formatDate(yesterday),
-          action: ({ rootElement, model }) => {
+          action: ({ rootComponent, model }) => {
             const yesterday = new Date();
             yesterday.setDate(yesterday.getDate() - 1);
-            insertContent(rootElement.host, model, formatDate(yesterday));
+            insertContent(rootComponent.host, model, formatDate(yesterday));
           },
         },
         {
@@ -594,8 +602,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
           icon: NowIcon,
           tooltip: slashMenuToolTips['Now'],
           description: formatTime(now),
-          action: ({ rootElement, model }) => {
-            insertContent(rootElement.host, model, formatTime(now));
+          action: ({ rootComponent, model }) => {
+            insertContent(rootComponent.host, model, formatTime(now));
           },
         },
       ];
@@ -613,14 +621,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         model.doc.schema.flavourSchemaMap.has('affine:database') &&
         !insideDatabase(model) &&
         !insideEdgelessText(model),
-      action: ({ rootElement, model }) => {
+      action: ({ rootComponent, model }) => {
         const id = createDatabaseBlockInNextLine(model);
         if (!id) {
           return;
         }
-        const service = rootElement.std.spec.getService('affine:database');
+        const service = rootComponent.std.spec.getService('affine:database');
         service.initDatabaseBlock(
-          rootElement.doc,
+          rootComponent.doc,
           model,
           id,
           viewPresets.tableViewConfig,
@@ -640,21 +648,21 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         !insideEdgelessText(model) &&
         !!model.doc.awarenessStore.getFlag('enable_block_query'),
 
-      action: ({ model, rootElement }) => {
-        const parent = rootElement.doc.getParent(model);
+      action: ({ model, rootComponent }) => {
+        const parent = rootComponent.doc.getParent(model);
         assertExists(parent);
         const index = parent.children.indexOf(model);
-        const id = rootElement.doc.addBlock(
+        const id = rootComponent.doc.addBlock(
           'affine:data-view',
           {},
-          rootElement.doc.getParent(model),
+          rootComponent.doc.getParent(model),
           index + 1
         );
-        const dataViewModel = rootElement.doc.getBlock(id)!;
+        const dataViewModel = rootComponent.doc.getBlock(id)!;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         Promise.resolve().then(() => {
           const dataView = getBlockComponentByPath(
-            rootElement.host,
+            rootComponent.host,
             dataViewModel.model.id
           ) as DataViewBlockComponent;
           dataView.viewSource.viewAdd('table');
@@ -672,14 +680,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         model.doc.schema.flavourSchemaMap.has('affine:database') &&
         !insideDatabase(model) &&
         !insideEdgelessText(model),
-      action: ({ model, rootElement }) => {
+      action: ({ model, rootComponent }) => {
         const id = createDatabaseBlockInNextLine(model);
         if (!id) {
           return;
         }
-        const service = rootElement.std.spec.getService('affine:database');
+        const service = rootComponent.std.spec.getService('affine:database');
         service.initDatabaseBlock(
-          rootElement.doc,
+          rootComponent.doc,
           model,
           id,
           viewPresets.kanbanViewConfig,
@@ -696,8 +704,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       description: 'Shift this line up.',
       icon: ArrowUpBigIcon,
       tooltip: slashMenuToolTips['Move Up'],
-      action: ({ rootElement, model }) => {
-        const doc = rootElement.doc;
+      action: ({ rootComponent, model }) => {
+        const doc = rootComponent.doc;
         const previousSiblingModel = doc.getPrev(model);
         if (!previousSiblingModel) return;
 
@@ -712,8 +720,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       description: 'Shift this line down.',
       icon: ArrowDownBigIcon,
       tooltip: slashMenuToolTips['Move Down'],
-      action: ({ rootElement, model }) => {
-        const doc = rootElement.doc;
+      action: ({ rootComponent, model }) => {
+        const doc = rootComponent.doc;
         const nextSiblingModel = doc.getNext(model);
         if (!nextSiblingModel) return;
 
@@ -728,13 +736,13 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       description: 'Copy this line to clipboard.',
       icon: PasteIcon,
       tooltip: slashMenuToolTips['Copy'],
-      action: ({ rootElement, model }) => {
-        const slice = Slice.fromModels(rootElement.std.doc, [model]);
+      action: ({ rootComponent, model }) => {
+        const slice = Slice.fromModels(rootComponent.std.doc, [model]);
 
-        rootElement.std.clipboard
+        rootComponent.std.clipboard
           .copy(slice)
           .then(() => {
-            toast(rootElement.host, 'Copied to clipboard');
+            toast(rootComponent.host, 'Copied to clipboard');
           })
           .catch(e => {
             console.error(e);
@@ -746,12 +754,12 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       description: 'Create a duplicate of this line.',
       icon: CopyIcon,
       tooltip: slashMenuToolTips['Copy'],
-      action: ({ rootElement, model }) => {
+      action: ({ rootComponent, model }) => {
         if (!model.text || !(model.text instanceof Text)) {
           console.error("Can't duplicate a block without text");
           return;
         }
-        const parent = rootElement.doc.getParent(model);
+        const parent = rootComponent.doc.getParent(model);
         if (!parent) {
           console.error(
             'Failed to duplicate block! Parent not found: ' +
@@ -764,15 +772,15 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         const index = parent.children.indexOf(model);
 
         // TODO add clone model util
-        rootElement.doc.addBlock(
+        rootComponent.doc.addBlock(
           model.flavour as never,
           {
             type: (model as ParagraphBlockModel).type,
-            text: rootElement.doc.Text.fromDelta(model.text.toDelta()),
+            text: rootComponent.doc.Text.fromDelta(model.text.toDelta()),
             // @ts-expect-error
             checked: model.checked,
           },
-          rootElement.doc.getParent(model),
+          rootComponent.doc.getParent(model),
           index
         );
       },
@@ -783,8 +791,8 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       alias: ['remove'],
       icon: DeleteIcon,
       tooltip: slashMenuToolTips['Delete'],
-      action: ({ rootElement, model }) => {
-        rootElement.doc.deleteBlock(model);
+      action: ({ rootComponent, model }) => {
+        rootComponent.doc.deleteBlock(model);
       },
     },
   ],

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -1,6 +1,6 @@
 import type { UIEventStateContext } from '@blocksuite/block-std';
 
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import {
   DisposableGroup,
   assertExists,
@@ -14,7 +14,7 @@ import {
   getInlineEditorByModel,
   matchFlavours,
 } from '../../../_common/utils/index.js';
-import { isRootElement } from '../../utils/guard.js';
+import { isRootComponent } from '../../utils/guard.js';
 import { getPopperPosition } from '../../utils/position.js';
 import {
   type SlashMenuActionItem,
@@ -67,7 +67,7 @@ const showSlashMenu = debounce(
     );
 
     const inlineEditor = getInlineEditorByModel(
-      context.rootElement.host,
+      context.rootComponent.host,
       context.model
     );
     if (!inlineEditor) return;
@@ -104,7 +104,7 @@ const showSlashMenu = debounce(
 export const AFFINE_SLASH_MENU_WIDGET = 'affine-slash-menu-widget';
 
 @customElement(AFFINE_SLASH_MENU_WIDGET)
-export class AffineSlashMenuWidget extends WidgetElement {
+export class AffineSlashMenuWidget extends WidgetComponent {
   private _onBeforeInput = (ctx: UIEventStateContext) => {
     const eventState = ctx.get('defaultState');
     const event = eventState.event as InputEvent;
@@ -126,8 +126,8 @@ export class AffineSlashMenuWidget extends WidgetElement {
     if (!inlineEditor) return;
 
     inlineEditor.slots.inlineRangeApply.once(() => {
-      const rootElement = this.block;
-      if (!isRootElement(rootElement)) {
+      const rootComponent = this.block;
+      if (!isRootComponent(rootComponent)) {
         console.error('SlashMenuWidget should be used in RootBlock');
         return;
       }
@@ -136,7 +136,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
         ...this.config,
         items: filterEnabledSlashMenuItems(this.config.items, {
           model,
-          rootElement,
+          rootComponent: rootComponent,
         }),
       };
 
@@ -147,7 +147,7 @@ export class AffineSlashMenuWidget extends WidgetElement {
 
         closeSlashMenu();
         showSlashMenu({
-          context: { model, rootElement },
+          context: { model, rootComponent: rootComponent },
           range: curRange,
           triggerKey,
           config,

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -252,7 +252,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
   }
 
   get host() {
-    return this.context.rootElement.host;
+    return this.context.rootComponent.host;
   }
 
   @state()
@@ -447,7 +447,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
     });
 
     const inlineEditor = getInlineEditorByModel(
-      this.context.rootElement.host,
+      this.context.rootComponent.host,
       this.context.model
     );
 

--- a/packages/blocks/src/root-block/widgets/slash-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/utils.ts
@@ -164,8 +164,8 @@ export function createConversionItem(
     icon,
     tooltip: slashMenuToolTips[name],
     showWhen: ({ model }) => model.doc.schema.flavourSchemaMap.has(flavour),
-    action: ({ rootElement }) => {
-      rootElement.host.std.command
+    action: ({ rootComponent }) => {
+      rootComponent.host.std.command
         .chain()
         .updateBlockType({
           flavour,

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { offset, shift } from '@floating-ui/dom';
 import { html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
@@ -27,7 +27,7 @@ import { edgelessToBlob, writeImageBlobToClipboard } from './utils.js';
 export const AFFINE_SURFACE_REF_TOOLBAR = 'affine-surface-ref-toolbar';
 
 @customElement(AFFINE_SURFACE_REF_TOOLBAR)
-export class AffineSurfaceRefToolbar extends WidgetElement<
+export class AffineSurfaceRefToolbar extends WidgetComponent<
   SurfaceRefBlockModel,
   SurfaceRefBlockComponent
 > {

--- a/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
+++ b/packages/blocks/src/root-block/widgets/viewport-overlay/viewport-overlay.ts
@@ -1,4 +1,4 @@
-import { WidgetElement } from '@blocksuite/block-std';
+import { WidgetComponent } from '@blocksuite/block-std';
 import { css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -9,7 +9,7 @@ import type { PageRootBlockComponent, RootBlockModel } from '../../index.js';
 export const AFFINE_VIEWPORT_OVERLAY_WIDGET = 'affine-viewport-overlay-widget';
 
 @customElement(AFFINE_VIEWPORT_OVERLAY_WIDGET)
-export class AffineViewportOverlayWidget extends WidgetElement<
+export class AffineViewportOverlayWidget extends WidgetComponent<
   RootBlockModel,
   PageRootBlockComponent
 > {

--- a/packages/docs/guide/block-widgets.md
+++ b/packages/docs/guide/block-widgets.md
@@ -6,15 +6,15 @@ The widget is designed to provide this kind of functionalities. Similar to block
 
 ## Widget Component
 
-The `WidgetElement` class can be used for building a widget view based on web component:
+The `WidgetComponent` class can be used for building a widget view based on web component:
 
 ```ts
-import { WidgetElement } from '@blocksuite/lit';
+import { WidgetComponent } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElements('my-widget')
-class MyWidgetView extends WidgetElement<MyBlockView> {
+class MyWidgetView extends WidgetComponent<MyBlockView> {
   override render() {
     return html`
       <div>
@@ -33,12 +33,12 @@ And we can get the host block by using `BlockComponent` property.
 For example, if you have a `code block` for displaying code examples, and you want to display a `language picker` widget to let users change the language of the code block. The widget could be defined in this manner:
 
 ```ts
-import { WidgetElement } from '@blocksuite/lit';
+import { WidgetComponent } from '@blocksuite/lit';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 @customElements('my-widget')
-class CodeLanguagePicker extends WidgetElement<CodeBlockComponent> {
+class CodeLanguagePicker extends WidgetComponent<CodeBlockComponent> {
   private _onChange = e => {
     this.doc.updateBlock(this.blockComponent.model, {
       language: e.target.value,

--- a/packages/framework/block-std/src/spec/slots.ts
+++ b/packages/framework/block-std/src/spec/slots.ts
@@ -1,16 +1,16 @@
 import { Slot } from '@blocksuite/global/utils';
 
 import type { BlockService } from '../service/index.js';
-import type { BlockComponent, WidgetElement } from '../view/index.js';
+import type { BlockComponent, WidgetComponent } from '../view/index.js';
 
 export type BlockSpecSlots<Service extends BlockService = BlockService> = {
   mounted: Slot<{ service: Service }>;
   unmounted: Slot<{ service: Service }>;
   viewConnected: Slot<{ component: BlockComponent; service: Service }>;
   viewDisconnected: Slot<{ component: BlockComponent; service: Service }>;
-  widgetConnected: Slot<{ component: WidgetElement; service: Service }>;
+  widgetConnected: Slot<{ component: WidgetComponent; service: Service }>;
   widgetDisconnected: Slot<{
-    component: WidgetElement;
+    component: WidgetComponent;
     service: Service;
   }>;
 };

--- a/packages/framework/block-std/src/view/element/block-component.ts
+++ b/packages/framework/block-std/src/view/element/block-component.ts
@@ -13,7 +13,7 @@ import { html } from 'lit/static-html.js';
 import type { EventName, UIEventHandler } from '../../event/index.js';
 import type { BlockStdScope } from '../../scope/index.js';
 import type { BlockService } from '../../service/index.js';
-import type { WidgetElement } from './widget-element.js';
+import type { WidgetComponent } from './widget-component.js';
 
 import { WithDisposable } from '../utils/with-disposable.js';
 import { docContext, stdContext } from './lit-host.js';
@@ -267,13 +267,13 @@ export class BlockComponent<
     return el?.closest('[data-block-id]') as BlockComponent;
   }
 
-  get rootElement(): BlockComponent | null {
+  get rootComponent(): BlockComponent | null {
     const rootId = this.doc.root?.id;
     if (!rootId) {
       return null;
     }
-    const rootElement = this.host.view.getBlock(rootId);
-    return rootElement ?? null;
+    const rootComponent = this.host.view.getBlock(rootId);
+    return rootComponent ?? null;
   }
 
   get selected() {
@@ -298,10 +298,10 @@ export class BlockComponent<
   }
 
   get topContenteditableElement(): BlockComponent | null {
-    return this.rootElement;
+    return this.rootComponent;
   }
 
-  get widgetElements(): Partial<Record<WidgetName, WidgetElement>> {
+  get widgetComponents(): Partial<Record<WidgetName, WidgetComponent>> {
     return Object.keys(this.widgets).reduce(
       (mapping, key) => ({
         ...mapping,

--- a/packages/framework/block-std/src/view/element/index.ts
+++ b/packages/framework/block-std/src/view/element/index.ts
@@ -2,4 +2,4 @@ export * from './block-component.js';
 export * from './edgeless-block-component.js';
 export * from './lit-host.js';
 export * from './shadowless-element.js';
-export * from './widget-element.js';
+export * from './widget-component.js';

--- a/packages/framework/block-std/src/view/element/widget-component.ts
+++ b/packages/framework/block-std/src/view/element/widget-component.ts
@@ -16,7 +16,7 @@ import {
 } from './block-component.js';
 import { docContext, stdContext } from './lit-host.js';
 
-export class WidgetElement<
+export class WidgetComponent<
   Model extends BlockModel = BlockModel,
   B extends BlockComponent = BlockComponent,
   S extends BlockService = BlockService,

--- a/packages/framework/block-std/src/view/view-store.ts
+++ b/packages/framework/block-std/src/view/view-store.ts
@@ -2,12 +2,12 @@ import type { BlockModel } from '@blocksuite/store';
 
 import { assertExists } from '@blocksuite/global/utils';
 
-import type { BlockComponent, WidgetElement } from './element/index.js';
+import type { BlockComponent, WidgetComponent } from './element/index.js';
 
 export class ViewStore {
   private readonly _blockMap = new Map<string, BlockComponent>();
 
-  private readonly _widgetMap = new Map<string, WidgetElement>();
+  private readonly _widgetMap = new Map<string, WidgetComponent>();
 
   calculatePath = (model: BlockModel): string[] => {
     const path: string[] = [];
@@ -23,7 +23,7 @@ export class ViewStore {
     this._blockMap.delete(node.id);
   };
 
-  deleteWidget = (node: WidgetElement) => {
+  deleteWidget = (node: WidgetComponent) => {
     const id = node.dataset.widgetId as string;
     const widgetIndex = `${node.model.id}|${id}`;
     this._widgetMap.delete(widgetIndex);
@@ -44,7 +44,7 @@ export class ViewStore {
   getWidget = (
     widgetName: string,
     hostBlockId: string
-  ): WidgetElement | null => {
+  ): WidgetComponent | null => {
     const widgetIndex = `${hostBlockId}|${widgetName}`;
     return this._widgetMap.get(widgetIndex) ?? null;
   };
@@ -53,7 +53,7 @@ export class ViewStore {
     this._blockMap.set(node.model.id, node);
   };
 
-  setWidget = (node: WidgetElement) => {
+  setWidget = (node: WidgetComponent) => {
     const id = node.dataset.widgetId as string;
     const widgetIndex = `${node.model.id}|${id}`;
     this._widgetMap.set(widgetIndex, node);
@@ -104,12 +104,12 @@ export class ViewStore {
 
   viewFromPath(type: 'block', path: string[]): null | BlockComponent;
 
-  viewFromPath(type: 'widget', path: string[]): null | WidgetElement;
+  viewFromPath(type: 'widget', path: string[]): null | WidgetComponent;
 
   viewFromPath(
     type: 'block' | 'widget',
     path: string[]
-  ): null | BlockComponent | WidgetElement {
+  ): null | BlockComponent | WidgetComponent {
     if (type === 'block') {
       return this.fromPath(path[path.length - 1]);
     }

--- a/packages/presets/src/ai/entries/slash-menu/setup-slash-menu.ts
+++ b/packages/presets/src/ai/entries/slash-menu/setup-slash-menu.ts
@@ -31,27 +31,27 @@ export function setupSlashMenuEntry(slashMenu: AffineSlashMenuWidget) {
 
   const showWhenWrapper =
     (item?: AIItemConfig) =>
-    ({ rootElement }: AffineSlashMenuContext) => {
-      const affineAIPanelWidget = rootElement.host.view.getWidget(
+    ({ rootComponent }: AffineSlashMenuContext) => {
+      const affineAIPanelWidget = rootComponent.host.view.getWidget(
         AFFINE_AI_PANEL_WIDGET,
-        rootElement.model.id
+        rootComponent.model.id
       );
       if (affineAIPanelWidget === null) return false;
 
-      const chain = rootElement.host.command.chain();
-      const editorMode = rootElement.service.docModeService.getMode(
-        rootElement.doc.id
+      const chain = rootComponent.host.command.chain();
+      const editorMode = rootComponent.service.docModeService.getMode(
+        rootComponent.doc.id
       );
 
-      return item?.showWhen?.(chain, editorMode, rootElement.host) ?? true;
+      return item?.showWhen?.(chain, editorMode, rootComponent.host) ?? true;
     };
 
   const actionItemWrapper = (
     item: AIItemConfig
   ): AffineSlashMenuActionItem => ({
     ...basicItemConfig(item),
-    action: ({ rootElement }: AffineSlashMenuContext) => {
-      item?.handler?.(rootElement.host);
+    action: ({ rootComponent }: AffineSlashMenuContext) => {
+      item?.handler?.(rootComponent.host);
     },
   });
 
@@ -62,7 +62,7 @@ export function setupSlashMenuEntry(slashMenu: AffineSlashMenuWidget) {
       subMenu: item.subItem.map<AffineSlashMenuActionItem>(
         ({ type, handler }) => ({
           name: type,
-          action: ({ rootElement }) => handler?.(rootElement.host),
+          action: ({ rootComponent }) => handler?.(rootComponent.host),
         })
       ),
     };
@@ -83,11 +83,11 @@ export function setupSlashMenuEntry(slashMenu: AffineSlashMenuWidget) {
       name: 'Ask AI',
       icon: AIStarIcon,
       showWhen: showWhenWrapper(),
-      action: ({ rootElement }) => {
-        const view = rootElement.host.view;
+      action: ({ rootComponent }) => {
+        const view = rootComponent.host.view;
         const affineAIPanelWidget = view.getWidget(
           AFFINE_AI_PANEL_WIDGET,
-          rootElement.model.id
+          rootComponent.model.id
         ) as AffineAIPanelWidget;
         assertExists(affineAIPanelWidget);
         assertExists(AIProvider.actions.chat);

--- a/packages/presets/src/fragments/outline-panel/body/outline-panel-body.ts
+++ b/packages/presets/src/fragments/outline-panel/body/outline-panel-body.ts
@@ -394,11 +394,11 @@ export class OutlinePanelBody extends WithDisposable(LitElement) {
   private _scrollToBlock(e: ClickBlockEvent) {
     if (this._isEdgelessMode() || !this.editorHost) return;
 
-    const rootElement = this.editorHost.querySelector('affine-page-root');
-    if (!rootElement) return;
+    const rootComponent = this.editorHost.querySelector('affine-page-root');
+    if (!rootComponent) return;
 
     const { blockPath } = e.detail;
-    const path = [rootElement.model.id, ...blockPath];
+    const path = [rootComponent.model.id, ...blockPath];
     const block = this.editorHost.view.viewFromPath('block', path);
     if (!block) return;
 
@@ -411,17 +411,17 @@ export class OutlinePanelBody extends WithDisposable(LitElement) {
     requestAnimationFrame(() => {
       const blockRect = block.getBoundingClientRect();
       const { top, left, width, height } = blockRect;
-      assertExists(rootElement.viewport, 'viewport should exist');
+      assertExists(rootComponent.viewport, 'viewport should exist');
       const {
         top: offsetY,
         left: offsetX,
         scrollTop,
         scrollLeft,
-      } = rootElement.viewport;
+      } = rootComponent.viewport;
 
       if (!this._highlightMask) {
         this._highlightMask = document.createElement('div');
-        rootElement.append(this._highlightMask);
+        rootComponent.append(this._highlightMask);
       }
 
       Object.assign(this._highlightMask.style, {


### PR DESCRIPTION
This follows #7715.

All remaining `rootElement` entries are only used for inline editor now.
