### PR TITLE
fix(std): can not scroll when dragging to selecte

### DIFF
--- a/packages/framework/block-std/src/view/utils/inline-range-provider.ts
+++ b/packages/framework/block-std/src/view/utils/inline-range-provider.ts
@@ -118,6 +118,7 @@ export const getInlineRangeProvider: (
     return calculateInlineRange(range, textSelection);
   };
 
+  let lastInlineRange: InlineRange | null = null;
   selectionManager.slots.changed.on(() => {
     const textSelection = selectionManager.find('text');
     if (!textSelection) return;
@@ -128,6 +129,15 @@ export const getInlineRangeProvider: (
     // wait for lit updated
     requestAnimationFrame(() => {
       const inlineRange = calculateInlineRange(range, textSelection);
+      if (
+        lastInlineRange &&
+        inlineRange &&
+        lastInlineRange.index === inlineRange.index &&
+        lastInlineRange.length === inlineRange.length
+      )
+        return;
+
+      lastInlineRange = inlineRange;
       inlineRangeUpdatedSlot.emit([inlineRange, false]);
     });
   });


### PR DESCRIPTION
Fix: [BS-1208](https://linear.app/affine-design/issue/BS-1028/无法向上跨页面拖拽选区)

In the previous implementation, the selection changes would trigger update of inline range of rich text, even though in some cases this range had not changed. It will lead the scroll behavior wired.

### Before:

Unexpected behavior: `Selection changed -> inlineRangeUpdate -> ScrollToView` for the first dragged `richtext` block

**From top to bottom.** 

https://github.com/user-attachments/assets/82e93da4-a3bf-4f5d-8005-4e0ae15658f9


**From bottom to top**

https://github.com/user-attachments/assets/4d3bf64f-8fa3-4338-bc36-e87df9c20fd9

