### PR TITLE
chore: update outline viewer style

### DIFF
--- a/packages/playground/apps/_common/components/custom-outline-viewer.ts
+++ b/packages/playground/apps/_common/components/custom-outline-viewer.ts
@@ -3,17 +3,16 @@ import type { AffineEditorContainer } from '@blocksuite/presets';
 import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
 @customElement('custom-outline-viewer')
 export class CustomOutlineViewer extends WithDisposable(LitElement) {
-  private static _paddingRight = 22;
-
   static override styles = css`
     .outline-viewer-container {
       position: fixed;
-      max-height: calc(100vh - 16px);
-      padding-right: ${this._paddingRight}px;
+      display: flex;
+      top: 256px;
+      right: 22px;
+      max-height: calc(100vh - 256px - 76px); // top(256px) and bottom(76px)
     }
   `;
 
@@ -24,29 +23,10 @@ export class CustomOutlineViewer extends WithDisposable(LitElement) {
     ></affine-outline-viewer>`;
   }
 
-  override connectedCallback() {
-    super.connectedCallback();
-    const observer = new ResizeObserver(() => {
-      if (!this.editor.host) return;
-
-      const { offsetTop, offsetWidth, offsetLeft } = this.editor.host;
-
-      this._containerPosition = {
-        top: `${offsetTop}px`,
-        right: `calc(100vw - ${offsetLeft + offsetWidth}px)`,
-      };
-    });
-    observer.observe(document.documentElement);
-    this.disposables.add(() => observer.disconnect());
-  }
-
   override render() {
     if (!this._show || this.editor.mode === 'edgeless') return nothing;
 
-    return html`<div
-      class="outline-viewer-container"
-      style=${styleMap(this._containerPosition)}
-    >
+    return html`<div class="outline-viewer-container">
       ${this._renderViewer()}
     </div>`;
   }
@@ -54,9 +34,6 @@ export class CustomOutlineViewer extends WithDisposable(LitElement) {
   toggleDisplay() {
     this._show = !this._show;
   }
-
-  @state()
-  private accessor _containerPosition: Readonly<StyleInfo> = {};
 
   @state()
   private accessor _show = false;

--- a/packages/presets/src/fragments/outline/body/outline-panel-body.ts
+++ b/packages/presets/src/fragments/outline/body/outline-panel-body.ts
@@ -4,6 +4,7 @@ import type {
   NoteBlockModel,
 } from '@blocksuite/blocks';
 import type { Doc } from '@blocksuite/store';
+import type { Signal } from '@lit-labs/preact-signals';
 
 import { WithDisposable } from '@blocksuite/block-std';
 import { BlocksUtils, NoteDisplayMode } from '@blocksuite/blocks';
@@ -163,7 +164,7 @@ export class OutlinePanelBody extends SignalWatcher(
                 .doc=${this.doc}
                 .editorMode=${this.mode}
                 .editorHost=${this.editorHost}
-                .activeHeadingId=${this.activeHeadingId}
+                .activeHeadingId=${this.activeHeadingId.value}
                 .status=${selectedNotesSet.has(note.note.id)
                   ? this._dragging
                     ? 'placeholder'
@@ -192,7 +193,7 @@ export class OutlinePanelBody extends SignalWatcher(
                   .number=${idx + 1}
                   .index=${note.index}
                   .doc=${this.doc}
-                  .activeHeadingId=${this.activeHeadingId}
+                  .activeHeadingId=${this.activeHeadingId.value}
                   .invisible=${true}
                   .showPreviewIcon=${this.showPreviewIcon}
                   .enableNotesSorting=${this.enableNotesSorting}
@@ -418,7 +419,7 @@ export class OutlinePanelBody extends SignalWatcher(
         if (!docTitle) return;
 
         docTitle.scrollIntoView({
-          behavior: 'smooth',
+          behavior: 'instant',
           block: 'start',
         });
       }}
@@ -474,7 +475,7 @@ export class OutlinePanelBody extends SignalWatcher(
         display: 'block',
       });
 
-      this.activeHeadingId = block.model.id;
+      this.activeHeadingId.value = block.model.id;
 
       // Clear the previous timeout if it exists
       if (this._highlightTimeoutId !== null) {
@@ -670,9 +671,10 @@ export class OutlinePanelBody extends SignalWatcher(
     const shouldRenderPageVisibleNotes = this._shouldRenderNoteList(
       this._pageVisibleNotes
     );
-    const shouldRenderEdgelessOnlyNotes = this._shouldRenderNoteList(
-      this._edgelessOnlyNotes
-    );
+    const shouldRenderEdgelessOnlyNotes =
+      this.renderEdgelessOnlyNotes &&
+      this._shouldRenderNoteList(this._edgelessOnlyNotes);
+
     const shouldRenderEmptyPanel =
       !shouldRenderPageVisibleNotes && !shouldRenderEdgelessOnlyNotes;
 
@@ -729,7 +731,7 @@ export class OutlinePanelBody extends SignalWatcher(
   accessor OutlinePanelContainer!: HTMLElement;
 
   @property({ attribute: false })
-  accessor activeHeadingId: string | null = null;
+  accessor activeHeadingId!: Signal<string | null>;
 
   @property({ attribute: false })
   accessor doc!: Doc;
@@ -760,6 +762,9 @@ export class OutlinePanelBody extends SignalWatcher(
 
   @query('.panel-list')
   accessor panelListElement!: HTMLElement;
+
+  @property({ attribute: false })
+  accessor renderEdgelessOnlyNotes: boolean = true;
 
   @property({ attribute: false })
   accessor setNoticeVisibility!: (visibility: boolean) => void;

--- a/packages/presets/src/fragments/outline/card/outline-preview.ts
+++ b/packages/presets/src/fragments/outline/card/outline-preview.ts
@@ -33,6 +33,11 @@ const styles = css`
     width: 100%;
   }
 
+  :host(:hover) {
+    cursor: pointer;
+    background: var(--affine-hover-color);
+  }
+
   :host(.active) {
     color: var(--affine-text-emphasis-color);
   }

--- a/packages/presets/src/fragments/outline/outline-panel.ts
+++ b/packages/presets/src/fragments/outline/outline-panel.ts
@@ -164,7 +164,7 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
           .fitPadding=${this.fitPadding}
           .edgeless=${this.edgeless}
           .editorHost=${this.host}
-          .activeHeadingId=${this._activeHeadingId$.value}
+          .activeHeadingId=${this._activeHeadingId$}
           .mode=${this.mode}
           .showPreviewIcon=${this._showPreviewIcon}
           .enableNotesSorting=${this._enableNotesSorting}


### PR DESCRIPTION
What changes:
- responsive height of outline viewer ([BS-988](https://linear.app/affine-design/issue/BS-988/ui-bug-响应式没处理),  [BS-989](https://linear.app/affine-design/issue/BS-989/630-ui-issues))
- Fix indicator highlight issue ([BS-994](https://linear.app/affine-design/issue/BS-994/点击-toc-里的-headings-之后，联动高亮不变))
- Update scrollbar style and hover style ([BS-986](https://linear.app/affine-design/issue/BS-986/ui-bug-滚动条坏了), [BS-989](https://linear.app/affine-design/issue/BS-989/630-ui-issues))
- Hide heading of edgeless only note in outline viewer ([BS-992](https://linear.app/affine-design/issue/BS-992/quick-toc-建议隐藏-hidden-content))
- Add more e2e test
