### PR TITLE
fix(blocks): image pasting when focusing non-empty block

### DIFF
--- a/packages/blocks/src/root-block/clipboard/index.ts
+++ b/packages/blocks/src/root-block/clipboard/index.ts
@@ -129,18 +129,33 @@ export class PageClipboard {
       .try(cmd => [
         cmd.getTextSelection().inline<'currentSelectionPath'>((ctx, next) => {
           const textSelection = ctx.currentTextSelection;
-          assertExists(textSelection);
+          if (!textSelection) {
+            return;
+          }
           const end = textSelection.to ?? textSelection.from;
           next({ currentSelectionPath: end.blockId });
         }),
         cmd.getBlockSelections().inline<'currentSelectionPath'>((ctx, next) => {
           const currentBlockSelections = ctx.currentBlockSelections;
-          assertExists(currentBlockSelections);
+          if (!currentBlockSelections) {
+            return;
+          }
           const blockSelection = currentBlockSelections.at(-1);
           if (!blockSelection) {
             return;
           }
           next({ currentSelectionPath: blockSelection.blockId });
+        }),
+        cmd.getImageSelections().inline<'currentSelectionPath'>((ctx, next) => {
+          const currentImageSelections = ctx.currentImageSelections;
+          if (!currentImageSelections) {
+            return;
+          }
+          const imageSelection = currentImageSelections.at(-1);
+          if (!imageSelection) {
+            return;
+          }
+          next({ currentSelectionPath: imageSelection.blockId });
         }),
       ])
       .getBlockIndex()

--- a/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
+++ b/packages/blocks/src/root-block/clipboard/middlewares/paste.ts
@@ -220,6 +220,9 @@ class PasteTr {
     if (this.snapshot.content.length === 0) {
       return false;
     }
+    if (!this.firstSnapshot!.props.text) {
+      return false;
+    }
     const firstTextSnapshot = this._textFromSnapshot(this.firstSnapshot!);
     const lastTextSnapshot = this._textFromSnapshot(this.lastSnapshot!);
     return (


### PR DESCRIPTION
This closes [BS-762](https://linear.app/affine-design/issue/BS-762), closes [BS-1046](https://linear.app/affine-design/issue/BS-1046)