### PR TITLE
refactor: add parent to BlockModel and rename parentBlock

### DIFF
--- a/packages/affine/shared/src/utils/model.ts
+++ b/packages/affine/shared/src/utils/model.ts
@@ -28,3 +28,17 @@ export function isInsideBlockByFlavour(
   }
   return isInsideBlockByFlavour(doc, parent, flavour);
 }
+
+export function findAncestorModel(
+  model: BlockModel,
+  match: (m: BlockModel) => boolean
+) {
+  let curModel: BlockModel | null = model;
+  while (curModel) {
+    if (match(curModel)) {
+      return curModel;
+    }
+    curModel = curModel.parent;
+  }
+  return null;
+}

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -8,12 +8,16 @@ import type { Point } from '@blocksuite/global/utils';
 import type { InlineEditor } from '@blocksuite/inline';
 import type { BlockModel } from '@blocksuite/store';
 
-import { clamp, matchFlavours } from '@blocksuite/affine-shared/utils';
+import {
+  clamp,
+  findAncestorModel,
+  matchFlavours,
+} from '@blocksuite/affine-shared/utils';
 import { assertExists } from '@blocksuite/global/utils';
 
 import type { Loader } from '../../_common/components/loader.js';
 import type { RichText } from '../../_common/components/rich-text/rich-text.js';
