### PR TITLE
fix(blocks): active state on icon button

### DIFF
--- a/packages/blocks/src/_common/components/toolbar/icon-button.ts
+++ b/packages/blocks/src/_common/components/toolbar/icon-button.ts
@@ -140,7 +140,6 @@ export class EditorIconButton extends LitElement {
         style=${iconContainerStyles}
         ?with-hover=${this.withHover}
         ?disabled=${this.disabled}
-        ?active=${this.active}
       >
         <slot></slot>
         ${cache(
@@ -157,7 +156,7 @@ export class EditorIconButton extends LitElement {
     `;
   }
 
-  @property({ attribute: false })
+  @property({ type: Boolean, reflect: true })
   accessor active = false;
 
   @property({ attribute: false })


### PR DESCRIPTION
### Before
<img width="415" alt="Screenshot 2024-08-02 at 06 08 21" src="https://github.com/user-attachments/assets/84b5e3c0-3f93-4d1f-8a4a-36b4e935bba8">

### After
<img width="461" alt="Screenshot 2024-08-02 at 06 08 50" src="https://github.com/user-attachments/assets/4aa38288-1b09-4728-be85-a86679a5dd95">
