### PR TITLE
fix(blocks): ui update issue when color picker is opened for the first time

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/color-picker/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/utils.ts
@@ -212,10 +212,17 @@ export const renderCanvas = (canvas: HTMLCanvasElement, rgb: Rgb) => {
 
 // Drops alpha value
 export const keepColor = (color: string) =>
-  color.length > 7 ? color.substring(0, 7) : color;
+  color.length > 7 && !color.endsWith('transparent')
+    ? color.substring(0, 7)
+    : color;
 
 export const parseStringToRgba = (value: string) => {
   value = value.trim();
+
+  // Compatible old format: `--affine-palette-transparent`
+  if (value.endsWith('transparent')) {
+    return { r: 1, g: 1, b: 1, a: 0 };
+  }
 
   if (value.startsWith('#')) {
     return parseHexToRgba(value);
@@ -240,7 +247,10 @@ export const parseStringToRgba = (value: string) => {
 export const preprocessColor = (style: CSSStyleDeclaration) => {
   return ({ type, value }: { type: ModeType; value: string }) => {
     if (value.startsWith('--')) {
-      value = style.getPropertyValue(value);
+      // Compatible old format: `--affine-palette-transparent`
+      value = value.endsWith('transparent')
+        ? 'transparent'
+        : style.getPropertyValue(value);
     }
 
     const rgba = parseStringToRgba(value);

--- a/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/color-panel.ts
@@ -48,7 +48,7 @@ export const DEFAULT_BRUSH_COLOR = LINE_COLORS[5];
 export const DEFAULT_CONNECTOR_COLOR = LINE_COLORS[9];
 
 export function isTransparent(color: string) {
-  return color.toLowerCase() === '--affine-palette-transparent';
+  return color.toLowerCase().endsWith('transparent');
 }
 
 function isSameColorWithBackground(color: string) {
@@ -134,7 +134,10 @@ export function ColorUnit(
 ) {
   const additionIcon = AdditionIcon(color, !!hollowCircle);
 
-  const colorStyle = !hollowCircle ? { background: `var(${color})` } : {};
+  const colorStyle =
+    !hollowCircle && !isTransparent(color)
+      ? { background: `var(${color})` }
+      : {};
 
   const borderStyle =
     isSameColorWithBackground(color) && !hollowCircle

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
@@ -164,21 +164,10 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
       onDrop: (el, bound) => {
         const xywh = bound.serialize();
         const shape = el.data;
-        const colorProps: Record<string, boolean | string> = {};
-        if (!this.edgeless.doc.awarenessStore.getFlag('enable_color_picker')) {
-          colorProps.filled = true;
-          colorProps.fillColor = this.color
-            .replace('var(', '')
-            .replace(')', '');
-          colorProps.strokeColor = this.stroke
-            .replace('var(', '')
-            .replace(')', '');
-        }
         const id = this.edgeless.service.addElement(CanvasElementType.SHAPE, {
           shapeType: shape.name === 'roundedRect' ? ShapeType.Rect : shape.name,
           xywh,
           radius: shape.name === 'roundedRect' ? 0.1 : 0,
-          ...colorProps,
         });
 
         this.edgeless.service.telemetryService?.track('CanvasElementAdded', {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu.ts
@@ -26,19 +26,21 @@ import {
 
 @customElement('edgeless-shape-menu')
 export class EdgelessShapeMenu extends LitElement {
+  private _setFillColor = (fillColor: string) => {
+    const filled = !isTransparent(fillColor);
+    let strokeColor = fillColor.replace(SHAPE_COLOR_PREFIX, LINE_COLOR_PREFIX);
+
+    if (strokeColor.endsWith('transparent')) {
+      strokeColor = '--affine-palette-line-grey';
+    }
+
+    this.onChange({ filled, fillColor, strokeColor });
+  };
+
   private _setShapeStyle = (shapeStyle: ShapeStyle) => {
     this.onChange({
       shapeStyle,
     });
-  };
-
-  private _setStrokeColor = (fillColor: string) => {
-    const strokeColor = fillColor.replace(
-      SHAPE_COLOR_PREFIX,
-      LINE_COLOR_PREFIX
-    );
-    const filled = !isTransparent(fillColor);
-    this.onChange({ filled, fillColor, strokeColor });
   };
 
   static override styles = css`
@@ -130,7 +132,7 @@ export class EdgelessShapeMenu extends LitElement {
             .hasTransparent=${!this.edgeless.doc.awarenessStore.getFlag(
               'enable_color_picker'
             )}
-            @select=${(e: ColorEvent) => this._setStrokeColor(e.detail)}
+            @select=${(e: ColorEvent) => this._setFillColor(e.detail)}
           ></edgeless-one-row-color-panel>
         </div>
       </edgeless-slide-menu>

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-tool-button.ts
@@ -1,4 +1,3 @@
-import { cssVar } from '@toeverything/theme';
 import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -116,15 +115,8 @@ export class EdgelessShapeToolButton extends EdgelessToolbarToolMixin(
       states: { fillColor, strokeColor },
     } = this;
 
-    let color = ThemeObserver.generateColorProperty(fillColor!);
-    let stroke = ThemeObserver.generateColorProperty(strokeColor!);
-
-    if (color.endsWith('transparent)')) {
-      color = cssVar('paletteShapeWhite');
-    }
-    if (stroke.endsWith('transparent)')) {
-      stroke = cssVar('paletteLineGrey');
-    }
+    const color = ThemeObserver.generateColorProperty(fillColor!);
+    const stroke = ThemeObserver.generateColorProperty(strokeColor!);
 
     return html`
       <edgeless-toolbar-button

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -166,12 +166,14 @@ export class EdgelessChangeShapeButton extends WithDisposable(LitElement) {
   ) {
     return (event: PickColorEvent) => {
       if (event.type === 'pick') {
-        this.elements.forEach(ele =>
-          this.service.updateElement(
-            ele.id,
-            packColor(key, { ...event.detail })
-          )
-        );
+        this.elements.forEach(ele => {
+          const props = packColor(key, { ...event.detail });
+          // If `filled` can be set separately, this logic can be removed
+          if (key === 'fillColor' && !ele.filled) {
+            Object.assign(props, { filled: true });
+          }
+          this.service.updateElement(ele.id, props);
+        });
         return;
       }
 

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/diamond.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/diamond.ts
@@ -39,7 +39,7 @@ export function diamond(
   );
 
   if (shapeStyle === 'General') {
-    drawGeneralShape(ctx, model, renderer, fillColor, strokeColor);
+    drawGeneralShape(ctx, model, renderer, filled, fillColor, strokeColor);
   } else {
     rc.polygon(
       [

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/ellipse.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/ellipse.ts
@@ -39,7 +39,7 @@ export function ellipse(
   );
 
   if (shapeStyle === 'General') {
-    drawGeneralShape(ctx, model, renderer, fillColor, strokeColor);
+    drawGeneralShape(ctx, model, renderer, filled, fillColor, strokeColor);
   } else {
     rc.ellipse(cx, cy, renderWidth, renderHeight, {
       seed,

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/rect.ts
@@ -47,7 +47,7 @@ export function rect(
   );
 
   if (shapeStyle === 'General') {
-    drawGeneralShape(ctx, model, renderer, fillColor, strokeColor);
+    drawGeneralShape(ctx, model, renderer, filled, fillColor, strokeColor);
   } else {
     rc.path(
       `

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/triangle.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/triangle.ts
@@ -39,7 +39,7 @@ export function triangle(
   );
 
   if (shapeStyle === 'General') {
-    drawGeneralShape(ctx, model, renderer, fillColor, strokeColor);
+    drawGeneralShape(ctx, model, renderer, filled, fillColor, strokeColor);
   } else {
     rc.polygon(
       [

--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/utils.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/utils.ts
@@ -27,6 +27,7 @@ export function drawGeneralShape(
   ctx: CanvasRenderingContext2D,
   shapeModel: ShapeElementModel,
   renderer: Renderer,
+  filled: boolean,
   fillColor: string,
   strokeColor: string
 ) {
@@ -50,7 +51,7 @@ export function drawGeneralShape(
 
   ctx.lineWidth = shapeModel.strokeWidth;
   ctx.strokeStyle = strokeColor;
-  ctx.fillStyle = fillColor;
+  ctx.fillStyle = filled ? fillColor : 'transparent';
 
   switch (shapeModel.strokeStyle) {
     case 'none':

--- a/tests/edgeless/color-picker.spec.ts
+++ b/tests/edgeless/color-picker.spec.ts
@@ -62,6 +62,9 @@ function getAlphaInput(locator: Locator) {
   return locator.locator('label.alpha input');
 }
 
+// Theme Observer
+test.describe('theme observer', () => {});
+
 // Basic functions
 test.describe('basic functions', () => {
   test('custom color button should be displayed', async ({ page }) => {


### PR DESCRIPTION
Closes [BS-1026](https://linear.app/affine-design/issue/BS-1026/优化-color-picker-第一次打开时-ui-问题) [BS-1016](https://linear.app/affine-design/issue/BS-1016/mindmap-和-connector-卡死，缩放失效)

* fix ui update issue when color picker is opened for the first time and lazy listen
* ~~remove `--affine-palette-transparent` and make setting up transparent logic easier~~
* enhance the fallback logic for both `getPropertyValue` and `getColorValue`