### PR TITLE
refactor: rewrite surface-ref with renderSpecPortal

### DIFF
--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -276,7 +276,7 @@ export class FrameBlockComponent extends GfxBlockComponent<
   }
 
   override renderGfxBlock() {
-    const { model, _isNavigator, doc, rootService } = this;
+    const { model, _isNavigator, showBorder, doc, rootService } = this;
 
     return html`
       <edgeless-frame-title
@@ -293,7 +293,10 @@ export class FrameBlockComponent extends GfxBlockComponent<
           height: '100%',
           width: '100%',
           borderRadius: '8px',
-          border: _isNavigator ? 'none' : `2px solid var(--affine-black-30)`,
+          border:
+            _isNavigator || !showBorder
+              ? 'none'
+              : `2px solid var(--affine-black-30)`,
         })}
       ></div>
     `;
@@ -301,6 +304,9 @@ export class FrameBlockComponent extends GfxBlockComponent<
 
   @state()
   private accessor _isNavigator = false;
+
+  @state()
+  accessor showBorder = true;
 }
 
 declare global {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -12,10 +12,7 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import type { AttachmentBlockProps } from '../../attachment-block/attachment-model.js';
-import type {
-  ImageBlockModel,
-  ImageBlockProps,
-} from '../../image-block/image-model.js';
+import type { ImageBlockProps } from '../../image-block/image-model.js';
 import type { SurfaceBlockComponent } from '../../surface-block/surface-block.js';
 import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
 import type { FontLoader } from '../font-loader/font-loader.js';
@@ -82,16 +79,6 @@ import {
   DEFAULT_NOTE_WIDTH,
 } from './utils/consts.js';
 import { getBackgroundGrid, isCanvasElement } from './utils/query.js';
-export interface EdgelessViewport {
-  left: number;
-  top: number;
-  scrollLeft: number;
-  scrollTop: number;
-  scrollWidth: number;
-  scrollHeight: number;
-  clientWidth: number;
-  clientHeight: number;
-}
 
 @customElement('affine-edgeless-root')
 export class EdgelessRootBlockComponent extends BlockComponent<
@@ -525,24 +512,6 @@ export class EdgelessRootBlockComponent extends BlockComponent<
     });
 
     return blockIds;
