### PR TITLE
fix(blocks): text overflow in icon button

### DIFF
--- a/packages/blocks/src/_common/components/button.ts
+++ b/packages/blocks/src/_common/components/button.ts
@@ -95,6 +95,7 @@ export class IconButton extends LitElement {
         var(--textColor-textSecondaryColor, #8e8d91)
       );
       line-height: var(--affine-line-height);
+      white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
       margin-top: -2px;

--- a/packages/blocks/src/_common/configs/text-conversion.ts
+++ b/packages/blocks/src/_common/configs/text-conversion.ts
@@ -130,7 +130,7 @@ export const textConversionConfigs: TextConversionConfig[] = [
     flavour: 'affine:divider',
     type: 'divider',
     name: 'Divider',
-    description: 'Insert a line to separate sections.',
+    description: 'Visually separate content.',
     hotkey: [`Mod-Alt-d`, `Mod-Shift-d`],
     icon: DividerIcon,
   },


### PR DESCRIPTION
Fix [BS-908](https://linear.app/affine-design/issue/BS-908/slash-menu-ui-bug)