### PR TITLE
fix(edgeless): fix group insertion from clipboard

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -47,7 +47,10 @@ import {
   type SerializedElement,
   SurfaceGroupLikeModel,
 } from '../../../surface-block/element-model/base.js';
-import { CanvasElementType } from '../../../surface-block/element-model/index.js';
+import {
+  CanvasElementType,
+  GroupElementModel,
+} from '../../../surface-block/element-model/index.js';
 import { splitIntoLines } from '../../../surface-block/elements/text/utils.js';
 import {
   type Connection,
@@ -1323,7 +1326,9 @@ export class EdgelessClipboardController extends PageClipboard {
       pasteCenter ??
       this.host.service.viewport.toModelCoord(lastMousePos.x, lastMousePos.y);
     const [modelX, modelY] = pasteCenter;
-    const oldCommonBound = edgelessElementsBound(allElements);
+    const oldCommonBound = edgelessElementsBound(
+      allElements.filter(el => !(el instanceof GroupElementModel))
+    );
     const pasteX = modelX - oldCommonBound.w / 2;
     const pasteY = modelY - oldCommonBound.h / 2;
 


### PR DESCRIPTION
During insertion of grouped objects the position being calculated on elements which forms the group itself.
The elements includes the group model and by definition of a group it doesn't have its own x-y-w-h values but serialize them by default as '[0,0,0,0]' xywh.
As of it, evaluating the position of insertion always will have zeroed x and y edge in `edgelessElementsBound` call and will always insert the group relative to center of the board and min/max edge of selection rather than center of the last pointer position.

https://github.com/user-attachments/assets/2412edde-b2b4-49af-9db5-aa952fab74b5

To overcome the issue, I suppose just to filter the group elements from insert collection passed to `edgelessElementsBound`