### PR TITLE
fix: linked doc popover closes when paste text

### DIFF
--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -1,7 +1,6 @@
 import type { EditorHost } from '@blocksuite/block-std';
-import type { InlineEditor } from '@blocksuite/inline';
+import type { InlineEditor, InlineRange } from '@blocksuite/inline';
 
-import { assertExists } from '@blocksuite/global/utils';
 import { BlockModel } from '@blocksuite/store';
 import { css, unsafeCSS } from 'lit';
 
@@ -11,33 +10,38 @@ import { isControlledKeyboardEvent } from '../../_common/utils/event.js';
 import { getInlineEditorByModel } from '../../_common/utils/query.js';
 import { getCurrentNativeRange } from '../../_common/utils/selection.js';
 
-export function getQuery(inlineEditor: InlineEditor, startIndex: number) {
-  const range = getCurrentNativeRange();
-  if (!range) {
+export function getQuery(
+  inlineEditor: InlineEditor,
+  startRange: InlineRange | null
+) {
+  const nativeRange = getCurrentNativeRange();
+  if (!nativeRange) {
     return null;
   }
-  if (range.startContainer !== range.endContainer) {
+  if (nativeRange.startContainer !== nativeRange.endContainer) {
     console.warn(
       'Failed to parse query! Current range is not collapsed.',
-      range
+      nativeRange
     );
     return null;
   }
-  const textNode = range.startContainer;
+  const textNode = nativeRange.startContainer;
   if (textNode.nodeType !== Node.TEXT_NODE) {
     console.warn(
       'Failed to parse query! Current range is not a text node.',
-      range
+      nativeRange
     );
     return null;
   }
-  const curIndex = inlineEditor.getInlineRange()?.index ?? 0;
-  if (curIndex < startIndex) {
+  const curRange = inlineEditor.getInlineRange();
+  if (!startRange || !curRange) {
     return null;
   }
-
+  if (curRange.index < startRange.index) {
+    return null;
+  }
   const text = inlineEditor.yText.toString();
-  return text.slice(startIndex, curIndex);
+  return text.slice(startRange.index, curRange.index);
 }
 
 interface ObserverParams {
@@ -83,6 +87,10 @@ export const createKeydownObserver = ({
             e.preventDefault();
             return;
           }
+          // Paste command
+          case 'v': {
+            return;
+          }
         }
       }
 
@@ -95,7 +103,7 @@ export const createKeydownObserver = ({
       }
 
       // Abort when press modifier key + any other key to avoid weird behavior
-      // e.g. press ctrl + a to select all or press ctrl + v to paste
+      // e.g. press ctrl + a to select all
       onAbort?.();
       return;
     }
@@ -177,6 +185,13 @@ export const createKeydownObserver = ({
     }
   );
 
+  // Fix paste input
+  target.addEventListener(
+    'paste',
+    () => requestAnimationFrame(() => onInput?.()),
+    { signal }
+  );
+
   // Fix composition input
   target.addEventListener(
     'input',
@@ -201,10 +216,13 @@ export function cleanSpecifiedTail(
     inlineEditorOrModel instanceof BlockModel
       ? getInlineEditorByModel(editorHost, inlineEditorOrModel)
       : inlineEditorOrModel;
-  assertExists(inlineEditor, 'Inline editor not found');
-
+  if (!inlineEditor) {
+    return;
+  }
   const inlineRange = inlineEditor.getInlineRange();
-  assertExists(inlineRange);
+  if (!inlineRange) {
+    return;
+  }
   const idx = inlineRange.index - str.length;
   const textStr = inlineEditor.yText.toString().slice(idx, idx + str.length);
   if (textStr !== str) {

--- a/tests/utils/actions/click.ts
+++ b/tests/utils/actions/click.ts
@@ -4,7 +4,7 @@ import type { Page } from '@playwright/test';
 import { toViewCoord } from './edgeless.js';
 import { waitNextFrame } from './misc.js';
 
-function getDebugMenu(page: Page) {
+export function getDebugMenu(page: Page) {
   const debugMenu = page.locator('debug-menu');
   return {
     debugMenu,


### PR DESCRIPTION
Close issue [BS-500](https://linear.app/affine-design/issue/BS-500) and [BS-708](https://linear.app/affine-design/issue/BS-708).

### What changed?

- Do not abort if user press `cmd + v`
- Add listener to `paste` event and process as user input
- Abort if query is `null`, which is an unexpected situation
- Remove assertExists
- Add e2e tests

---

