### PR TITLE
refactor(edgeless): use `GfxElementGeometry` interface

### DIFF
--- a/packages/blocks/src/_common/edgeless/mixin/gfx-compatible.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/gfx-compatible.ts
@@ -3,21 +3,21 @@ import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { BlockModel } from '@blocksuite/store';
 
-import { EdgelessBlockModel } from '../../../root-block/edgeless/edgeless-block-model.js';
+import { GfxBlockModel } from '../../../root-block/edgeless/block-model.js';
 
-export type EdgelessSelectableProps = {
+export type GfxCompatibleProps = {
   xywh: SerializedXYWH;
   index: string;
 };
 
-export function selectable<
-  Props extends EdgelessSelectableProps,
+export function GfxCompatible<
+  Props extends GfxCompatibleProps,
   T extends Constructor<BlockModel<Props>> = Constructor<BlockModel<Props>>,
->(SuperClass: T) {
-  if (SuperClass === BlockModel) {
-    return EdgelessBlockModel as unknown as typeof EdgelessBlockModel<Props>;
+>(BlockModelSuperClass: T) {
+  if (BlockModelSuperClass === BlockModel) {
+    return GfxBlockModel as unknown as typeof GfxBlockModel<Props>;
   } else {
-    let currentClass = SuperClass;
+    let currentClass = BlockModelSuperClass;
 
     while (
       Object.getPrototypeOf(currentClass.prototype) !== BlockModel.prototype &&
@@ -30,8 +30,8 @@ export function selectable<
       throw new Error('The SuperClass is not a subclass of BlockModel');
     }
 
-    Object.setPrototypeOf(currentClass.prototype, EdgelessBlockModel.prototype);
+    Object.setPrototypeOf(currentClass.prototype, GfxBlockModel.prototype);
   }
 
-  return SuperClass as unknown as typeof EdgelessBlockModel<Props>;
+  return BlockModelSuperClass as unknown as typeof GfxBlockModel<Props>;
 }

--- a/packages/blocks/src/_common/edgeless/mixin/index.ts
+++ b/packages/blocks/src/_common/edgeless/mixin/index.ts
@@ -1,1 +1,1 @@
-export * from './edgeless-selectable.js';
+export * from './gfx-compatible.js';

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -10,7 +10,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { EdgelessRootService } from '../../root-block/edgeless/edgeless-root-service.js';
 import type { DragHandleOption } from '../../root-block/widgets/drag-handle/config.js';
-import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
+import type { GfxCompatibleProps } from '../edgeless/mixin/index.js';
 
 import {
   AFFINE_DRAG_HANDLE_WIDGET,
@@ -31,8 +31,7 @@ import {
 import { styles } from './styles.js';
 
 export class EmbedBlockComponent<
-  Model extends
-    BlockModel<EdgelessSelectableProps> = BlockModel<EdgelessSelectableProps>,
+  Model extends BlockModel<GfxCompatibleProps> = BlockModel<GfxCompatibleProps>,
   Service extends BlockService = BlockService,
   WidgetName extends string = string,
 > extends CaptionedBlockComponent<Model, Service, WidgetName> {

--- a/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-model.ts
@@ -4,16 +4,16 @@ import type { BlockModel } from '@blocksuite/store';
 import type { EmbedProps } from './types.js';
 
 import {
-  type EdgelessSelectableProps,
-  selectable,
+  GfxCompatible,
+  type GfxCompatibleProps,
 } from '../edgeless/mixin/index.js';
 
 export function defineEmbedModel<
   Props extends object,
   T extends Constructor<BlockModel<Props>> = Constructor<BlockModel<Props>>,
->(SuperClass: T) {
-  return selectable<Props & EdgelessSelectableProps>(
-    SuperClass as Constructor<BlockModel<Props & EdgelessSelectableProps>>
+>(BlockModelSuperClass: T) {
+  return GfxCompatible<Props & GfxCompatibleProps>(
+    BlockModelSuperClass as Constructor<BlockModel<Props & GfxCompatibleProps>>
   );
 }
 

--- a/packages/blocks/src/_common/embed-block-helper/types.ts
+++ b/packages/blocks/src/_common/embed-block-helper/types.ts
@@ -1,6 +1,6 @@
-import type { EdgelessSelectableProps } from '../edgeless/mixin/index.js';
+import type { GfxCompatibleProps } from '../edgeless/mixin/index.js';
 
-export type EmbedProps<Props = object> = Props & EdgelessSelectableProps;
+export type EmbedProps<Props = object> = Props & GfxCompatibleProps;
 
 export type LinkPreviewData = {
   description: string | null;

--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -6,7 +6,7 @@ import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { assertExists } from '@blocksuite/global/utils';
 import { Bound } from '@blocksuite/global/utils';
 
-import type { EdgelessBlockModel } from '../../root-block/edgeless/edgeless-block-model.js';
+import type { GfxBlockModel } from '../../root-block/edgeless/block-model.js';
 import type { EdgelessRootBlockComponent } from '../../root-block/edgeless/edgeless-root-block.js';
 import type { RootBlockModel } from '../../root-block/index.js';
 
@@ -402,7 +402,7 @@ export class ExportManager {
     bound: IBound,
     blockComponentGetter: (model: BlockModel) => Element | null = () => null,
     edgeless?: EdgelessRootBlockComponent,
-    nodes?: EdgelessBlockModel[],
+    nodes?: GfxBlockModel[],
     surfaces?: BlockSuite.SurfaceElementModel[],
     edgelessBackground?: {
       zoom: number;

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -16,7 +16,7 @@ import type { EmbedSyncedDocCard } from '../../embed-synced-doc-block/components
 import type { ImageBlockModel } from '../../image-block/index.js';
 import type { NoteBlockModel } from '../../note-block/note-model.js';
 
-import { EdgelessBlockModel } from '../../root-block/edgeless/edgeless-block-model.js';
+import { GfxBlockModel } from '../../root-block/edgeless/block-model.js';
 import {
   getElementProps,
   sortEdgelessElements,
@@ -568,7 +568,7 @@ export function createLinkedDocFromEdgelessElements(
     const ids = new Map<string, string>();
     sortedElements.forEach(model => {
       let newId = model.id;
-      if (model instanceof EdgelessBlockModel) {
+      if (model instanceof GfxBlockModel) {
         const blockProps = getBlockProps(model);
         if (isNoteBlock(model)) {
           newId = linkedDoc.addBlock('affine:note', blockProps, rootId);

--- a/packages/blocks/src/attachment-block/attachment-model.ts
+++ b/packages/blocks/src/attachment-block/attachment-model.ts
@@ -1,10 +1,11 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import type { EmbedCardStyle } from '../_common/types.js';
 
-import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/gfx-compatible.js';
 import { AttachmentBlockTransformer } from './attachment-transformer.js';
 
 /**
@@ -88,9 +89,9 @@ export const AttachmentBlockSchema = defineBlockSchema({
   toModel: () => new AttachmentBlockModel(),
 });
 
-export class AttachmentBlockModel extends selectable<AttachmentBlockProps>(
-  BlockModel
-) {}
+export class AttachmentBlockModel
+  extends GfxCompatible<AttachmentBlockProps>(BlockModel)
+  implements GfxElementGeometry {}
 
 declare global {
   namespace BlockSuite {

--- a/packages/blocks/src/bookmark-block/bookmark-model.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-model.ts
@@ -1,3 +1,4 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
@@ -5,7 +6,7 @@ import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 import type { LinkPreviewData } from '../_common/embed-block-helper/index.js';
 import type { EmbedCardStyle } from '../_common/types.js';
 
-import { selectable } from '../_common/edgeless/mixin/index.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/index.js';
 
 export interface BookmarkBlockEdgelessProps {
   index: string;
@@ -59,9 +60,9 @@ export const BookmarkBlockSchema = defineBlockSchema({
   toModel: () => new BookmarkBlockModel(),
 });
 
-export class BookmarkBlockModel extends selectable<BookmarkBlockProps>(
-  BlockModel
-) {}
+export class BookmarkBlockModel
+  extends GfxCompatible<BookmarkBlockProps>(BlockModel)
+  implements GfxElementGeometry {}
 
 declare global {
   namespace BlockSuite {

--- a/packages/blocks/src/edgeless-text/edgeless-text-model.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-model.ts
@@ -1,8 +1,9 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/gfx-compatible.js';
 import {
   FontFamily,
   FontStyle,
@@ -52,6 +53,6 @@ export const EdgelessTextBlockSchema = defineBlockSchema({
   },
 });
 
-export class EdgelessTextBlockModel extends selectable<EdgelessTextProps>(
-  BlockModel
-) {}
+export class EdgelessTextBlockModel
+  extends GfxCompatible<EdgelessTextProps>(BlockModel)
+  implements GfxElementGeometry {}

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -40,8 +40,6 @@ export class FrameBlockModel
   extends GfxCompatible<FrameBlockProps>(BlockModel)
   implements GfxElementGeometry
 {
-  static PADDING = [8, 10];
-
   override includesPoint(x: number, y: number, _: PointTestOptions): boolean {
     const bound = Bound.deserialize(this.xywh);
     const hit = bound.isPointNearBound([x, y], 5);

--- a/packages/blocks/src/frame-block/frame-model.ts
+++ b/packages/blocks/src/frame-block/frame-model.ts
@@ -1,3 +1,4 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 import type { Text } from '@blocksuite/store';
 
@@ -7,7 +8,7 @@ import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 import type { Color } from '../surface-block/consts.js';
 import type { PointTestOptions } from '../surface-block/element-model/base.js';
 
-import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/gfx-compatible.js';
 
 type FrameBlockProps = {
   title: Text;
@@ -35,7 +36,10 @@ export const FrameBlockSchema = defineBlockSchema({
   },
 });
 
-export class FrameBlockModel extends selectable<FrameBlockProps>(BlockModel) {
+export class FrameBlockModel
+  extends GfxCompatible<FrameBlockProps>(BlockModel)
+  implements GfxElementGeometry
+{
   static PADDING = [8, 10];
 
   override includesPoint(x: number, y: number, _: PointTestOptions): boolean {

--- a/packages/blocks/src/image-block/image-model.ts
+++ b/packages/blocks/src/image-block/image-model.ts
@@ -1,8 +1,9 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
-import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/gfx-compatible.js';
 import { ImageBlockTransformer } from './image-transformer.js';
 
 export type ImageBlockProps = {
@@ -38,7 +39,9 @@ export const ImageBlockSchema = defineBlockSchema({
   toModel: () => new ImageBlockModel(),
 });
 
-export class ImageBlockModel extends selectable<ImageBlockProps>(BlockModel) {}
+export class ImageBlockModel
+  extends GfxCompatible<ImageBlockProps>(BlockModel)
+  implements GfxElementGeometry {}
 
 declare global {
   namespace BlockSuite {

--- a/packages/blocks/src/note-block/note-model.ts
+++ b/packages/blocks/src/note-block/note-model.ts
@@ -1,10 +1,11 @@
+import type { GfxElementGeometry } from '@blocksuite/block-std/gfx';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { Bound } from '@blocksuite/global/utils';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 import { NOTE_WIDTH } from '../_common/consts.js';
-import { selectable } from '../_common/edgeless/mixin/edgeless-selectable.js';
+import { GfxCompatible } from '../_common/edgeless/mixin/gfx-compatible.js';
 import {
   DEFAULT_NOTE_BACKGROUND_COLOR,
   DEFAULT_NOTE_SHADOW,
@@ -81,7 +82,10 @@ type NoteEdgelessProps = {
   scale?: number;
 };
 
-export class NoteBlockModel extends selectable<NoteProps>(BlockModel) {
+export class NoteBlockModel
+  extends GfxCompatible<NoteProps>(BlockModel)
+  implements GfxElementGeometry
+{
   private _isSelectable(): boolean {
     return this.displayMode !== NoteDisplayMode.DocOnly;
   }

--- a/packages/blocks/src/root-block/edgeless/block-model.ts
+++ b/packages/blocks/src/root-block/edgeless/block-model.ts
@@ -1,0 +1,1 @@
+export { GfxBlockElementModel as GfxBlockModel } from '@blocksuite/block-std/gfx';

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -24,7 +24,7 @@ import {
 } from '@blocksuite/store';
 import DOMPurify from 'dompurify';
 
-import type { EdgelessSelectableProps } from '../../../_common/edgeless/mixin/edgeless-selectable.js';
+import type { GfxCompatibleProps } from '../../../_common/edgeless/mixin/gfx-compatible.js';
 import type { NoteBlockModel } from '../../../note-block/note-model.js';
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
@@ -1213,7 +1213,7 @@ export class EdgelessClipboardController extends PageClipboard {
     elementsRawData.forEach(data => {
       const { data: blockSnapshot } = BlockSnapshotSchema.safeParse(data);
       if (blockSnapshot) {
-        const props = blockSnapshot.props as EdgelessSelectableProps;
+        const props = blockSnapshot.props as GfxCompatibleProps;
         originalIndexes.set(blockSnapshot.id, props.index);
 
         blockRawData.push(blockSnapshot);

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/edgeless-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/edgeless-tool.ts
@@ -1,6 +1,6 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 
-import type { EdgelessBlockModel } from '../../edgeless-block-model.js';
+import type { GfxBlockModel } from '../../block-model.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import type { EdgelessRootService } from '../../edgeless-root-service.js';
 import type { SelectionArea } from '../../services/tools-manager.js';
@@ -21,7 +21,7 @@ export abstract class EdgelessToolController<
     this._service = service;
   }
 
-  protected get _blocks(): EdgelessBlockModel[] {
+  protected get _blocks(): GfxBlockModel[] {
     return this._edgeless.service.blocks;
   }
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-block-model.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-block-model.ts
@@ -1,1 +1,0 @@
-export { GfxBlockElementModel as EdgelessBlockModel } from '@blocksuite/block-std/gfx';

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -23,10 +23,10 @@ import {
   ShapeType,
 } from '../../surface-block/index.js';
 import { PageKeyboardManager } from '../keyboard/keyboard-manager.js';
+import { GfxBlockModel } from './block-model.js';
 import { CopilotSelectionController } from './controllers/tools/copilot-tool.js';
 import { LassoToolController } from './controllers/tools/lasso-tool.js';
 import { ShapeToolController } from './controllers/tools/shape-tool.js';
-import { EdgelessBlockModel } from './edgeless-block-model.js';
 import {
   DEFAULT_NOTE_CHILD_FLAVOUR,
   DEFAULT_NOTE_CHILD_TYPE,
@@ -127,8 +127,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
 
           if (
             selection.selectedElements.length === 1 &&
-            selection.firstElement instanceof EdgelessBlockModel &&
-            matchFlavours(selection.firstElement as EdgelessBlockModel, [
+            selection.firstElement instanceof GfxBlockModel &&
+            matchFlavours(selection.firstElement as GfxBlockModel, [
               'affine:note',
             ])
           ) {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -30,7 +30,7 @@ import {
 import { LayerManager } from '../../surface-block/managers/layer-manager.js';
 import { compare } from '../../surface-block/managers/layer-utils.js';
 import { RootService, type TelemetryEvent } from '../root-service.js';
-import { EdgelessBlockModel } from './edgeless-block-model.js';
+import { GfxBlockModel } from './block-model.js';
 import { EdgelessFrameManager } from './frame-manager.js';
 import { EdgelessSelectionManager } from './services/selection-manager.js';
 import { TemplateJob } from './services/template.js';
@@ -502,7 +502,7 @@ export class EdgelessRootService extends RootService {
   pickElementsByBound(
     bound: IBound | Bound,
     type: 'blocks' | 'frame'
-  ): EdgelessBlockModel[];
+  ): GfxBlockModel[];
 
   pickElementsByBound(
     bound: IBound | Bound,
@@ -559,7 +559,7 @@ export class EdgelessRootService extends RootService {
     id = typeof id === 'string' ? id : id.id;
 
     const el = this.getElementById(id);
-    if (el instanceof EdgelessBlockModel) {
+    if (el instanceof GfxBlockModel) {
       this.doc.deleteBlock(el);
       return;
     }
@@ -577,7 +577,7 @@ export class EdgelessRootService extends RootService {
     const index = this._layer.getReorderedIndex(element, direction);
 
     // block should be updated in transaction
-    if (element instanceof EdgelessBlockModel) {
+    if (element instanceof GfxBlockModel) {
       this.doc.transact(() => {
         element.index = index;
       });
@@ -683,7 +683,7 @@ export class EdgelessRootService extends RootService {
   }
 
   get blocks() {
-    return (this.frames as EdgelessBlockModel[]).concat(this._layer.blocks);
+    return (this.frames as GfxBlockModel[]).concat(this._layer.blocks);
   }
 
   /**

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -10,7 +10,7 @@ import type { NoteBlockModel } from '../../note-block/note-model.js';
 import type { SurfaceBlockModel } from '../../surface-block/surface-model.js';
 
 import { Overlay, type RoughCanvas } from '../../surface-block/index.js';
-import { EdgelessBlockModel } from './edgeless-block-model.js';
+import { GfxBlockModel } from './block-model.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import { isFrameBlock } from './utils/query.js';
 
@@ -173,7 +173,7 @@ export function getBlocksInFrame(
   ).concat(
     surfaceModel[0].children.filter(ele => {
       if (ele.id === model.id) return;
-      if (ele instanceof EdgelessBlockModel) {
+      if (ele instanceof GfxBlockModel) {
         const blockBound = Bound.deserialize(ele.xywh);
         return fullyContained
           ? bound.contains(blockBound)

--- a/packages/blocks/src/root-block/edgeless/index.ts
+++ b/packages/blocks/src/root-block/edgeless/index.ts
@@ -1,6 +1,6 @@
+export { GfxBlockModel as EdgelessBlockModel } from './block-model.js';
 export { FramePreview } from './components/frame/frame-preview.js';
 export { EdgelessToolController } from './controllers/tools/index.js';
-export { EdgelessBlockModel } from './edgeless-block-model.js';
 export * from './edgeless-root-block.js';
 export { EdgelessRootService } from './edgeless-root-service.js';
 export * from './types.js';

--- a/packages/blocks/src/root-block/edgeless/types.ts
+++ b/packages/blocks/src/root-block/edgeless/types.ts
@@ -1,6 +1,6 @@
 import type { GfxModel as EModel } from '@blocksuite/block-std/gfx';
 
-import type { EdgelessBlockModel } from './edgeless-block-model.js';
+import type { GfxBlockModel } from './block-model.js';
 
 export type EdgelessTool = BlockSuite.EdgelessToolType;
 
@@ -10,7 +10,7 @@ declare global {
     type EdgelessBlockModelKeyType = keyof EdgelessBlockModelMap;
     type EdgelessBlockModelType =
       | EdgelessBlockModelMap[EdgelessBlockModelKeyType]
-      | EdgelessBlockModel;
+      | GfxBlockModel;
 
     type EdgelessModel = EModel;
     type EdgelessModelKeys = EdgelessBlockModelKeyType | SurfaceModelKeyType;

--- a/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clone-utils.ts
@@ -18,7 +18,7 @@ import {
   GroupElementModel,
   MindmapElementModel,
 } from '../../../surface-block/index.js';
-import { EdgelessBlockModel } from '../edgeless-block-model.js';
+import { GfxBlockModel } from '../block-model.js';
 import { isFrameBlock } from '../utils/query.js';
 
 export function getCloneElements(
@@ -59,7 +59,7 @@ export async function serializeElement(
   elements: BlockSuite.EdgelessModel[],
   job: Job
 ) {
-  if (element instanceof EdgelessBlockModel) {
+  if (element instanceof GfxBlockModel) {
     const snapshot = await job.blockToSnapshot(element);
     if (!snapshot) {
       return;

--- a/packages/blocks/src/root-block/edgeless/utils/convert.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/convert.ts
@@ -1,8 +1,8 @@
 import { deserializeXYWH } from '@blocksuite/global/utils';
 
-import type { EdgelessBlockModel } from '../edgeless-block-model.js';
+import type { GfxBlockModel } from '../block-model.js';
 
-export function xywhArrayToObject(element: EdgelessBlockModel) {
+export function xywhArrayToObject(element: GfxBlockModel) {
   const [x, y, w, h] = deserializeXYWH(element.xywh);
   return { x, y, w, h };
 }

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -20,7 +20,7 @@ import type { FrameBlockModel } from '../../../frame-block/index.js';
 import type { ImageBlockModel } from '../../../image-block/index.js';
 import type { NoteBlockModel } from '../../../note-block/index.js';
 import type { Viewport } from '../../../root-block/edgeless/utils/viewport.js';
-import type { EdgelessBlockModel } from '../edgeless-block-model.js';
+import type { GfxBlockModel } from '../block-model.js';
 import type { EdgelessTool } from '../types.js';
 
 import {
@@ -37,14 +37,14 @@ import {
 import { getElementsWithoutGroup } from './group.js';
 
 export function isMindmapNode(
-  element: EdgelessBlockModel | BlockSuite.EdgelessModel | null
+  element: GfxBlockModel | BlockSuite.EdgelessModel | null
 ) {
   return element?.group instanceof MindmapElementModel;
 }
 
 export function isTopLevelBlock(
   selectable: BlockModel | BlockSuite.EdgelessModel | BlockModel | null
-): selectable is EdgelessBlockModel {
+): selectable is GfxBlockModel {
   return !!selectable && 'flavour' in selectable;
 }
 

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -25,7 +25,7 @@ import type {
 } from '../../../note-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../../root-block/edgeless/edgeless-root-block.js';
 import type { RootBlockModel } from '../../../root-block/root-model.js';
-import type { EdgelessBlockModel } from '../../edgeless/edgeless-block-model.js';
+import type { GfxBlockModel } from '../../edgeless/block-model.js';
 import type { EdgelessTool } from '../../edgeless/types.js';
 import type { DragHandleOption, DropResult, DropType } from './config.js';
 
@@ -1462,7 +1462,7 @@ export class AffineDragHandleWidget extends WidgetComponent<
   }
 
   private _getHoverAreaRectTopLevelBlock(
-    edgelessElement: EdgelessBlockModel
+    edgelessElement: GfxBlockModel
   ): Rect | null {
     if (isInsidePageEditor(this.host)) return null;
     const edgelessRoot = this.rootComponent as EdgelessRootBlockComponent;
@@ -1653,7 +1653,7 @@ export class AffineDragHandleWidget extends WidgetComponent<
     return this._getBlockComponentFromViewStore(this._anchorBlockPath);
   }
 
-  get anchorEdgelessElement(): EdgelessBlockModel | null {
+  get anchorEdgelessElement(): GfxBlockModel | null {
     if (isInsidePageEditor(this.host) || !this._anchorBlockId) return null;
     const { service } = this.rootComponent as EdgelessRootBlockComponent;
     const edgelessElement = service.getElementById(this._anchorBlockId);

--- a/packages/blocks/src/surface-block/managers/layer-manager.ts
+++ b/packages/blocks/src/surface-block/managers/layer-manager.ts
@@ -11,7 +11,7 @@ import type { SurfaceBlockModel } from '../surface-model.js';
 import { last, nToLast } from '../../_common/utils/iterable.js';
 import { matchFlavours } from '../../_common/utils/model.js';
 import { FrameBlockModel } from '../../frame-block/frame-model.js';
-import { EdgelessBlockModel } from '../../root-block/edgeless/edgeless-block-model.js';
+import { GfxBlockModel } from '../../root-block/edgeless/block-model.js';
 import {
   SurfaceElementModel,
   SurfaceGroupLikeModel,
@@ -42,7 +42,7 @@ type BaseLayer<T> = {
   indexes: [string, string];
 };
 
-export type BlockLayer = BaseLayer<EdgelessBlockModel> & {
+export type BlockLayer = BaseLayer<GfxBlockModel> & {
   type: 'block';
 
   /**
@@ -73,9 +73,9 @@ export class LayerManager {
 
   static INITAL_INDEX = 'a0';
 
-  blocks!: EdgelessBlockModel[];
+  blocks!: GfxBlockModel[];
 
-  blocksGrid = new GridManager<EdgelessBlockModel>();
+  blocksGrid = new GridManager<GfxBlockModel>();
 
   canvasElements!: SurfaceElementModel[];
 
@@ -120,7 +120,7 @@ export class LayerManager {
           .getBlocks()
           .filter(
             model =>
-              model instanceof EdgelessBlockModel &&
+              model instanceof GfxBlockModel &&
               renderableInEdgeless(doc, surface, model)
           ) as BlockSuite.EdgelessModel[]
       ).concat(surface.elementModels)
@@ -547,7 +547,7 @@ export class LayerManager {
     } else {
       updateType = 'block';
       updateArray(this.blocks, element);
-      this.blocksGrid.update(element as EdgelessBlockModel);
+      this.blocksGrid.update(element as GfxBlockModel);
     }
 
     if (updateType && (indexChanged || childIdsChanged)) {
@@ -567,11 +567,11 @@ export class LayerManager {
           const block = doc.getBlockById(payload.id)!;
 
           if (
-            block instanceof EdgelessBlockModel &&
+            block instanceof GfxBlockModel &&
             renderableInEdgeless(doc, surface, block) &&
             this.blocks.indexOf(block) === -1
           ) {
-            this.add(block as EdgelessBlockModel);
+            this.add(block as GfxBlockModel);
           }
         }
         if (payload.type === 'update') {
@@ -580,10 +580,10 @@ export class LayerManager {
           if (
             payload.props.key === 'index' ||
             (payload.props.key === 'xywh' &&
-              block instanceof EdgelessBlockModel &&
+              block instanceof GfxBlockModel &&
               renderableInEdgeless(doc, surface, block))
           ) {
-            this.update(block as EdgelessBlockModel, {
+            this.update(block as GfxBlockModel, {
               [payload.props.key]: true,
             });
           }
@@ -591,8 +591,8 @@ export class LayerManager {
         if (payload.type === 'delete') {
           const block = doc.getBlockById(payload.id);
 
-          if (block instanceof EdgelessBlockModel) {
-            this.delete(block as EdgelessBlockModel);
+          if (block instanceof GfxBlockModel) {
+            this.delete(block as GfxBlockModel);
           }
         }
       })
@@ -640,7 +640,7 @@ export class LayerManager {
     } else {
       insertType = 'block';
       insertToOrderedArray(this.blocks, element);
-      this.blocksGrid.add(element as EdgelessBlockModel);
+      this.blocksGrid.add(element as GfxBlockModel);
     }
 
     if (insertType) {

--- a/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-portal.ts
@@ -11,7 +11,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { literal, html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 
 import type { FrameBlockModel } from '../frame-block/index.js';
-import type { EdgelessBlockModel } from '../root-block/edgeless/edgeless-block-model.js';
+import type { GfxBlockModel } from '../root-block/edgeless/block-model.js';
 import type { Renderer } from '../surface-block/canvas-renderer/renderer.js';
 import type { GroupElementModel } from '../surface-block/element-model/group.js';
 import type { BlockLayer } from '../surface-block/managers/layer-manager.js';
@@ -30,9 +30,7 @@ const getPortalTag = (model: BlockModel) => {
 
 @customElement('surface-ref-portal')
 export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
-  private _getBlocksInFrame = (
-    model: FrameBlockModel
-  ): EdgelessBlockModel[] => {
+  private _getBlocksInFrame = (model: FrameBlockModel): GfxBlockModel[] => {
     const bound = model.elementBound;
     const candidates =
       this.surfaceService?.layer.blocksGrid.search(bound) ?? [];
@@ -130,9 +128,9 @@ export class SurfaceRefPortal extends WithDisposable(ShadowlessElement) {
       .catch(console.error);
   };
 
-  private _getBlocksInGroup(model: GroupElementModel): EdgelessBlockModel[] {
+  private _getBlocksInGroup(model: GroupElementModel): GfxBlockModel[] {
     return Array.from(model.childIds)
-      .map(id => this.doc.getBlockById(id) as EdgelessBlockModel)
+      .map(id => this.doc.getBlockById(id) as GfxBlockModel)
       .filter(el => el);
   }
 

--- a/packages/framework/block-std/src/gfx/gfx-block-model.ts
+++ b/packages/framework/block-std/src/gfx/gfx-block-model.ts
@@ -22,27 +22,13 @@ import type {
   GfxElementGeometry,
   GfxGroupLikeElementModel,
   GfxPrimitiveElementModel,
+  PointTestOptions,
 } from './surface/element-model.js';
 
 import { SurfaceBlockModel } from './surface/block-model.js';
 
-export interface PointTestOptions {
-  expand?: number;
-
-  /**
-   * If true, the transparent area of the element will be ignored during the point inclusion test.
-   * Otherwise, the transparent area will be considered as filled area.
-   *
-   * Default is true.
-   */
-  ignoreTransparent?: boolean;
-
-  all?: boolean;
-  zoom?: number;
-}
-
 export class GfxBlockElementModel<
-    Props extends GfxSelectableProps = GfxSelectableProps,
+    Props extends GfxCompatibleProps = GfxCompatibleProps,
   >
   extends BlockModel<Props>
   implements GfxElementGeometry
@@ -154,19 +140,19 @@ export class GfxBlockElementModel<
   }
 }
 
-export type GfxSelectableProps = {
+type GfxCompatibleProps = {
   xywh: SerializedXYWH;
   index: string;
 };
 
-export function selectable<
-  Props extends GfxSelectableProps,
+export function GfxCompatible<
+  Props extends GfxCompatibleProps,
   T extends Constructor<BlockModel<Props>> = Constructor<BlockModel<Props>>,
->(SuperClass: T) {
-  if (SuperClass === BlockModel) {
+>(BlockModelSuperClass: T) {
+  if (BlockModelSuperClass === BlockModel) {
     return GfxBlockElementModel as unknown as typeof GfxBlockElementModel<Props>;
   } else {
-    let currentClass = SuperClass;
+    let currentClass = BlockModelSuperClass;
 
     while (
       Object.getPrototypeOf(currentClass.prototype) !== BlockModel.prototype &&
@@ -188,7 +174,7 @@ export function selectable<
     );
   }
 
-  return SuperClass as unknown as typeof GfxBlockElementModel<Props>;
+  return BlockModelSuperClass as unknown as typeof GfxBlockElementModel<Props>;
 }
 
 export type GfxModel = GfxBlockElementModel | GfxPrimitiveElementModel;

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -1,4 +1,4 @@
-export * from './model.js';
+export * from './gfx-block-model.js';
 export {
   SurfaceBlockModel,
   type SurfaceBlockProps,
@@ -20,9 +20,11 @@ export {
 } from './surface/decorators/index.js';
 export {
   type BaseElementProps,
+  type GfxElementGeometry,
   GfxGroupLikeElementModel,
   GfxLocalElementModel,
   GfxPrimitiveElementModel,
+  type PointTestOptions,
   type SerializedElement,
 } from './surface/element-model.js';
 export * from './viewport.js';

--- a/packages/framework/block-std/src/gfx/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/element-model.ts
@@ -1,5 +1,4 @@
 import type { EditorHost } from '@blocksuite/block-std';
-import type { PointTestOptions } from '@blocksuite/block-std/gfx';
 import type { IVec, SerializedXYWH, XYWH } from '@blocksuite/global/utils';
 import type { Y } from '@blocksuite/store';
 
@@ -17,7 +16,7 @@ import {
   rotatePoints,
 } from '@blocksuite/global/utils';
 
-import type { GfxBlockElementModel, GfxModel } from '../model.js';
+import type { GfxBlockElementModel, GfxModel } from '../gfx-block-model.js';
 import type { SurfaceBlockModel } from './block-model.js';
 
 import {
@@ -29,8 +28,6 @@ import {
   watch,
   yfield,
 } from './decorators/index.js';
-
-export type { PointTestOptions } from '@blocksuite/block-std/gfx';
 
 export type BaseElementProps = {
   index: string;
@@ -44,6 +41,21 @@ export type SerializedElement = Record<string, unknown> & {
   index: string;
   props: Record<string, unknown>;
 };
+
+export interface PointTestOptions {
+  expand?: number;
+
+  /**
+   * If true, the transparent area of the element will be ignored during the point inclusion test.
+   * Otherwise, the transparent area will be considered as filled area.
+   *
+   * Default is true.
+   */
+  ignoreTransparent?: boolean;
+
+  all?: boolean;
+  zoom?: number;
+}
 
 export interface GfxElementGeometry {
   containsBound(bound: Bound): boolean;

--- a/packages/presets/src/blocks/ai-chat-block/ai-chat-model.ts
+++ b/packages/presets/src/blocks/ai-chat-block/ai-chat-model.ts
@@ -1,6 +1,6 @@
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
-import { selectable } from '@blocksuite/block-std/gfx';
+import { GfxCompatible } from '@blocksuite/block-std/gfx';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
 type AIChatProps = {
@@ -30,4 +30,4 @@ export const AIChatBlockSchema = defineBlockSchema({
   },
 });
 
-export class AIChatBlockModel extends selectable<AIChatProps>(BlockModel) {}
+export class AIChatBlockModel extends GfxCompatible<AIChatProps>(BlockModel) {}


### PR DESCRIPTION
This comes together with #7750. Before:

``` ts
export class FrameBlockModel extends selectable<FrameBlockProps>(BlockModel) {
  override boxSelect(selectedBound: Bound): boolean {
    const bound = Bound.deserialize(this.xywh);
    return (
      bound.isIntersectWithBound(selectedBound) || selectedBound.contains(bound)
    );
  }

  override hitTest(x: number, y: number, _: ElementHitTestOptions): boolean {
    const bound = Bound.deserialize(this.xywh);
    const hit = bound.isPointNearBound([x, y], 5);

    if (hit) return true;

    return this.externalBound?.isPointInBound([x, y]) ?? false;
  }
}
```

After:

``` ts
export class FrameBlockModel
  extends GfxCompatible<FrameBlockProps>(BlockModel)
  implements GfxElementGeometry
{
  override includesPoint(x: number, y: number, _: PointTestOptions): boolean {
    const bound = Bound.deserialize(this.xywh);
    const hit = bound.isPointNearBound([x, y], 5);

    if (hit) return true;

    return this.externalBound?.isPointInBound([x, y]) ?? false;
  }

  override intersectsBound(selectedBound: Bound): boolean {
    const bound = Bound.deserialize(this.xywh);
    return (
      bound.isIntersectWithBound(selectedBound) || selectedBound.contains(bound)
    );
  }
}

```

* `selectable` -> `GfxCompatible`, we can switch to decorator in upcoming refactorings.