### PR TITLE
feat: the view component in block spec could be a function

### DIFF
--- a/packages/framework/block-std/src/__tests__/editor-host.unit.spec.ts
+++ b/packages/framework/block-std/src/__tests__/editor-host.unit.spec.ts
@@ -1,0 +1,53 @@
+import { DocCollection, IdGeneratorType, Schema } from '@blocksuite/store';
+import { describe, expect, test } from 'vitest';
+
+import { TestEditorContainer } from './test-editor.js';
+import {
+  type HeadingBlockModel,
+  HeadingBlockSchema,
+  NoteBlockSchema,
+  RootBlockSchema,
+} from './test-schema.js';
+import { testSpecs } from './test-spec.js';
+
+function createTestOptions() {
+  const idGenerator = IdGeneratorType.AutoIncrement;
+  const schema = new Schema();
+  schema.register([RootBlockSchema, NoteBlockSchema, HeadingBlockSchema]);
+  return { id: 'test-collection', idGenerator, schema };
+}
+
+function wait(time: number) {
+  return new Promise(resolve => setTimeout(resolve, time));
+}
+
+describe('editor host', () => {
+  test('editor host should rerender model when view changes', async () => {
+    const collection = new DocCollection(createTestOptions());
+
+    collection.meta.initialize();
+    const doc = collection.createDoc({ id: 'home' });
+    doc.load();
+    const rootId = doc.addBlock('test:page');
+    const noteId = doc.addBlock('test:note', {}, rootId);
+    const headingId = doc.addBlock('test:heading', { type: 'h1' }, noteId);
+    const headingBlock = doc.getBlock(headingId)!;
+
+    const editorContainer = new TestEditorContainer();
+    editorContainer.doc = doc;
+    editorContainer.specs = testSpecs;
+
+    document.body.append(editorContainer);
+
+    await wait(50);
+    let headingElm = editorContainer.editorRef.value?.view.getBlock(headingId);
+
+    expect(headingElm!.tagName).toBe('TEST-H1-BLOCK');
+
+    (headingBlock.model as HeadingBlockModel).type = 'h2';
+    await wait(50);
+    headingElm = editorContainer.editorRef.value?.view.getBlock(headingId);
+
+    expect(headingElm!.tagName).toBe('TEST-H2-BLOCK');
+  });
+});

--- a/packages/framework/block-std/src/__tests__/test-block.ts
+++ b/packages/framework/block-std/src/__tests__/test-block.ts
@@ -1,0 +1,42 @@
+import { html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import type {
+  HeadingBlockModel,
+  NoteBlockModel,
+  RootBlockModel,
+} from './test-schema.js';
+
+import { BlockComponent } from '../view/index.js';
+
+@customElement('test-root-block')
+export class RootBlockComponent extends BlockComponent<RootBlockModel> {
+  override renderBlock() {
+    return html`
+      <div class="test-root-block">${this.renderChildren(this.model)}</div>
+    `;
+  }
+}
+
+@customElement('test-note-block')
+export class NoteBlockComponent extends BlockComponent<NoteBlockModel> {
+  override renderBlock() {
+    return html`
+      <div class="test-note-block">${this.renderChildren(this.model)}</div>
+    `;
+  }
+}
+
+@customElement('test-h1-block')
+export class HeadingH1BlockComponent extends BlockComponent<HeadingBlockModel> {
+  override renderBlock() {
+    return html` <div class="test-heading-block h1">${this.model.text}</div> `;
+  }
+}
+
+@customElement('test-h2-block')
+export class HeadingH2BlockComponent extends BlockComponent<HeadingBlockModel> {
+  override renderBlock() {
+    return html` <div class="test-heading-block h2">${this.model.text}</div> `;
+  }
+}

--- a/packages/framework/block-std/src/__tests__/test-editor.ts
+++ b/packages/framework/block-std/src/__tests__/test-editor.ts
@@ -1,0 +1,35 @@
+import type { Doc } from '@blocksuite/store';
+import type { Ref } from 'lit/directives/ref.js';
+
+import { SignalWatcher } from '@lit-labs/preact-signals';
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+
+import type { BlockSpec } from '../spec/type.js';
+import type { EditorHost } from '../view/index.js';
+
+import { ShadowlessElement, WithDisposable } from '../view/index.js';
+
+@customElement('test-editor-container')
+export class TestEditorContainer extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
+  editorRef: Ref<EditorHost> = createRef();
+
+  protected override render() {
+    return html` <div class="test-editor-container">
+      <editor-host
+        ${ref(this.editorRef)}
+        .doc=${this.doc}
+        .specs=${this.specs}
+      ></editor-host>
+    </div>`;
+  }
+
+  @property({ attribute: false })
+  accessor doc!: Doc;
+
+  @property({ attribute: false })
+  accessor specs: BlockSpec[] = [];
+}

