### PR TITLE
fix(blocks): skip to break when undefined before getting assets name

### DIFF
--- a/packages/blocks/src/_common/adapters/html.ts
+++ b/packages/blocks/src/_common/adapters/html.ts
@@ -1133,10 +1133,10 @@ export class HtmlAdapter extends BaseAdapter<Html> {
           await assets.readFromBlob(blobId);
           const blob = assets.getAssets().get(blobId);
           assetsIds.push(blobId);
-          const blobName = getAssetName(assets.getAssets(), blobId);
           if (!blob) {
             break;
           }
+          const blobName = getAssetName(assets.getAssets(), blobId);
           const isScaledImage = o.node.props.width && o.node.props.height;
           const widthStyle = isScaledImage
             ? {

--- a/packages/blocks/src/_common/adapters/markdown.ts
+++ b/packages/blocks/src/_common/adapters/markdown.ts
@@ -586,10 +586,10 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
           await assets.readFromBlob(blobId);
           const blob = assets.getAssets().get(blobId);
           assetsIds.push(blobId);
-          const blobName = getAssetName(assets.getAssets(), blobId);
           if (!blob) {
             break;
           }
+          const blobName = getAssetName(assets.getAssets(), blobId);
           context
             .openNode(
               {


### PR DESCRIPTION
This possibly fix #7466.