### PR TITLE
feat: add commands to BlockSpec and register commands in spec store

### DIFF
--- a/packages/blocks/src/_common/configs/quick-action/config.ts
+++ b/packages/blocks/src/_common/configs/quick-action/config.ts
@@ -143,15 +143,7 @@ export const quickActionConfig: QuickActionConfig[] = [
       const autofill = getTitleFromSelectedModels(selectedModels);
       void promptDocTitle(host, autofill).then(title => {
         if (title === null) return;
-        const linkedDoc = convertSelectedBlocksToLinkedDoc(
-          doc,
-          selectedModels,
-          title
-        );
-        const linkedDocService = host.spec.getService(
-          'affine:embed-linked-doc'
-        );
-        linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+        convertSelectedBlocksToLinkedDoc(doc, selectedModels, title);
         notifyDocCreated(host, doc);
       });
     },

--- a/packages/blocks/src/embed-linked-doc-block/commands/index.ts
+++ b/packages/blocks/src/embed-linked-doc-block/commands/index.ts
@@ -1,0 +1,7 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { insertLinkByQuickSearchCommand } from './insert-link-by-quick-search.js';
+
+export const commands: BlockCommands = {
+  insertLinkByQuickSearch: insertLinkByQuickSearchCommand,
+};

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -1,5 +1,3 @@
-import type { EditorHost } from '@blocksuite/block-std';
-
 import { Bound } from '@blocksuite/global/utils';
 import { assertExists } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
@@ -11,6 +9,7 @@ import type { DocMode } from '../_common/types.js';
 import type { RootBlockComponent } from '../root-block/index.js';
 import type { SurfaceRefBlockService } from '../surface-ref-block/index.js';
 import type { SurfaceRefRenderer } from '../surface-ref-block/surface-ref-renderer.js';
