### PR TITLE
feat(blocks): configurable remote block selection bg-transparent

### DIFF
--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -1,6 +1,9 @@
 import type { EdgelessRootBlockComponent } from './edgeless/edgeless-root-block.js';
 import type { PageRootBlockComponent } from './page/page-root-block.js';
-import type { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from './widgets/doc-remote-selection/doc-remote-selection.js';
+import type {
+  AFFINE_DOC_REMOTE_SELECTION_WIDGET,
+  DocRemoteSelectionConfig,
+} from './widgets/doc-remote-selection/index.js';
 import type { AFFINE_DRAG_HANDLE_WIDGET } from './widgets/drag-handle/drag-handle.js';
 import type { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from './widgets/edgeless-remote-selection/index.js';
 import type { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from './widgets/edgeless-zoom-toolbar/index.js';
@@ -56,4 +59,5 @@ export type PieMenuId = typeof AFFINE_PIE_MENU_ID_EDGELESS_TOOLS;
 
 export interface RootBlockConfig {
   linkedWidget?: Partial<LinkedWidgetConfig>;
+  docRemoteSelectionWidget?: Partial<DocRemoteSelectionConfig>;
 }

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/config.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/config.ts
@@ -1,0 +1,5 @@
+import type { BlockModel } from '@blocksuite/store';
+
+export type DocRemoteSelectionConfig = {
+  blockSelectionBackgroundTransparent: (block: BlockModel) => boolean;
+};

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/index.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/index.ts
@@ -1,0 +1,2 @@
+export * from './config.js';
+export * from './doc-remote-selection.js';

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/utils.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/utils.ts
@@ -14,7 +14,7 @@ export function selectionStyle(
     height: `${rect.height}px`,
     top: `${rect.top}px`,
     left: `${rect.left}px`,
-    backgroundColor: color,
+    backgroundColor: rect.transparent ? 'transparent' : color,
     pointerEvent: 'none',
     opacity: '20%',
     borderRadius: '3px',


### PR DESCRIPTION
Close [BS-993](https://linear.app/affine-design/issue/BS-993/协同用户选择整个block时，不需要显示背景色，只需要显示光标铭牌)

### What changes
- make the block selection background transparency can be configurable
- make the following blocks remote selection background transparent
  - `affine:code`
  - `affine:database`
  - `affine:image`
  - `affine:embed-*`

### Before

![CleanShot 2024-08-07 at 15.38.53@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/8204e699-62e0-422b-9b3b-4b57e3a454c9.png)

### After

![CleanShot 2024-08-07 at 15.38.09@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/b22f2241-aba0-4d72-91a0-53f49facdba5.png)

