### PR TITLE
fix(blocks): old source or target data may be undefined on connector

### DIFF
--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -353,8 +353,8 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     this._toBeMoved = this._toBeMoved.filter(ele => {
       if (
         ele instanceof ConnectorElementModel &&
-        ele.source.id &&
-        ele.target.id
+        ele.source?.id &&
+        ele.target?.id
       ) {
         if (
           this._toBeMoved.some(e => e.id === ele.source.id) &&


### PR DESCRIPTION
Closes [BS-942](https://linear.app/affine-design/issue/BS-942/typeerror-cannot-read-properties-of-undefined-reading-id)