+import type { EmbedLinkedDocBlockConfig } from './embed-linked-doc-config.js';
 import type {
   EmbedLinkedDocModel,
   EmbedLinkedDocStyles,
@@ -25,11 +24,6 @@ import { renderLinkedDocInCard } from '../_common/utils/render-linked-doc.js';
 import { SyncedDocErrorIcon } from '../embed-synced-doc-block/styles.js';
 import { styles } from './styles.js';
 import { getEmbedLinkedDocIcons } from './utils.js';
-
-export interface EmbedLinkedDocBlockConfig {
-  handleClick?: (e: MouseEvent, host: EditorHost) => void;
-  handleDoubleClick?: (e: MouseEvent, host: EditorHost) => void;
-}
 
 @customElement('affine-embed-linked-doc-block')
 @Peekable({

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-config.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-config.ts
@@ -1,0 +1,14 @@
+import type { EditorHost } from '@blocksuite/block-std';
+
+export interface EmbedLinkedDocBlockConfig {
+  handleClick?: (e: MouseEvent, host: EditorHost) => void;
+  handleDoubleClick?: (e: MouseEvent, host: EditorHost) => void;
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockConfigs {
+      'affine:embed-linked-doc': EmbedLinkedDocBlockConfig;
+    }
+  }
+}

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-model.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-model.ts
@@ -27,5 +27,8 @@ declare global {
     interface EdgelessBlockModelMap {
       'affine:embed-linked-doc': EmbedLinkedDocModel;
     }
+    interface BlockModels {
+      'affine:embed-linked-doc': EmbedLinkedDocModel;
+    }
   }
 }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-service.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-service.ts
@@ -1,20 +1,5 @@
 import { BlockService } from '@blocksuite/block-std';
-import { Slot } from '@blocksuite/store';
 
 import type { EmbedLinkedDocModel } from './embed-linked-doc-model.js';
 
-import { insertLinkByQuickSearchCommand } from './commands/insert-link-by-quick-search.js';
-
-export class EmbedLinkedDocBlockService extends BlockService<EmbedLinkedDocModel> {
-  slots = {
-    linkedDocCreated: new Slot<{ docId: string }>(),
-  };
-
-  override mounted() {
-    super.mounted();
-    this.std.command.add(
-      'insertLinkByQuickSearch',
-      insertLinkByQuickSearchCommand
-    );
-  }
-}
+export class EmbedLinkedDocBlockService extends BlockService<EmbedLinkedDocModel> {}

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-spec.ts
@@ -2,14 +2,13 @@ import type { BlockSpec } from '@blocksuite/block-std';
 
 import { literal } from 'lit/static-html.js';
 
-import type { EmbedLinkedDocBlockConfig } from './embed-linked-doc-block.js';
+import type { EmbedLinkedDocBlockConfig } from './embed-linked-doc-config.js';
 
+import { commands } from './commands/index.js';
 import { EmbedLinkedDocBlockSchema } from './embed-linked-doc-schema.js';
-import { EmbedLinkedDocBlockService } from './embed-linked-doc-service.js';
 
 export type EmbedLinkedDocBlockSpecType = BlockSpec<
   string,
-  EmbedLinkedDocBlockService,
   EmbedLinkedDocBlockConfig
 >;
 
@@ -18,5 +17,5 @@ export const EmbedLinkedDocBlockSpec: EmbedLinkedDocBlockSpecType = {
   view: {
     component: literal`affine-embed-linked-doc-block`,
   },
-  service: EmbedLinkedDocBlockService,
+  commands,
 };

--- a/packages/blocks/src/embed-linked-doc-block/index.ts
+++ b/packages/blocks/src/embed-linked-doc-block/index.ts
@@ -1,29 +1,8 @@
 import { noop } from '@blocksuite/global/utils';
 
-import type { EmbedLinkedDocModel } from './embed-linked-doc-model.js';
-import type { EmbedLinkedDocBlockService } from './embed-linked-doc-service.js';
-
-import {
-  EmbedLinkedDocBlockComponent,
-  type EmbedLinkedDocBlockConfig,
-} from './embed-linked-doc-block.js';
+import { EmbedLinkedDocBlockComponent } from './embed-linked-doc-block.js';
 noop(EmbedLinkedDocBlockComponent);
 
 export * from './embed-linked-doc-block.js';
 export * from './embed-linked-doc-model.js';
-export * from './embed-linked-doc-service.js';
 export * from './embed-linked-doc-spec.js';
-
-declare global {
-  namespace BlockSuite {
-    interface BlockModels {
-      'affine:embed-linked-doc': EmbedLinkedDocModel;
-    }
-    interface BlockServices {
-      'affine:embed-linked-doc': EmbedLinkedDocBlockService;
-    }
-    interface BlockConfigs {
-      'affine:embed-linked-doc': EmbedLinkedDocBlockConfig;
-    }
-  }
-}

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -46,7 +46,6 @@ export type EdgelessRootBlockWidgetName =
 
 export type EdgelessRootBlockSpecType = BlockSpec<
   EdgelessRootBlockWidgetName,
-  BlockService,
   RootBlockConfig
 >;
 

--- a/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
+++ b/packages/blocks/src/root-block/keyboard/keyboard-manager.ts
@@ -107,15 +107,7 @@ export class PageKeyboardManager {
     const autofill = getTitleFromSelectedModels(selectedModels);
     void promptDocTitle(rootComponent.host, autofill).then(title => {
       if (title === null) return;
-      const linkedDoc = convertSelectedBlocksToLinkedDoc(
-        doc,
-        selectedModels,
-        title
-      );
-      const linkedDocService = rootComponent.host.spec.getService(
-        'affine:embed-linked-doc'
-      );
-      linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+      convertSelectedBlocksToLinkedDoc(doc, selectedModels, title);
       notifyDocCreated(rootComponent.host, doc);
     });
   }

--- a/packages/blocks/src/root-block/page/page-root-spec.ts
+++ b/packages/blocks/src/root-block/page/page-root-spec.ts
@@ -1,4 +1,4 @@
-import type { BlockService, BlockSpec } from '@blocksuite/block-std';
+import type { BlockSpec } from '@blocksuite/block-std';
 
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
@@ -32,7 +32,6 @@ export type PageRootBlockWidgetName =
 
 export type PageRootBlockSpecType = BlockSpec<
   PageRootBlockWidgetName,
-  BlockService,
   RootBlockConfig
 >;
 

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -213,15 +213,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
         const autofill = getTitleFromSelectedModels(selectedModels);
         void promptDocTitle(host, autofill).then(title => {
           if (title === null) return;
-          const linkedDoc = convertSelectedBlocksToLinkedDoc(
-            doc,
-            selectedModels,
-            title
-          );
-          const linkedDocService = host.spec.getService(
-            'affine:embed-linked-doc'
-          );
-          linkedDocService.slots.linkedDocCreated.emit({ docId: linkedDoc.id });
+          convertSelectedBlocksToLinkedDoc(doc, selectedModels, title);
           notifyDocCreated(host, doc);
           host.spec
             .getService('affine:page')

--- a/packages/framework/block-std/src/spec/spec-store.ts
+++ b/packages/framework/block-std/src/spec/spec-store.ts
@@ -70,12 +70,23 @@ export class SpecStore {
     });
   }
 
+  private _registerCommands(specs: Map<string, BlockSpec>) {
+    specs.forEach((spec, _flavour) => {
+      const { commands } = spec;
+      if (!commands) return;
+      Object.entries(commands).forEach(([key, command]) => {
+        this.std.command.add(key as keyof BlockSuite.Commands, command);
+      });
+    });
+  }
+
   applySpecs(specs: BlockSpec[]) {
     this.slots.beforeApply.emit();
 
     const oldSpecs = this._specs;
     const newSpecs = this._buildSpecMap(specs);
     this._diffServices(oldSpecs, newSpecs);
+    this._registerCommands(newSpecs);
     this._specs = newSpecs;
 
     this.slots.afterApply.emit();

--- a/packages/framework/block-std/src/spec/type.ts
+++ b/packages/framework/block-std/src/spec/type.ts
@@ -2,6 +2,7 @@ import type { DisposableGroup } from '@blocksuite/global/utils';
 import type { BlockSchemaType } from '@blocksuite/store';
 import type { StaticValue } from 'lit/static-html.js';
 
+import type { Command } from '../command/types.js';
 import type { BlockService } from '../service/index.js';
 import type { BlockServiceConstructor } from '../service/index.js';
 import type { BlockSpecSlots } from './slots.js';
@@ -11,14 +12,17 @@ export interface BlockView<WidgetNames extends string = string> {
   widgets?: Record<WidgetNames, StaticValue>;
 }
 
+export type BlockCommands = Partial<Record<keyof BlockSuite.Commands, Command>>;
+
 export interface BlockSpec<
   WidgetNames extends string = string,
-  Service extends BlockService = BlockService,
   BlockConfig = object,
+  Service extends BlockService = BlockService,
 > {
   schema: BlockSchemaType;
   view: BlockView<WidgetNames>;
   config?: BlockConfig;
+  commands?: BlockCommands;
   service?: BlockServiceConstructor<Service>;
   setup?: (slots: BlockSpecSlots, disposableGroup: DisposableGroup) => void;
 }

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -43,17 +43,13 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   const specs = getExampleSpecs();
   editor.pageSpecs = [...specs.pageModeSpecs].map(spec => {
     if (spec.schema.model.flavour === 'affine:page') {
-      spec = patchPageRootSpec(
-        spec as BlockSpec<'affine:page', PageRootService>
-      );
+      spec = patchPageRootSpec(spec);
     }
     return spec;
   });
   editor.edgelessSpecs = [...specs.edgelessModeSpecs].map(spec => {
     if (spec.schema.model.flavour === 'affine:page') {
-      spec = patchPageRootSpec(
-        spec as BlockSpec<'affine:page', PageRootService>
-      );
+      spec = patchPageRootSpec(spec);
     }
     return spec;
   });
@@ -104,7 +100,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
 
   return editor;
 
-  function patchPageRootSpec(spec: BlockSpec<'affine:page', PageRootService>) {
+  function patchPageRootSpec(spec: BlockSpec) {
     const setup = spec.setup;
     const newSpec: typeof spec = {
       ...spec,

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -56,17 +56,13 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   const editor = new AffineEditorContainer();
   editor.pageSpecs = [...PageEditorBlockSpecs].map(spec => {
     if (spec.schema.model.flavour === 'affine:page') {
-      spec = patchPageRootSpec(
-        spec as BlockSpec<'affine:page', PageRootService>
-      );
+      spec = patchPageRootSpec(spec);
     }
     return spec;
   });
   editor.edgelessSpecs = [...EdgelessEditorBlockSpecs].map(spec => {
     if (spec.schema.model.flavour === 'affine:page') {
-      spec = patchPageRootSpec(
-        spec as BlockSpec<'affine:page', PageRootService>
-      );
+      spec = patchPageRootSpec(spec);
     }
     return spec;
   });
@@ -148,7 +144,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
 
   return editor;
 
-  function patchPageRootSpec(spec: BlockSpec<'affine:page', PageRootService>) {
+  function patchPageRootSpec(spec: BlockSpec) {
     const setup = spec.setup;
     const newSpec: typeof spec = {
       ...spec,


### PR DESCRIPTION
### What changed?
- Add commands in `BlockSpec`, which can be easily expanded externally
- Register declared commands in `spec-store`
- Refactor `embed-linked-doc-block` and remove useless service