### PR TITLE
feat: limit AI Chat block width and height

### DIFF
--- a/packages/blocks/src/root-block/edgeless/utils/consts.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/consts.ts
@@ -57,3 +57,8 @@ export const BlendColor = '#7D91FF';
 export const SHAPE_TEXT_COLOR_PURE_WHITE = '--affine-palette-line-white';
 export const SHAPE_TEXT_COLOR_PURE_BLACK = '--affine-palette-line-black';
 export const SHAPE_FILL_COLOR_BLACK = '--affine-palette-shape-black';
+
+export const AI_CHAT_BLOCK_MIN_WIDTH = 260;
+export const AI_CHAT_BLOCK_MIN_HEIGHT = 160;
+export const AI_CHAT_BLOCK_MAX_WIDTH = 320;
+export const AI_CHAT_BLOCK_MAX_HEIGHT = 300;

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -104,6 +104,23 @@ export function isEmbeddedBlock(
   );
 }
 
+/**
+ * TODO: Remove this function after the edgeless refactor completed
+ * This function is used to check if the block is an AI chat block for edgeless selected rect
+ * Should not be used in the future
+ * Related issue: https://linear.app/affine-design/issue/BS-1009/
+ * @deprecated
+ */
+export function isAIChatBlock(
+  element: BlockModel | BlockSuite.EdgelessModel | null
+) {
+  return (
+    !!element &&
+    'flavour' in element &&
+    element.flavour === 'affine:embed-ai-chat'
+  );
+}
+
 export function isEmbeddedLinkBlock(
   element: BlockModel | BlockSuite.EdgelessModel | null
 ) {


### PR DESCRIPTION
Related [BS-957](https://linear.app/affine-design/issue/BS-957/ui-chat-block-的最小尺寸，以及内容压缩)

The implementation should be updated after [BS-1009](https://linear.app/affine-design/issue/BS-1009/支持显式设置最小宽高) completed.
