### PR TITLE
fix: preserve @blocksuite/global declaration

### DIFF
--- a/packages/framework/store/src/index.ts
+++ b/packages/framework/store/src/index.ts
@@ -1,4 +1,4 @@
-/// <reference types="@blocksuite/global" />
+/// <reference types="@blocksuite/global" preserve="true" />
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../shim.d.ts" />
 


### PR DESCRIPTION
According to TypeScript 5.5 Announcment [Simplified Reference Directive Declaration Emit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit):https://github.com/toeverything/blocksuite/pull/7787/files
> Reference directives are no longer synthesized. User-written reference directives are no longer preserved, unless annotated with a new preserve="true" attribute.

https://github.com/toeverything/blocksuite/blob/9afdb19e6b3f30414ae210ddbcae6c00365c1d62/packages/framework/store/src/index.ts#L1

This line will be removed in build artifact (after https://github.com/toeverything/blocksuite/pull/7762), which make type check failed in AFFiNE side. 
([AFFiNE PR: bump blocksuite](https://github.com/toeverything/AFFiNE/pull/7680);  [AFFiNE PR Action](https://github.com/toeverything/AFFiNE/actions/runs/10178865908/job/28153400322))

```sh
Run yarn typecheck
Error: packages/common/infra/src/atom/settings.ts(37,29): error TS2304: Cannot find name 'BlockSuiteFlags'.
Error: packages/common/infra/src/atom/settings.ts(89,24): error TS2304: Cannot find name 'BlockSuiteFlags'.
Error: Process completed with exit code 2.
```