### PR TITLE
chore(blocks): update palette canvas border radius on color picker

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
@@ -115,7 +115,7 @@ export const COLOR_PICKER_STYLE = css`
     position: absolute;
     width: 100%;
     height: 100%;
-    border-radius: 4px;
+    border-radius: 8px;
   }
   .color-palette-wrapper::after {
     content: '';
@@ -126,7 +126,7 @@ export const COLOR_PICKER_STYLE = css`
     bottom: 0;
     border: 1px solid rgba(0, 0, 0, 0.1);
     box-sizing: border-box;
-    border-radius: 4px;
+    border-radius: 8px;
     overflow: hidden;
     pointer-events: none;
   }


### PR DESCRIPTION
Closes [BS-1043](https://linear.app/affine-design/issue/BS-1043/ui-bug-颜色面板的圆角应该为-8px)