### PR TITLE
feat: add requiredProperties decorator for runtime LitComponent props type check

### DIFF
--- a/packages/blocks/src/_common/components/ai-item/ai-item-list.ts
+++ b/packages/blocks/src/_common/components/ai-item/ai-item-list.ts
@@ -1,6 +1,6 @@
-import type { EditorHost } from '@blocksuite/block-std';
-
+import { EditorHost } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/block-std';
+import { PropTypes, requiredProperties } from '@blocksuite/block-std';
 import { flip, offset } from '@floating-ui/dom';
 import { baseTheme } from '@toeverything/theme';
 import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
@@ -17,6 +17,7 @@ import {
   SUBMENU_OFFSET_MAIN_AXIS,
 } from './const.js';
 
+@requiredProperties({ host: PropTypes.instanceOf(EditorHost) })
 @customElement('ai-item-list')
 export class AIItemList extends WithDisposable(LitElement) {
   private _abortController: AbortController | null = null;
@@ -134,7 +135,7 @@ export class AIItemList extends WithDisposable(LitElement) {
   }
 
   @property({ attribute: false })
-  accessor groups!: AIItemGroupConfig[];
+  accessor groups: AIItemGroupConfig[] = [];
 
   @property({ attribute: false })
   accessor host!: EditorHost;

--- a/packages/blocks/src/_common/components/ai-item/ai-item.ts
+++ b/packages/blocks/src/_common/components/ai-item/ai-item.ts
@@ -1,6 +1,6 @@
-import type { EditorHost } from '@blocksuite/block-std';
-
+import { EditorHost } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/block-std';
+import { PropTypes, requiredProperties } from '@blocksuite/block-std';
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
@@ -10,6 +10,10 @@ import { ArrowRightIcon, EnterIcon } from '../../icons/ai.js';
 import './ai-sub-item-list.js';
 import { menuItemStyles } from './styles.js';
 
+@requiredProperties({
+  host: PropTypes.instanceOf(EditorHost),
+  item: PropTypes.object,
+})
 @customElement('ai-item')
 export class AIItem extends WithDisposable(LitElement) {
   static override styles = css`
@@ -49,7 +53,7 @@ export class AIItem extends WithDisposable(LitElement) {
   accessor item!: AIItemConfig;
 
   @query('.menu-item')
-  accessor menuItem!: HTMLDivElement;
+  accessor menuItem: HTMLDivElement | null = null;
 
   @property({ attribute: false })
   accessor onClick: (() => void) | undefined;

--- a/packages/blocks/src/_common/components/ai-item/ai-sub-item-list.ts
+++ b/packages/blocks/src/_common/components/ai-item/ai-sub-item-list.ts
@@ -1,6 +1,6 @@
-import type { EditorHost } from '@blocksuite/block-std';
-
+import { EditorHost } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/block-std';
+import { PropTypes, requiredProperties } from '@blocksuite/block-std';
 import { baseTheme } from '@toeverything/theme';
 import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -10,6 +10,10 @@ import type { AIItemConfig, AISubItemConfig } from './types.js';
 import { EnterIcon } from '../../icons/ai.js';
 import { menuItemStyles } from './styles.js';
 
+@requiredProperties({
+  host: PropTypes.instanceOf(EditorHost),
+  item: PropTypes.object,
+})
 @customElement('ai-sub-item-list')
 export class AISubItemList extends WithDisposable(LitElement) {
   private _handleClick = (subItem: AISubItemConfig) => {
@@ -67,7 +71,7 @@ export class AISubItemList extends WithDisposable(LitElement) {
   }
 
   @property({ attribute: false })
-  accessor abortController!: AbortController;
+  accessor abortController: AbortController = new AbortController();
 
   @property({ attribute: false })
   accessor host!: EditorHost;

--- a/packages/framework/block-std/src/scope/block-std-scope.ts
+++ b/packages/framework/block-std/src/scope/block-std-scope.ts
@@ -1,13 +1,13 @@
 import type { Doc, DocCollection } from '@blocksuite/store';
 
-import type { EditorHost } from '../view/index.js';
+import type { EditorHost } from '../view/element/index.js';
 
 import { Clipboard } from '../clipboard/index.js';
 import { CommandManager } from '../command/index.js';
 import { UIEventDispatcher } from '../event/index.js';
 import { SelectionManager } from '../selection/index.js';
 import { SpecStore } from '../spec/index.js';
-import { ViewStore } from '../view/index.js';
+import { ViewStore } from '../view/view-store.js';
 
 export interface BlockStdOptions {
   host: EditorHost;

--- a/packages/framework/block-std/src/view/decorators/index.ts
+++ b/packages/framework/block-std/src/view/decorators/index.ts
@@ -1,0 +1,1 @@
+export { PropTypes, requiredProperties } from './required.js';

--- a/packages/framework/block-std/src/view/decorators/required.ts
+++ b/packages/framework/block-std/src/view/decorators/required.ts
@@ -1,0 +1,58 @@
+import type { Constructor } from '@blocksuite/global/utils';
+import type { LitElement } from 'lit';
+
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
+
+type ValidatorFunction = (value: unknown) => boolean;
+
+export const PropTypes = {
+  string: (value: unknown) => typeof value === 'string',
+  number: (value: unknown) => typeof value === 'number',
+  boolean: (value: unknown) => typeof value === 'boolean',
+  object: (value: unknown) => typeof value === 'object',
+  array: (value: unknown) => Array.isArray(value),
+  instanceOf: (expectedClass: Constructor) => (value: unknown) =>
+    value instanceof expectedClass,
+  arrayOf: (validator: ValidatorFunction) => (value: unknown) =>
+    Array.isArray(value) && value.every(validator),
+  recordOf: (validator: ValidatorFunction) => (value: unknown) => {
+    if (typeof value !== 'object' || value === null) return false;
+    return Object.values(value).every(validator);
+  },
+};
+
+function validatePropTypes<T extends InstanceType<Constructor>>(
+  instance: T,
+  propTypes: Record<string, ValidatorFunction>
+) {
+  for (const [propName, validator] of Object.entries(propTypes)) {
+    const key = propName as keyof T;
+    if (instance[key] === undefined) {
+      throw new BlockSuiteError(
+        ErrorCode.DefaultRuntimeError,
+        `Property ${propName} is required to ${instance.constructor.name}.`
+      );
+    }
+    if (validator && !validator(instance[key])) {
+      throw new BlockSuiteError(
+        ErrorCode.DefaultRuntimeError,
+        `Property ${propName} is invalid to ${instance.constructor.name}.`
+      );
+    }
+  }
+}
+
+export function requiredProperties(
+  propTypes: Record<string, ValidatorFunction>
+) {
+  return function (constructor: Constructor<LitElement>) {
+    const connectedCallback = constructor.prototype.connectedCallback;
+
+    constructor.prototype.connectedCallback = function () {
+      if (connectedCallback) {
+        connectedCallback.call(this);
+      }
+      validatePropTypes(this, propTypes);
+    };
+  };
+}

--- a/packages/framework/block-std/src/view/element/block-component.ts
+++ b/packages/framework/block-std/src/view/element/block-component.ts
@@ -1,6 +1,5 @@
-import type { Doc } from '@blocksuite/store';
-
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
+import { Doc } from '@blocksuite/store';
 import { type BlockModel, BlockViewType } from '@blocksuite/store';
 import { consume, createContext, provide } from '@lit/context';
 import { SignalWatcher, computed } from '@lit-labs/preact-signals';
@@ -11,10 +10,11 @@ import { when } from 'lit/directives/when.js';
 import { html } from 'lit/static-html.js';
 
 import type { EventName, UIEventHandler } from '../../event/index.js';
-import type { BlockStdScope } from '../../scope/index.js';
 import type { BlockService } from '../../service/index.js';
 import type { WidgetComponent } from './widget-component.js';
 
+import { BlockStdScope } from '../../scope/index.js';
+import { PropTypes, requiredProperties } from '../decorators/required.js';
 import { WithDisposable } from '../utils/with-disposable.js';
 import { docContext, stdContext } from './lit-host.js';
 import { ShadowlessElement } from './shadowless-element.js';
@@ -22,6 +22,11 @@ import { ShadowlessElement } from './shadowless-element.js';
 export const modelContext = createContext<BlockModel>('model');
 export const serviceContext = createContext<BlockService>('service');
 
+@requiredProperties({
+  doc: PropTypes.instanceOf(Doc),
+  std: PropTypes.instanceOf(BlockStdScope),
+  widgets: PropTypes.recordOf(PropTypes.object),
+})
 export class BlockComponent<
   Model extends BlockModel = BlockModel,
   Service extends BlockService = BlockService,
@@ -55,7 +60,7 @@ export class BlockComponent<
     this._disposables.add(this.host.event.add(name, handler, config));
   };
 
-  path!: string[];
+  path: string[] = [];
 
   renderChildren = (model: BlockModel): TemplateResult => {
     return this.host.renderChildren(model);

--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -6,7 +6,8 @@ import {
   handleError,
 } from '@blocksuite/global/exceptions';
 import { Slot } from '@blocksuite/global/utils';
-import { type BlockModel, BlockViewType, type Doc } from '@blocksuite/store';
+import { Doc } from '@blocksuite/store';
+import { type BlockModel, BlockViewType } from '@blocksuite/store';
 import { createContext, provide } from '@lit/context';
 import { SignalWatcher } from '@lit-labs/preact-signals';
 import {
@@ -26,7 +27,8 @@ import type { SelectionManager } from '../../selection/index.js';
 import type { BlockSpec, SpecStore } from '../../spec/index.js';
 import type { ViewStore } from '../view-store.js';
 
-import { BlockStdScope } from '../../scope/index.js';
+import { BlockStdScope } from '../../scope/block-std-scope.js';
+import { PropTypes, requiredProperties } from '../decorators/required.js';
 import { RangeManager } from '../utils/range-manager.js';
 import { WithDisposable } from '../utils/with-disposable.js';
 import { ShadowlessElement } from './shadowless-element.js';
@@ -34,6 +36,11 @@ import { ShadowlessElement } from './shadowless-element.js';
 export const docContext = createContext<Doc>('doc');
 export const stdContext = createContext<BlockStdScope>('std');
 
+@requiredProperties({
+  doc: PropTypes.instanceOf(Doc),
+  std: PropTypes.instanceOf(BlockStdScope),
+  specs: PropTypes.arrayOf(PropTypes.object),
+})
 @customElement('editor-host')
 export class EditorHost extends SignalWatcher(
   WithDisposable(ShadowlessElement)

--- a/packages/framework/block-std/src/view/index.ts
+++ b/packages/framework/block-std/src/view/index.ts
@@ -1,3 +1,4 @@
+export * from './decorators/index.js';
 export * from './element/index.js';
 export * from './utils/index.js';
 export * from './view-store.js';

--- a/packages/framework/inline/src/components/v-element.ts
+++ b/packages/framework/inline/src/components/v-element.ts
@@ -58,7 +58,7 @@ export class VElement<
   };
 
   @property({ attribute: false })
-  accessor selected!: boolean;
+  accessor selected: boolean = false;
 }
 
 declare global {


### PR DESCRIPTION
### What Changed?
- Add `@requiredProperties` decorator for runtime LitComponent property type checking.
- Add some usage examples of this decorator.

### Some principles？
- Do not use the `!` non-null assertion operator unless necessary. 
  - If the property type is `boolean` or `Array`, you can fill in the default value of `false` or `[]`.
- Be sure to add `@requiredProperties` for property end with `!`.
- Do not use the `!` operator after property with `@query` decorator. The query result for a DOM element probably be null.

### What's Next?
If the view layer is refactored by Vue, maybe we don't need this `@requiredProperties`.