### PR TITLE
fix(edgeless): missing content when pasting edgeless note

### DIFF
--- a/packages/blocks/src/note-block/note-edgeless-block.ts
+++ b/packages/blocks/src/note-block/note-edgeless-block.ts
@@ -532,3 +532,9 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
   @query('.edgeless-note-page-content .affine-note-block-container')
   private accessor _notePageContent: HTMLElement | null = null;
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'affine-edgeless-note': EdgelessNoteBlockComponent;
+  }
+}

--- a/packages/blocks/src/root-block/clipboard/index.ts
+++ b/packages/blocks/src/root-block/clipboard/index.ts
@@ -82,22 +82,19 @@ export class PageClipboard {
 
   host: BlockComponent;
 
-  onBlockSnapshotPaste = (
+  onBlockSnapshotPaste = async (
     snapshot: BlockSnapshot,
     doc: Doc,
     parent?: string,
     index?: number
   ) => {
-    this._std.command
-      .chain()
-      .inline((_ctx, next) => {
-        this._std.clipboard
-          .pasteBlockSnapshot(snapshot, doc, parent, index)
-          .catch(console.error);
-
-        return next();
-      })
-      .run();
+    const block = await this._std.clipboard.pasteBlockSnapshot(
+      snapshot,
+      doc,
+      parent,
+      index
+    );
+    return block?.id ?? null;
   };
 
   onPageCopy: UIEventHandler = ctx => {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -411,16 +411,16 @@ test('when no note block, click editing area auto add a new note block', async (
   await page.locator('affine-edgeless-note').click({ force: true });
   await pressBackspace(page);
   await switchEditorMode(page);
-  let note = await page.evaluate(() => {
+  const edgelessNote = await page.evaluate(() => {
     return document.querySelector('affine-edgeless-note');
   });
-  expect(note).toBeNull();
+  expect(edgelessNote).toBeNull();
   await click(page, { x: 200, y: 280 });
 
-  note = await page.evaluate(() => {
+  const pageNote = await page.evaluate(() => {
     return document.querySelector('affine-note');
   });
-  expect(note).not.toBeNull();
+  expect(pageNote).not.toBeNull();
 });
 
 test(scoped`automatic identify url text`, async ({ page }) => {

--- a/tests/edgeless/paste-block.spec.ts
+++ b/tests/edgeless/paste-block.spec.ts
@@ -1,0 +1,97 @@
+import { type Page, expect } from '@playwright/test';
+import {
+  click,
+  copyByKeyboard,
+  enterPlaygroundRoom,
+  focusRichText,
+  getAllEdgelessNoteIds,
+  getAllEdgelessTextIds,
+  getNoteBoundBoxInEdgeless,
+  initEmptyEdgelessState,
+  pasteByKeyboard,
+  pasteTestImage,
+  pressEnter,
+  pressEnterWithShortkey,
+  pressEscape,
+  setEdgelessTool,
+  switchEditorMode,
+  type,
+} from 'utils/actions/index.js';
+
+import { test } from '../utils/playwright.js';
+
+test.describe('pasting blocks', () => {
+  const initContent = async (page: Page) => {
+    // Text
+    await type(page, 'hello');
+    await pressEnter(page);
+    // Image
+    await pasteTestImage(page);
+    await pressEnter(page);
+    // Text
+    await type(page, 'world');
+    await pressEnter(page);
+    // code
+    await type(page, '``` ');
+    await type(page, 'code');
+    await pressEnterWithShortkey(page);
+  };
+  test('pasting a note block', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    const { noteId } = await initEmptyEdgelessState(page);
+    await focusRichText(page);
+    await initContent(page);
+    await switchEditorMode(page);
+    const box = await getNoteBoundBoxInEdgeless(page, noteId);
+    await click(page, {
+      x: box.x + 10,
+      y: box.y + 10,
+    });
+    await copyByKeyboard(page);
+    await pasteByKeyboard(page);
+    // not equal to noteId
+    const noteIds = await getAllEdgelessNoteIds(page);
+    expect(noteIds.length).toBe(2);
+    expect(noteIds[0]).toBe(noteId);
+    const newNoteId = noteIds[1];
+    const newNote = page.locator(
+      `affine-edgeless-note[data-block-id="${newNoteId}"]`
+    );
+    await expect(newNote).toBeVisible();
+    const blocks = newNote.locator('[data-block-id]');
+    await expect(blocks.nth(0)).toContainText('hello');
+    await expect(blocks.nth(1).locator('.resizable-img')).toBeVisible();
+    await expect(blocks.nth(2)).toContainText('world');
+    await expect(blocks.nth(3)).toContainText('code');
+  });
+  test('pasting a edgeless block', async ({ page }) => {
+    await enterPlaygroundRoom(page, {
+      flags: {
+        enable_edgeless_text: true,
+      },
+    });
+    await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+    await setEdgelessTool(page, 'default');
+    await page.mouse.dblclick(130, 140, {
+      delay: 100,
+    });
+    await initContent(page);
+    await pressEscape(page, 3);
+    await page.mouse.click(130, 140);
+    await copyByKeyboard(page);
+    await pasteByKeyboard(page);
+    const textIds = await getAllEdgelessTextIds(page);
+    expect(textIds.length).toBe(2);
+    const newTextId = textIds[1];
+    const newText = page.locator(
+      `affine-edgeless-text[data-block-id="${newTextId}"]`
+    );
+    await expect(newText).toBeVisible();
+    const blocks = newText.locator('[data-block-id]');
+    await expect(blocks.nth(0)).toContainText('hello');
+    await expect(blocks.nth(1).locator('.resizable-img')).toBeVisible();
+    await expect(blocks.nth(2)).toContainText('world');
+    await expect(blocks.nth(3)).toContainText('code');
+  });
+});

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -650,6 +650,22 @@ export async function getAllNoteIds(page: Page) {
   });
 }
 
+export async function getAllEdgelessNoteIds(page: Page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll('affine-edgeless-note')).map(
+      note => note.model.id
+    );
+  });
+}
+
+export async function getAllEdgelessTextIds(page: Page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll('affine-edgeless-text')).map(
+      text => text.model.id
+    );
+  });
+}
+
 export async function countBlock(page: Page, flavour: string) {
   return page.evaluate(
     ([flavour]) => {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -931,6 +931,31 @@ export async function pasteContent(
   await waitNextFrame(page);
 }
 
+export async function pasteTestImage(page: Page) {
+  await page.evaluate(async () => {
+    const imageBlob = await fetch(`${location.origin}/test-card-1.png`).then(
+      response => response.blob()
+    );
+
+    const imageFile = new File([imageBlob], 'test-card-1.png', {
+      type: 'image/png',
+    });
+
+    const e = new ClipboardEvent('paste', {
+      clipboardData: new DataTransfer(),
+    });
+
+    Object.defineProperty(e, 'target', {
+      writable: false,
+      value: document,
+    });
+
+    e.clipboardData?.items.add(imageFile);
+    document.dispatchEvent(e);
+  });
+  await waitNextFrame(page);
+}
+
 export async function getClipboardHTML(page: Page) {
   const dataInClipboard = await page.evaluate(async () => {
     function format(node: HTMLElement, level: number) {


### PR DESCRIPTION
Fix [BS-332](https://linear.app/affine-design/issue/BS-332/bug-长-note-带-image-时报错)

## What changes
- Update the pasting logic for edgeless note and edgeless-text blocks
 - The previous implementation involved manually pasting child blocks, which could lead to potential timing issues. For instance, in the first figure, not all promise function calls in the `forEach` may execute sequentially. For example, pasting

    ```
    <paragraph-1 /> // parent index = 0
    <image />       // parent index = 1
    <paragraph-2 /> // parent index = 2
    ```

    ```
    // actual unexpected order, because paste <image /> is time-consuming
    <paragraph-1 /> // parent index = 0
    <paragraph-2 /> // parent index = 2 <- throw Y doc error 
    <image />       // parent index = 1
    ```

    ![CleanShot 2024-08-05 at 18 01 03@2x](https://github.com/user-attachments/assets/ec482830-f6c3-4798-bc68-2e6cbabc9d0a)


- Update related e2e tests