### PR TITLE
fix(edgeless): limit edgeless toolbar's min-width

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/edgeless-toolbar.ts
@@ -126,6 +126,7 @@ export class EdgelessToolbar extends WithDisposable(LitElement) {
       padding-bottom: 16px;
       width: fit-content;
       max-width: calc(100% - ${unsafeCSS(SAFE_AREA_WIDTH)}px * 2);
+      min-width: 264px;
     }
     .edgeless-toolbar-toggle-control[data-enable='true'] {
       transition: 0.23s ease;


### PR DESCRIPTION
- before
  ![CleanShot 2024-08-02 at 14.59.46@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/6cd66edf-bdcb-436d-8482-65da0aa7c6a3.png)
- after
  ![CleanShot 2024-08-02 at 14.59.21@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/b6023b35-d1c5-4264-bf2e-fd12a00aa0c9.png)

