### PR TITLE
fix(edgeless): discard group like model from calculating bound

### DIFF
--- a/packages/blocks/src/root-block/edgeless/utils/bound-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/bound-utils.ts
@@ -1,8 +1,13 @@
 import { Bound } from '@blocksuite/global/utils';
 
+import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
+
 export function edgelessElementsBound(elements: BlockSuite.EdgelessModel[]) {
   if (elements.length === 0) return new Bound();
   return elements.reduce((prev, element) => {
+    if (element instanceof SurfaceGroupLikeModel) {
+      return prev;
+    }
     return prev.unite(element.elementBound);
   }, elements[0].elementBound);
 }


### PR DESCRIPTION
This closes [BS-824](https://linear.app/affine-design/issue/BS-824).