### PR TITLE
fix(blocks): show filter-bar when an filter added

### DIFF
--- a/packages/blocks/src/database-block/data-view/view-manager/single-view.ts
+++ b/packages/blocks/src/database-block/data-view/view-manager/single-view.ts
@@ -152,7 +152,7 @@ export abstract class SingleViewBase<
   ViewData extends DataViewDataType = DataViewDataType,
 > implements SingleView<ViewData>
 {
-  private _filterVisible$ = signal(false);
+  private _filterVisible$ = signal<boolean | undefined>(undefined);
 
   private searchString = signal('');
 

--- a/packages/blocks/src/database-block/data-view/view-manager/single-view.ts
+++ b/packages/blocks/src/database-block/data-view/view-manager/single-view.ts
@@ -51,8 +51,6 @@ export interface SingleView<
   filter$: ReadonlySignal<FilterGroup>;
   filterVisible$: ReadonlySignal<boolean>;
 
-  filterSetVisible(visible: boolean): void;
-
   updateFilter(filter: FilterGroup): void;
 
   vars$: ReadonlySignal<Variable[]>;
@@ -152,8 +150,6 @@ export abstract class SingleViewBase<
   ViewData extends DataViewDataType = DataViewDataType,
 > implements SingleView<ViewData>
 {
-  private _filterVisible$ = signal<boolean | undefined>(undefined);
-
   private searchString = signal('');
 
   columnManagerList$ = computed(() => {
@@ -163,10 +159,7 @@ export abstract class SingleViewBase<
   });
 
   filterVisible$ = computed(() => {
-    return (
-      this._filterVisible$.value ??
-      (this.filter$.value?.conditions.length ?? 0) > 0
-    );
+    return (this.filter$.value?.conditions.length ?? 0) > 0;
   });
 
   name$: ReadonlySignal<string> = computed(() => {
@@ -366,10 +359,6 @@ export abstract class SingleViewBase<
 
   duplicate(): void {
     this.viewManager.viewDuplicate(this.id);
-  }
-
-  filterSetVisible(visible: boolean): void {
-    this._filterVisible$.value = visible;
   }
 
   getContext<T>(key: DataViewContextKey<T>): T | undefined {

--- a/packages/blocks/src/database-block/data-view/widget/tools/presets/filter/filter.ts
+++ b/packages/blocks/src/database-block/data-view/widget/tools/presets/filter/filter.ts
@@ -51,7 +51,6 @@ export class DataViewHeaderToolsFilter extends WidgetBase {
             ...this._filter,
             conditions: [filter],
           };
-          this.view.filterSetVisible(true);
         },
         onClose: () => {
           this.showToolBar(false);

--- a/packages/blocks/src/database-block/data-view/widget/tools/presets/filter/filter.ts
+++ b/packages/blocks/src/database-block/data-view/widget/tools/presets/filter/filter.ts
@@ -42,23 +42,20 @@ export class DataViewHeaderToolsFilter extends WidgetBase {
   }
 
   private addFilter(event: MouseEvent) {
-    if (!this._filter.conditions.length && !this.view.filterVisible$.value) {
-      this.showToolBar(true);
-      popCreateFilter(event.target as HTMLElement, {
-        vars: this.view.vars$.value,
-        onSelect: filter => {
-          this._filter = {
-            ...this._filter,
-            conditions: [filter],
-          };
-        },
-        onClose: () => {
-          this.showToolBar(false);
-        },
-      });
-      return;
-    }
-    this.view.filterSetVisible(!this.view.filterVisible$.value);
+    this.showToolBar(true);
+    popCreateFilter(event.target as HTMLElement, {
+      vars: this.view.vars$.value,
+      onSelect: filter => {
+        this._filter = {
+          ...this._filter,
+          conditions: [filter],
+        };
+      },
+      onClose: () => {
+        this.showToolBar(false);
+      },
+    });
+    return;
   }
 
   private get readonly() {


### PR DESCRIPTION
When adding a filter, `SingleViewBase` is initialized multiple times, causing it to be unable to set the status through `this.view.filterSetVisible(true);`.

Before

https://github.com/user-attachments/assets/e2fc4a4c-e0c5-4557-9a22-56dfbba6f4d3

https://github.com/user-attachments/assets/dfdc4f51-8278-4911-87bb-39c9af56331b



