### PR TITLE
refactor(std): move RangeManager from host component to std scope

### DIFF
--- a/packages/blocks/src/_common/configs/move-block.ts
+++ b/packages/blocks/src/_common/configs/move-block.ts
@@ -1,8 +1,6 @@
 import type { BlockSelection } from '@blocksuite/block-std';
 import type { BlockComponent } from '@blocksuite/block-std';
 
-import { assertExists } from '@blocksuite/global/utils';
-
 const getSelection = (blockComponent: BlockComponent) =>
   blockComponent.host.selection;
 
@@ -55,9 +53,7 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
         );
         block.updateComplete
           .then(() => {
-            const rangeManager = block.host.rangeManager;
-            assertExists(rangeManager);
-            rangeManager.syncTextSelectionToRange(textSelection);
+            block.std.range.syncTextSelectionToRange(textSelection);
           })
           .catch(console.error);
         return true;
@@ -106,10 +102,7 @@ export const moveBlockConfigs: MoveBlockConfig[] = [
         doc.moveBlocks([currentModel], parentModel, nextSiblingModel, false);
         block.updateComplete
           .then(() => {
-            // `textSelection` will not change so we need wo sync it manually
-            const rangeManager = block.host.rangeManager;
-            assertExists(rangeManager);
-            rangeManager.syncTextSelectionToRange(textSelection);
+            block.std.range.syncTextSelectionToRange(textSelection);
           })
           .catch(console.error);
         return true;

--- a/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/blocks/src/_common/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -353,8 +353,8 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
   private _onConfirm() {
     if (!this.inlineEditor.isValidInlineRange(this.targetInlineRange)) return;
+    if (!this.linkInput) return;
 
-    assertExists(this.linkInput);
     const linkInputValue = this.linkInput.value;
     if (!linkInputValue || !isValidUrl(linkInputValue)) return;
 
@@ -367,8 +367,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
       });
       this.inlineEditor.setInlineRange(this.targetInlineRange);
       const textSelection = this.host?.selection.find('text');
-      assertExists(textSelection);
-      this.host?.rangeManager?.syncTextSelectionToRange(textSelection);
+      if (!textSelection) return;
+
+      this.std?.range.syncTextSelectionToRange(textSelection);
     } else if (this.type === 'edit') {
       const text = this.textInput?.value ?? link;
       this.inlineEditor.insertText(this.targetInlineRange, text, {
@@ -380,8 +381,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
         length: text.length,
       });
       const textSelection = this.host?.selection.find('text');
-      assertExists(textSelection);
-      this.host?.rangeManager?.syncTextSelectionToRange(textSelection);
+      if (!textSelection) return;
+
+      this.std?.range.syncTextSelectionToRange(textSelection);
     }
 
     this.abortController.abort();

