### PR TITLE
fix: step of wheel to zomm viewport is too large

### DIFF
--- a/packages/blocks/src/surface-block/consts.ts
+++ b/packages/blocks/src/surface-block/consts.ts
@@ -5,6 +5,7 @@ export const ZOOM_MAX = 6.0;
 export const ZOOM_MIN = 0.1;
 export const ZOOM_STEP = 0.25;
 export const ZOOM_INITIAL = 1.0;
+export const ZOOM_WHEEL_STEP = 0.1;
 export const GRID_SIZE = 3000;
 export const GRID_GAP_MIN = 10;
 export const GRID_GAP_MAX = 50;

--- a/packages/blocks/src/surface-block/utils/index.ts
+++ b/packages/blocks/src/surface-block/utils/index.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 
-import { ZOOM_STEP } from '../consts.js';
+import { ZOOM_WHEEL_STEP } from '../consts.js';
 
 export { generateKeyBetween, generateNKeysBetween } from 'fractional-indexing';
 
@@ -19,7 +19,7 @@ export function generateElementId() {
 export function normalizeWheelDeltaY(delta: number, zoom = 1) {
   const sign = Math.sign(delta);
   const abs = Math.abs(delta);
-  const maxStep = ZOOM_STEP * 100;
+  const maxStep = ZOOM_WHEEL_STEP * 100;
   if (abs > maxStep) {
     delta = maxStep * sign;
   }

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -110,9 +110,9 @@ test('zoom by mouse', async ({ page }) => {
   await assertEdgelessSelectedRect(page, original);
 
   await zoomByMouseWheel(page, 0, 125);
-  await assertZoomLevel(page, 75);
+  await assertZoomLevel(page, 90);
 
-  const zoomed = [172.5, 414.375, original[2] * 0.75, original[3] * 0.75];
+  const zoomed = [117, 407.25, original[2] * 0.9, original[3] * 0.9];
   await assertEdgelessSelectedRect(page, zoomed);
 });
 


### PR DESCRIPTION
[BS-715](https://linear.app/affine-design/issue/BS-715/edgeless-10percent-35percent缩放过于激进)