### PR TITLE
fix(presets): doc title not highlight after clicking outline title

### DIFF
--- a/packages/presets/src/fragments/outline/body/outline-panel-body.ts
+++ b/packages/presets/src/fragments/outline/body/outline-panel-body.ts
@@ -11,6 +11,7 @@ import { Bound, DisposableGroup } from '@blocksuite/global/utils';
 import { SignalWatcher, effect } from '@lit-labs/preact-signals';
 import { LitElement, type PropertyValues, css, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import type { AffineEditorContainer } from '../../../editors/editor-container.js';
@@ -387,6 +388,8 @@ export class OutlinePanelBody extends SignalWatcher(
   }
 
   private _renderDocTitle() {
+    if (!this.doc.root) return nothing;
+
     const hasNotEmptyHeadings =
       getHeadingBlocksFromDoc(
         this.doc,
@@ -395,7 +398,11 @@ export class OutlinePanelBody extends SignalWatcher(
       ).length > 0;
 
     if (!hasNotEmptyHeadings) return nothing;
+
     return html`<affine-outline-block-preview
+      class=${classMap({
+        active: this.doc.root.id === this.activeHeadingId.value,
+      })}
       .block=${this.doc.root}
       .cardNumber=${1}
       .enableNotesSorting=${false}

--- a/packages/presets/src/fragments/outline/outline-panel.ts
+++ b/packages/presets/src/fragments/outline/outline-panel.ts
@@ -138,7 +138,7 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
     super.connectedCallback();
     this._loadSettingsFromLocalStorage();
     this.disposables.add(
-      observeActiveHeading(() => this.host, this._activeHeadingId$)
+      observeActiveHeading(() => this.editor, this._activeHeadingId$)
     );
   }
 

--- a/packages/presets/src/fragments/outline/outline-viewer.ts
+++ b/packages/presets/src/fragments/outline/outline-viewer.ts
@@ -133,12 +133,21 @@ export class OutlineViewer extends SignalWatcher(WithDisposable(LitElement)) {
       true
     );
 
+    const hasNoEmptyTitle =
+      this.editor.doc.meta && this.editor.doc.meta.title !== '';
+
     return html`<div
       class=${classMap({
         'outline-heading-indicator-container': true,
         hidden: this._showViewer,
       })}
     >
+      ${hasNoEmptyTitle && headingBlocks.length !== 0
+        ? html`<div
+            class="outline-heading-indicator"
+            ?active=${this._activeHeadingId$.value === this.editor.doc.root?.id}
+          ></div>`
+        : nothing}
       ${repeat(
         headingBlocks,
         block => block.id,
@@ -202,7 +211,7 @@ export class OutlineViewer extends SignalWatcher(WithDisposable(LitElement)) {
     super.connectedCallback();
 
     this.disposables.add(
-      observeActiveHeading(() => this.editor.host, this._activeHeadingId$)
+      observeActiveHeading(() => this.editor, this._activeHeadingId$)
     );
   }
 

--- a/packages/presets/src/fragments/outline/utils/scroll.ts
+++ b/packages/presets/src/fragments/outline/utils/scroll.ts
@@ -1,4 +1,3 @@
-import type { EditorHost } from '@blocksuite/block-std';
 import type { Signal } from '@lit-labs/preact-signals';
 
 import { NoteDisplayMode } from '@blocksuite/blocks';
@@ -37,27 +36,18 @@ export function scrollToBlock(editor: AffineEditorContainer, blockId: string) {
 }
 
 export const observeActiveHeading = (
-  getEditorHost: () => EditorHost | null | undefined, // workaround for editor changed
+  getEditor: () => AffineEditorContainer, // workaround for editor changed
   activeHeadingId$: Signal<string | null>
 ) => {
-  const host = getEditorHost();
-  if (host) {
-    const headings = getHeadingBlocksFromDoc(
-      host.doc,
-      [NoteDisplayMode.DocAndEdgeless, NoteDisplayMode.DocOnly],
-      true
-    );
-    // TODO(@L-Sun) use doc title
-    activeHeadingId$.value = headings[0]?.id ?? null;
-  }
+  const editor = getEditor();
+  activeHeadingId$.value = editor.doc.root?.id ?? null;
 
   const disposables = new DisposableGroup();
-
   disposables.addFromEvent(
     window,
     'scroll',
     () => {
-      const host = getEditorHost();
+      const { host } = getEditor();
       if (!host) return;
 
       const headings = getHeadingBlocksFromDoc(

--- a/tests/fragments/outline.spec.ts
+++ b/tests/fragments/outline.spec.ts
@@ -64,6 +64,8 @@ test.describe('toc-panel', () => {
 
     const noHeadingPlaceholder = panel.locator('.note-placeholder');
 
+    await focusTitle(page);
+    await type(page, 'Title');
     await focusRichTextEnd(page);
     await type(page, 'Hello World');
 
@@ -77,6 +79,8 @@ test.describe('toc-panel', () => {
     await initEmptyParagraphState(page);
     const panel = await toggleTocPanel(page);
 
+    await focusTitle(page);
+    await type(page, 'Title');
     await focusRichTextEnd(page);
 
     // heading 1 to 6
@@ -85,6 +89,9 @@ test.describe('toc-panel', () => {
       await pressEnter(page);
       await expect(getHeading(panel, i)).toBeHidden();
     }
+
+    // Title also should be hidden
+    await expect(getTitle(panel)).toBeHidden();
   });
 
   test('should display title and headings when there are non-empty headings in editor', async ({
@@ -280,6 +287,25 @@ test.describe('toc-viewer', () => {
     }
   });
 
+  test('should be hidden when only empty headings exists', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await toggleTocViewer(page);
+
+    await focusTitle(page);
+    await type(page, 'Title');
+    await focusRichTextEnd(page);
+
+    const indicators = getIndicators(page);
+
+    // heading 1 to 6
+    for (let i = 1; i <= 6; i++) {
+      await type(page, `${'#'.repeat(i)} `);
+      await pressEnter(page);
+      await expect(indicators).toHaveCount(0);
+    }
+  });
+
   test('should display outline viewer when hovering over indicators', async ({
     page,
   }) => {
@@ -372,7 +398,7 @@ test.describe('toc-viewer', () => {
     await expect(indicators).toHaveCount(0);
   });
 
-  test('should hide edgeless only note headings', async ({ page }) => {
+  test('should hide edgeless-only note headings', async ({ page }) => {
     await enterPlaygroundRoom(page);
     await initEmptyEdgelessState(page);
     await toggleTocViewer(page);


### PR DESCRIPTION
Fix [BS-1051](https://linear.app/affine-design/issue/BS-1051/跳转到title后高亮的确是第一个heading，引起误解)

Add highlight for doc title in outline viewer and panel