### PR TITLE
feat: support extending preview spec

### DIFF
--- a/packages/blocks/src/specs/utils/spec-provider.ts
+++ b/packages/blocks/src/specs/utils/spec-provider.ts
@@ -28,6 +28,15 @@ export class SpecProvider {
     this.specMap.delete(id);
   }
 
+  extendSpec(id: string, newSpec: BlockSpec[]) {
+    const existingSpec = this.specMap.get(id);
+    if (!existingSpec) {
+      console.error(`Spec not found for ${id}`);
+      return;
+    }
+    this.specMap.set(id, [...existingSpec, ...newSpec]);
+  }
+
   getSpec(id: string) {
     const spec = this.specMap.get(id);
     assertExists(spec, `Spec not found for ${id}`);


### PR DESCRIPTION
[BS-1011](https://linear.app/affine-design/issue/BS-1011/添加拓展自定义-spec-的方式)
related: [BS-1017](https://linear.app/affine-design/issue/BS-1017/含有chat-block的页面被embed时，embed预览不会渲染chatblock)

extend spec example:
```
const specProvider = SpecProvider.getInstance();
specProvider.extendSpec('edgeless:preview', CustomSpecs);
```