### PR TITLE
fix(blocks): photos field is optional in tweet media

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/helper.ts
+++ b/packages/blocks/src/_common/embed-block-helper/helper.ts
@@ -81,7 +81,7 @@ export class LinkPreviewer {
           title: tweet.author.name,
           icon: tweet.author.avatar_url,
           description: tweet.text,
-          image: tweet.media?.photos[0].url || tweet.author.banner_url,
+          image: tweet.media?.photos?.[0].url || tweet.author.banner_url,
         };
       } catch (e) {
         console.error(`Failed to fetch tweet: ${url}`);


### PR DESCRIPTION
Closes [BS-1075](https://linear.app/affine-design/issue/BS-1075/抓取的-tweet-中-photos-可能是可选)
See https://github.com/FixTweet/FxTwitter/wiki/Status-Fetch-API#embeds