### PR TITLE
feat: add click handle config for embed linked doc

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -1,3 +1,5 @@
+import type { EditorHost } from '@blocksuite/block-std';
+
 import { Bound } from '@blocksuite/global/utils';
 import { assertExists } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
@@ -23,6 +25,11 @@ import { renderLinkedDocInCard } from '../_common/utils/render-linked-doc.js';
 import { SyncedDocErrorIcon } from '../embed-synced-doc-block/styles.js';
 import { styles } from './styles.js';
 import { getEmbedLinkedDocIcons } from './utils.js';
+
+export interface EmbedLinkedDocBlockConfig {
+  handleClick?: (e: MouseEvent, host: EditorHost) => void;
+  handleDoubleClick?: (e: MouseEvent, host: EditorHost) => void;
+}
 
 @customElement('affine-embed-linked-doc-block')
 @Peekable({
@@ -201,12 +208,22 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<
     });
   };
 
-  private _handleClick(_event: MouseEvent) {
+  private _handleClick(event: MouseEvent) {
+    if (this.config.handleClick) {
+      this.config.handleClick(event, this.host);
+      return;
+    }
+
     if (this.isInSurface) return;
     this._selectBlock();
   }
 
   private _handleDoubleClick(event: MouseEvent) {
+    if (this.config.handleDoubleClick) {
+      this.config.handleDoubleClick(event, this.host);
+      return;
+    }
+
     if (isPeekable(this)) {
       return;
     }
@@ -463,6 +480,10 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<
         });
       });
     }
+  }
+
+  get config(): EmbedLinkedDocBlockConfig {
+    return this.std.spec.getConfig('affine:embed-linked-doc') || {};
   }
 
   get docTitle() {

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
@@ -2,10 +2,18 @@ import type { BlockSpec } from '@blocksuite/block-std';
 
 import { literal } from 'lit/static-html.js';
 
+import type { EmbedLinkedDocBlockConfig } from './embed-linked-doc-block.js';
+
 import { EmbedLinkedDocBlockSchema } from './embed-linked-doc-schema.js';
 import { EmbedLinkedDocBlockService } from './embed-linked-doc-service.js';
 
-export const EmbedLinkedDocBlockSpec: BlockSpec = {
+export type EmbedLinkedDocBlockSpecType = BlockSpec<
+  string,
+  EmbedLinkedDocBlockService,
+  EmbedLinkedDocBlockConfig
+>;
+
+export const EmbedLinkedDocBlockSpec: EmbedLinkedDocBlockSpecType = {
   schema: EmbedLinkedDocBlockSchema,
   view: {
     component: literal`affine-embed-linked-doc-block`,

--- a/packages/blocks/src/embed-linked-doc-block/index.ts
+++ b/packages/blocks/src/embed-linked-doc-block/index.ts
@@ -3,7 +3,10 @@ import { noop } from '@blocksuite/global/utils';
 import type { EmbedLinkedDocModel } from './embed-linked-doc-model.js';
 import type { EmbedLinkedDocBlockService } from './embed-linked-doc-service.js';
 
-import { EmbedLinkedDocBlockComponent } from './embed-linked-doc-block.js';
+import {
+  EmbedLinkedDocBlockComponent,
+  type EmbedLinkedDocBlockConfig,
+} from './embed-linked-doc-block.js';
 noop(EmbedLinkedDocBlockComponent);
 
 export * from './embed-linked-doc-block.js';
@@ -18,6 +21,9 @@ declare global {
     }
     interface BlockServices {
       'affine:embed-linked-doc': EmbedLinkedDocBlockService;
+    }
+    interface BlockConfigs {
+      'affine:embed-linked-doc': EmbedLinkedDocBlockConfig;
     }
   }
 }

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -191,7 +191,7 @@ export class AffineLinkedDocWidget extends WidgetComponent {
       ignoreBlockTypes: ['affine:code'],
       convertTriggerKey: true,
       getMenus,
-      ...this.std.spec.getConfig(this.flavour)?.linkedWidget,
+      ...this.std.spec.getConfig('affine:page')?.linkedWidget,
     };
   }
 }

--- a/packages/framework/block-std/src/spec/spec-store.ts
+++ b/packages/framework/block-std/src/spec/spec-store.ts
@@ -82,7 +82,7 @@ export class SpecStore {
   }
 
   getConfig<Key extends BlockSuite.ConfigKeys>(
-    flavour: string
+    flavour: Key
   ): BlockSuite.BlockConfigs[Key] | null;
 
   getConfig(flavour: string) {


### PR DESCRIPTION
### What Changed?
- Add click handle config for embed linked doc
- Custom click handle in AFFiNE like:
```typescript
{ 
    ...EmbedLinkedDocBlockSpec,
    config: {
      handleClick: (e: MouseEvent, host: EditorHost) => {
        console.log(e, host);
      }
    }
  },
```