-import type { RootBlockComponent } from '../../index.js';
+import type { NoteBlockModel, RootBlockComponent } from '../../index.js';
 import type { PageRootBlockComponent } from '../../root-block/page/page-root-block.js';
 
 import {
@@ -830,4 +834,10 @@ function getCellRect(element: Element, bounds?: DOMRect) {
  */
 export function hasClassNameInList(element: Element, classList: string[]) {
   return classList.some(className => element.classList.contains(className));
+}
+
+export function findNoteBlockModel(model: BlockModel) {
+  return findAncestorModel(model, m =>
+    matchFlavours(m, ['affine:note'])
+  ) as NoteBlockModel | null;
 }

--- a/packages/blocks/src/edgeless-text/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text/edgeless-text-block.ts
@@ -65,7 +65,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<
 
   private _initDragEffect() {
     const edgelessSelection = this.rootService.selection;
-    const selectedRect = this.parentBlock.selectedRect;
+    const selectedRect = this.parentComponent.selectedRect;
     const disposables = this.disposables;
 
     if (!edgelessSelection || !selectedRect) {
@@ -371,8 +371,8 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<
     );
   }
 
-  override get parentBlock() {
-    return super.parentBlock as EdgelessRootBlockComponent;
+  override get parentComponent() {
+    return super.parentComponent as EdgelessRootBlockComponent;
   }
 
   @state()

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -62,6 +62,7 @@ export {
 } from './_common/types.js';
 export {
   createButtonPopper,
+  findNoteBlockModel,
   matchFlavours,
   on,
   once,

--- a/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/drag-handle.ts
@@ -31,6 +31,7 @@ import type { DragHandleOption, DropResult, DropType } from './config.js';
 
 import {
   Rect,
+  findNoteBlockModel,
   getBlockComponentsExcludeSubtrees,
   getCurrentNativeRange,
   getModelByBlockComponent,
@@ -70,7 +71,6 @@ import {
   getDragHandleContainerHeight,
   getDragHandleLeftPadding,
   getDuplicateBlocks,
-  getNoteId,
   includeTextSelection,
   insideDatabaseTable,
   isBlockPathEqual,
@@ -799,8 +799,9 @@ export class AffineDragHandleWidget extends WidgetComponent<
         });
         if (!newSelectedBlocks) return;
 
-        const noteId = getNoteId(parentElement);
-        this._setSelectedBlocks(newSelectedBlocks as BlockComponent[], noteId);
+        const note = findNoteBlockModel(parentElement.model);
+        if (!note) return;
+        this._setSelectedBlocks(newSelectedBlocks as BlockComponent[], note.id);
       }
     }, 0);
 
@@ -1079,7 +1080,10 @@ export class AffineDragHandleWidget extends WidgetComponent<
     // When current page is edgeless page
     // We need to remain surface selection and set editing as true
     if (isInsideEdgelessEditor(this.host)) {
-      const surfaceElementId = noteId ? noteId : getNoteId(blocks[0]);
+      const surfaceElementId = noteId
+        ? noteId
+        : findNoteBlockModel(blocks[0].model)?.id;
+      if (!surfaceElementId) return;
       const surfaceSelection = selection.create(
         'surface',
         blocks[0]!.blockId,

--- a/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/utils.ts
@@ -96,15 +96,6 @@ export const captureEventTarget = (target: EventTarget | null) => {
     : null;
 };
 
-export const getNoteId = (block: BlockComponent) => {
-  let element = block;
-  while (element && element.flavour !== 'affine:note') {
-    element = element.parentBlock;
-  }
-
-  return element.model.id;
-};
-
 export const includeTextSelection = (selections: BaseSelection[]) => {
   return selections.some(selection => selection.type === 'text');
 };

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -242,7 +242,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   }
 
   get edgeless() {
-    return this.parentBlock as EdgelessRootBlockComponent;
+    return this.parentComponent as EdgelessRootBlockComponent;
   }
 
   get renderer() {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -502,7 +502,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     return (
       this.isConnected &&
       // prevent surface-ref from render itself in loop
-      !this.parentBlock.closest('affine-surface-ref')
+      !this.parentComponent?.closest('affine-surface-ref')
     );
   }
 

--- a/packages/framework/block-std/src/view/element/block-component.ts
+++ b/packages/framework/block-std/src/view/element/block-component.ts
@@ -277,10 +277,10 @@ export class BlockComponent<
     return model;
   }
 
-  get parentBlock(): BlockComponent {
-    const el = this.parentElement;
-    // TODO(mirone/#6534): find a better way to get block element from a node
-    return el?.closest('[data-block-id]') as BlockComponent;
+  get parentComponent(): BlockComponent | null {
+    const parent = this.model.parent;
+    if (!parent) return null;
+    return this.std.view.getBlock(parent.id);
   }
 
   get rootComponent(): BlockComponent | null {

--- a/packages/framework/store/src/schema/base.ts
+++ b/packages/framework/store/src/schema/base.ts
@@ -291,4 +291,8 @@ export class BlockModel<
   set doc(doc: Doc) {
     this.page = doc;
   }
+
+  get parent() {
+    return this.doc.getParent(this);
+  }
 }

--- a/packages/presets/src/ai/ai-panel.ts
+++ b/packages/presets/src/ai/ai-panel.ts
@@ -8,6 +8,7 @@ import {
   type AffineAIPanelWidgetConfig,
   ImageBlockModel,
   NoteDisplayMode,
+  findNoteBlockModel,
   isInsideEdgelessEditor,
   matchFlavours,
 } from '@blocksuite/blocks';
@@ -28,7 +29,7 @@ import { INSERT_ABOVE_ACTIONS } from './actions/consts.js';
 import { createTextRenderer } from './messages/text.js';
 import { AIProvider } from './provider.js';
 import { reportResponse } from './utils/action-reporter.js';
-import { findNoteBlockModel, getService } from './utils/edgeless.js';
+import { getService } from './utils/edgeless.js';
 import {
   copyTextAnswer,
   insertAbove,
@@ -98,7 +99,7 @@ function createNewNote(host: EditorHost): AIItemConfig {
       const { selectedBlocks } = getSelections(host);
       if (!selectedBlocks || !selectedBlocks.length) return;
       const firstBlock = selectedBlocks[0];
-      const noteModel = findNoteBlockModel(firstBlock);
+      const noteModel = findNoteBlockModel(firstBlock.model);
       if (!noteModel) return;
 
       // create a new note block at the left of the current note block

--- a/packages/presets/src/ai/utils/edgeless.ts
+++ b/packages/presets/src/ai/utils/edgeless.ts
@@ -1,4 +1,4 @@
-import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
+import type { EditorHost } from '@blocksuite/block-std';
 import type {
   EdgelessCopilotWidget,
   EdgelessRootService,
@@ -8,7 +8,6 @@ import {
   AFFINE_EDGELESS_COPILOT_WIDGET,
   MindmapElementModel,
   type ShapeElementModel,
-  matchFlavours,
 } from '@blocksuite/blocks';
 
 export function mindMapToMarkdown(mindmap: MindmapElementModel) {
@@ -60,18 +59,4 @@ export function getEdgelessCopilotWidget(
   ) as EdgelessCopilotWidget;
 
   return copilotWidget;
-}
-
-export function findNoteBlockModel(block: BlockComponent) {
-  let curBlock = block;
-  while (curBlock) {
-    if (matchFlavours(curBlock.model, ['affine:note'])) {
-      return curBlock.model;
-    }
-    if (matchFlavours(curBlock.model, ['affine:page', 'affine:surface'])) {
-      return null;
-    }
-    curBlock = curBlock.parentBlock;
-  }
-  return null;
 }


### PR DESCRIPTION
### What Changed?
- add parent field to `BlockModel`
- rename `parentBlock` to `parentComponent` and refactor the way to get block element from a node
- remove `getNoteId` utils