### PR TITLE
fix(blocks): slash menu and at menu not closed

### DIFF
--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -122,6 +122,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     createKeydownObserver({
       target: eventSource,
       signal: this.abortController.signal,
+      inlineEditor: this.inlineEditor,
       onInput: () => {
         this._activatedItemIndex = 0;
         void this._updateLinkedDocGroup();

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -189,6 +189,7 @@ export class SlashMenu extends WithDisposable(LitElement) {
     createKeydownObserver({
       target: inlineEditor.eventSource,
       signal: this.abortController.signal,
+      inlineEditor: this.inlineEditor,
       interceptor: (event, next) => {
         const { key, isComposing, code } = event;
         if (key === this.triggerKey) {


### PR DESCRIPTION
Fix [BS-1004](https://linear.app/affine-design/issue/BS-974/【ios-safari特供bug】slashmenu-和-menu-无法通过backspace关闭)

## What changes
use `inlineEditor.slots.onRangeUpdate` instead of `requestAnimationFrame` in `createKeyObserver`, which is used by `slash-menu` and `@ menu` . 

In iOS webkit, using requestAnimationFrame has some timing issues when selection updating.

## Before

https://github.com/user-attachments/assets/e337fb8e-29ff-4312-bd81-1359cce40a1c

## After

https://github.com/user-attachments/assets/68dd60f0-8b64-45fd-9ea0-8c72781aec72