--- a/packages/blocks/src/root-block/commands/block-crud/get-selected-blocks.ts
+++ b/packages/blocks/src/root-block/commands/block-crud/get-selected-blocks.ts
@@ -32,13 +32,11 @@ export const getSelectedBlocksCommand: Command<
 
   const textSelection = ctx.textSelection ?? ctx.currentTextSelection;
   if (types.includes('text') && textSelection) {
-    const rangeManager = ctx.std.host.rangeManager;
     try {
-      if (!rangeManager) return;
-      const range = rangeManager.textSelectionToRange(textSelection);
+      const range = ctx.std.range.textSelectionToRange(textSelection);
       if (!range) return;
 
-      const selectedBlocks = rangeManager.getSelectedBlockComponentsByRange(
+      const selectedBlocks = ctx.std.range.getSelectedBlockComponentsByRange(
         range,
         {
           match: (el: BlockComponent) => roles.includes(el.model.role),

--- a/packages/blocks/src/root-block/commands/text-crud/delete-text.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/delete-text.ts
@@ -13,12 +13,9 @@ export const deleteTextCommand: Command<
   const textSelection = ctx.textSelection ?? ctx.currentTextSelection;
   if (!textSelection) return;
 
-  const host = ctx.std.host;
-  if (!host.rangeManager) return;
-
-  const range = host.rangeManager.textSelectionToRange(textSelection);
+  const range = ctx.std.range.textSelectionToRange(textSelection);
   if (!range) return;
-  const selectedElements = host.rangeManager.getSelectedBlockComponentsByRange(
+  const selectedElements = ctx.std.range.getSelectedBlockComponentsByRange(
     range,
     {
       mode: 'flat',

--- a/packages/blocks/src/root-block/commands/text-crud/format-text.ts
+++ b/packages/blocks/src/root-block/commands/text-crud/format-text.ts
@@ -83,7 +83,7 @@ export const formatTextCommand: Command<
 
       Promise.all(selectedBlocks.map(el => el.updateComplete))
         .then(() => {
-          ctx.std.host.rangeManager?.syncTextSelectionToRange(textSelection);
+          ctx.std.range.syncTextSelectionToRange(textSelection);
         })
         .catch(console.error);
 

--- a/packages/blocks/src/root-block/page/page-root-block.ts
+++ b/packages/blocks/src/root-block/page/page-root-block.ts
@@ -238,9 +238,9 @@ export class PageRootBlockComponent extends BlockComponent<
         const index = notes.indexOf(prevNote);
         if (index !== 0) return;
 
-        const range = this.host.rangeManager?.value;
+        const range = this.std.range.value;
         requestAnimationFrame(() => {
-          const currentRange = this.host.rangeManager?.value;
+          const currentRange = this.std.range.value;
 
           if (!range || !currentRange) return;
 

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -227,10 +227,7 @@ export class RootService extends BlockService<RootBlockModel> {
   };
 
   private _insertLink = (url: string) => {
-    const host = this.host;
-    const rootService = host.spec.getService('affine:page');
-
-    const embedOptions = rootService.getEmbedBlockOptions(url);
+    const embedOptions = this.getEmbedBlockOptions(url);
 
     let flavour = 'affine:bookmark';
     let targetStyle: EmbedCardStyle = 'vertical';
@@ -265,9 +262,9 @@ export class RootService extends BlockService<RootBlockModel> {
 
   readonly editPropsStore: EditPropsStore = new EditPropsStore(this);
 
-  exportManager!: ExportManager;
+  readonly exportManager = new ExportManager(this, this._exportOptions);
 
-  fileDropManager!: FileDropManager;
+  readonly fileDropManager = new FileDropManager(this, this._fileDropOptions);
 
   readonly fontLoader = new FontLoader();
 
@@ -383,9 +380,6 @@ export class RootService extends BlockService<RootBlockModel> {
 
     this.loadFonts();
 
-    this.exportManager = new ExportManager(this, this._exportOptions);
-
-    this.fileDropManager = new FileDropManager(this, this._fileDropOptions);
     this.disposables.addFromEvent(
       this.host,
       'dragover',

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -80,9 +80,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
     const containerRect = this._containerRect;
 
     if (textSelection) {
-      const rangeManager = this.host.rangeManager;
-      assertExists(rangeManager);
-      const range = rangeManager.textSelectionToRange(
+      const range = this.std.range.textSelectionToRange(
         this._selectionManager.create('text', {
           from: {
             blockId: textSelection.to
@@ -156,9 +154,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
     const container = this._container;
     const containerRect = this._containerRect;
     if (textSelection) {
-      const rangeManager = this.host.rangeManager;
-      assertExists(rangeManager);
-      const range = rangeManager.textSelectionToRange(textSelection);
+      const range = this.std.range.textSelectionToRange(textSelection);
 
       if (range) {
         const nativeRects = Array.from(range.getClientRects());

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -1480,7 +1480,7 @@ export class AffineDragHandleWidget extends WidgetComponent<
   }
 
   private get _rangeManager() {
-    return this.host.rangeManager;
+    return this.std.range;
   }
 
   private get dragHandleContainerOffsetParent() {

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -130,8 +130,7 @@ export class AffineFormatBarWidget extends WidgetComponent {
               block.model.role === 'content'
             ) {
               this._displayType = 'text';
-              assertExists(rootComponent.host.rangeManager);
-
+              if (!rootComponent.std.range) return;
               this.host.std.command
                 .chain()
                 .getTextSelection()
@@ -140,8 +139,7 @@ export class AffineFormatBarWidget extends WidgetComponent {
                 })
                 .inline(ctx => {
                   const { selectedBlocks } = ctx;
-                  assertExists(selectedBlocks);
-
+                  if (!selectedBlocks) return;
                   this._selectedBlocks = selectedBlocks;
                 })
                 .run();

--- a/packages/framework/block-std/src/index.ts
+++ b/packages/framework/block-std/src/index.ts
@@ -1,6 +1,7 @@
 export * from './clipboard/index.js';
 export * from './command/index.js';
 export * from './event/index.js';
+export * from './range/index.js';
 export * from './scope/index.js';
 export * from './selection/index.js';
 export * from './service/index.js';

--- a/packages/framework/block-std/src/range/index.ts
+++ b/packages/framework/block-std/src/range/index.ts
@@ -1,0 +1,3 @@
+export * from './inline-range-provider.js';
+export * from './range-binding.js';
+export * from './range-manager.js';

--- a/packages/framework/block-std/src/range/inline-range-provider.ts
+++ b/packages/framework/block-std/src/range/inline-range-provider.ts
@@ -7,15 +7,15 @@ import {
   type InlineRangeUpdatedProp,
 } from '@blocksuite/inline';
 
-import type { TextSelection } from '../../selection/index.js';
-import type { BlockComponent } from '../element/block-component.js';
+import type { TextSelection } from '../selection/index.js';
+import type { BlockComponent } from '../view/element/block-component.js';
 
 export const getInlineRangeProvider: (
   element: BlockComponent
 ) => InlineRangeProvider | null = element => {
   const editorHost = element.host;
   const selectionManager = editorHost.selection;
-  const rangeManager = editorHost.rangeManager;
+  const rangeManager = editorHost.range;
   const inlineRangeUpdatedSlot = new Slot<InlineRangeUpdatedProp>();
 
   if (!selectionManager || !rangeManager) {
@@ -81,7 +81,7 @@ export const getInlineRangeProvider: (
   const setInlineRange = (inlineRange: InlineRange | null, sync = true) => {
     // skip `setInlineRange` from `inlineEditor` when composing happens across blocks,
     // selection will be updated in `range-binding`
-    if (rangeManager.binding.isComposing) return;
+    if (rangeManager.binding?.isComposing) return;
 
     if (!inlineRange) {
       selectionManager.clear(['text']);

--- a/packages/framework/block-std/src/range/range-binding.ts
+++ b/packages/framework/block-std/src/range/range-binding.ts
@@ -1,8 +1,8 @@
 import { throttle } from '@blocksuite/global/utils';
 
-import type { BaseSelection, TextSelection } from '../../selection/index.js';
+import type { BaseSelection, TextSelection } from '../selection/index.js';
 
-import { BlockComponent } from '../element/block-component.js';
+import { BlockComponent } from '../view/element/block-component.js';
 import { RangeManager } from './range-manager.js';
 
 /**
@@ -318,7 +318,7 @@ export class RangeBinding {
   }
 
   get rangeManager() {
-    return this.host.rangeManager;
+    return this.host.range;
   }
 
   get selectionManager() {

--- a/packages/framework/block-std/src/range/range-manager.ts
+++ b/packages/framework/block-std/src/range/range-manager.ts
@@ -3,8 +3,8 @@ import type { TextSelection } from '@blocksuite/block-std';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { INLINE_ROOT_ATTR, type InlineRootElement } from '@blocksuite/inline';
 
-import type { BlockComponent } from '../element/block-component.js';
-import type { EditorHost } from '../element/lit-host.js';
+import type { BlockComponent } from '../view/element/block-component.js';
+import type { EditorHost } from '../view/element/lit-host.js';
 
 import { RangeBinding } from './range-binding.js';
 
@@ -22,7 +22,7 @@ export class RangeManager {
    */
   static rangeSyncExcludeAttr = 'data-range-sync-exclude';
 
-  readonly binding = new RangeBinding(this);
+  binding: RangeBinding | null = null;
 
   constructor(public host: EditorHost) {}
 
@@ -130,6 +130,10 @@ export class RangeManager {
     }
 
     return result;
+  }
+
+  mount() {
+    this.binding = new RangeBinding(this);
   }
 
   queryInlineEditorByPath(path: string) {

--- a/packages/framework/block-std/src/scope/block-std-scope.ts
+++ b/packages/framework/block-std/src/scope/block-std-scope.ts
@@ -5,6 +5,7 @@ import type { EditorHost } from '../view/element/index.js';
 import { Clipboard } from '../clipboard/index.js';
 import { CommandManager } from '../command/index.js';
 import { UIEventDispatcher } from '../event/index.js';
+import { RangeManager } from '../range/index.js';
 import { SelectionManager } from '../selection/index.js';
 import { SpecStore } from '../spec/index.js';
 import { ViewStore } from '../view/view-store.js';
@@ -27,6 +28,8 @@ export class BlockStdScope {
 
   readonly host: EditorHost;
 
+  readonly range: RangeManager;
+
   readonly selection: SelectionManager;
 
   readonly spec: SpecStore;
@@ -39,6 +42,7 @@ export class BlockStdScope {
     this.doc = options.doc;
     this.event = new UIEventDispatcher(this);
     this.selection = new SelectionManager(this);
+    this.range = new RangeManager(this.host);
     this.command = new CommandManager(this);
     this.spec = new SpecStore(this);
     this.view = new ViewStore(this);
@@ -47,6 +51,7 @@ export class BlockStdScope {
 
   mount() {
     this.selection.mount();
+    this.range.mount();
     this.event.mount();
     this.view.mount();
     this.spec.mount();

--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -23,13 +23,13 @@ import { html, unsafeStatic } from 'lit/static-html.js';
 
 import type { CommandManager } from '../../command/index.js';
 import type { UIEventDispatcher } from '../../event/index.js';
+import type { RangeManager } from '../../range/index.js';
 import type { SelectionManager } from '../../selection/index.js';
 import type { BlockSpec, SpecStore } from '../../spec/index.js';
 import type { ViewStore } from '../view-store.js';
 
 import { BlockStdScope } from '../../scope/block-std-scope.js';
 import { PropTypes, requiredProperties } from '../decorators/required.js';
-import { RangeManager } from '../utils/range-manager.js';
 import { WithDisposable } from '../utils/with-disposable.js';
 import { ShadowlessElement } from './shadowless-element.js';
 
@@ -84,8 +84,6 @@ export class EditorHost extends SignalWatcher(
     }
   `;
 
-  rangeManager: RangeManager | null = null;
-
   renderChildren = (model: BlockModel): TemplateResult => {
     return html`${repeat(
       model.children,
@@ -134,14 +132,12 @@ export class EditorHost extends SignalWatcher(
 
     this.std.mount();
     this.std.spec.applySpecs(this.specs);
-    this.rangeManager = new RangeManager(this);
     this.tabIndex = 0;
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
     this.std.unmount();
-    this.rangeManager = null;
     this.slots.unmounted.emit();
   }
 
@@ -194,6 +190,10 @@ export class EditorHost extends SignalWatcher(
 
   get event(): UIEventDispatcher {
     return this.std.event;
+  }
+
+  get range(): RangeManager {
+    return this.std.range;
   }
 
   get selection(): SelectionManager {

--- a/packages/framework/block-std/src/view/utils/index.ts
+++ b/packages/framework/block-std/src/view/utils/index.ts
@@ -1,4 +1,1 @@
-export * from './inline-range-provider.js';
-export * from './range-binding.js';
-export * from './range-manager.js';
 export * from './with-disposable.js';


### PR DESCRIPTION
### What Changed?
- Move `RangeManager` from host component to std scope
- Remove `!` non-null assertion operator in `root-service`
- Remove some `assertExists`

### Why make this change?
- In some edge case, the `EditorHost` component reference might be undefined.
- I will add a `DocCollectionService` and initialize `BlockStdScope` in the constructor instead of `connectedCallback`.