--- a/packages/framework/block-std/src/__tests__/test-schema.ts
+++ b/packages/framework/block-std/src/__tests__/test-schema.ts
@@ -1,0 +1,56 @@
+import { type SchemaToModel, defineBlockSchema } from '@blocksuite/store';
+
+export const RootBlockSchema = defineBlockSchema({
+  flavour: 'test:page',
+  props: internal => ({
+    title: internal.Text(),
+    count: 0,
+    style: {} as Record<string, unknown>,
+    items: [] as unknown[],
+  }),
+  metadata: {
+    version: 2,
+    role: 'root',
+    children: ['test:note'],
+  },
+});
+
+export type RootBlockModel = SchemaToModel<typeof RootBlockSchema>;
+
+export const NoteBlockSchema = defineBlockSchema({
+  flavour: 'test:note',
+  props: () => ({}),
+  metadata: {
+    version: 1,
+    role: 'hub',
+    parent: ['test:page'],
+    children: ['test:heading'],
+  },
+});
+
+export type NoteBlockModel = SchemaToModel<typeof NoteBlockSchema>;
+
+export const HeadingBlockSchema = defineBlockSchema({
+  flavour: 'test:heading',
+  props: internal => ({
+    type: 'h1',
+    text: internal.Text(),
+  }),
+  metadata: {
+    version: 1,
+    role: 'content',
+    parent: ['test:note'],
+  },
+});
+
+export type HeadingBlockModel = SchemaToModel<typeof HeadingBlockSchema>;
+
+declare global {
+  namespace BlockSuite {
+    interface BlockModels {
+      'test:page': RootBlockModel;
+      'test:note': NoteBlockModel;
+      'test:heading': HeadingBlockModel;
+    }
+  }
+}

--- a/packages/framework/block-std/src/__tests__/test-spec.ts
+++ b/packages/framework/block-std/src/__tests__/test-spec.ts
@@ -1,0 +1,42 @@
+import { literal } from 'lit/static-html.js';
+
+import type { BlockSpec } from '../spec/type.js';
+
+import './test-block.js';
+import {
+  type HeadingBlockModel,
+  HeadingBlockSchema,
+  NoteBlockSchema,
+  RootBlockSchema,
+} from './test-schema.js';
+
+export const testSpecs: BlockSpec[] = [
+  {
+    schema: RootBlockSchema,
+    view: {
+      component: literal`test-root-block`,
+    },
+  },
+
+  {
+    schema: NoteBlockSchema,
+    view: {
+      component: literal`test-note-block`,
+    },
+  },
+
+  {
+    schema: HeadingBlockSchema,
+    view: {
+      component: model => {
+        const h = (model as HeadingBlockModel).type$.value;
+
+        if (h === 'h1') {
+          return literal`test-h1-block`;
+        }
+
+        return literal`test-h2-block`;
+      },
+    },
+  },
+];

--- a/packages/framework/block-std/src/spec/type.ts
+++ b/packages/framework/block-std/src/spec/type.ts
@@ -1,5 +1,5 @@
 import type { DisposableGroup } from '@blocksuite/global/utils';
-import type { BlockSchemaType } from '@blocksuite/store';
+import type { BlockModel, BlockSchemaType } from '@blocksuite/store';
 import type { StaticValue } from 'lit/static-html.js';
 
 import type { BlockService } from '../service/index.js';
@@ -7,7 +7,7 @@ import type { BlockServiceConstructor } from '../service/index.js';
 import type { BlockSpecSlots } from './slots.js';
 
 export interface BlockView<WidgetNames extends string = string> {
-  component: StaticValue;
+  component: StaticValue | ((model: BlockModel) => StaticValue);
   widgets?: Record<WidgetNames, StaticValue>;
 }
 

--- a/packages/framework/block-std/vitest.config.ts
+++ b/packages/framework/block-std/vitest.config.ts
@@ -5,21 +5,20 @@ export default defineConfig({
     target: 'es2018',
   },
   test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      name: 'chromium',
+      provider: 'playwright',
+      isolate: false,
+      providerOptions: {},
+    },
     include: ['src/__tests__/**/*.unit.spec.ts'],
     testTimeout: 500,
     coverage: {
       provider: 'istanbul', // or 'c8'
       reporter: ['lcov'],
       reportsDirectory: '../../.coverage/block-std',
-    },
-    /**
-     * Custom handler for console.log in tests.
-     *
-     * Return `false` to ignore the log.
-     */
-    onConsoleLog(log, type) {
-      console.warn(`Unexpected ${type} log`, log);
-      throw new Error(log);
     },
     restoreMocks: true,
   },


### PR DESCRIPTION
### Changed
- Allow to define the `view.component` in spec as a function which receive a model and return a literal template