### PR TITLE
fix(blocks): edit text on shape when it is transprent

### DIFF
--- a/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
+++ b/packages/blocks/src/surface-block/canvas-renderer/element-renderer/shape/index.ts
@@ -9,6 +9,7 @@ import type {
 import type { RoughCanvas } from '../../../rough/canvas.js';
 import type { Renderer } from '../../renderer.js';
 
+import { TextAlign } from '../../../consts.js';
 import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
@@ -155,9 +156,17 @@ function renderText(
     }
   }
 
+  const offsetX =
+    model.textAlign === TextAlign.Center
+      ? (w - maxLineWidth) / 2
+      : model.textAlign === TextAlign.Left
+        ? horOffset
+        : horOffset - maxLineWidth;
+  const offsetY = vertOffset - lineHeight + verticalPadding / 2;
+
   const bound = new Bound(
-    x + (w - maxLineWidth) / 2,
-    y + vertOffset - 2,
+    x + offsetX,
+    y + offsetY,
     maxLineWidth,
     lineHeight * lines.length
   ) as IBound;

--- a/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/diamond.ts
@@ -53,10 +53,11 @@ export const diamond = {
     y: number,
     options: PointTestOptions
   ) {
+    const point: IVec = [x, y];
     const points = getPointsFromBoundsWithRotation(this, diamond.points);
 
     let hit = pointOnPolygonStoke(
-      [x, y],
+      point,
       points,
       (options?.expand ?? 1) / (options.zoom ?? 1)
     );
@@ -77,14 +78,15 @@ export const diamond = {
             centralBounds,
             diamond.points
           );
-          hit = pointInPolygon([x, y], centralPoints);
-        } else {
-          hit = this.textBound
-            ? pointInPolygon(
-                [x, y],
-                getPointsFromBoundsWithRotation(this.textBound)
-              )
-            : false;
+          hit = pointInPolygon(point, centralPoints);
+        } else if (this.textBound) {
+          hit = pointInPolygon(
+            point,
+            getPointsFromBoundsWithRotation(
+              this,
+              () => Bound.from(this.textBound!).points
+            )
+          );
         }
       }
     }

--- a/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/ellipse.ts
@@ -70,13 +70,14 @@ export const ellipse = {
           const centralRx = rx * DEFAULT_CENTRAL_AREA_RATIO;
           const centralRy = ry * DEFAULT_CENTRAL_AREA_RATIO;
           hit = pointInEllipse(point, center, centralRx, centralRy, rad);
-        } else {
-          hit = this.textBound
-            ? pointInPolygon(
-                [x, y],
-                getPointsFromBoundsWithRotation(this.textBound)
-              )
-            : false;
+        } else if (this.textBound) {
+          hit = pointInPolygon(
+            point,
+            getPointsFromBoundsWithRotation(
+              this,
+              () => Bound.from(this.textBound!).points
+            )
+          );
         }
       }
     }

--- a/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/rect.ts
@@ -42,10 +42,11 @@ export const rect = {
     y: number,
     options: PointTestOptions
   ) {
+    const point: IVec = [x, y];
     const points = getPointsFromBoundsWithRotation(this);
 
     let hit = pointOnPolygonStoke(
-      [x, y],
+      point,
       points,
       (options?.expand ?? 1) / (options.zoom ?? 1)
     );
@@ -68,13 +69,14 @@ export const rect = {
           const centralPoints = getPointsFromBoundsWithRotation(centralBounds);
           // Check if the point is in the center area
           hit = pointInPolygon([x, y], centralPoints);
-        } else {
-          hit = this.textBound
-            ? pointInPolygon(
-                [x, y],
-                getPointsFromBoundsWithRotation(this.textBound)
-              )
-            : false;
+        } else if (this.textBound) {
+          hit = pointInPolygon(
+            point,
+            getPointsFromBoundsWithRotation(
+              this,
+              () => Bound.from(this.textBound!).points
+            )
+          );
         }
       }
     }

--- a/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/shape/triangle.ts
@@ -50,10 +50,11 @@ export const triangle = {
     y: number,
     options: PointTestOptions
   ) {
+    const point: IVec = [x, y];
     const points = getPointsFromBoundsWithRotation(this, triangle.points);
 
     let hit = pointOnPolygonStoke(
-      [x, y],
+      point,
       points,
       (options?.expand ?? 1) / (options?.zoom ?? 1)
     );
@@ -75,13 +76,14 @@ export const triangle = {
             triangle.points
           );
           hit = pointInPolygon([x, y], centralPoints);
-        } else {
-          hit = this.textBound
-            ? pointInPolygon(
-                [x, y],
-                getPointsFromBoundsWithRotation(this.textBound)
-              )
-            : false;
+        } else if (this.textBound) {
+          hit = pointInPolygon(
+            point,
+            getPointsFromBoundsWithRotation(
+              this,
+              () => Bound.from(this.textBound!).points
+            )
+          );
         }
       }
     }

--- a/tests/edgeless/shape.spec.ts
+++ b/tests/edgeless/shape.spec.ts
@@ -679,4 +679,44 @@ test.describe('shape hit test', () => {
     await type(page, 'hello');
     await assertEdgelessCanvasText(page, 'hello');
   });
+
+  test('should enter edit mode when double-clicking a text area in a shape with a transparent background', async ({
+    page,
+  }) => {
+    await addTransparentRect(page, rect.start, rect.end);
+    await page.mouse.click(rect.start.x - 20, rect.start.y - 20);
+    await assertEdgelessNonSelectedRect(page);
+
+    await assertEdgelessTool(page, 'default');
+    await page.mouse.dblclick(rect.start.x + 50, rect.start.y + 50);
+    await waitNextFrame(page);
+    await type(page, 'hello');
+
+    await pressEscape(page);
+    await waitNextFrame(page);
+
+    const textAlignBtn = locatorComponentToolbar(page).getByRole('button', {
+      name: 'Alignment',
+    });
+    await textAlignBtn.click();
+
+    await page
+      .locator('edgeless-align-panel')
+      .getByRole('button', { name: 'Left' })
+      .click();
+
+    // creates an edgeless-text
+    await page.mouse.dblclick(rect.start.x + 80, rect.start.y + 20);
+    await waitNextFrame(page);
+    await page.locator('edgeless-text-editor').isVisible();
+
+    await pressEscape(page);
+    await waitNextFrame(page);
+
+    // enters edit mode
+    await page.mouse.dblclick(rect.start.x + 20, rect.start.y + 50);
+    await page.locator('edgeless-shape-text-editor').isVisible();
+    await type(page, ' world');
+    await assertEdgelessCanvasText(page, 'hello world');
+  });
 });


### PR DESCRIPTION
Closes [BS-784](https://linear.app/affine-design/issue/BS-784/无背景的shape，无法编辑文本内容)


https://github.com/user-attachments/assets/3bf3779b-a12b-4fcf-a972-b06b9cb6c4e3

