### PR TITLE
fix(blocks): fix IME and keyboard layout issues of linked-doc-popover

### DIFF
--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -1,9 +1,6 @@
 import type { EditorHost, UIEventStateContext } from '@blocksuite/block-std';
 
-import {
-  isControlledKeyboardEvent,
-  matchFlavours,
-} from '@blocksuite/affine-shared/utils';
+import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { WidgetComponent } from '@blocksuite/block-std';
 import { DisposableGroup, throttle } from '@blocksuite/global/utils';
 import { InlineEditor } from '@blocksuite/inline';
@@ -44,14 +41,34 @@ export interface LinkedWidgetConfig {
 
 @customElement(AFFINE_LINKED_DOC_WIDGET)
 export class AffineLinkedDocWidget extends WidgetComponent {
+  private _onCompositionEnd = (ctx: UIEventStateContext) => {
+    const event = ctx.get('defaultState').event as CompositionEvent;
+
+    if (
+      !this.config.triggerKeys.some(triggerKey =>
+        triggerKey.includes(event.data)
+      )
+    )
+      return;
+
+    const inlineEditor = this.getInlineEditor(event);
+    if (!inlineEditor) return;
+
+    this._handleInput(inlineEditor, true);
+  };
+
   private _onKeyDown = (ctx: UIEventStateContext) => {
     const eventState = ctx.get('keyboardState');
     const event = eventState.raw;
-    // FIXME: Event can be undefined sometimes for unknown reason
-    // Need to investigate
-    // Maybe related to the lifecycle of the widget
-    if (!event || isControlledKeyboardEvent(event) || event.key.length !== 1)
+
+    const key = event.key;
+    if (
+      key === undefined || // in mac os, the key may be undefined
+      key === 'Process' ||
+      event.isComposing
+    )
       return;
+
     const inlineEditor = this.getInlineEditor(event);
     if (!inlineEditor) return;
     const inlineRange = inlineEditor.getInlineRange();
@@ -63,47 +80,10 @@ export class AffineLinkedDocWidget extends WidgetComponent {
       return;
     }
 
-    const textPoint = inlineEditor.getTextPoint(inlineRange.index);
-    if (!textPoint) return;
-    const [leafStart, offsetStart] = textPoint;
-    const prefixText = leafStart.textContent
-      ? leafStart.textContent.slice(0, offsetStart)
-      : '';
-
-    const matchedKey = this.config.triggerKeys.find(triggerKey =>
-      (prefixText + event.key).endsWith(triggerKey)
-    );
-    if (!matchedKey) return;
-
-    const primaryTriggerKey = this.config.triggerKeys[0];
-    inlineEditor.slots.inlineRangeApply.once(() => {
-      if (this.config.convertTriggerKey && primaryTriggerKey !== matchedKey) {
-        // Convert to the primary trigger key
-        // e.g. [[ -> @
-        const startIdxBeforeMatchKey =
-          inlineRange.index - (matchedKey.length - 1);
-        inlineEditor.deleteText({
-          index: startIdxBeforeMatchKey,
-          length: matchedKey.length,
-        });
-        inlineEditor.insertText(
-          { index: startIdxBeforeMatchKey, length: 0 },
-          primaryTriggerKey
-        );
-        inlineEditor.setInlineRange({
-          index: startIdxBeforeMatchKey + primaryTriggerKey.length,
-          length: 0,
-        });
-        inlineEditor.slots.inlineRangeApply.once(() => {
-          this.showLinkedDocPopover(inlineEditor, primaryTriggerKey);
-        });
-        return;
-      }
-      this.showLinkedDocPopover(inlineEditor, matchedKey);
-    });
+    this._handleInput(inlineEditor, false);
   };
 
-  private getInlineEditor = (evt: KeyboardEvent) => {
+  private getInlineEditor = (evt: KeyboardEvent | CompositionEvent) => {
     if (evt.target instanceof HTMLElement) {
       const editor = (
         evt.target.closest('.can-link-doc > .inline-editor') as {
@@ -182,9 +162,63 @@ export class AffineLinkedDocWidget extends WidgetComponent {
     return linkedDoc;
   };
 
+  private _handleInput(inlineEditor: InlineEditor, isCompositionEnd: boolean) {
+    const primaryTriggerKey = this.config.triggerKeys[0];
+
+    const inlineRangeApplyCallback = (callback: () => void) => {
+      // the inline ranged updated in compositionEnd event before this event callback
+      if (isCompositionEnd) callback();
+      else inlineEditor.slots.inlineRangeApply.once(callback);
+    };
+
+    inlineRangeApplyCallback(() => {
+      const inlineRange = inlineEditor.getInlineRange();
+      if (!inlineRange) return;
+      const textPoint = inlineEditor.getTextPoint(inlineRange.index);
+      if (!textPoint) return;
+      const [leafStart, offsetStart] = textPoint;
+
+      const text = leafStart.textContent
+        ? leafStart.textContent.slice(0, offsetStart)
+        : '';
+
+      const matchedKey = this.config.triggerKeys.find(triggerKey =>
+        text.endsWith(triggerKey)
+      );
+      if (!matchedKey) return;
+
+      if (this.config.convertTriggerKey && primaryTriggerKey !== matchedKey) {
+        const inlineRange = inlineEditor.getInlineRange();
+        if (!inlineRange) return;
+
+        // Convert to the primary trigger key
+        // e.g. [[ -> @
+        const startIdxBeforeMatchKey = inlineRange.index - matchedKey.length;
+        inlineEditor.deleteText({
+          index: startIdxBeforeMatchKey,
+          length: matchedKey.length,
+        });
+        inlineEditor.insertText(
+          { index: startIdxBeforeMatchKey, length: 0 },
+          primaryTriggerKey
+        );
+        inlineEditor.setInlineRange({
+          index: startIdxBeforeMatchKey + primaryTriggerKey.length,
+          length: 0,
+        });
+        inlineRangeApplyCallback(() => {
+          this.showLinkedDocPopover(inlineEditor, primaryTriggerKey);
+        });
+        return;
+      }
+      this.showLinkedDocPopover(inlineEditor, matchedKey);
+    });
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     this.handleEvent('keyDown', this._onKeyDown);
+    this.handleEvent('compositionEnd', this._onCompositionEnd);
   }
 
   get config(): LinkedWidgetConfig {


### PR DESCRIPTION
Fix [BS-1081](https://linear.app/affine-design/issue/BS-1081/某些键盘布局唤不起link-doc-面板)

## What changes
- Remove `isControlledKeyboardEvent` detection since inputting `@` or `[` need modified with right <kbd>⌥</kbd> or right <kbd>Alt</kbd>(a.k.a <kbd>AltGr</kbd>) in some keyboard layout, such as France layout.
- Move trigger detection after `inlineRange` updated, because  detecting on the inputed content is better than pressed key
- Add `compositionend` for IME compatibility
 
### France Keyboard Layout

https://github.com/user-attachments/assets/538f3846-c19b-4125-a28d-f9747f8ffc5c

### IME

https://github.com/user-attachments/assets/e743f59f-ed8a-4986-b91e-eb272196bf18

