### PR TITLE
fix(blocks): missing transparent button when color picker is not enabled

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/color-picker/button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/button.ts
@@ -90,6 +90,7 @@ export class EdgelessColorPickerButton extends WithDisposable(LitElement) {
                   .options=${this.palettes}
                   .hollowCircle=${this.hollowCircle}
                   .openColorPicker=${this.switchToCustomTab}
+                  .hasTransparent=${false}
                   @select=${this.#select}
                 >
                   <edgeless-color-custom-button

--- a/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
@@ -280,7 +280,7 @@ export class EdgelessColorPanel extends LitElement {
   override render() {
     return html`
       ${repeat(
-        this.options,
+        this.palettes,
         color => color,
         color => {
           const unit = ColorUnit(color, {
@@ -303,6 +303,15 @@ export class EdgelessColorPanel extends LitElement {
       <slot name="custom"></slot>
     `;
   }
+
+  get palettes() {
+    return this.hasTransparent
+      ? ['--affine-palette-transparent', ...this.options]
+      : this.options;
+  }
+
+  @property({ attribute: false })
+  accessor hasTransparent: boolean = true;
 
   @property({ attribute: false })
   accessor hollowCircle = false;

--- a/packages/blocks/src/root-block/edgeless/components/panel/stroke-style-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/stroke-style-panel.ts
@@ -46,7 +46,7 @@ export class StrokeStylePanel extends WithDisposable(LitElement) {
       <edgeless-color-panel
         role="listbox"
         aria-label="Border colors"
-        .options=${['--affine-palette-transparent', ...STROKE_COLORS]}
+        .options=${STROKE_COLORS}
         .value=${this.strokeColor}
         .hollowCircle=${this.hollowCircle}
         @select=${(e: ColorEvent) => this.setStrokeColor(e)}

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-menu.ts
@@ -55,6 +55,9 @@ export class EdgelessBrushMenu extends EdgelessToolbarToolMixin(LitElement) {
           <menu-divider .vertical=${true}></menu-divider>
           <edgeless-one-row-color-panel
             .value=${color}
+            .hasTransparent=${!this.edgeless.doc.awarenessStore.getFlag(
+              'enable_color_picker'
+            )}
             @select=${(e: ColorEvent) => this.onChange({ color: e.detail })}
           ></edgeless-one-row-color-panel>
         </div>

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-menu.ts
@@ -119,6 +119,9 @@ export class EdgelessConnectorMenu extends EdgelessToolbarToolMixin(
           <div class="submenu-divider"></div>
           <edgeless-one-row-color-panel
             .value=${color}
+            .hasTransparent=${!this.edgeless.doc.awarenessStore.getFlag(
+              'enable_color_picker'
+            )}
             @select=${(e: ColorEvent) => this.onChange({ stroke: e.detail })}
           ></edgeless-one-row-color-panel>
         </div>

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
@@ -164,10 +164,21 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
       onDrop: (el, bound) => {
         const xywh = bound.serialize();
         const shape = el.data;
+        const colorProps: Record<string, boolean | string> = {};
+        if (!this.edgeless.doc.awarenessStore.getFlag('enable_color_picker')) {
+          colorProps.filled = true;
+          colorProps.fillColor = this.color
+            .replace('var(', '')
+            .replace(')', '');
+          colorProps.strokeColor = this.stroke
+            .replace('var(', '')
+            .replace(')', '');
+        }
         const id = this.edgeless.service.addElement(CanvasElementType.SHAPE, {
           shapeType: shape.name === 'roundedRect' ? ShapeType.Rect : shape.name,
           xywh,
           radius: shape.name === 'roundedRect' ? 0.1 : 0,
+          ...colorProps,
         });
 
         this.edgeless.service.telemetryService?.track('CanvasElementAdded', {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import type { Color } from '../../../../../surface-block/consts.js';
+import type { EdgelessRootBlockComponent } from '../../../edgeless-root-block.js';
 import type { ShapeName } from './shape-tool-element.js';
 
 import {
@@ -126,12 +127,18 @@ export class EdgelessShapeMenu extends LitElement {
           <edgeless-one-row-color-panel
             .value=${color}
             .options=${FILL_COLORS}
+            .hasTransparent=${!this.edgeless.doc.awarenessStore.getFlag(
+              'enable_color_picker'
+            )}
             @select=${(e: ColorEvent) => this._setStrokeColor(e.detail)}
           ></edgeless-one-row-color-panel>
         </div>
       </edgeless-slide-menu>
     `;
   }
+
+  @property({ attribute: false })
+  accessor edgeless!: EdgelessRootBlockComponent;
 
   @property({ attribute: false })
   accessor fillColor!: Color;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -119,11 +119,11 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
     let color = ThemeObserver.generateColorProperty(fillColor!);
     let stroke = ThemeObserver.generateColorProperty(strokeColor!);
 
-    if (color.endsWith('transparent')) {
-      color = cssVar('white60');
+    if (color.endsWith('transparent)')) {
+      color = cssVar('paletteShapeWhite');
     }
-    if (stroke.endsWith('transparent')) {
-      stroke = cssVar('black10');
+    if (stroke.endsWith('transparent)')) {
+      stroke = cssVar('paletteLineGrey');
     }
 
     return html`

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
@@ -139,7 +139,6 @@ export class EdgelessChangeBrushButton extends WithDisposable(LitElement) {
             `}
           >
             <edgeless-color-panel
-              .options=${['--affine-palette-transparent', ...LINE_COLORS]}
               .value=${selectedColor}
               @select=${this._setBrushColor}
             >

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
@@ -412,7 +412,6 @@ export class EdgelessChangeConnectorButton extends WithDisposable(LitElement) {
               `}
             >
               <stroke-style-panel
-                .options=${['--affine-palette-transparent', ...LINE_COLORS]}
                 .strokeWidth=${selectedLineSize}
                 .strokeStyle=${selectedLineStyle}
                 .strokeColor=${selectedColor}

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -28,7 +28,7 @@ import {
 import { DEFAULT_NOTE_HEIGHT } from '../../edgeless/utils/consts.js';
 import { mountFrameTitleEditor } from '../../edgeless/utils/text.js';
 
-const FRAME_BACKGROUND: string[] = [
+const FRAME_BACKGROUND = [
   '--affine-tag-gray',
   '--affine-tag-red',
   '--affine-tag-orange',
@@ -197,10 +197,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
             >
               <edgeless-color-panel
                 .value=${background}
-                .options=${[
-                  '--affine-palette-transparent',
-                  ...FRAME_BACKGROUND,
-                ]}
+                .options=${FRAME_BACKGROUND}
                 @select=${(e: ColorEvent) => this._setFrameBackground(e.detail)}
               >
               </edgeless-color-panel>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -318,10 +318,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
               >
                 <edgeless-color-panel
                   .value=${background}
-                  .options=${[
-                    '--affine-palette-transparent',
-                    ...NOTE_BACKGROUND_COLORS,
-                  ]}
+                  .options=${NOTE_BACKGROUND_COLORS}
                   @select=${(e: ColorEvent) => this._setBackground(e.detail)}
                 >
                 </edgeless-color-panel>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -29,6 +29,8 @@ import { LineWidth } from '../../../_common/types.js';
 import { countBy, maxBy } from '../../../_common/utils/iterable.js';
 import { FontFamily } from '../../../surface-block/consts.js';
 import {
+  DEFAULT_SHAPE_FILL_COLOR,
+  DEFAULT_SHAPE_STROKE_COLOR,
   FILL_COLORS,
   STROKE_COLORS,
   ShapeType,
@@ -274,9 +276,10 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
     const elements = this.elements;
     const selectedShape = getMostCommonShape(elements);
     const selectedFillColor =
-      getMostCommonFillColor(elements, colorScheme) ?? FILL_COLORS[0];
+      getMostCommonFillColor(elements, colorScheme) ?? DEFAULT_SHAPE_FILL_COLOR;
     const selectedStrokeColor =
-      getMostCommonStrokeColor(elements, colorScheme) ?? STROKE_COLORS[0];
+      getMostCommonStrokeColor(elements, colorScheme) ??
+      DEFAULT_SHAPE_STROKE_COLOR;
     const selectedLineSize = getMostCommonLineSize(elements) ?? LineWidth.Four;
     const selectedLineStyle =
       getMostCommonLineStyle(elements) ?? StrokeStyle.Solid;
@@ -365,7 +368,7 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
                 role="listbox"
                 aria-label="Fill colors"
                 .value=${selectedFillColor}
-                .options=${['--affine-palette-transparent', ...FILL_COLORS]}
+                .options=${FILL_COLORS}
                 @select=${(e: ColorEvent) => this._setShapeFillColor(e.detail)}
               >
               </edgeless-color-panel>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
@@ -420,7 +420,6 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
             >
               <edgeless-color-panel
                 .value=${selectedColor}
-                .options=${['--affine-palette-transparent', ...LINE_COLORS]}
                 @select=${this._setTextColor}
               ></edgeless-color-panel>
             </editor-menu-button>

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
@@ -67,19 +67,12 @@ export function shape(
     DEFAULT_SHAPE_STROKE_COLOR,
     true
   );
-  const customStyle = { color, fillColor, strokeColor };
+  const colors = { color, fillColor, strokeColor };
 
-  shapeRenderers[model.shapeType](
-    model,
-    ctx,
-    matrix,
-    renderer,
-    rc,
-    customStyle
-  );
+  shapeRenderers[model.shapeType](model, ctx, matrix, renderer, rc, colors);
 
   if (model.textDisplay) {
-    renderText(model, ctx, customStyle);
+    renderText(model, ctx, colors);
   }
 }
 


### PR DESCRIPTION
Closes [BS-1020](https://linear.app/affine-design/issue/BS-1020/当没有启用-color-picker-时，在-edgeless-toolbar-上-transparent-缺失)