### PR TITLE
refactor(blocks): theme observer singleton

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -23,11 +23,8 @@ import {
 } from '../../root-block/widgets/drag-handle/utils.js';
 import { CaptionedBlockComponent } from '../components/captioned-block-component.js';
 import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../consts.js';
-import {
-  type EmbedCardStyle,
-  getThemeMode,
-  matchFlavours,
-} from '../utils/index.js';
+import { ThemeObserver } from '../theme/theme-observer.js';
+import { type EmbedCardStyle, matchFlavours } from '../utils/index.js';
 import { styles } from './styles.js';
 
 export class EmbedBlockComponent<
@@ -138,7 +135,7 @@ export class EmbedBlockComponent<
   static override styles = styles;
 
   renderEmbed = (children: () => TemplateResult) => {
-    const theme = getThemeMode();
+    const theme = ThemeObserver.mode;
     const isSelected = !!this.selected?.is('block');
 
     if (!this.isInSurface) {

--- a/packages/blocks/src/_common/theme/css-variables.ts
+++ b/packages/blocks/src/_common/theme/css-variables.ts
@@ -1,7 +1,5 @@
 /* CSS variables. You need to handle all places where `CSS variables` are marked. */
 
-import type { Color } from '../../surface-block/consts.js';
-
 export const ColorVariables = [
   '--affine-brand-color',
   '--affine-primary-color',
@@ -139,16 +137,3 @@ export type CssVariableName = Extract<
 >;
 
 export type CssVariablesMap = Record<CssVariableName, string>;
-
-export function isCssVariable(name: string): name is CssVariableName {
-  return (
-    name.startsWith('--') && StyleVariables.includes(name as CssVariableName)
-  );
-}
-
-export function isTransparent(color: Color) {
-  return (
-    typeof color === 'string' &&
-    color.toLowerCase() === '--affine-palette-transparent'
-  );
-}

--- a/packages/blocks/src/_common/theme/theme-observer.ts
+++ b/packages/blocks/src/_common/theme/theme-observer.ts
@@ -1,45 +1,32 @@
-import { Slot } from '@blocksuite/global/utils';
+import { signal } from '@lit-labs/preact-signals';
 
 import type { Color } from '../../surface-block/consts.js';
-import type { CssVariablesMap } from './css-variables.js';
-
-import { StyleVariables, isCssVariable } from './css-variables.js';
 
 export enum ColorScheme {
   Dark = 'dark',
   Light = 'light',
-  Normal = 'normal',
-}
-
-export function extractCssVariables(element: Element): CssVariablesMap {
-  const styles = window.getComputedStyle(element);
-  const variables = StyleVariables.reduce((acc, cssName) => {
-    const value = styles.getPropertyValue(cssName).trim();
-    acc[cssName] = value;
-
-    // --affine-palette-transparent: special values added for the sake of logical consistency.
-    if (cssName === '--affine-palette-transparent' && !value) {
-      acc[cssName] = '#00000000';
-    }
-
-    return acc;
-  }, {} as CssVariablesMap);
-  return variables;
 }
 
 /**
  * Observer theme changing by `data-theme` property
  */
-export class ThemeObserver extends Slot<CssVariablesMap> {
-  private _cssVariables: CssVariablesMap | null = null;
+export class ThemeObserver {
+  static #computedStyle: CSSStyleDeclaration;
 
-  private _mode: ColorScheme = ColorScheme.Normal;
+  static #instance: ThemeObserver;
 
-  private _observer?: MutationObserver;
+  #observer?: MutationObserver;
 
-  override dispose() {
-    super.dispose();
-    this._observer?.disconnect();
+  mode$ = signal<ColorScheme>(ColorScheme.Light);
+
+  // A live `CSSStyleDeclaration` object, which updates automatically when the element's styles are changed.
+  static get computedStyle() {
+    let computedStyle = ThemeObserver.#computedStyle;
+    if (!computedStyle) {
+      computedStyle = window.getComputedStyle(document.documentElement);
+      ThemeObserver.#computedStyle = computedStyle;
+    }
+    return computedStyle;
   }
 
   /**
@@ -60,11 +47,11 @@ export class ThemeObserver extends Slot<CssVariablesMap> {
    * `var(--affine-palette-shape-blue)`
    * ```
    */
-  generateColorProperty(color: Color, fallback = 'transparent') {
+  static generateColorProperty(color: Color, fallback = 'transparent') {
     fallback = fallback.startsWith('--') ? `var(${fallback})` : fallback;
 
     if (typeof color === 'string') {
-      return color.startsWith('--') ? `var(${color})` : (color ?? fallback);
+      return (color.startsWith('--') ? `var(${color})` : color) ?? fallback;
     }
 
     if (color.light && color.dark) {
@@ -78,7 +65,7 @@ export class ThemeObserver extends Slot<CssVariablesMap> {
    * Gets a color with the current theme.
    *
    * @param color - A color value.
-   * @param fallback  - If color value processing fails, it will be used as a fallback.
+   * @param fallback - If color value processing fails, it will be used as a fallback.
    * @param real - If true, it returns the computed style.
    * @returns - A color property string.
    *
@@ -90,7 +77,7 @@ export class ThemeObserver extends Slot<CssVariablesMap> {
    * `--affine-palette-shape-blue`
    * ```
    */
-  getColorValue(
+  static getColorValue(
     color: Color,
     fallback = '--affine-palette-transparent',
     real?: boolean
@@ -98,51 +85,55 @@ export class ThemeObserver extends Slot<CssVariablesMap> {
     color =
       (typeof color === 'string'
         ? color
-        : (color[this.mode] ?? color['normal'])) ??
+        : (color[ThemeObserver.mode] ?? color.normal)) ??
       fallback ??
       'transparent';
-    return real ? this.getVariableValue(color) : color;
+    return real ? ThemeObserver.getPropertyValue(color) : color;
   }
 
-  getVariableValue(variable: string) {
-    if (isCssVariable(variable)) {
-      const value = this._cssVariables?.[variable];
+  static getPropertyValue(property: string) {
+    return property.startsWith('--')
+      ? ThemeObserver.computedStyle.getPropertyValue(property).trim()
+      : property;
+  }
 
-      if (value === undefined) {
-        console.error(new Error(`Cannot find css variable: ${variable}`));
-      } else {
-        return value;
-      }
+  static get instance(): ThemeObserver {
+    if (!ThemeObserver.#instance) {
+      const instance = new ThemeObserver();
+      instance.observe(document.documentElement);
+      ThemeObserver.#instance = instance;
     }
 
-    return variable;
+    return ThemeObserver.#instance;
+  }
+
+  static get mode() {
+    return ThemeObserver.instance.mode$.peek();
+  }
+
+  static subscribe(callback: (T: ColorScheme) => void) {
+    return ThemeObserver.instance.mode$.subscribe(callback);
+  }
+
+  disconnect() {
+    this.#observer?.disconnect();
   }
 
   observe(element: HTMLElement) {
     const callback = () => {
       const mode = element.dataset.theme;
-      if (mode && this._mode !== mode) {
-        this._mode = mode as ColorScheme;
-        this._cssVariables = extractCssVariables(element);
-        this.emit(this._cssVariables);
+      if (mode && this.mode$.peek() !== mode) {
+        this.mode$.value = mode as ColorScheme;
       }
     };
 
-    this._observer?.disconnect();
-    this._observer = new MutationObserver(callback);
-    this._observer.observe(element, {
+    this.#observer?.disconnect();
+    this.#observer = new MutationObserver(callback);
+    this.#observer.observe(element, {
       attributes: true,
       attributeFilter: ['data-theme'],
     });
 
     callback();
-  }
-
-  get cssVariables() {
-    return this._cssVariables;
-  }
-
-  get mode() {
-    return this._mode;
   }
 }

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -747,18 +747,6 @@ function findBlockComponent(elements: Element[], parent?: Element) {
   return null;
 }
 
-export function getThemeMode(): 'light' | 'dark' {
-  const mode = getComputedStyle(document.documentElement).getPropertyValue(
-    '--affine-theme-mode'
-  );
-
-  if (mode.trim() === 'dark') {
-    return 'dark';
-  } else {
-    return 'light';
-  }
-}
-
 /**
  * Get hovering note with given a point in edgeless mode.
  */

--- a/packages/blocks/src/_common/utils/url.ts
+++ b/packages/blocks/src/_common/utils/url.ts
@@ -14,7 +14,7 @@ import {
   EmbedCardLightVerticalIcon,
   LightLoadingIcon,
 } from '../icons/text.js';
-import { getThemeMode } from './query.js';
+import { ThemeObserver } from '../theme/theme-observer.js';
 
 export const ALLOWED_SCHEMES = [
   'http',
@@ -173,7 +173,7 @@ type EmbedCardIcons = {
 };
 
 export function getEmbedCardIcons(): EmbedCardIcons {
-  const theme = getThemeMode();
+  const theme = ThemeObserver.mode;
   if (theme === 'light') {
     return {
       LoadingIcon: LightLoadingIcon,

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -46,8 +46,6 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<
 
   private _isSelected = false;
 
-  private readonly _themeObserver = new ThemeObserver();
-
   private _whenHover = new HoverController(this, ({ abortController }) => {
     const selection = this.host.selection;
     const textSelection = selection.find('text');
@@ -170,9 +168,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<
     });
 
     // Workaround for https://github.com/toeverything/blocksuite/issues/4724
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => this.requestUpdate());
-    this.disposables.add(() => this._themeObserver.dispose());
+    this.disposables.add(ThemeObserver.subscribe(() => this.requestUpdate()));
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(

--- a/packages/blocks/src/bookmark-block/components/bookmark-card.ts
+++ b/packages/blocks/src/bookmark-block/components/bookmark-card.ts
@@ -12,8 +12,6 @@ import { styles } from '../styles.js';
 
 @customElement('bookmark-card')
 export class BookmarkCard extends WithDisposable(ShadowlessElement) {
-  private readonly _themeObserver = new ThemeObserver();
-
   static override styles = styles;
 
   private _handleClick(event: MouseEvent) {
@@ -45,9 +43,7 @@ export class BookmarkCard extends WithDisposable(ShadowlessElement) {
       })
     );
 
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => this.requestUpdate());
-    this.disposables.add(() => this._themeObserver.dispose());
+    this.disposables.add(ThemeObserver.subscribe(() => this.requestUpdate()));
 
     this.disposables.add(
       this.bookmark.selection.slots.changed.on(() => {

--- a/packages/blocks/src/code-block/affine-code-line.ts
+++ b/packages/blocks/src/code-block/affine-code-line.ts
@@ -9,7 +9,7 @@ import { customElement, property } from 'lit/decorators.js';
 import type { AffineTextAttributes } from '../_common/inline/presets/affine-inline-specs.js';
 import type { HighlightOptionsGetter } from './code-model.js';
 
-import { getThemeMode } from '../_common/utils/query.js';
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { DARK_THEME, LIGHT_THEME } from './utils/consts.js';
 import {
   highlightCache,
@@ -29,7 +29,7 @@ export class AffineCodeLine extends ShadowlessElement {
       return html`<span><v-text .str=${this.delta.insert}></v-text></span>`;
     }
 
-    const mode = getThemeMode();
+    const mode = ThemeObserver.mode;
     const cacheKey: highlightCacheKey = `${this.delta.insert}-${lang}-${mode}`;
     const cache = highlightCache.get(cacheKey);
 

--- a/packages/blocks/src/code-block/code-block.ts
+++ b/packages/blocks/src/code-block/code-block.ts
@@ -63,8 +63,6 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
     this._updateLineNumbers();
   });
 
-  private readonly _themeObserver = new ThemeObserver();
-
   static override styles = codeBlockStyles;
 
   readonly attributesSchema = z.object({});
@@ -140,18 +138,18 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
       };
     });
 
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => {
-      if (!this._highlighter) return;
-      const richText = this.querySelector('rich-text');
-      const inlineEditor = richText?.inlineEditor;
-      if (!inlineEditor) return;
-      // update code-line theme
-      setTimeout(() => {
-        inlineEditor.requestUpdate();
-      });
-    });
-    this.disposables.add(() => this._themeObserver.dispose());
+    this.disposables.add(
+      ThemeObserver.subscribe(() => {
+        if (!this._highlighter) return;
+        const richText = this.querySelector('rich-text');
+        const inlineEditor = richText?.inlineEditor;
+        if (!inlineEditor) return;
+        // update code-line theme
+        setTimeout(() => {
+          inlineEditor.requestUpdate();
+        });
+      })
+    );
 
     bindContainerHotkey(this);
 

--- a/packages/blocks/src/edgeless-text/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-block.ts
@@ -13,6 +13,7 @@ import type {
 import type { EdgelessTextBlockModel } from './edgeless-text-model.js';
 import type { EdgelessTextBlockService } from './edgeless-text-service.js';
 
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { matchFlavours } from '../_common/utils/model.js';
 import { HandleDirection } from '../root-block/edgeless/components/resize/resize-handles.js';
 import {
@@ -317,7 +318,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<
 
   override renderPageContent() {
     const { fontFamily, fontStyle, fontWeight, textAlign } = this.model;
-    const color = this.rootService.themeObserver.generateColorProperty(
+    const color = ThemeObserver.generateColorProperty(
       this.model.color,
       '#000000'
     );

--- a/packages/blocks/src/embed-linked-doc-block/utils.ts
+++ b/packages/blocks/src/embed-linked-doc-block/utils.ts
@@ -9,7 +9,7 @@ import {
   LightLoadingIcon,
   ReloadIcon,
 } from '../_common/icons/text.js';
-import { getThemeMode } from '../_common/utils/query.js';
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import {
   DarkSyncedDocErrorBanner,
   LightSyncedDocErrorBanner,
@@ -48,7 +48,7 @@ export function getEmbedLinkedDocIcons(
   editorMode: 'page' | 'edgeless',
   style: (typeof EmbedLinkedDocStyles)[number]
 ): EmbedCardImages {
-  const theme = getThemeMode();
+  const theme = ThemeObserver.mode;
   const small = style !== 'vertical';
   if (editorMode === 'page') {
     if (theme === 'light') {

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -22,8 +22,8 @@ import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 import { EmbedBlockComponent } from '../_common/embed-block-helper/embed-block-element.js';
 import { EmbedEdgelessIcon, EmbedPageIcon } from '../_common/icons/text.js';
 import { REFERENCE_NODE } from '../_common/inline/presets/nodes/consts.js';
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { type DocMode, NoteDisplayMode } from '../_common/types.js';
-import { getThemeMode } from '../_common/utils/query.js';
 import { isEmptyDoc } from '../_common/utils/render-linked-doc.js';
 import { SpecProvider } from '../specs/utils/spec-provider.js';
 import './components/embed-synced-doc-card.js';
@@ -144,7 +144,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
       });
     }
 
-    const theme = getThemeMode();
+    const theme = ThemeObserver.mode;
     const isSelected = !!this.selected?.is('block');
     const scale = isInSurface ? (this.model.scale ?? 1) : undefined;
 

--- a/packages/blocks/src/embed-synced-doc-block/utils.ts
+++ b/packages/blocks/src/embed-synced-doc-block/utils.ts
@@ -7,7 +7,7 @@ import {
   LightLoadingIcon,
   ReloadIcon,
 } from '../_common/icons/text.js';
-import { getThemeMode } from '../_common/utils/query.js';
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import {
   DarkSyncedDocDeletedBanner,
   DarkSyncedDocEmptyBanner,
@@ -33,7 +33,7 @@ type SyncedCardImages = {
 export function getSyncedDocIcons(
   editorMode: 'page' | 'edgeless'
 ): SyncedCardImages {
-  const theme = getThemeMode();
+  const theme = ThemeObserver.mode;
   if (theme === 'light') {
     return {
       LoadingIcon: LightLoadingIcon,

--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -12,6 +12,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { EdgelessRootService } from '../root-block/index.js';
 
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { FrameBlockModel } from './frame-model.js';
 
 const NESTED_FRAME_OFFSET = 4;
@@ -276,19 +277,10 @@ export class FrameBlockComponent extends GfxBlockComponent<
 
   override renderGfxBlock() {
     const { model, _isNavigator, showBorder, doc, rootService } = this;
-    let backgroundColor = '--affine-platte-transparent';
-
-    // The root service may not be initialized when switching page mode
-    if (rootService) {
-      backgroundColor = rootService.themeObserver.generateColorProperty(
-        model.background,
-        backgroundColor
-      );
-    } else if (typeof model.background === 'string') {
-      backgroundColor = model.background.startsWith('--')
-        ? `var(${model.background})`
-        : model.background;
-    }
+    const backgroundColor = ThemeObserver.generateColorProperty(
+      model.background,
+      '--affine-platte-transparent'
+    );
 
     return html`
       <edgeless-frame-title

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -70,10 +70,7 @@ export {
   SizeVariables,
   StyleVariables,
 } from './_common/theme/css-variables.js';
-export {
-  ThemeObserver,
-  extractCssVariables,
-} from './_common/theme/theme-observer.js';
+export { ThemeObserver } from './_common/theme/theme-observer.js';
 export * from './_common/transformers/index.js';
 export {
   type AbstractEditor,
@@ -89,7 +86,6 @@ export {
 } from './_common/utils/index.js';
 export { createDefaultDoc } from './_common/utils/init.js';
 export {
-  getThemeMode,
   isInsideEdgelessEditor,
   isInsidePageEditor,
 } from './_common/utils/query.js';

--- a/packages/blocks/src/note-block/note-edgeless-block.ts
+++ b/packages/blocks/src/note-block/note-edgeless-block.ts
@@ -19,6 +19,7 @@ import type { NoteBlockModel } from './note-model.js';
 import { EDGELESS_BLOCK_CHILD_PADDING } from '../_common/consts.js';
 import { DEFAULT_NOTE_BACKGROUND_COLOR } from '../_common/edgeless/note/consts.js';
 import { MoreIndicatorIcon } from '../_common/icons/edgeless.js';
+import { ThemeObserver } from '../_common/theme/theme-observer.js';
 import { NoteDisplayMode } from '../_common/types.js';
 import { matchFlavours } from '../_common/utils/model.js';
 import { getClosestBlockComponentByPoint } from '../_common/utils/query.js';
@@ -405,19 +406,10 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
     };
 
     const extra = this._editing ? ACTIVE_NOTE_EXTRA_PADDING : 0;
-    let backgroundColor = `${DEFAULT_NOTE_BACKGROUND_COLOR}`;
-
-    // The root service may not be initialized when switching page mode
-    if (this.rootService) {
-      backgroundColor = this.rootService.themeObserver.generateColorProperty(
-        model.background,
-        backgroundColor
-      );
-    } else if (typeof model.background === 'string') {
-      backgroundColor = model.background.startsWith('--')
-        ? `var(${model.background})`
-        : model.background;
-    }
+    const backgroundColor = ThemeObserver.generateColorProperty(
+      model.background,
+      DEFAULT_NOTE_BACKGROUND_COLOR
+    );
 
     const backgroundStyle = {
       position: 'absolute',

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -22,6 +22,7 @@ import {
   SmallNoteIcon,
 } from '../../../../_common/icons/edgeless.js';
 import { FontFamilyIcon } from '../../../../_common/icons/text.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import {
   FontFamily,
   FontStyle,
@@ -180,7 +181,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
 
     let color = '';
     if (isShape(this.currentSource)) {
-      const tmpColor = this.edgeless.surface.themeObserver.getColorValue(
+      const tmpColor = ThemeObserver.getColorValue(
         this.currentSource.fillColor,
         DEFAULT_SHAPE_FILL_COLOR
       );
@@ -192,7 +193,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
         color = tmpColor;
       }
     } else {
-      color = this.edgeless.surface.themeObserver.getColorValue(
+      color = ThemeObserver.getColorValue(
         this.currentSource.background,
         DEFAULT_NOTE_BACKGROUND_COLOR
       );
@@ -480,7 +481,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
 
     let color = '';
     if (isShape(this.currentSource)) {
-      const tmpColor = this.edgeless.surface.themeObserver.getColorValue(
+      const tmpColor = ThemeObserver.getColorValue(
         this.currentSource.fillColor,
         DEFAULT_SHAPE_FILL_COLOR
       );
@@ -492,7 +493,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
         color = tmpColor;
       }
     } else {
-      color = this.edgeless.surface.themeObserver.getColorValue(
+      color = ThemeObserver.getColorValue(
         this.currentSource.background,
         DEFAULT_NOTE_BACKGROUND_COLOR
       );
@@ -539,12 +540,12 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
         ? this.currentSource
         : this.edgeless.service.editPropsStore.getLastProps('shape');
 
-    const stroke = this.edgeless.surface.themeObserver.getColorValue(
+    const stroke = ThemeObserver.getColorValue(
       strokeColor,
       DEFAULT_SHAPE_STROKE_COLOR,
       true
     );
-    const fill = this.edgeless.surface.themeObserver.getColorValue(
+    const fill = ThemeObserver.getColorValue(
       fillColor,
       DEFAULT_SHAPE_FILL_COLOR,
       true

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -21,6 +21,7 @@ import {
   MindMapSiblingIcon,
   NoteAutoCompleteIcon,
 } from '../../../../_common/icons/index.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { handleNativeRangeAtPoint } from '../../../../_common/utils/index.js';
 import {
   type Connection,
@@ -221,12 +222,12 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
 
     let color = '';
     if (isShape(current)) {
-      color = edgeless.surface.themeObserver.getColorValue(
+      color = ThemeObserver.getColorValue(
         current.strokeColor,
         DEFAULT_SHAPE_STROKE_COLOR
       );
     } else {
-      const tmpColor = edgeless.surface.themeObserver.getColorValue(
+      const tmpColor = ThemeObserver.getColorValue(
         current.background,
         DEFAULT_NOTE_BACKGROUND_COLOR
       );

--- a/packages/blocks/src/root-block/edgeless/components/color-picker/button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/button.ts
@@ -25,10 +25,7 @@ type Type = 'normal' | 'custom';
 @customElement('edgeless-color-picker-button')
 export class EdgelessColorPickerButton extends WithDisposable(LitElement) {
   #select = (e: ColorEvent) => {
-    this.#pick({
-      type: 'palette',
-      value: e.detail,
-    });
+    this.#pick({ palette: e.detail });
   };
 
   switchToCustomTab = (e: MouseEvent) => {

--- a/packages/blocks/src/root-block/edgeless/components/color-picker/color-picker.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/color-picker.ts
@@ -32,6 +32,7 @@ import {
   clamp,
   defaultHsva,
   eq,
+  hsvaToHex8,
   hsvaToRgba,
   linearGradientAt,
   parseHexToHsva,
@@ -117,10 +118,15 @@ export class EdgelessColorPicker extends SignalWatcher(
   #pick() {
     const hsva = this.hsva$.peek();
     const type = this.modeType$.peek();
-    const rgba = hsvaToRgba(hsva);
-    const value = rgbaToHex8(rgba);
+    const detail = { [type]: hsvaToHex8(hsva) };
 
-    this.pick?.({ type: 'pick', detail: { type, value } });
+    if (type !== 'normal') {
+      const another = type === 'light' ? 'dark' : 'light';
+      const { hsva } = this[`${another}$`].peek();
+      detail[another] = hsvaToHex8(hsva);
+    }
+
+    this.pick?.({ type: 'pick', detail });
   }
 
   #pickEnd() {
@@ -498,7 +504,7 @@ export class EdgelessColorPicker extends SignalWatcher(
           ({ type, name, hsva }) => html`
             <div
               class="${classMap({ mode: true, [type]: true })}"
-              style=${styleMap({ '--c': rgbaToHex8(hsvaToRgba(hsva)) })}
+              style=${styleMap({ '--c': hsvaToHex8(hsva) })}
             >
               <button
                 ?active=${this.modeType$.value === type}

--- a/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
@@ -78,7 +78,7 @@ export const COLOR_PICKER_STYLE = css`
 
     ${FONT_XS};
     font-weight: 400;
-    color: var(--affine-text-primary-color);
+    color: #8e8d91;
   }
   .modes .mode.light button {
     background: white;

--- a/packages/blocks/src/root-block/edgeless/components/color-picker/types.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/types.ts
@@ -40,7 +40,7 @@ export type NavType = 'colors' | 'custom';
 
 export type NavTab<Type> = { type: Type; name: string };
 
-export type ModeType = `${ColorScheme}`;
+export type ModeType = 'normal' | `${ColorScheme}`;
 
 export type ModeTab<Type> = NavTab<Type> & { hsva: Hsva };
 
@@ -48,7 +48,7 @@ export type ModeRgba = { type: ModeType; rgba: Rgba };
 
 export type PickColorType = 'palette' | ModeType;
 
-export type PickColorDetail = { type: PickColorType; value: string };
+export type PickColorDetail = { [K in PickColorType]?: string };
 
 export type PickColorEvent =
   | { type: 'start' | 'end' }

--- a/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
@@ -3,14 +3,12 @@ import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { CssVariableName } from '../../../../_common/theme/css-variables.js';
-
 import { TransparentIcon } from '../../../../_common/icons/index.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { createZodUnion } from '../../../../_common/utils/index.js';
-import { getThemeMode } from '../../../../_common/utils/query.js';
 
 export class ColorEvent extends Event {
-  detail: CssVariableName;
+  detail: string;
 
   constructor(
     type: string,
@@ -18,7 +16,7 @@ export class ColorEvent extends Event {
       detail,
       composed,
       bubbles,
-    }: { detail: CssVariableName; composed: boolean; bubbles: boolean }
+    }: { detail: string; composed: boolean; bubbles: boolean }
   ) {
     super(type, { bubbles, composed });
     this.detail = detail;
@@ -42,18 +40,18 @@ export const LINE_COLORS = [
 export const LineColorsSchema = createZodUnion(LINE_COLORS);
 
 export const GET_DEFAULT_LINE_COLOR = () =>
-  getThemeMode() === 'dark' ? LINE_COLORS[10] : LINE_COLORS[8];
+  ThemeObserver.mode === 'dark' ? LINE_COLORS[10] : LINE_COLORS[8];
 
 export const GET_DEFAULT_TEXT_COLOR = () => LINE_COLORS[5];
 
 export const DEFAULT_BRUSH_COLOR = LINE_COLORS[5];
 export const DEFAULT_CONNECTOR_COLOR = LINE_COLORS[9];
 
-export function isTransparent(color: CssVariableName) {
+export function isTransparent(color: string) {
   return color.toLowerCase() === '--affine-palette-transparent';
 }
 
-function isSameColorWithBackground(color: CssVariableName) {
+function isSameColorWithBackground(color: string) {
   return [
     '--affine-note-background-black',
     '--affine-note-background-white',
@@ -90,7 +88,7 @@ function TransparentColor(hollowCircle = false) {
   `;
 }
 
-function BorderedHollowCircle(color: CssVariableName) {
+function BorderedHollowCircle(color: string) {
   const valid = color.startsWith('--');
   const strokeWidth = valid && isSameColorWithBackground(color) ? 1 : 0;
   const style = {
@@ -114,7 +112,7 @@ function BorderedHollowCircle(color: CssVariableName) {
   `;
 }
 
-function AdditionIcon(color: CssVariableName, hollowCircle: boolean) {
+function AdditionIcon(color: string, hollowCircle: boolean) {
   if (isTransparent(color)) {
     return TransparentColor(hollowCircle);
   }
@@ -125,7 +123,7 @@ function AdditionIcon(color: CssVariableName, hollowCircle: boolean) {
 }
 
 export function ColorUnit(
-  color: CssVariableName,
+  color: string,
   {
     hollowCircle,
     letter,
@@ -213,7 +211,7 @@ export class EdgelessColorButton extends LitElement {
   }
 
   @property({ attribute: false })
-  accessor color!: CssVariableName;
+  accessor color!: string;
 
   @property({ attribute: false })
   accessor hollowCircle: boolean | undefined = undefined;
@@ -268,7 +266,7 @@ export class EdgelessColorPanel extends LitElement {
     ${colorContainerStyles}
   `;
 
-  onSelect(value: CssVariableName) {
+  onSelect(value: string) {
     this.dispatchEvent(
       new ColorEvent('select', {
         detail: value,
@@ -319,7 +317,7 @@ export class EdgelessColorPanel extends LitElement {
   accessor showLetterMark = false;
 
   @property({ attribute: false })
-  accessor value: CssVariableName | null = null;
+  accessor value: string | null = null;
 }
 
 @customElement('edgeless-text-color-icon')
@@ -367,7 +365,7 @@ export class EdgelessTextColorIcon extends LitElement {
   }
 
   @property({ attribute: false })
-  accessor color!: CssVariableName;
+  accessor color!: string;
 }
 
 declare global {

--- a/packages/blocks/src/root-block/edgeless/components/panel/note-shadow-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/note-shadow-panel.ts
@@ -9,7 +9,7 @@ import {
   NoteNoShadowIcon,
   NoteShadowSampleIcon,
 } from '../../../../_common/icons/edgeless.js';
-import { getThemeMode } from '../../../../_common/utils/query.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import '../buttons/tool-icon-button.js';
 
 const TOOLBAR_SHADOWS_LIGHT = [
@@ -70,7 +70,7 @@ export class EdgelessNoteShadowPanel extends WithDisposable(LitElement) {
   `;
 
   override render() {
-    const mode = getThemeMode();
+    const mode = ThemeObserver.mode;
     const SHADOWS =
       mode === 'dark' ? TOOLBAR_SHADOWS_DARK : TOOLBAR_SHADOWS_LIGHT;
     return repeat(

--- a/packages/blocks/src/root-block/edgeless/components/panel/stroke-style-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/stroke-style-panel.ts
@@ -2,7 +2,6 @@ import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { CssVariableName } from '../../../../_common/theme/css-variables.js';
 import type { ColorEvent } from './color-panel.js';
 
 import '../../../../_common/components/button.js';
@@ -66,7 +65,7 @@ export class StrokeStylePanel extends WithDisposable(LitElement) {
   accessor setStrokeStyle!: (e: LineStyleEvent) => void;
 
   @property({ attribute: false })
-  accessor strokeColor!: CssVariableName;
+  accessor strokeColor!: string;
 
   @property({ attribute: false })
   accessor strokeStyle!: StrokeStyle;

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
@@ -15,6 +15,7 @@ import type { ConnectorElementModel } from '../../../../surface-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 
 import '../../../../_common/components/rich-text/rich-text.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { almostEqual } from '../../../../_common/utils/math.js';
 import { getLineHeight } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 
@@ -245,10 +246,7 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
     ];
 
     const isEmpty = !connector.text!.length && !this._isComposition;
-    const color = this.edgeless.surface.themeObserver.getColorValue(
-      labelColor,
-      '#000000'
-    );
+    const color = ThemeObserver.generateColorProperty(labelColor, '#000000');
 
     return html`
       <div
@@ -263,7 +261,7 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
           maxWidth: hasMaxWidth
             ? `${maxWidth + BORDER_WIDTH * 2 + HORIZONTAL_PADDING * 2}px`
             : 'initial',
-          color: color.startsWith('--') ? `var(${color})` : color,
+          color,
           transform: transformOperation.join(' '),
         })}
       >

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -17,6 +17,7 @@ import {
   getNearestTranslation,
   isElementOutsideViewport,
 } from '../../../../_common/edgeless/mindmap/index.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { TextResizing } from '../../../../surface-block/consts.js';
 import {
   MindmapElementModel,
@@ -282,7 +283,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       leftTopY
     );
     const autoWidth = textResizing === TextResizing.AUTO_WIDTH;
-    const color = this.edgeless.surface.themeObserver.getColorValue(
+    const color = ThemeObserver.generateColorProperty(
       this.element.color,
       '#000000'
     );
@@ -313,7 +314,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       outline: 'none',
       transform: `scale(${zoom}, ${zoom}) rotate(${rotate}deg)`,
       transformOrigin: 'top left',
-      color: color.startsWith('--') ? `var(${color})` : color,
+      color,
       padding: `${verticalPadding}px ${horiPadding}px`,
       textAlign: this.element.textAlign,
       display: 'grid',

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
@@ -14,6 +14,7 @@ import type { TextElementModel } from '../../../../surface-block/element-model/t
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 
 import '../../../../_common/components/rich-text/rich-text.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { getLineHeight } from '../../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { toRadian } from '../../../../surface-block/index.js';
 import { wrapFontFamily } from '../../../../surface-block/utils/font.js';
@@ -343,7 +344,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
     ];
 
     const isEmpty = !text.length && !this._isComposition;
-    const color = this.edgeless.surface.themeObserver.getColorValue(
+    const color = ThemeObserver.generateColorProperty(
       this.element.color,
       '#000000'
     );
@@ -357,7 +358,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
         fontSize: `${fontSize}px`,
         fontWeight,
         fontStyle,
-        color: color.startsWith('--') ? `var(${color})` : color,
+        color,
         textAlign,
         lineHeight: `${lineHeight}px`,
         boxSizing: 'content-box',

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
@@ -1,11 +1,16 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import type { Color } from '../../../../../surface-block/consts.js';
 import type { EdgelessTool } from '../../../types.js';
-import type { ColorEvent } from '../../panel/color-panel.js';
 import type { LineWidthEvent } from '../../panel/line-width-panel.js';
 
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
 import '../../buttons/tool-icon-button.js';
+import {
+  type ColorEvent,
+  GET_DEFAULT_LINE_COLOR,
+} from '../../panel/color-panel.js';
 import '../../panel/one-row-color-panel.js';
 import '../common/slide-menu.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
@@ -33,12 +38,16 @@ export class EdgelessBrushMenu extends EdgelessToolbarToolMixin(LitElement) {
   type: EdgelessTool['type'] = 'brush';
 
   override render() {
-    const { color, lineWidth } = this;
+    const color = ThemeObserver.getColorValue(
+      this.color,
+      GET_DEFAULT_LINE_COLOR()
+    );
+
     return html`
       <edgeless-slide-menu>
         <div class="menu-content">
           <edgeless-line-width-panel
-            .selectedSize=${lineWidth}
+            .selectedSize=${this.lineWidth}
             @select=${(e: LineWidthEvent) =>
               this.onChange({ lineWidth: e.detail })}
           >
@@ -54,7 +63,7 @@ export class EdgelessBrushMenu extends EdgelessToolbarToolMixin(LitElement) {
   }
 
   @property({ attribute: false })
-  accessor color!: string;
+  accessor color!: Color;
 
   @property({ attribute: false })
   accessor lineWidth!: number;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -8,6 +8,7 @@ import {
   EdgelessPenDarkIcon,
   EdgelessPenLightIcon,
 } from '../../../../../_common/icons/edgeless.js';
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
 import { LineWidth } from '../../../../../_common/utils/index.js';
 import '../../buttons/toolbar-button.js';
 import { DEFAULT_BRUSH_COLOR } from '../../panel/color-panel.js';
@@ -88,6 +89,7 @@ export class EdgelessBrushToolButton extends EdgelessToolbarToolMixin(
   override render() {
     const { active, theme } = this;
     const icon = theme === 'dark' ? EdgelessPenDarkIcon : EdgelessPenLightIcon;
+    const color = ThemeObserver.generateColorProperty(this.states.color);
 
     return html`
       <edgeless-toolbar-button
@@ -96,16 +98,9 @@ export class EdgelessBrushToolButton extends EdgelessToolbarToolMixin(
         .tooltipOffset=${4}
         .active=${active}
         .withHover=${true}
-        @click=${() => {
-          this._toggleBrushMenu();
-        }}
+        @click=${() => this._toggleBrushMenu()}
       >
-        <div
-          style=${styleMap({ color: `var(${this.states.color})` })}
-          class="pen-wrapper"
-        >
-          ${icon}
-        </div>
+        <div style=${styleMap({ color })} class="pen-wrapper">${icon}</div>
       </edgeless-toolbar-button>
     `;
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/common/create-popper.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/common/create-popper.ts
@@ -83,7 +83,7 @@ export function createPopper<T extends keyof HTMLElementTagNameMap>(
 
   const popper: MenuPopper<HTMLElementTagNameMap[T]> = {
     element: menu,
-    dispose: function () {
+    dispose: () => {
       // apply leave transition
       animateLeave(menu);
       menu.addEventListener('transitionend', remove, { once: true });

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import type { Color } from '../../../../../surface-block/consts.js';
 import type { EdgelessTool } from '../../../types.js';
 import type { ColorEvent } from '../../panel/color-panel.js';
 import type { LineWidthEvent } from '../../panel/line-width-panel.js';
@@ -10,7 +11,9 @@ import {
   ConnectorLWithArrowIcon,
   ConnectorXWithArrowIcon,
 } from '../../../../../_common/icons/index.js';
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
 import { ConnectorMode } from '../../../../../surface-block/index.js';
+import { DEFAULT_CONNECTOR_COLOR } from '../../panel/color-panel.js';
 import '../../panel/one-row-color-panel.js';
 import '../common/slide-menu.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
@@ -100,6 +103,7 @@ export class EdgelessConnectorMenu extends EdgelessToolbarToolMixin(
       this.mode,
       this.onChange
     );
+    const color = ThemeObserver.getColorValue(stroke, DEFAULT_CONNECTOR_COLOR);
 
     return html`
       <edgeless-slide-menu>
@@ -114,7 +118,7 @@ export class EdgelessConnectorMenu extends EdgelessToolbarToolMixin(
           </edgeless-line-width-panel>
           <div class="submenu-divider"></div>
           <edgeless-one-row-color-panel
-            .value=${stroke}
+            .value=${color}
             @select=${(e: ColorEvent) => this.onChange({ stroke: e.detail })}
           ></edgeless-one-row-color-panel>
         </div>
@@ -129,7 +133,7 @@ export class EdgelessConnectorMenu extends EdgelessToolbarToolMixin(
   accessor onChange!: (props: Record<string, unknown>) => void;
 
   @property({ attribute: false })
-  accessor stroke!: string;
+  accessor stroke!: Color;
 
   @property({ attribute: false })
   accessor strokeWidth!: number;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -63,13 +63,10 @@ export class EdgelessConnectorToolButton extends QuickToolMixin(LitElement) {
     applyLastProps(edgeless.service, type, stateKeys, states);
 
     this.disposables.add(
-      observeLastProps(
-        edgeless.service,
-        type,
-        stateKeys,
-        states,
-        updates => (this.states = { ...this.states, ...updates })
-      )
+      observeLastProps(edgeless.service, type, stateKeys, states, updates => {
+        this.states = { ...this.states, ...updates };
+        this.updateMenu();
+      })
     );
   }
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/context.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/context.ts
@@ -2,6 +2,7 @@ import type { Slot } from '@blocksuite/store';
 
 import { createContext } from '@lit/context';
 
+import type { ColorScheme } from '../../../../_common/theme/theme-observer.js';
 import type { EdgelessToolbar } from './edgeless-toolbar.js';
 
 export interface EdgelessToolbarSlots {
@@ -12,7 +13,7 @@ export const edgelessToolbarSlotsContext = createContext<EdgelessToolbarSlots>(
   Symbol('edgelessToolbarSlotsContext')
 );
 
-export const edgelessToolbarThemeContext = createContext<'light' | 'dark'>(
+export const edgelessToolbarThemeContext = createContext<ColorScheme>(
   Symbol('edgelessToolbarThemeContext')
 );
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -22,9 +22,11 @@ import {
   ArrowRightSmallIcon,
   MoreHorizontalIcon,
 } from '../../../../_common/icons/index.js';
-import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
+import {
+  ColorScheme,
+  ThemeObserver,
+} from '../../../../_common/theme/theme-observer.js';
 import { stopPropagation } from '../../../../_common/utils/event.js';
-import { getThemeMode } from '../../../../_common/utils/query.js';
 import '../buttons/tool-icon-button.js';
 import '../buttons/toolbar-button.js';
 import {
@@ -91,11 +93,9 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
     initialValue: { resize: new Slot() } satisfies EdgelessToolbarSlots,
   });
 
-  private _themeObserver = new ThemeObserver();
-
   private _themeProvider = new ContextProvider(this, {
     context: edgelessToolbarThemeContext,
-    initialValue: getThemeMode(),
+    initialValue: ColorScheme.Light,
   });
 
   private _toolbarProvider = new ContextProvider(this, {
@@ -513,9 +513,9 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       }
     });
     this._resizeObserver.observe(this);
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => this._themeProvider.setValue(getThemeMode()));
-    this._disposables.add(() => this._themeObserver.dispose());
+    this._disposables.add(
+      ThemeObserver.subscribe(mode => this._themeProvider.setValue(mode))
+    );
     this._disposables.add(
       this.edgeless.slots.edgelessToolUpdated.on(tool => {
         this.edgelessTool = tool;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/assets.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/assets.ts
@@ -1,5 +1,6 @@
 import type { TemplateResult } from 'lit';
 
+import { ColorScheme } from '../../../../../_common/theme/theme-observer.js';
 import { MindmapStyle } from '../../../../../surface-block/index.js';
 import { type DraggableTool, getMindmapRender } from './basket-elements.js';
 import {
@@ -18,10 +19,10 @@ export type ToolbarMindmapItem = {
   render: DraggableTool['render'];
 };
 
-export const getMindMaps = (theme: 'dark' | 'light'): ToolbarMindmapItem[] => [
+export const getMindMaps = (theme: ColorScheme): ToolbarMindmapItem[] => [
   {
     type: 'mindmap',
-    icon: theme === 'light' ? mindMapStyle1Light : mindMapStyle1Dark,
+    icon: theme === ColorScheme.Dark ? mindMapStyle1Dark : mindMapStyle1Light,
     style: MindmapStyle.ONE,
     render: getMindmapRender(MindmapStyle.ONE),
   },

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
@@ -36,57 +36,16 @@ export type DraggableTool = {
 
 const unitMap = { x: 'px', y: 'px', r: 'deg', s: '', z: '', o: '' };
 export const textConfig: ToolConfig = {
-  default: {
-    x: -20,
-    y: -8,
-    r: 7.74,
-    s: 0.92,
-    z: 2,
-  },
-  active: {
-    x: -22,
-    y: -9,
-    r: -8,
-    s: 0.92,
-  },
-  hover: {
-    x: -22,
-    y: -9,
-    r: -8,
-    s: 1,
-    z: 3,
-  },
-  next: {
-    x: -22,
-    y: 64,
-    r: 0,
-  },
+  default: { x: -20, y: -8, r: 7.74, s: 0.92, z: 2 },
+  active: { x: -22, y: -9, r: -8, s: 0.92 },
+  hover: { x: -22, y: -9, r: -8, s: 1, z: 3 },
+  next: { x: -22, y: 64, r: 0 },
 };
 export const mindmapConfig: ToolConfig = {
-  default: {
-    x: 4,
-    y: -4,
-    s: 1,
-    z: 1,
-    r: -7,
-  },
-  active: {
-    x: 11,
-    y: -14,
-    r: 9,
-    s: 1,
-  },
-  hover: {
-    x: 11,
-    y: -14,
-    r: 9,
-    s: 1.16,
-    z: 3,
-  },
-  next: {
-    y: 64,
-    r: 0,
-  },
+  default: { x: 4, y: -4, s: 1, z: 1, r: -7 },
+  active: { x: 11, y: -14, r: 9, s: 1 },
+  hover: { x: 11, y: -14, r: 9, s: 1.16, z: 3 },
+  next: { y: 64, r: 0 },
 };
 
 export const getMindmapRender =

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/tool.mixin.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mixins/tool.mixin.ts
@@ -6,6 +6,7 @@ import { consume } from '@lit/context';
 import { cssVar } from '@toeverything/theme';
 import { property, state } from 'lit/decorators.js';
 
+import type { ColorScheme } from '../../../../../_common/theme/theme-observer.js';
 import type { EdgelessRootBlockComponent } from '../../../edgeless-root-block.js';
 import type { EdgelessTool } from '../../../types.js';
 import type { EdgelessToolbar } from '../edgeless-toolbar.js';
@@ -33,7 +34,7 @@ export declare abstract class EdgelessToolbarToolClass extends DisposableClass {
 
   setEdgelessTool: EdgelessRootBlockComponent['tools']['setEdgelessTool'];
 
-  theme: 'light' | 'dark';
+  theme: ColorScheme;
 
   toolbarContainer: HTMLElement | null;
 
@@ -133,7 +134,7 @@ export const EdgelessToolbarToolMixin = <T extends Constructor<LitElement>>(
     public accessor popper: MenuPopper<HTMLElement> | null = null;
 
     @consume({ context: edgelessToolbarThemeContext, subscribe: true })
-    accessor theme!: 'light' | 'dark';
+    accessor theme!: ColorScheme;
 
     @consume({ context: edgelessToolbarContext })
     accessor toolbar!: EdgelessToolbar;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-senior-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-senior-button.ts
@@ -9,6 +9,7 @@ import {
   LinkIcon,
   TextIcon,
 } from '../../../../../_common/icons/text.js';
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import { EdgelessToolbarToolMixin } from '../mixins/tool.mixin.js';
 import { toShapeNotToAdapt } from './icon.js';
@@ -172,15 +173,24 @@ export class EdgelessNoteSeniorButton extends EdgelessToolbarToolMixin(
   override connectedCallback() {
     super.connectedCallback();
 
-    this._noteBg =
-      this.edgeless.service.editPropsStore.getLastProps(this.type).background ??
-      DEFAULT_NOTE_BACKGROUND_COLOR;
+    const { background } = this.edgeless.service.editPropsStore.getLastProps(
+      this.type
+    );
+    this._noteBg = ThemeObserver.generateColorProperty(
+      background,
+      DEFAULT_NOTE_BACKGROUND_COLOR
+    );
 
     this.disposables.add(
       this.edgeless.service.editPropsStore.slots.lastPropsUpdated.on(
         ({ type, props }) => {
           if (type !== this.type) return;
-          if (props.background) this._noteBg = props.background as string;
+          if (props.background) {
+            this._noteBg = ThemeObserver.generateColorProperty(
+              props.background,
+              DEFAULT_NOTE_BACKGROUND_COLOR
+            );
+          }
         }
       )
     );
@@ -198,7 +208,7 @@ export class EdgelessNoteSeniorButton extends EdgelessToolbarToolMixin(
         class="note-root"
         data-dark=${theme === 'dark'}
         @click=${this._toggleNoteMenu}
-        style="--paper-bg: var(${_noteBg})"
+        style="--paper-bg: ${_noteBg}"
       >
         <div class="paper">${toShapeNotToAdapt}</div>
         <div class="edgeless-toolbar-note-icon link">${LinkIcon}</div>
@@ -209,7 +219,7 @@ export class EdgelessNoteSeniorButton extends EdgelessToolbarToolMixin(
   }
 
   @state()
-  private accessor _noteBg: string = DEFAULT_NOTE_BACKGROUND_COLOR;
+  private accessor _noteBg: string = `var(${DEFAULT_NOTE_BACKGROUND_COLOR})`;
 
   // TODO: better to extract these states outside of component?
   @state()

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
@@ -1,13 +1,18 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { CssVariableName } from '../../../../../_common/theme/css-variables.js';
+import type { Color } from '../../../../../surface-block/consts.js';
 import type { ShapeName } from './shape-tool-element.js';
 
 import {
   GeneralStyleIcon,
   ScribbledStyleIcon,
 } from '../../../../../_common/icons/index.js';
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
+import {
+  DEFAULT_SHAPE_FILL_COLOR,
+  FILL_COLORS,
+} from '../../../../../surface-block/elements/shape/consts.js';
 import { ShapeStyle } from '../../../../../surface-block/index.js';
 import '../../buttons/tool-icon-button.js';
 import { type ColorEvent, isTransparent } from '../../panel/color-panel.js';
@@ -26,16 +31,13 @@ export class EdgelessShapeMenu extends LitElement {
     });
   };
 
-  private _setStrokeColor = (strokeColor: CssVariableName) => {
-    const props: Record<string, unknown> = { strokeColor };
-    const fillColor = strokeColor.replace(
-      LINE_COLOR_PREFIX,
-      SHAPE_COLOR_PREFIX
+  private _setStrokeColor = (fillColor: string) => {
+    const strokeColor = fillColor.replace(
+      SHAPE_COLOR_PREFIX,
+      LINE_COLOR_PREFIX
     );
     const filled = !isTransparent(fillColor);
-    props.fillColor = fillColor;
-    props.filled = filled;
-    this.onChange(props);
+    this.onChange({ filled, fillColor, strokeColor });
   };
 
   static override styles = css`
@@ -66,11 +68,15 @@ export class EdgelessShapeMenu extends LitElement {
   `;
 
   override render() {
-    const { radius, strokeColor, shapeStyle } = this;
+    const { radius, fillColor, shapeStyle } = this;
     let { shapeType } = this;
     if (shapeType === 'rect' && radius > 0) {
       shapeType = 'roundedRect';
     }
+    const color = ThemeObserver.getColorValue(
+      fillColor,
+      DEFAULT_SHAPE_FILL_COLOR
+    );
 
     return html`
       <edgeless-slide-menu>
@@ -118,7 +124,8 @@ export class EdgelessShapeMenu extends LitElement {
           </div>
           <menu-divider .vertical=${true}></menu-divider>
           <edgeless-one-row-color-panel
-            .value=${strokeColor}
+            .value=${color}
+            .options=${FILL_COLORS}
             @select=${(e: ColorEvent) => this._setStrokeColor(e.detail)}
           ></edgeless-one-row-color-panel>
         </div>
@@ -127,7 +134,7 @@ export class EdgelessShapeMenu extends LitElement {
   }
 
   @property({ attribute: false })
-  accessor fillColor!: CssVariableName;
+  accessor fillColor!: Color;
 
   @property({ attribute: false })
   accessor onChange!: (props: Record<string, unknown>) => void;
@@ -142,7 +149,7 @@ export class EdgelessShapeMenu extends LitElement {
   accessor shapeType!: ShapeName;
 
   @property({ attribute: false })
-  accessor strokeColor!: CssVariableName;
+  accessor strokeColor!: Color;
 }
 
 declare global {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -7,7 +7,7 @@ import type { LastProps } from '../../../../../surface-block/managers/edit-sessi
 import type { ShapeName } from './shape-tool-element.js';
 import type { DraggableShape } from './utils.js';
 
-import { isTransparent } from '../../../../../_common/theme/css-variables.js';
+import { ThemeObserver } from '../../../../../_common/theme/theme-observer.js';
 import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
@@ -104,21 +104,27 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
         states,
         updates => {
           this.states = { ...this.states, ...updates };
+          this.updateMenu();
         }
       )
     );
   }
 
   override render() {
-    const { active, states } = this;
-    const { fillColor, strokeColor } = states;
+    const {
+      active,
+      states: { fillColor, strokeColor },
+    } = this;
 
-    const shapeColor = isTransparent(fillColor!)
-      ? cssVar('white60')
-      : `var(${fillColor})`;
-    const shapeStroke = isTransparent(strokeColor!)
-      ? cssVar('black10')
-      : `var(${strokeColor})`;
+    let color = ThemeObserver.generateColorProperty(fillColor!);
+    let stroke = ThemeObserver.generateColorProperty(strokeColor!);
+
+    if (color.endsWith('transparent')) {
+      color = cssVar('white60');
+    }
+    if (stroke.endsWith('transparent')) {
+      stroke = cssVar('black10');
+    }
 
     return html`
       <edgeless-toolbar-button
@@ -131,12 +137,9 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
           .edgeless=${this.edgeless}
           .toolbarContainer=${this.toolbarContainer}
           class="shapes"
-          style=${styleMap({
-            color: shapeColor,
-            stroke: shapeStroke,
-          })}
-          .color=${shapeColor}
-          .stroke=${shapeStroke}
+          style=${styleMap({ color, stroke })}
+          .color=${color}
+          .stroke=${stroke}
           @click=${this._toggleMenu}
           .onShapeClick=${this._handleShapeClick.bind(this)}
         >

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-tool-button.ts
@@ -7,6 +7,8 @@ import {
 } from '@floating-ui/dom';
 import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 import type { EdgelessTool } from '../../../types.js';
 import type { EdgelessTemplatePanel } from './template-panel.js';
@@ -187,17 +189,32 @@ export class EdgelessTemplateButton extends EdgelessToolbarToolMixin(
   }
 
   override render() {
-    const { theme } = this;
-    const expanded = this._openedPanel !== null;
+    const { cards, _openedPanel } = this;
+    const expanded = _openedPanel !== null;
 
     return html`<edgeless-toolbar-button @click=${this._togglePanel}>
       <div class="template-cards ${expanded ? 'expanded' : ''}">
         <div class="arrow-icon">${ArrowDownSmallIcon}</div>
-        <div class="template-card card1">${TemplateCard1[theme]}</div>
-        <div class="template-card card2">${TemplateCard2[theme]}</div>
-        <div class="template-card card3">${TemplateCard3[theme]}</div>
+        ${repeat(
+          cards,
+          (card, n) => html`
+            <div
+              class=${classMap({
+                'template-card': true,
+                [`card${n + 1}`]: true,
+              })}
+            >
+              ${card}
+            </div>
+          `
+        )}
       </div>
     </edgeless-toolbar-button>`;
+  }
+
+  get cards() {
+    const { theme } = this;
+    return [TemplateCard1[theme], TemplateCard2[theme], TemplateCard3[theme]];
   }
 
   @state()

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/lasso-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/lasso-tool.ts
@@ -6,6 +6,7 @@ import { Bound, Vec, noop } from '@blocksuite/global/utils';
 
 import type { EdgelessTool } from '../../types.js';
 
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { LassoMode } from '../../../../_common/types.js';
 import {
   Overlay,
@@ -27,12 +28,12 @@ class LassoOverlay extends Overlay {
 
   render(ctx: CanvasRenderingContext2D): void {
     const path = new Path2D(this.d);
-    const { zoom } = this._renderer.viewport;
+    const zoom = this._renderer?.viewport.zoom ?? 1.0;
     ctx.save();
-    const primaryColor = this._renderer.getVariableColor(
+    const primaryColor = ThemeObserver.getPropertyValue(
       '--affine-primary-color'
     );
-    const strokeColor = this._renderer.getVariableColor(
+    const strokeColor = ThemeObserver.getPropertyValue(
       '--affine-secondary-color'
     );
     if (this.startPoint) {

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/shape-tool.ts
@@ -11,7 +11,12 @@ import type {
 import type { SelectionArea } from '../../services/tools-manager.js';
 import type { EdgelessTool } from '../../types.js';
 
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 import { hasClassNameInList } from '../../../../_common/utils/index.js';
+import {
+  DEFAULT_SHAPE_FILL_COLOR,
+  DEFAULT_SHAPE_STROKE_COLOR,
+} from '../../../../surface-block/elements/shape/consts.js';
 import { CanvasElementType } from '../../../../surface-block/index.js';
 import {
   EXCLUDING_MOUSE_OUT_CLASS_LIST,
@@ -179,8 +184,16 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
     const options = SHAPE_OVERLAY_OPTIONS;
     const attributes =
       this._edgeless.service.editPropsStore.getLastProps('shape');
-    options.stroke = attributes.strokeColor;
-    options.fill = attributes.fillColor;
+    options.stroke = ThemeObserver.getColorValue(
+      attributes.strokeColor,
+      DEFAULT_SHAPE_STROKE_COLOR,
+      true
+    );
+    options.fill = ThemeObserver.getColorValue(
+      attributes.fillColor,
+      DEFAULT_SHAPE_FILL_COLOR,
+      true
+    );
 
     switch (attributes.strokeStyle!) {
       case 'dash':
@@ -199,8 +212,8 @@ export class ShapeToolController extends EdgelessToolController<ShapeTool> {
     }
     this._shapeOverlay = new ShapeOverlay(this._edgeless, shapeType, options, {
       shapeStyle: attributes.shapeStyle,
-      fillColor: options.fill,
-      strokeColor: options.stroke,
+      fillColor: attributes.fillColor,
+      strokeColor: attributes.strokeColor,
     });
     this._edgeless.surface.renderer.addOverlay(this._shapeOverlay);
   }

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -29,7 +29,6 @@ import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
 } from '../../_common/consts.js';
-import { ThemeObserver } from '../../_common/theme/theme-observer.js';
 import {
   NoteDisplayMode,
   type Viewport,
@@ -101,8 +100,6 @@ export class EdgelessRootBlockComponent extends BlockComponent<
   }, this);
 
   private _resizeObserver: ResizeObserver | null = null;
-
-  private readonly _themeObserver = new ThemeObserver();
 
   private _viewportElement: HTMLElement | null = null;
 
@@ -297,9 +294,9 @@ export class EdgelessRootBlockComponent extends BlockComponent<
   private _initSlotEffects() {
     const { disposables, slots } = this;
 
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => this.surface.refresh());
-    this.disposables.add(() => this._themeObserver.dispose());
+    this.disposables.add(
+      this.service.themeObserver.mode$.subscribe(() => this.surface.refresh())
+    );
 
     disposables.add(this.service.selection);
     disposables.add(

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
@@ -13,7 +13,6 @@ import type { RootBlockModel } from '../root-model.js';
 import type { EdgelessRootBlockWidgetName } from '../types.js';
 import type { EdgelessRootService } from './edgeless-root-service.js';
 
-import { ThemeObserver } from '../../_common/theme/theme-observer.js';
 import { requestThrottledConnectFrame } from '../../_common/utils/index.js';
 import '../../surface-block/surface-block.js';
 import './components/note-slicer/index.js';
@@ -45,8 +44,6 @@ export class EdgelessRootPreviewBlockComponent extends BlockComponent<
   }, this);
 
   private _resizeObserver: ResizeObserver | null = null;
-
-  private readonly _themeObserver = new ThemeObserver();
 
   private _viewportElement: HTMLElement | null = null;
 
@@ -158,9 +155,9 @@ export class EdgelessRootPreviewBlockComponent extends BlockComponent<
   private _initSlotEffects() {
     const { disposables } = this;
 
-    this._themeObserver.observe(document.documentElement);
-    this._themeObserver.on(() => this.surface.refresh());
-    this.disposables.add(() => this._themeObserver.dispose());
+    this.disposables.add(
+      this.service.themeObserver.mode$.subscribe(() => this.surface.refresh())
+    );
 
     disposables.add(this.service.selection);
   }

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -32,14 +32,14 @@ export class FrameOverlay extends Overlay {
 
   clear() {
     this.bound = null;
-    this._renderer.refresh();
+    this._renderer?.refresh();
   }
 
   highlight(frame: FrameBlockModel) {
     const bound = Bound.deserialize(frame.xywh);
 
     this.bound = bound;
-    this._renderer.refresh();
+    this._renderer?.refresh();
   }
 
   override render(ctx: CanvasRenderingContext2D, _rc: RoughCanvas): void {

--- a/packages/blocks/src/root-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/text.ts
@@ -9,6 +9,7 @@ import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { GroupElementModel } from '../../../surface-block/element-model/group.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
+import { ThemeObserver } from '../../../_common/theme/theme-observer.js';
 import { getCursorByCoord } from '../../../surface-block/canvas-renderer/element-renderer/text/utils.js';
 import { FontFamily } from '../../../surface-block/consts.js';
 import { ShapeElementModel } from '../../../surface-block/element-model/shape.js';
@@ -68,7 +69,7 @@ export function mountShapeTextEditor(
 ) {
   if (!shapeElement.text) {
     const text = new DocCollection.Y.Text();
-    let color = edgeless.surface.themeObserver.getColorValue(
+    let color = ThemeObserver.getColorValue(
       shapeElement.fillColor,
       GET_DEFAULT_LINE_COLOR()
     );

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -331,7 +331,7 @@ export class RootService extends BlockService<RootBlockModel> {
 
   telemetryService: TelemetryService | null = null;
 
-  readonly themeObserver = new ThemeObserver();
+  readonly themeObserver = ThemeObserver.instance;
 
   transformers = {
     markdown: MarkdownTransformer,

--- a/packages/blocks/src/root-block/widgets/ai-panel/components/generating-placeholder.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/components/generating-placeholder.ts
@@ -14,7 +14,7 @@ import {
   DarkLoadingIcon,
   LightLoadingIcon,
 } from '../../../../_common/icons/text.js';
-import { getThemeMode } from '../../../../_common/utils/query.js';
+import { ThemeObserver } from '../../../../_common/theme/theme-observer.js';
 
 @customElement('generating-placeholder')
 class GeneratingPlaceholder extends WithDisposable(LitElement) {
@@ -91,7 +91,7 @@ class GeneratingPlaceholder extends WithDisposable(LitElement) {
   `;
 
   protected override render() {
-    const theme = getThemeMode();
+    const theme = ThemeObserver.mode;
     const loadingText = this.stages[this.loadingProgress - 1] || '';
 
     return html`<style>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
@@ -65,13 +65,12 @@ export class EdgelessChangeBrushButton extends WithDisposable(LitElement) {
 
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      const { type, value } = event.detail;
-      this.elements.forEach(ele => {
+      this.elements.forEach(ele =>
         this.service.updateElement(
           ele.id,
-          packColor(type, 'color', value, ele.color)
-        );
-      });
+          packColor('color', { ...event.detail })
+        )
+      );
       return;
     }
 

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
@@ -7,7 +7,6 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { ColorScheme } from '../../../_common/theme/theme-observer.js';
 import type {
   ConnectorElementProps,
@@ -236,13 +235,12 @@ const MODE_CHOOSE: [ConnectorMode, () => TemplateResult<1>][] = [
 export class EdgelessChangeConnectorButton extends WithDisposable(LitElement) {
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      const { type, value } = event.detail;
-      this.elements.forEach(ele => {
+      this.elements.forEach(ele =>
         this.service.updateElement(
           ele.id,
-          packColor(type, 'stroke', value, ele.stroke)
-        );
-      });
+          packColor('stroke', { ...event.detail })
+        )
+      );
       return;
     }
 
@@ -276,7 +274,7 @@ export class EdgelessChangeConnectorButton extends WithDisposable(LitElement) {
     );
   }
 
-  private _setConnectorColor(stroke: CssVariableName) {
+  private _setConnectorColor(stroke: string) {
     this._setConnectorProp('stroke', stroke);
   }
 

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -5,7 +5,6 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { join } from 'lit/directives/join.js';
 import { when } from 'lit/directives/when.js';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { ColorScheme } from '../../../_common/theme/theme-observer.js';
 import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { EdgelessColorPickerButton } from '../../edgeless/components/color-picker/button.js';
@@ -29,7 +28,7 @@ import {
 import { DEFAULT_NOTE_HEIGHT } from '../../edgeless/utils/consts.js';
 import { mountFrameTitleEditor } from '../../edgeless/utils/text.js';
 
-const FRAME_BACKGROUND: CssVariableName[] = [
+const FRAME_BACKGROUND: string[] = [
   '--affine-tag-gray',
   '--affine-tag-red',
   '--affine-tag-orange',
@@ -58,13 +57,12 @@ function getMostCommonColor(
 export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      const { type, value } = event.detail;
-      this.frames.forEach(ele => {
+      this.frames.forEach(ele =>
         this.service.updateElement(
           ele.id,
-          packColor(type, 'background', value, ele.background)
-        );
-      });
+          packColor('background', { ...event.detail })
+        )
+      );
       return;
     }
 
@@ -116,7 +114,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
     toast(this.edgeless.host, 'Frame has been inserted into doc');
   }
 
-  private _setFrameBackground(color: CssVariableName) {
+  private _setFrameBackground(color: string) {
     this.frames.forEach(frame => {
       this.service.updateElement(frame.id, { background: color });
     });

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -8,7 +8,6 @@ import { type Ref, createRef, ref } from 'lit/directives/ref.js';
 import { when } from 'lit/directives/when.js';
 
 import type { EditorMenuButton } from '../../../_common/components/toolbar/menu-button.js';
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { ColorScheme } from '../../../_common/theme/theme-observer.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { StrokeStyle } from '../../../surface-block/index.js';
@@ -109,13 +108,13 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
 
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      const { type, value } = event.detail;
-      this.notes.forEach(ele => {
-        this.doc.updateBlock(
-          ele,
-          packColor(type, 'background', value, ele.background)
-        );
-      });
+      this.notes.forEach(ele =>
+        this.doc.updateBlock(ele, packColor('background', { ...event.detail }))
+      );
+      this.edgeless.service.editPropsStore.recordLastProps(
+        'affine:note',
+        packColor('background', event.detail)
+      );
       return;
     }
 
@@ -135,7 +134,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     this.edgeless.slots.toggleNoteSlicer.emit();
   }
 
-  private _setBackground(background: CssVariableName) {
+  private _setBackground(background: string) {
     this.notes.forEach(note => {
       this.doc.updateBlock(note, { background });
     });

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -7,7 +7,6 @@ import { join } from 'lit/directives/join.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { ColorScheme } from '../../../_common/theme/theme-observer.js';
 import type { ShapeProps } from '../../../surface-block/element-model/shape.js';
 import type { EdgelessColorPickerButton } from '../../edgeless/components/color-picker/button.js';
@@ -165,13 +164,12 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
   ) {
     return (event: PickColorEvent) => {
       if (event.type === 'pick') {
-        const { type, value } = event.detail;
-        this.elements.forEach(ele => {
+        this.elements.forEach(ele =>
           this.service.updateElement(
             ele.id,
-            packColor(type, key, value, ele[key])
-          );
-        });
+            packColor(key, { ...event.detail })
+          )
+        );
         return;
       }
 
@@ -185,7 +183,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     mountShapeTextEditor(this.elements[0], this.edgeless);
   }
 
-  private _getTextColor(fillColor: CssVariableName) {
+  private _getTextColor(fillColor: string) {
     // When the shape is filled with black color, the text color should be white.
     // When the shape is transparent, the text color should be set according to the theme.
     // Otherwise, the text color should be black.
@@ -198,7 +196,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     return textColor;
   }
 
-  private _setShapeFillColor(fillColor: CssVariableName) {
+  private _setShapeFillColor(fillColor: string) {
     const filled = !isTransparent(fillColor);
     const color = this._getTextColor(fillColor);
     this.elements.forEach(ele =>
@@ -206,7 +204,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     );
   }
 
-  private _setShapeStrokeColor(strokeColor: CssVariableName) {
+  private _setShapeStrokeColor(strokeColor: string) {
     this.elements.forEach(ele =>
       this.service.updateElement(ele.id, { strokeColor })
     );

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
@@ -308,14 +308,12 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      const { type, value } = event.detail;
-
       this.elements.forEach(ele => {
         if (ele instanceof ConnectorElementModel) {
           this.service.updateElement(ele.id, {
             labelStyle: {
               ...ele.labelStyle,
-              ...packColor(type, 'color', value, ele.labelStyle.color),
+              ...packColor('color', { ...event.detail }),
             },
           });
           this._updateElementBound(ele);
@@ -324,7 +322,7 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
         this.service.updateElement(
           ele.id,
-          packColor(type, 'color', value, ele.color)
+          packColor('color', { ...event.detail })
         );
         this._updateElementBound(ele);
       });

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -26,6 +26,7 @@ import '../../../_common/components/toolbar/menu-button.js';
 import { renderToolbarSeparator } from '../../../_common/components/toolbar/separator.js';
 import '../../../_common/components/toolbar/toolbar.js';
 import { ConnectorCWithArrowIcon } from '../../../_common/icons/edgeless.js';
+import { ThemeObserver } from '../../../_common/theme/theme-observer.js';
 import {
   atLeastNMatches,
   groupBy,
@@ -278,6 +279,12 @@ export class EdgelessElementToolbarWidget extends WidgetComponent<
     _disposables.add(
       edgeless.slots.readonlyUpdated.on(() => this.requestUpdate())
     );
+
+    this.updateComplete
+      .then(() => {
+        _disposables.add(ThemeObserver.subscribe(() => this.requestUpdate()));
+      })
+      .catch(console.error);
   }
 
   registerEntry(entry: CustomEntry) {

--- a/packages/blocks/src/root-block/widgets/pie-menu/base.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/base.ts
@@ -1,6 +1,5 @@
 import type { TemplateResult } from 'lit';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 import type { PieMenuId } from '../../types.js';
 import type { AffinePieMenuWidget } from './index.js';
@@ -70,10 +69,10 @@ export interface PieSubmenuNodeModel extends PieBaseNodeModel {
 
 export interface PieColorNodeModel extends PieBaseNodeModel {
   type: 'color';
-  color: CssVariableName;
+  color: string;
   hollowCircle: boolean;
   text?: string;
-  onChange: (color: CssVariableName, ctx: PieMenuContext) => void;
+  onChange: (color: string, ctx: PieMenuContext) => void;
 }
 
 export type IPieNodeWithAction =

--- a/packages/blocks/src/root-block/widgets/pie-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/config.ts
@@ -1,7 +1,6 @@
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type { LastProps } from '../../../surface-block/managers/edit-session.js';
 import type { PieMenuContext } from './base.js';
 
@@ -77,7 +76,7 @@ pie.expandableCommand({
     pie.colorPicker({
       label: 'Pen Color',
       active: getActiveConnectorStrokeColor,
-      onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+      onChange: (color: string, { rootComponent }: PieMenuContext) => {
         rootComponent.service.editPropsStore.recordLastProps('brush', {
           color: color as LastProps['brush']['color'],
         });
@@ -216,7 +215,7 @@ pie.command({
 pie.colorPicker({
   label: 'Line Color',
   active: getActiveConnectorStrokeColor,
-  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+  onChange: (color: string, { rootComponent }: PieMenuContext) => {
     rootComponent.service.editPropsStore.recordLastProps('connector', {
       stroke: color as LastProps['connector']['stroke'],
     });
@@ -310,7 +309,7 @@ pie.command({
 pie.colorPicker({
   label: 'Fill',
   active: getActiveShapeColor('fill'),
-  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+  onChange: (color: string, { rootComponent }: PieMenuContext) => {
     rootComponent.service.editPropsStore.recordLastProps('shape', {
       fillColor: color as LastProps['shape']['fillColor'],
     });
@@ -323,7 +322,7 @@ pie.colorPicker({
   label: 'Stroke',
   hollow: true,
   active: getActiveShapeColor('stroke'),
-  onChange: (color: CssVariableName, { rootComponent }: PieMenuContext) => {
+  onChange: (color: string, { rootComponent }: PieMenuContext) => {
     rootComponent.service.editPropsStore.recordLastProps('shape', {
       strokeColor: color as LastProps['shape']['strokeColor'],
     });

--- a/packages/blocks/src/root-block/widgets/pie-menu/pie-builder.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/pie-builder.ts
@@ -1,6 +1,5 @@
 import { assertExists } from '@blocksuite/global/utils';
 
-import type { CssVariableName } from '../../../_common/theme/css-variables.js';
 import type {
   ActionFunction,
   PieColorNodeModel,
@@ -17,11 +16,11 @@ import { calcNodeAngles, calcNodeWedges, isNodeWithChildren } from './utils.js';
 
 export interface IPieColorPickerNodeProps {
   label: string;
-  active: (ctx: PieMenuContext) => CssVariableName;
+  active: (ctx: PieMenuContext) => string;
   onChange: PieColorNodeModel['onChange'];
   openOnHover?: PieSubmenuNodeModel['openOnHover'];
   hollow?: boolean;
-  colors: { color: CssVariableName }[];
+  colors: { color: string }[];
 }
 
 type PieBuilderConstructorProps = Omit<

--- a/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
@@ -13,6 +13,7 @@ import type {
   PieSubmenuNodeModel,
 } from './base.js';
 
+import { ThemeObserver } from '../../../_common/theme/theme-observer.js';
 import { ShapeToolController } from '../../edgeless/controllers/tools/shape-tool.js';
 import { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
@@ -27,8 +28,8 @@ export function getActiveShapeColor(type: 'fill' | 'stroke') {
   return ({ rootComponent }: PieMenuContext) => {
     if (rootComponent instanceof EdgelessRootBlockComponent) {
       const props = rootComponent.service.editPropsStore.getLastProps('shape');
-      if (type == 'fill') return props.fillColor;
-      else return props.strokeColor;
+      const color = type == 'fill' ? props.fillColor : props.strokeColor;
+      return ThemeObserver.getColorValue(color);
     }
     return '';
   };
@@ -40,7 +41,8 @@ export function getActiveConnectorStrokeColor({
   if (rootComponent instanceof EdgelessRootBlockComponent) {
     const props =
       rootComponent.service.editPropsStore.getLastProps('connector');
-    return props.stroke;
+    const color = props.stroke;
+    return ThemeObserver.getColorValue(color);
   }
   return '';
 }

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/group/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/group/index.ts
@@ -21,7 +21,7 @@ export function group(
   } else if (model.childElements.some(child => elements.includes(child.id))) {
     const bound = Bound.deserialize(xywh);
     ctx.setLineDash([2, 2]);
-    ctx.strokeStyle = renderer.getVariableColor('--affine-blue');
+    ctx.strokeStyle = renderer.getPropertyValue('--affine-blue');
     ctx.lineWidth = 1;
     ctx.strokeRect(0, 0, bound.w, bound.h);
 

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/diamond.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/diamond.ts
@@ -2,7 +2,7 @@ import type { ShapeElementModel } from '../../../element-model/shape.js';
 import type { RoughCanvas } from '../../../rough/canvas.js';
 import type { Renderer } from '../../renderer.js';
 
-import { type CustomStyle, drawGeneralShape } from './utils.js';
+import { type Colors, drawGeneralShape } from './utils.js';
 
 export function diamond(
   model: ShapeElementModel,
@@ -10,7 +10,7 @@ export function diamond(
   matrix: DOMMatrix,
   renderer: Renderer,
   rc: RoughCanvas,
-  customStyle: CustomStyle
+  colors: Colors
 ) {
   const {
     seed,
@@ -28,7 +28,7 @@ export function diamond(
   const cx = renderWidth / 2;
   const cy = renderHeight / 2;
 
-  const { fillColor, strokeColor } = customStyle;
+  const { fillColor, strokeColor } = colors;
 
   ctx.setTransform(
     matrix

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/ellipse.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/ellipse.ts
@@ -2,7 +2,7 @@ import type { ShapeElementModel } from '../../../element-model/shape.js';
 import type { RoughCanvas } from '../../../rough/canvas.js';
 import type { Renderer } from '../../renderer.js';
 
-import { type CustomStyle, drawGeneralShape } from './utils.js';
+import { type Colors, drawGeneralShape } from './utils.js';
 
 export function ellipse(
   model: ShapeElementModel,
@@ -10,7 +10,7 @@ export function ellipse(
   matrix: DOMMatrix,
   renderer: Renderer,
   rc: RoughCanvas,
-  customStyle: CustomStyle
+  colors: Colors
 ) {
   const {
     seed,
@@ -28,7 +28,7 @@ export function ellipse(
   const cx = renderWidth / 2;
   const cy = renderHeight / 2;
 
-  const { fillColor, strokeColor } = customStyle;
+  const { fillColor, strokeColor } = colors;
 
   ctx.setTransform(
     matrix

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
@@ -27,7 +27,7 @@ import { diamond } from './diamond.js';
 import { ellipse } from './ellipse.js';
 import { rect } from './rect.js';
 import { triangle } from './triangle.js';
-import { type CustomStyle, horizontalOffset, verticalOffset } from './utils.js';
+import { type Colors, horizontalOffset, verticalOffset } from './utils.js';
 
 const shapeRenderers: {
   [key in ShapeType]: (
@@ -36,7 +36,7 @@ const shapeRenderers: {
     matrix: DOMMatrix,
     renderer: Renderer,
     rc: RoughCanvas,
-    custom: CustomStyle
+    colors: Colors
   ) => void;
 } = {
   diamond,
@@ -59,12 +59,12 @@ export function shape(
   );
   const fillColor = renderer.getColorValue(
     model.fillColor,
-    DEFAULT_SHAPE_STROKE_COLOR,
+    DEFAULT_SHAPE_FILL_COLOR,
     true
   );
   const strokeColor = renderer.getColorValue(
     model.strokeColor,
-    DEFAULT_SHAPE_FILL_COLOR,
+    DEFAULT_SHAPE_STROKE_COLOR,
     true
   );
   const customStyle = { color, fillColor, strokeColor };
@@ -86,7 +86,7 @@ export function shape(
 function renderText(
   model: ShapeElementModel,
   ctx: CanvasRenderingContext2D,
-  { color }: CustomStyle
+  { color }: Colors
 ) {
   const {
     x,

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
@@ -2,7 +2,7 @@ import type { ShapeElementModel } from '../../../element-model/shape.js';
 import type { RoughCanvas } from '../../../rough/canvas.js';
 import type { Renderer } from '../../renderer.js';
 
-import { type CustomStyle, drawGeneralShape } from './utils.js';
+import { type Colors, drawGeneralShape } from './utils.js';
 
 /**
  * "magic number" for bezier approximations of arcs (http://itc.ktu.lt/itc354/Riskus354.pdf)
@@ -15,7 +15,7 @@ export function rect(
   matrix: DOMMatrix,
   renderer: Renderer,
   rc: RoughCanvas,
-  customStyle: CustomStyle
+  colors: Colors
 ) {
   const {
     filled,
@@ -36,7 +36,7 @@ export function rect(
   const cx = renderWidth / 2;
   const cy = renderHeight / 2;
 
-  const { fillColor, strokeColor } = customStyle;
+  const { fillColor, strokeColor } = colors;
 
   ctx.setTransform(
     matrix

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/triangle.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/triangle.ts
@@ -2,7 +2,7 @@ import type { ShapeElementModel } from '../../../element-model/shape.js';
 import type { RoughCanvas } from '../../../rough/canvas.js';
 import type { Renderer } from '../../renderer.js';
 
-import { type CustomStyle, drawGeneralShape } from './utils.js';
+import { type Colors, drawGeneralShape } from './utils.js';
 
 export function triangle(
   model: ShapeElementModel,
@@ -10,7 +10,7 @@ export function triangle(
   matrix: DOMMatrix,
   renderer: Renderer,
   rc: RoughCanvas,
-  customStyle: CustomStyle
+  colors: Colors
 ) {
   const {
     seed,
@@ -28,7 +28,7 @@ export function triangle(
   const cx = renderWidth / 2;
   const cy = renderHeight / 2;
 
-  const { fillColor, strokeColor } = customStyle;
+  const { fillColor, strokeColor } = colors;
 
   ctx.setTransform(
     matrix

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/utils.ts
@@ -17,7 +17,7 @@ import {
   wrapTextDeltas,
 } from '../text/utils.js';
 
-export type CustomStyle = {
+export type Colors = {
   color: string;
   fillColor: string;
   strokeColor: string;
@@ -58,11 +58,9 @@ export function drawGeneralShape(
       break;
     case 'dash':
       ctx.setLineDash([12, 12]);
-      ctx.strokeStyle = renderer.getVariableColor(shapeModel.strokeStyle);
       break;
-    default:
-      ctx.strokeStyle = renderer.getVariableColor(shapeModel.strokeStyle);
   }
+
   if (shapeModel.shadow) {
     const { blur, offsetX, offsetY, color } = shapeModel.shadow;
     const scale = ctx.getTransform().a;
@@ -70,7 +68,7 @@ export function drawGeneralShape(
     ctx.shadowBlur = blur * scale;
     ctx.shadowOffsetX = offsetX * scale;
     ctx.shadowOffsetY = offsetY * scale;
-    ctx.shadowColor = renderer.getVariableColor(color);
+    ctx.shadowColor = renderer.getPropertyValue(color);
   }
 
   ctx.stroke();

--- a/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/renderer.ts
@@ -20,12 +20,11 @@ import { modelRenderer } from './element-renderer/index.js';
  * can be used for rendering non-CRDT state indicators.
  */
 export abstract class Overlay {
-  protected _renderer!: Renderer;
+  protected _renderer: Renderer | null = null;
 
   constructor() {}
 
   setRenderer(renderer: Renderer | null) {
-    // @ts-ignore
     this._renderer = renderer;
   }
 
@@ -33,11 +32,11 @@ export abstract class Overlay {
 }
 
 type EnvProvider = {
-  getVariableColor: (val: string) => string;
-  getColorScheme: () => ColorScheme;
-  selectedElements?: () => string[];
-  getColorValue: (color: Color, fallback?: string, real?: boolean) => string;
   generateColorProperty: (color: Color, fallback: string) => string;
+  getColorScheme: () => ColorScheme;
+  getColorValue: (color: Color, fallback?: string, real?: boolean) => string;
+  getPropertyValue: (property: string) => string;
+  selectedElements?: () => string[];
 };
 
 type RendererOptions = {
@@ -351,10 +350,10 @@ export class Renderer {
   }
 
   generateColorProperty(color: Color, fallback: string) {
-    return (this.provider.generateColorProperty?.(color, fallback) ??
-      fallback.startsWith('--'))
-      ? `var(${fallback})`
-      : fallback;
+    return (
+      this.provider.generateColorProperty?.(color, fallback) ??
+      (fallback.startsWith('--') ? `var(${fallback})` : fallback)
+    );
   }
 
   getCanvasByBound(
@@ -397,8 +396,8 @@ export class Renderer {
     );
   }
 
-  getVariableColor(val: string) {
-    return this.provider.getVariableColor?.(val) ?? val;
+  getPropertyValue(property: string) {
+    return this.provider.getPropertyValue?.(property) ?? '';
   }
 
   refresh() {

--- a/packages/blocks/src/surface-block/consts.ts
+++ b/packages/blocks/src/surface-block/consts.ts
@@ -13,11 +13,7 @@ export const DEFAULT_ROUGHNESS = 1.4;
 // TODO: need to check the default central area ratio
 export const DEFAULT_CENTRAL_AREA_RATIO = 0.3;
 
-export type Color =
-  | string
-  | {
-      [K in ColorScheme]?: string;
-    };
+export type Color = string | { [K in ColorScheme | 'normal']?: string };
 
 export enum ShapeStyle {
   General = 'General',

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -836,7 +836,7 @@ export class ConnectionOverlay extends Overlay {
   _clearRect() {
     this.points = [];
     this.highlightPoint = null;
-    this._renderer.refresh();
+    this._renderer?.refresh();
   }
 
   private _findConnectablesInViews() {
@@ -961,7 +961,7 @@ export class ConnectionOverlay extends Overlay {
           rBound(connectable, true),
           nearestPoint
         );
-        this._renderer.refresh();
+        this._renderer?.refresh();
         target = connectable;
         result = {
           id: connectable.id,
@@ -1004,7 +1004,7 @@ export class ConnectionOverlay extends Overlay {
       };
     }
 
-    this._renderer.refresh();
+    this._renderer?.refresh();
 
     return result;
   }

--- a/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
@@ -21,8 +21,6 @@ export class MindmapSurfaceBlock extends BlockComponent<SurfaceBlockModel> {
 
   private _renderer!: Renderer;
 
-  private _theme = new ThemeObserver();
-
   private _viewport!: Viewport;
 
   private _adjustNodeWidth() {
@@ -86,16 +84,15 @@ export class MindmapSurfaceBlock extends BlockComponent<SurfaceBlockModel> {
       enableStackingCanvas: true,
       provider: {
         selectedElements: () => [],
-        getColorScheme: () => this._theme.mode,
-        getVariableColor: (val: string) => this._theme.getVariableValue(val),
+        getColorScheme: () => ThemeObserver.mode,
         getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          this._theme.getColorValue(color, fallback, real),
+          ThemeObserver.getColorValue(color, fallback, real),
         generateColorProperty: (color: Color, fallback: string) =>
-          this._theme.generateColorProperty(color, fallback),
+          ThemeObserver.generateColorProperty(color, fallback),
+        getPropertyValue: (property: string) =>
+          ThemeObserver.getPropertyValue(property),
       },
     });
-    this._theme.observe(this.ownerDocument.documentElement);
-    this.disposables.add(() => this._theme.dispose());
   }
 
   override firstUpdated(_changedProperties: Map<PropertyKey, unknown>): void {

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -41,9 +41,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   };
 
   private _initThemeObserver = () => {
-    this.themeObserver.observe(document.documentElement);
-    this.themeObserver.on(() => this.requestUpdate());
-    this.disposables.add(() => this.themeObserver.dispose());
+    this.disposables.add(ThemeObserver.subscribe(() => this.requestUpdate()));
   };
 
   private _lastTime = 0;
@@ -140,8 +138,6 @@ export class SurfaceBlockComponent extends BlockComponent<
     this._renderer?.refresh();
   };
 
-  readonly themeObserver = new ThemeObserver();
-
   private _getReversedTransform() {
     const { translateX, translateY, zoom } = this.edgeless.service.viewport;
 
@@ -167,14 +163,14 @@ export class SurfaceBlockComponent extends BlockComponent<
       layerManager: service.layer,
       enableStackingCanvas: true,
       provider: {
-        selectedElements: () => service.selection.selectedIds,
-        getColorScheme: () => this.themeObserver.mode,
-        getVariableColor: (val: string) =>
-          this.themeObserver.getVariableValue(val),
-        getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          this.themeObserver.getColorValue(color, fallback, real),
         generateColorProperty: (color: Color, fallback: string) =>
-          this.themeObserver.generateColorProperty(color, fallback),
+          ThemeObserver.generateColorProperty(color, fallback),
+        getColorValue: (color: Color, fallback?: string, real?: boolean) =>
+          ThemeObserver.getColorValue(color, fallback, real),
+        getColorScheme: () => ThemeObserver.mode,
+        getPropertyValue: (property: string) =>
+          ThemeObserver.getPropertyValue(property),
+        selectedElements: () => service.selection.selectedIds,
       },
       onStackingCanvasCreated(canvas) {
         canvas.className = 'indexable-canvas';

--- a/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
@@ -39,29 +39,24 @@ export class SurfaceRefRenderer {
       enableStackingCanvas: false,
     }
   ) {
-    const themeObserver = new ThemeObserver();
     const viewport = new Viewport();
     const renderer = new Renderer({
       viewport,
       layerManager: this.surfaceService.layer,
       enableStackingCanvas: options.enableStackingCanvas,
       provider: {
-        getColorScheme: () => themeObserver.mode,
-        getVariableColor: (variable: string) =>
-          themeObserver.getVariableValue(variable),
-        getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          themeObserver.getColorValue(color, fallback, real),
         generateColorProperty: (color: Color, fallback: string) =>
-          themeObserver.generateColorProperty(color, fallback),
+          ThemeObserver.generateColorProperty(color, fallback),
+        getColorScheme: () => ThemeObserver.mode,
+        getColorValue: (color: Color, fallback?: string, real?: boolean) =>
+          ThemeObserver.getColorValue(color, fallback, real),
+        getPropertyValue: (property: string) =>
+          ThemeObserver.getPropertyValue(property),
       },
     });
 
-    themeObserver.observe(document.documentElement);
     this._surfaceRenderer = renderer;
     this._viewport = viewport;
-    this.slots.unmounted.once(() => {
-      themeObserver.dispose();
-    });
   }
 
   private _initSurfaceModel() {

--- a/packages/playground/apps/_common/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/_common/components/quick-edgeless-menu.ts
@@ -5,11 +5,7 @@ import type { DeltaInsert } from '@blocksuite/inline';
 import type { AffineEditorContainer } from '@blocksuite/presets';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
-import {
-  ColorVariables,
-  EdgelessRootService,
-  extractCssVariables,
-} from '@blocksuite/blocks';
+import { EdgelessRootService } from '@blocksuite/blocks';
 import { type DocCollection, Text, Utils } from '@blocksuite/store';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
@@ -38,12 +34,6 @@ import type { LeftSidePanel } from './left-side-panel.js';
 
 import { notify } from '../../default/utils/notify.js';
 import { generateRoomId } from '../sync/websocket/utils.js';
-
-const cssVariablesMap = extractCssVariables(document.documentElement);
-const plate: Record<string, string> = {};
-ColorVariables.forEach((key: string) => {
-  plate[key] = cssVariablesMap[key];
-});
 
 const basePath = import.meta.env.DEV
   ? '/node_modules/@shoelace-style/shoelace/dist'

--- a/packages/playground/starter/index.html
+++ b/packages/playground/starter/index.html
@@ -30,6 +30,15 @@
         margin-top: 78px;
       }
 
+      :root .tp-dfwv {
+        position: fixed;
+        overflow: scroll;
+
+        top: 0;
+        bottom: 0;
+        right: 0;
+      }
+
       @media print {
         doc-title {
           margin-top: 0px;

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -14,7 +14,6 @@ import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
 import {
   EdgelessEditorBlockSpecs,
   PageEditorBlockSpecs,
-  ThemeObserver,
 } from '@blocksuite/blocks';
 import { Slot, assertExists, noop } from '@blocksuite/global/utils';
 import {
@@ -204,16 +203,9 @@ export class AffineEditorContainer
   /**
    * @deprecated need to refactor
    */
-  readonly themeObserver = new ThemeObserver();
-
-  /**
-   * @deprecated need to refactor
-   */
   override connectedCallback() {
     super.connectedCallback();
 
-    this.themeObserver.observe(document.documentElement);
-    this._disposables.add(this.themeObserver);
     this._disposables.add(
       this.doc.slots.rootAdded.on(() => this.requestUpdate())
     );

--- a/packages/presets/src/fragments/outline/card/outline-card.ts
+++ b/packages/presets/src/fragments/outline/card/outline-card.ts
@@ -4,8 +4,8 @@ import { WithDisposable } from '@blocksuite/block-std';
 import {
   type NoteBlockModel,
   NoteDisplayMode,
+  ThemeObserver,
   createButtonPopper,
-  getThemeMode,
   on,
   once,
 } from '@blocksuite/blocks';
@@ -351,7 +351,7 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
   override render() {
     if (this.note.isEmpty.peek()) return nothing;
 
-    const mode = getThemeMode();
+    const mode = ThemeObserver.mode;
     const { children, displayMode } = this.note;
     const currentMode = this._getCurrentModeLabel(displayMode);
     const cardHeaderClasses = classMap({

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -1,4 +1,3 @@
-import type { CssVariableName } from '@blocks/_common/theme/css-variables.js';
 import type { NoteDisplayMode } from '@blocks/_common/types.js';
 import type { NoteBlockModel } from '@blocks/note-block/index.js';
 import type { IPoint, IVec } from '@global/utils/index.js';
@@ -581,7 +580,7 @@ export async function rotateElementByHandle(
   );
 }
 
-export async function selectBrushColor(page: Page, color: CssVariableName) {
+export async function selectBrushColor(page: Page, color: string) {
   const colorButton = page.locator(
     `edgeless-brush-menu .color-unit[aria-label="${color.toLowerCase()}"]`
   );
@@ -1272,17 +1271,14 @@ export async function triggerComponentToolbarAction(
   }
 }
 
-export async function changeEdgelessNoteBackground(
-  page: Page,
-  color: CssVariableName
-) {
+export async function changeEdgelessNoteBackground(page: Page, color: string) {
   const colorButton = page
     .locator('edgeless-change-note-button')
     .locator(`.color-unit[aria-label="${color}"]`);
   await colorButton.click();
 }
 
-export async function changeShapeFillColor(page: Page, color: CssVariableName) {
+export async function changeShapeFillColor(page: Page, color: string) {
   const colorButton = page
     .locator('edgeless-change-shape-button')
     .getByRole('listbox', { name: 'Fill colors' })
@@ -1290,10 +1286,7 @@ export async function changeShapeFillColor(page: Page, color: CssVariableName) {
   await colorButton.click();
 }
 
-export async function changeShapeStrokeColor(
-  page: Page,
-  color: CssVariableName
-) {
+export async function changeShapeStrokeColor(page: Page, color: string) {
   const colorButton = page
     .locator('edgeless-change-shape-button')
     .getByRole('listbox', { name: 'Border colors' })
@@ -1373,10 +1366,7 @@ export async function changeShapeStyle(
   await button.click();
 }
 
-export async function changeConnectorStrokeColor(
-  page: Page,
-  color: CssVariableName
-) {
+export async function changeConnectorStrokeColor(page: Page, color: string) {
   const colorButton = page
     .locator('edgeless-change-connector-button')
     .locator('edgeless-color-panel')

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import type { EditorHost } from '@block-std/view/element/lit-host.js';
-import type { CssVariableName } from '@blocks/_common/theme/css-variables.js';
-import type {
-  DatabaseBlockModel,
-  ListType,
-  RichText,
-  ThemeObserver,
-} from '@blocks/index.js';
+import type { DatabaseBlockModel, ListType, RichText } from '@blocks/index.js';
 import type { InlineRange, InlineRootElement } from '@inline/index.js';
 import type { CustomFramePanel } from '@playground/apps/_common/components/custom-frame-panel.js';
 import type { CustomOutlinePanel } from '@playground/apps/_common/components/custom-outline-panel.js';
@@ -1334,23 +1328,29 @@ export async function getCurrentEditorTheme(page: Page) {
   const mode = await page
     .locator('affine-editor-container')
     .first()
-    .evaluate(ele => {
-      return (ele as unknown as Element & { themeObserver: ThemeObserver })
-        .themeObserver.cssVariables?.['--affine-theme-mode'];
-    });
+    .evaluate(() =>
+      window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue('--affine-theme-mode')
+        .trim()
+    );
   return mode;
 }
 
 export async function getCurrentThemeCSSPropertyValue(
   page: Page,
-  property: CssVariableName
+  property: string
 ) {
   const value = await page
     .locator('affine-editor-container')
-    .evaluate((ele, property: CssVariableName) => {
-      return (ele as unknown as Element & { themeObserver: ThemeObserver })
-        .themeObserver.cssVariables?.[property];
-    }, property);
+    .evaluate(
+      (_, property) =>
+        window
+          .getComputedStyle(document.documentElement)
+          .getPropertyValue(property)
+          .trim(),
+      property
+    );
   return value;
 }
 

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -5,7 +5,6 @@ import type {
   BlockComponent,
   EditorHost,
 } from '@block-std/view/element/index.js';
-import type { CssVariableName } from '@blocks/_common/theme/css-variables.js';
 import type {
   AffineInlineEditor,
   NoteBlockModel,
@@ -989,7 +988,7 @@ export async function assertSelectionInNote(
 export async function assertEdgelessNoteBackground(
   page: Page,
   noteId: string,
-  color: CssVariableName
+  color: string
 ) {
   const editor = getEditorLocator(page);
   const backgroundColor = await editor
@@ -1033,12 +1032,12 @@ function toHex(color: string) {
 
 export async function assertEdgelessColorSameWithHexColor(
   page: Page,
-  edgelessColor: CssVariableName,
+  edgelessColor: string,
   hexColor: `#${string}`
 ) {
   const themeColor = await getCurrentThemeCSSPropertyValue(page, edgelessColor);
   expect(themeColor).toBeTruthy();
-  const edgelessHexColor = toHex(themeColor as string);
+  const edgelessHexColor = toHex(themeColor);
 
   assertSameColor(hexColor, edgelessHexColor as `#${string}`);
 }
@@ -1212,10 +1211,7 @@ export async function assertBlockSelections(page: Page, paths: string[]) {
   expect(actualPaths).toEqual(paths);
 }
 
-export async function assertConnectorStrokeColor(
-  page: Page,
-  color: CssVariableName
-) {
+export async function assertConnectorStrokeColor(page: Page, color: string) {
   const colorButton = page
     .locator('edgeless-change-connector-button')
     .locator('edgeless-color-panel')


### PR DESCRIPTION
Closes: [BS-975](https://linear.app/affine-design/issue/BS-975/重构-theme-observer)

Use the theme observer singleton to monitor system theme switching.

* use `signals` instead of `slot`
* add helper functions
  * `getColorValue`
  * `getPropertyValue`
  * `generatorColorProperty`
* remove redundant functions and types
  *  `getThemeMode` 
  * `extractCssVariables` 
  * `CssVariableName`
