### PR TITLE
fix(presets): disable horizontal scrollbar of outline viewer

### DIFF
--- a/packages/presets/src/fragments/outline/outline-viewer.ts
+++ b/packages/presets/src/fragments/outline/outline-viewer.ts
@@ -93,6 +93,7 @@ export class OutlineViewer extends SignalWatcher(WithDisposable(LitElement)) {
       flex-direction: column;
       align-items: flex-start;
       overflow-y: auto;
+      overflow-x: hidden;
     }
 
     ${scrollbarStyle('.outline-viewer-inner-container')}


### PR DESCRIPTION
Before

![CleanShot 2024-08-01 at 21.04.51.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/a93e6f50-5097-452a-801c-587a4ef003be.gif)

After

![CleanShot 2024-08-01 at 21.05.22.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/991128be-d3d2-4a39-bbfc-42a8b30b45b1.gif)

