### PR TITLE
fix: mindmap enter key behaviour

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -45,6 +45,8 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
     this._disposables.addFromEvent(this, 'keydown', evt => {
       switch (evt.key) {
         case 'Enter': {
+          if (evt.shiftKey || evt.isComposing) return;
+
           evt.preventDefault();
           const edgeless = this.edgeless;
           const element = this.element;


### PR DESCRIPTION
Fixes [BS-736](https://linear.app/affine-design/issue/BS-736/015-beta-release-mindmap-node-doest-support-ime-with-enter)
Fixes [BS-1048](https://linear.app/affine-design/issue/BS-1048/进入-mind-map-的-node-编辑态，shift-enter-应该是软换行)