-  }
-
-  addImage(model: Partial<ImageBlockModel>, point: IPoint) {
-    const options = {
-      width: model.width ?? 0,
-      height: model.height ?? 0,
-    };
-    {
-      delete model.width;
-      delete model.height;
-    }
-    const [x, y] = this.service.viewport.toModelCoord(point.x, point.y);
-    const bound = new Bound(x, y, options.width, options.height);
-    return this.service.addBlock(
-      'affine:image',
-      { ...model, xywh: bound.serialize() },
-      this.surface.model
-    );
   }
 
   async addImages(

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
@@ -1,0 +1,274 @@
+import type { SurfaceSelection } from '@blocksuite/block-std';
+import type { IBound } from '@blocksuite/global/utils';
+
+import { BlockComponent } from '@blocksuite/block-std';
+import { assertExists } from '@blocksuite/global/utils';
+import { css, html } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+
+import type { SurfaceBlockComponent } from '../../surface-block/surface-block.js';
+import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
+import type { FontLoader } from '../font-loader/font-loader.js';
+import type { RootBlockModel } from '../root-model.js';
+import type { EdgelessRootBlockWidgetName } from '../types.js';
+import type { EdgelessRootService } from './edgeless-root-service.js';
+
+import { ThemeObserver } from '../../_common/theme/theme-observer.js';
+import { requestThrottledConnectFrame } from '../../_common/utils/index.js';
+import '../../surface-block/surface-block.js';
+import './components/note-slicer/index.js';
+import './components/presentation/edgeless-navigator-black-background.js';
+import './components/rects/edgeless-dragging-area-rect.js';
+import './components/rects/edgeless-selected-rect.js';
+import './components/toolbar/edgeless-toolbar.js';
+import { edgelessElementsBound } from './utils/bound-utils.js';
+import { getBackgroundGrid, isCanvasElement } from './utils/query.js';
+
+@customElement('affine-edgeless-root-preview')
+export class EdgelessRootPreviewBlockComponent extends BlockComponent<
+  RootBlockModel,
+  EdgelessRootService,
+  EdgelessRootBlockWidgetName
+> {
+  private _refreshLayerViewport = requestThrottledConnectFrame(() => {
+    const { zoom, translateX, translateY } = this.service.viewport;
+    const { gap } = getBackgroundGrid(zoom, true);
+
+    this.background.style.setProperty(
+      'background-position',
+      `${translateX}px ${translateY}px`
+    );
+    this.background.style.setProperty('background-size', `${gap}px ${gap}px`);
+
+    this.layer.style.setProperty('transform', this._getLayerViewport());
+    this.layer.dataset.scale = zoom.toString();
+  }, this);
+
+  private _resizeObserver: ResizeObserver | null = null;
+
+  private readonly _themeObserver = new ThemeObserver();
+
+  private _viewportElement: HTMLElement | null = null;
+
+  static override styles = css`
+    affine-edgeless-root {
+      -webkit-user-select: none;
+      user-select: none;
+      display: block;
+      height: 100%;
+    }
+
+    .widgets-container {
+      position: absolute;
+      left: 0;
+      top: 0;
+      contain: size layout;
+      z-index: 1;
+      height: 100%;
+    }
+
+    .edgeless-background {
+      height: 100%;
+      background-color: var(--affine-background-primary-color);
+      background-image: radial-gradient(
+        var(--affine-edgeless-grid-color) 1px,
+        var(--affine-background-primary-color) 1px
+      );
+    }
+
+    .edgeless-layer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      contain: size layout style;
+    }
+
+    @media print {
+      .selected {
+        background-color: transparent !important;
+      }
+    }
+  `;
+
+  fontLoader!: FontLoader;
+
+  mouseRoot!: HTMLElement;
+
+  private _getLayerViewport(negative = false) {
+    const { translateX, translateY, zoom } = this.service.viewport;
+
+    if (negative) {
+      return `scale(${1 / zoom}) translate(${-translateX}px, ${-translateY}px)`;
+    }
+
+    return `translate(${translateX}px, ${translateY}px) scale(${zoom})`;
+  }
+
+  private _initFontLoader() {
+    const fontLoader = this.service?.fontLoader;
+    assertExists(fontLoader);
+
+    fontLoader.ready
+      .then(() => {
+        this.surface.refresh();
+      })
+      .catch(console.error);
+  }
+
+  private _initPixelRatioChangeEffect() {
+    let media: MediaQueryList;
+
+    const onPixelRatioChange = () => {
+      if (media) {
+        this.service.viewport.onResize();
+        media.removeEventListener('change', onPixelRatioChange);
+      }
+
+      media = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+      media.addEventListener('change', onPixelRatioChange);
+    };
+
+    onPixelRatioChange();
+
+    this._disposables.add(() => {
+      media?.removeEventListener('change', onPixelRatioChange);
+    });
+  }
+
+  private _initResizeEffect() {
+    if (!this._viewportElement) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver((_: ResizeObserverEntry[]) => {
+      // FIXME: find a better way to get rid of empty check
+      if (!this.service || !this.service.selection || !this.service.viewport) {
+        console.error('Service not ready');
+        return;
+      }
+      this.service.selection.set(this.service.selection.surfaceSelections);
+      this.service.viewport.onResize();
+    });
+
+    resizeObserver.observe(this.viewportElement);
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = resizeObserver;
+  }
+
+  private _initSlotEffects() {
+    const { disposables } = this;
+
+    this._themeObserver.observe(document.documentElement);
+    this._themeObserver.on(() => this.surface.refresh());
+    this.disposables.add(() => this._themeObserver.dispose());
+
+    disposables.add(this.service.selection);
+  }
+
+  private _initViewport() {
+    this.service.viewport.setContainer(this);
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    this.handleEvent('selectionChange', () => {
+      const surface = this.host.selection.value.find(
+        (sel): sel is SurfaceSelection => sel.is('surface')
+      );
+      if (!surface) return;
+
+      const el = this.service.getElementById(surface.elements[0]);
+      if (isCanvasElement(el)) {
+        return true;
+      }
+
+      return;
+    });
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect();
+      this._resizeObserver = null;
+    }
+  }
+
+  override firstUpdated() {
+    this._initSlotEffects();
+    this._initResizeEffect();
+    this._initPixelRatioChangeEffect();
+    this._initFontLoader();
+    this._initViewport();
+
+    this._disposables.add(
+      this.service.viewport.viewportUpdated.on(() => {
+        this._refreshLayerViewport();
+      })
+    );
+
+    this._refreshLayerViewport();
+  }
+
+  getElementsBound(): IBound | null {
+    const { service } = this;
+    return edgelessElementsBound([...service.elements, ...service.blocks]);
+  }
+
+  override renderBlock() {
+    return html`
+      <div class="edgeless-background edgeless-container">
+        <div class="edgeless-layer">
+          ${this.renderChildren(this.model)}${this.renderChildren(
+            this.surfaceBlockModel
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  override willUpdate(_changedProperties: Map<PropertyKey, unknown>): void {
+    if (_changedProperties.has('editorViewportSelector')) {
+      this._initResizeEffect();
+    }
+  }
+
+  get dispatcher() {
+    return this.service?.uiEventDispatcher;
+  }
+
+  get surfaceBlockModel() {
+    return this.model.children.find(
+      child => child.flavour === 'affine:surface'
+    ) as SurfaceBlockModel;
+  }
+
+  get viewportElement(): HTMLElement {
+    if (this._viewportElement) return this._viewportElement;
+    this._viewportElement = this.host.closest(
+      this.editorViewportSelector
+    ) as HTMLElement | null;
+    assertExists(this._viewportElement);
+    return this._viewportElement;
+  }
+
+  @query('.edgeless-background')
+  accessor background!: HTMLDivElement;
+
+  @state()
+  accessor editorViewportSelector = '.affine-edgeless-viewport';
+
+  @query('.edgeless-layer')
+  accessor layer!: HTMLDivElement;
+
+  @query('affine-surface')
+  accessor surface!: SurfaceBlockComponent;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'affine-edgeless-root-preview': EdgelessRootPreviewBlockComponent;
+  }
+}

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -8,7 +8,6 @@ import type {
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
 import type { RootBlockConfig } from '../index.js';
-import type { EdgelessRootBlockComponent } from './edgeless-root-block.js';
 
 import { RootBlockSchema } from '../root-model.js';
 import { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from '../widgets/doc-remote-selection/doc-remote-selection.js';
@@ -25,6 +24,7 @@ import { AFFINE_MODAL_WIDGET } from '../widgets/modal/modal.js';
 import { AFFINE_PIE_MENU_WIDGET } from '../widgets/pie-menu/index.js';
 import { AFFINE_SLASH_MENU_WIDGET } from '../widgets/slash-menu/index.js';
 import { AFFINE_VIEWPORT_OVERLAY_WIDGET } from '../widgets/viewport-overlay/viewport-overlay.js';
+import './edgeless-root-preview-block.js';
 import { EdgelessRootService } from './edgeless-root-service.js';
 
 export type EdgelessRootBlockWidgetName =
@@ -101,19 +101,11 @@ export const PreviewEdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
   schema: RootBlockSchema,
   service: EdgelessRootService,
   view: {
-    component: literal`affine-edgeless-root`,
+    component: literal`affine-edgeless-root-preview`,
   },
   setup(slots: BlockSpecSlots) {
     slots.viewConnected.on(
-      ({
-        component,
-        service,
-      }: {
-        component: BlockComponent;
-        service: BlockService;
-      }) => {
-        // Does not allow the edgeless to display toolbar.
-        (component as EdgelessRootBlockComponent).disableComponents = true;
+      ({ service }: { component: BlockComponent; service: BlockService }) => {
         // Does not allow the user to move and zoom.
         (service as EdgelessRootService).locked = true;
       }

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -9,6 +9,7 @@ import type {
   SurfaceRefBlockComponent,
   SurfaceRefBlockModel,
 } from '../../../surface-ref-block/index.js';
+import type { EdgelessRootPreviewBlockComponent } from '../../edgeless/edgeless-root-preview-block.js';
 
 import { HoverController } from '../../../_common/components/hover/controller.js';
 import { isPeekable, peek } from '../../../_common/components/peekable.js';
@@ -145,12 +146,21 @@ function SurfaceRefToolbarOptions(options: {
             name: 'Copy',
             icon: CopyIcon,
             handler: () => {
+              if (!block.referenceModel || !block.doc.root) return;
+
+              const editor = block.previewEditor;
+              const edgelessRootElement = editor?.view.getBlock(
+                block.doc.root.id
+              );
+              const surfaceRenderer = (
+                edgelessRootElement as EdgelessRootPreviewBlockComponent
+              )?.surface?.renderer;
+
               edgelessToBlob(block.host, {
                 surfaceRefBlock: block,
-                surfaceRenderer: block.surfaceRenderer,
+                surfaceRenderer,
                 edgelessElement:
                   block.referenceModel as BlockSuite.EdgelessModel,
-                blockContainer: block.portal,
               })
                 .then(blob => {
                   return writeImageBlobToClipboard(blob);
@@ -168,15 +178,21 @@ function SurfaceRefToolbarOptions(options: {
             name: 'Download',
             icon: DownloadIcon,
             handler: () => {
-              const referencedModel = block.referenceModel;
+              if (!block.referenceModel || !block.doc.root) return;
 
-              if (!referencedModel) return;
+              const referencedModel = block.referenceModel;
+              const editor = block.previewEditor;
+              const edgelessRootElement = editor?.view.getBlock(
+                block.doc.root.id
+              );
+              const surfaceRenderer = (
+                edgelessRootElement as EdgelessRootPreviewBlockComponent
+              )?.surface?.renderer;
 
               edgelessToBlob(block.host, {
                 surfaceRefBlock: block,
-                surfaceRenderer: block.surfaceRenderer,
+                surfaceRenderer,
                 edgelessElement: referencedModel,
-                blockContainer: block.portal,
               })
                 .then(blob => {
                   const fileName =

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
@@ -6,6 +6,7 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { Renderer } from '../../../surface-block/canvas-renderer/renderer.js';
 import type { SurfaceRefBlockComponent } from '../../../surface-ref-block/surface-ref-block.js';
 
+import { blockComponentGetter } from '../../../_common/utils/query.js';
 import { isTopLevelBlock } from '../../../root-block/edgeless/utils/query.js';
 
 export const edgelessToBlob = async (
@@ -14,10 +15,9 @@ export const edgelessToBlob = async (
     surfaceRefBlock: SurfaceRefBlockComponent;
     surfaceRenderer: Renderer;
     edgelessElement: BlockSuite.EdgelessModel;
-    blockContainer: HTMLElement;
   }
 ): Promise<Blob> => {
-  const { edgelessElement, blockContainer } = options;
+  const { edgelessElement, surfaceRefBlock } = options;
   const rootService = host.spec.getService('affine:page');
   const exportManager = rootService.exportManager;
   const bound = Bound.deserialize(edgelessElement.xywh);
@@ -27,10 +27,7 @@ export const edgelessToBlob = async (
     .edgelessToCanvas(
       options.surfaceRenderer,
       bound,
-      model =>
-        blockContainer.querySelector(
-          `[data-portal-reference-block-id="${model.id}"]`
-        ),
+      model => blockComponentGetter(model, surfaceRefBlock.host.view),
       undefined,
       isBlock ? [edgelessElement] : undefined,
       isBlock ? undefined : [edgelessElement],

--- a/packages/blocks/src/specs/preset/edgeless-specs.ts
+++ b/packages/blocks/src/specs/preset/edgeless-specs.ts
@@ -8,10 +8,7 @@ import {
 } from '../../root-block/edgeless/edgeless-root-spec.js';
 import { EdgelessSurfaceBlockSpec } from '../../surface-block/surface-spec.js';
 import { EdgelessSurfaceRefBlockSpec } from '../../surface-ref-block/surface-ref-spec.js';
-import {
-  CommonFirstPartyBlockSpecs,
-  EdgelessFirstPartyBlockSpecs,
-} from '../common.js';
+import { EdgelessFirstPartyBlockSpecs } from '../common.js';
 
 export const EdgelessEditorBlockSpecs: BlockSpec[] = [
   EdgelessRootBlockSpec,
@@ -24,8 +21,9 @@ export const EdgelessEditorBlockSpecs: BlockSpec[] = [
 
 export const PreviewEdgelessEditorBlockSpecs: BlockSpec[] = [
   PreviewEdgelessRootBlockSpec,
-  ...CommonFirstPartyBlockSpecs,
+  ...EdgelessFirstPartyBlockSpecs,
   EdgelessSurfaceBlockSpec,
   EdgelessSurfaceRefBlockSpec,
   FrameBlockSpec,
+  EdgelessTextBlockSpec,
 ];

--- a/packages/blocks/src/specs/utils/spec-builder.ts
+++ b/packages/blocks/src/specs/utils/spec-builder.ts
@@ -1,6 +1,7 @@
 import type { BlockSpec, BlockSpecSlots } from '@blocksuite/block-std';
+import type { DisposableGroup } from '@blocksuite/global/utils';
 
-import { type DisposableGroup, assertExists } from '@blocksuite/global/utils';
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 
 export class SpecBuilder {
   private readonly _value: BlockSpec[];
@@ -16,9 +17,24 @@ export class SpecBuilder {
       disposableGroup: DisposableGroup
     ) => void
   ) {
-    const spec = this._value.find(s => s.schema.model.flavour === flavour);
-    assertExists(spec, `BlockSpec not found for ${flavour}`);
+    const specIndex = this._value.findIndex(
+      s => s.schema.model.flavour === flavour
+    );
+
+    if (specIndex === -1) {
+      throw new BlockSuiteError(
+        ErrorCode.ValueNotExists,
+        `BlockSpec not found for ${flavour}`
+      );
+    }
+
+    this._value[specIndex] = {
+      ...this._value[specIndex],
+    };
+
+    const spec = this._value[specIndex];
     const oldSetup = spec.setup;
+
     spec.setup = (slots, disposableGroup) => {
       oldSetup?.(slots, disposableGroup);
       setup(

--- a/packages/blocks/src/surface-block/surface-block-void.ts
+++ b/packages/blocks/src/surface-block/surface-block-void.ts
@@ -1,0 +1,22 @@
+import { BlockComponent } from '@blocksuite/block-std';
+import { nothing } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import type { SurfaceBlockModel } from './surface-model.js';
+import type { SurfaceBlockService } from './surface-service.js';
+
+@customElement('affine-surface-void')
+export class SurfaceBlockVoidComponent extends BlockComponent<
+  SurfaceBlockModel,
+  SurfaceBlockService
+> {
+  override render() {
+    return nothing;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'affine-surface-void': SurfaceBlockVoidComponent;
+  }
+}

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -1,6 +1,6 @@
 import { BlockComponent, RangeManager } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
-import { css, html, nothing } from 'lit';
+import { css, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 
 import type { EdgelessRootBlockComponent } from '../root-block/edgeless/edgeless-root-block.js';
@@ -8,7 +8,6 @@ import type { SurfaceBlockModel } from './surface-model.js';
 import type { SurfaceBlockService } from './surface-service.js';
 
 import { ThemeObserver } from '../_common/theme/theme-observer.js';
-import { isInsideEdgelessEditor } from '../_common/utils/index.js';
 import { values } from '../_common/utils/iterable.js';
 import { isShape } from '../root-block/edgeless/components/auto-complete/utils.js';
 import { FrameOverlay } from '../root-block/edgeless/frame-manager.js';
@@ -137,7 +136,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   };
 
   refresh = () => {
-    this._renderer.refresh();
+    this._renderer?.refresh();
   };
 
   readonly themeObserver = new ThemeObserver();
@@ -211,16 +210,10 @@ export class SurfaceBlockComponent extends BlockComponent<
     );
   }
 
-  private get _isEdgeless() {
-    return isInsideEdgelessEditor(this.host);
-  }
-
   override connectedCallback() {
     super.connectedCallback();
 
     this.setAttribute(RangeManager.rangeSyncExcludeAttr, 'true');
-
-    if (!this._isEdgeless) return;
 
     this._initThemeObserver();
     this._initRenderer();
@@ -228,16 +221,12 @@ export class SurfaceBlockComponent extends BlockComponent<
   }
 
   override firstUpdated() {
-    if (!this._isEdgeless) return;
-
     this._renderer.attach(this._surfaceContainer);
     this._surfaceContainer.append(...this._renderer.stackingCanvas);
     this._initCanvasTransform();
   }
 
   override render() {
-    if (!this._isEdgeless) return nothing;
-
     return html`
       <div class="affine-edgeless-surface-block-container">
         <!-- attach canvas later in renderer -->

--- a/packages/blocks/src/surface-block/surface-spec.ts
+++ b/packages/blocks/src/surface-block/surface-spec.ts
@@ -2,13 +2,14 @@ import type { BlockSpec } from '@blocksuite/block-std';
 
 import { literal } from 'lit/static-html.js';
 
+import './surface-block-void.js';
 import { SurfaceBlockSchema } from './surface-model.js';
 import { SurfaceBlockService } from './surface-service.js';
 
 export const PageSurfaceBlockSpec: BlockSpec = {
   schema: SurfaceBlockSchema,
   view: {
-    component: literal`affine-surface`,
+    component: literal`affine-surface-void`,
   },
   service: SurfaceBlockService,
 };

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -1,24 +1,23 @@
-import { PathFinder } from '@blocksuite/block-std';
+import type { EditorHost } from '@blocksuite/block-std';
+
 import { BlockComponent } from '@blocksuite/block-std';
-import { deserializeXYWH } from '@blocksuite/global/utils';
-import { Bound } from '@blocksuite/global/utils';
-import { type Disposable, assertExists, noop } from '@blocksuite/global/utils';
+import { GfxBlockElementModel } from '@blocksuite/block-std/gfx';
 import {
-  type PropertyDeclaration,
-  type TemplateResult,
-  css,
-  html,
-  nothing,
-} from 'lit';
+  Bound,
+  type SerializedXYWH,
+  deserializeXYWH,
+} from '@blocksuite/global/utils';
+import { assertExists, noop } from '@blocksuite/global/utils';
+import { BlockViewType, type Doc } from '@blocksuite/store';
+import { type TemplateResult, css, html, nothing } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import type { BlockCaptionEditor } from '../_common/components/block-caption.js';
-import type { FrameBlockModel } from '../frame-block/index.js';
-import type { Renderer } from '../surface-block/canvas-renderer/renderer.js';
-import type { SurfaceBlockModel } from '../surface-block/index.js';
+import type { FrameBlockComponent } from '../frame-block/frame-block.js';
+import type { EdgelessRootPreviewBlockComponent } from '../root-block/edgeless/edgeless-root-preview-block.js';
+import type { EdgelessRootService } from '../root-block/index.js';
 import type { SurfaceRefBlockModel } from './surface-ref-model.js';
-import type { SurfaceRefRenderer } from './surface-ref-renderer.js';
 import type { SurfaceRefBlockService } from './surface-ref-service.js';
 
 import { Peekable } from '../_common/components/peekable.js';
@@ -29,7 +28,11 @@ import {
   MoreDeleteIcon,
 } from '../_common/icons/index.js';
 import { requestConnectedFrame } from '../_common/utils/event.js';
-import { getBackgroundGrid } from '../root-block/edgeless/utils/query.js';
+import { SpecProvider } from '../specs/index.js';
+import {
+  type SurfaceBlockModel,
+  SurfaceElementModel,
+} from '../surface-block/index.js';
 import './surface-ref-portal.js';
 import { SurfaceRefPortal } from './surface-ref-portal.js';
 import { noContentPlaceholder } from './utils.js';
@@ -52,19 +55,19 @@ const NO_CONTENT_REASON = {
   DEFAULT: 'This content was deleted on edgeless mode',
 } as Record<string, string>;
 
-type RefElementModel = BlockSuite.SurfaceElementModel | FrameBlockModel;
-
 @customElement('affine-surface-ref')
 @Peekable()
 export class SurfaceRefBlockComponent extends BlockComponent<
   SurfaceRefBlockModel,
   SurfaceRefBlockService
 > {
-  private _isInSurface = false;
+  private _previewDoc: Doc | null = null;
 
-  private _referencedModel: RefElementModel | null = null;
+  private _previewSpec = SpecProvider.getInstance().getSpec('edgeless:preview');
 
-  private _surfaceRefRenderer!: SurfaceRefRenderer;
+  private _referenceXYWH: SerializedXYWH | null = null;
+
+  private _referencedModel: BlockSuite.EdgelessModel | null = null;
 
   static override styles = css`
     .affine-surface-ref {
@@ -161,12 +164,6 @@ export class SurfaceRefBlockComponent extends BlockComponent<
       border: 1px solid var(--affine-black-30);
     }
 
-    .ref-canvas-container {
-      height: 100%;
-      width: 100%;
-      position: relative;
-    }
-
     .surface-ref-mask {
       position: absolute;
       left: 0;
@@ -231,32 +228,6 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     }
   `;
 
-  private _attachRenderer() {
-    if (
-      this._surfaceRefRenderer?.surfaceRenderer.canvas.isConnected ||
-      !this.container ||
-      !this.portal
-    )
-      return;
-
-    this._surfaceRefRenderer.viewport.setContainer(this.container);
-    this.surfaceRenderer.attach(this.container);
-
-    if (this.portal.isUpdatePending) {
-      this.portal.updateComplete
-        .then(() => {
-          this.portal.setStackingCanvas(
-            this._surfaceRefRenderer.surfaceRenderer.stackingCanvas
-          );
-        })
-        .catch(console.error);
-    } else {
-      this.portal.setStackingCanvas(
-        this._surfaceRefRenderer.surfaceRenderer.stackingCanvas
-      );
-    }
-  }
-
   private _deleteThis() {
     this.doc.deleteBlock(this.model);
   }
@@ -308,58 +279,61 @@ export class SurfaceRefBlockComponent extends BlockComponent<
   }
 
   private _initReferencedModel() {
-    let refWatcher: Disposable | null = null;
+    const surfaceModel: SurfaceBlockModel | null =
+      (this.doc.getBlocksByFlavour('affine:surface')[0]?.model as
+        | SurfaceBlockModel
+        | undefined) ?? null;
+    this._surfaceModel = surfaceModel;
+
+    const selector = () => BlockViewType.Display;
     const init = () => {
-      refWatcher?.dispose();
+      const referencedModel: BlockSuite.EdgelessModel =
+        (this.doc.getBlock(this.model.reference)
+          ?.model as GfxBlockElementModel) ??
+        surfaceModel?.getElementById(this.model.reference) ??
+        null;
 
-      const referencedModel = this._surfaceRefRenderer.getModel(
-        this.model.reference
-      ) as RefElementModel;
       this._referencedModel =
-        referencedModel && 'xywh' in referencedModel ? referencedModel : null;
-
-      if (!referencedModel) return;
-
-      if ('propsUpdated' in referencedModel) {
-        refWatcher = referencedModel.propsUpdated.on(() => {
-          if (referencedModel.flavour !== this.model.refFlavour) {
-            this.doc.updateBlock(this.model, {
-              refFlavour: referencedModel.flavour,
-            });
-          }
-
-          this.updateComplete
-            .then(() => {
-              this._refreshViewport();
-            })
-            .catch(console.error);
-        });
-      }
-
-      this._refreshViewport();
+        referencedModel && referencedModel.xywh ? referencedModel : null;
+      this._previewDoc = this.doc.collection.getDoc(this.doc.id, {
+        readonly: true,
+        selector,
+      });
+      this._referenceXYWH = this._referencedModel?.xywh ?? null;
     };
 
     init();
 
-    this._disposables.add(() => {
-      this.doc.slots.blockUpdated.on(({ type, id }) => {
-        if (type === 'delete' && id === this.model.reference) {
+    this._disposables.add(
+      this.model.propsUpdated.on(payload => {
+        if (
+          payload.key === 'reference' &&
+          this.model.reference !== this._referencedModel?.id
+        ) {
           init();
         }
-      });
-    });
+      })
+    );
 
-    this._disposables.add(() => {
-      this.model.propsUpdated.on(() => {
-        if (this.model.reference !== this._referencedModel?.id) {
-          init();
-        }
-      });
-    });
+    if (surfaceModel && this._referencedModel instanceof SurfaceElementModel) {
+      this._disposables.add(
+        surfaceModel.elementRemoved.on(({ id }) => {
+          if (this.model.reference === id) {
+            init();
+          }
+        })
+      );
+    }
 
-    this._disposables.add(() => {
-      refWatcher?.dispose();
-    });
+    if (this._referencedModel instanceof GfxBlockElementModel) {
+      this._disposables.add(
+        this.doc.slots.blockUpdated.on(({ type, id }) => {
+          if (type === 'delete' && id === this.model.reference) {
+            init();
+          }
+        })
+      );
+    }
   }
 
   private _initSelection() {
@@ -373,30 +347,48 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     );
   }
 
-  private _refreshViewport() {
-    if (!this._referencedModel) {
-      return;
-    }
+  private _initSpec() {
+    this._previewSpec.setup('affine:page', ({ viewConnected }) => {
+      viewConnected.once(({ component }) => {
+        const edgelessBlock = component as EdgelessRootPreviewBlockComponent;
 
-    const referencedModel = this._referencedModel;
+        edgelessBlock.editorViewportSelector = 'ref-viewport';
+        edgelessBlock.service.viewport.sizeUpdated.once(() => {
+          this._refreshViewport();
+        });
+      });
+    });
 
-    // trigger a rerender to update element's size
-    // and set viewport after element's size has been updated
-    this.requestUpdate();
-    this.updateComplete
-      .then(() => {
-        this.surfaceRenderer.viewport.onResize();
-        this.surfaceRenderer.viewport.setViewportByBound(
-          Bound.fromXYWH(deserializeXYWH(referencedModel.xywh))
-        );
+    // @ts-ignore
+    this._previewSpec.setup('affine:frame', ({ viewConnected }) => {
+      viewConnected.once(({ component }) => {
+        const frameBlock = component as FrameBlockComponent;
 
-        // update portal transform
-        this.portal?.setViewport(this.surfaceRenderer.viewport);
-      })
-      .catch(console.error);
+        frameBlock.showBorder = false;
+      });
+    });
   }
 
-  private _renderMask(referencedModel: RefElementModel, flavourOrType: string) {
+  private _refreshViewport() {
+    if (!this._referenceXYWH) return;
+
+    const previewEditorHost = this.previewEditor;
+
+    if (!previewEditorHost) return;
+
+    const edgelessService = previewEditorHost.spec.getService(
+      'affine:page'
+    ) as EdgelessRootService;
+
+    edgelessService.viewport.setViewportByBound(
+      Bound.deserialize(this._referenceXYWH)
+    );
+  }
+
+  private _renderMask(
+    referencedModel: BlockSuite.EdgelessModel,
+    flavourOrType: string
+  ) {
     const title = 'title' in referencedModel ? referencedModel.title : '';
 
     return html`
@@ -413,33 +405,15 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     `;
   }
 
-  private _renderRefContent(
-    referencedModel: RefElementModel,
-    renderer: Renderer
-  ) {
+  private _renderRefContent(referencedModel: BlockSuite.EdgelessModel) {
     const [, , w, h] = deserializeXYWH(referencedModel.xywh);
-    const { zoom } = renderer.viewport;
-    const { gap } = getBackgroundGrid(zoom, true);
     const flavourOrType =
       'flavour' in referencedModel
         ? referencedModel.flavour
         : referencedModel.type;
-    const edgelessBlocks =
-      flavourOrType === 'affine:frame' || flavourOrType === 'group'
-        ? html`<surface-ref-portal
-            .doc=${this.doc}
-            .host=${this.host}
-            .refModel=${referencedModel}
-            .renderModel=${this.host.renderModel}
-          ></surface-ref-portal>`
-        : nothing;
+    const _previewSpec = this._previewSpec.value;
 
-    return html`<div
-      class="ref-content"
-      style=${styleMap({
-        backgroundSize: `${gap}px ${gap}px`,
-      })}
-    >
+    return html`<div class="ref-content">
       <div
         class="ref-viewport ${flavourOrType === 'affine:frame' ? 'frame' : ''}"
         style=${styleMap({
@@ -447,10 +421,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<
           aspectRatio: `${w} / ${h}`,
         })}
       >
-        ${edgelessBlocks}
-        <div class="ref-canvas-container">
-          <!-- attach canvas here -->
-        </div>
+        ${this.host.renderSpecPortal(this._previewDoc!, _previewSpec)}
       </div>
       ${this._renderMask(referencedModel, flavourOrType)}
     </div>`;
@@ -480,7 +451,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<
   private get _shouldRender() {
     return (
       this.isConnected &&
-      this.parentElement &&
+      // prevent surface-ref from render itself in loop
       !this.parentBlock.closest('affine-surface-ref')
     );
   }
@@ -492,69 +463,25 @@ export class SurfaceRefBlockComponent extends BlockComponent<
 
     this.contentEditable = 'false';
 
-    const parent = this.host.doc.getParent(this.model);
-    this._isInSurface = parent?.flavour === 'affine:surface';
-
     if (!this._shouldRender) return;
 
     const service = this.service;
     assertExists(service, `Surface ref block must run with its service.`);
-    this._surfaceRefRenderer = service.getRenderer(
-      PathFinder.id(this.path),
-      this.doc,
-      true
-    );
-    this._disposables.add(() => {
-      this.service?.removeRenderer(this._surfaceRefRenderer.id);
-    });
-    this._disposables.add(
-      this._surfaceRefRenderer.slots.surfaceModelChanged.on(model => {
-        this._surfaceModel = model;
-      })
-    );
-    this._disposables.add(
-      this._surfaceRefRenderer.slots.surfaceRendererRefresh.on(() => {
-        this.requestUpdate();
-      })
-    );
-    this._disposables.add(
-      this._surfaceRefRenderer.slots.surfaceRendererInit.on(() => {
-        let lastWidth = 0;
-        const observer = new ResizeObserver(entries => {
-          if (entries[0].contentRect.width !== lastWidth) {
-            lastWidth = entries[0].contentRect.width;
-            this._refreshViewport();
-          }
-        });
-        observer.observe(this);
-
-        this._disposables.add(() => observer.disconnect());
-      })
-    );
-    this._disposables.add(
-      this._surfaceRefRenderer.surfaceService.layer.slots.layerUpdated.on(
-        () => {
-          this.portal.setStackingCanvas(
-            this._surfaceRefRenderer.surfaceRenderer.stackingCanvas
-          );
-        }
-      )
-    );
-    this._surfaceRefRenderer.mount();
     this._initHotkey();
+    this._initSpec();
     this._initReferencedModel();
     this._initSelection();
   }
 
   override render() {
-    if (!this._shouldRender) return;
+    if (!this._shouldRender) return nothing;
 
-    const { _surfaceModel, _referencedModel, surfaceRenderer, model } = this;
+    const { _surfaceModel, _referencedModel, model } = this;
     const isEmpty =
       !_surfaceModel || !_referencedModel || !_referencedModel.xywh;
     const content = isEmpty
       ? this._renderRefPlaceholder(model)
-      : this._renderRefContent(_referencedModel, surfaceRenderer);
+      : this._renderRefContent(_referencedModel);
 
     return html`
       <div
@@ -575,28 +502,11 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     `;
   }
 
-  override requestUpdate(
-    name?: PropertyKey | undefined,
-    oldValue?: unknown,
-    options?: PropertyDeclaration<unknown, unknown> | undefined
-  ): void {
-    super.requestUpdate(name, oldValue, options);
-
-    this._surfaceRefRenderer?.surfaceRenderer?.refresh();
-    this.portal?.requestUpdate();
-  }
-
-  override updated() {
-    if (!this._shouldRender) return;
-
-    this._attachRenderer();
-  }
-
   viewInEdgeless() {
-    if (!this._referencedModel) return;
+    if (!this._referenceXYWH) return;
 
     const viewport = {
-      xywh: this._referencedModel.xywh,
+      xywh: this._referenceXYWH,
       padding: [60, 20, 20, 20] as [number, number, number, number],
     };
     const pageService = this.std.spec.getService('affine:page');
@@ -605,16 +515,14 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     pageService.docModeService.setMode('edgeless');
   }
 
-  get isInSurface() {
-    return this._isInSurface;
+  override willUpdate(_changedProperties: Map<PropertyKey, unknown>): void {
+    if (_changedProperties.has('_referencedModel')) {
+      this._refreshViewport();
+    }
   }
 
   get referenceModel() {
     return this._referencedModel;
-  }
-
-  get surfaceRenderer() {
-    return this._surfaceRefRenderer.surfaceRenderer;
   }
 
   @state()
@@ -626,11 +534,8 @@ export class SurfaceRefBlockComponent extends BlockComponent<
   @query('affine-surface-ref > block-caption-editor')
   accessor captionElement!: BlockCaptionEditor;
 
-  @query('.ref-canvas-container')
-  accessor container!: HTMLDivElement;
-
-  @query('surface-ref-portal')
-  accessor portal!: SurfaceRefPortal;
+  @query('editor-host')
+  accessor previewEditor!: EditorHost | null;
 }
 
 declare global {

--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -103,10 +103,10 @@ describe('basic', () => {
       `affine-surface-ref[data-block-id="${surfaceRefId}"]`
     ) as HTMLElement;
     const refBlocks = Array.from(
-      surfaceRef.querySelectorAll('surface-ref-note-portal')
-    );
+      surfaceRef.querySelectorAll('affine-edgeless-note')
+    ) as HTMLElement[];
     const stackingCanvas = Array.from(
-      surfaceRef.querySelector('.stacking-canvas')!.children
+      surfaceRef.querySelectorAll('.indexable-canvas')!
     ) as HTMLCanvasElement[];
 
     expect(refBlocks.length).toBe(2);
@@ -140,10 +140,10 @@ describe('basic', () => {
       `affine-surface-ref[data-block-id="${surfaceRefId}"]`
     ) as HTMLElement;
     const refBlocks = Array.from(
-      surfaceRef.querySelectorAll('surface-ref-note-portal')
-    );
+      surfaceRef.querySelectorAll('affine-edgeless-note')
+    ) as HTMLElement[];
     const stackingCanvas = Array.from(
-      surfaceRef.querySelector('.stacking-canvas')!.children
+      surfaceRef.querySelectorAll('.indexable-canvas')
     ) as HTMLCanvasElement[];
 
     expect(refBlocks.length).toBe(2);


### PR DESCRIPTION
### Changed
- Rewrite `surface-ref` block with `renderSpecPortal`
- `SpecBuilder` should append `setup` function on cloned spec rather than the original one.