### PR TITLE
fix: sentry-77acd79e678f4d8dbee1248ef0648da1

### DIFF
--- a/packages/blocks/src/surface-block/element-model/utils/mindmap/utils.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/mindmap/utils.ts
@@ -44,9 +44,8 @@ export function showMergeIndicator(
 
   // the target cannot be the child of source
   const mergeCheck = (sourceTree: MindmapNode): boolean => {
-    if (target === sourceTree) {
-      return false;
-    }
+    if (!target || !sourceTree) return false;
+    if (target === sourceTree) return false;
 
     if (sourceTree.children.length) {
       return sourceTree.children.every(node => mergeCheck(node));


### PR DESCRIPTION
Closes [BS-917](https://linear.app/affine-design/issue/BS-917/typeerror-cannot-read-properties-of-null-reading-children)