### PR TITLE
refactor: move commands to block spec declarations

### DIFF
--- a/packages/affine/components/src/rich-text/format/delete-text.ts
+++ b/packages/affine/components/src/rich-text/format/delete-text.ts
@@ -79,3 +79,11 @@ export const deleteTextCommand: Command<
 
   next();
 };
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      deleteText: typeof deleteTextCommand;
+    }
+  }
+}

--- a/packages/affine/components/src/rich-text/format/format-block.ts
+++ b/packages/affine/components/src/rich-text/format/format-block.ts
@@ -70,3 +70,11 @@ export const formatBlockCommand: Command<
 
   if (success) next();
 };
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      formatBlock: typeof formatBlockCommand;
+    }
+  }
+}

--- a/packages/affine/components/src/rich-text/format/format-native.ts
+++ b/packages/affine/components/src/rich-text/format/format-native.ts
@@ -54,3 +54,11 @@ export const formatNativeCommand: Command<
 
   next();
 };
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      formatNative: typeof formatNativeCommand;
+    }
+  }
+}

--- a/packages/affine/components/src/rich-text/format/format-text.ts
+++ b/packages/affine/components/src/rich-text/format/format-text.ts
@@ -93,3 +93,11 @@ export const formatTextCommand: Command<
 
   if (success) next();
 };
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      formatText: typeof formatTextCommand;
+    }
+  }
+}

--- a/packages/affine/components/src/rich-text/format/index.ts
+++ b/packages/affine/components/src/rich-text/format/index.ts
@@ -1,9 +1,21 @@
-import type { AffineTextAttributes } from '../inline/index.js';
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { getTextSelectionCommand } from '@blocksuite/affine-shared/commands';
 
 import { deleteTextCommand } from './delete-text.js';
+export { textFormatConfigs } from './config.js';
 import { formatBlockCommand } from './format-block.js';
+export {
+  FORMAT_BLOCK_SUPPORT_FLAVOURS,
+  FORMAT_NATIVE_SUPPORT_FLAVOURS,
+  FORMAT_TEXT_SUPPORT_FLAVOURS,
+} from './consts.js';
+import './delete-text.js';
+import './format-block.js';
 import { formatNativeCommand } from './format-native.js';
+import './format-native.js';
 import { formatTextCommand } from './format-text.js';
+import './format-text.js';
 import {
   getTextStyle,
   isTextStyleActive,
@@ -14,50 +26,21 @@ import {
   toggleStrike,
   toggleUnderline,
 } from './text-style.js';
-
-export const registerTextStyleCommands = (std: BlockSuite.Std) => {
-  std.command
-    .add('toggleBold', toggleBold)
-    .add('toggleItalic', toggleItalic)
-    .add('toggleUnderline', toggleUnderline)
-    .add('toggleStrike', toggleStrike)
-    .add('toggleCode', toggleCode)
-    .add('toggleLink', toggleLink)
-    .add('getTextStyle', getTextStyle)
-    .add('isTextStyleActive', isTextStyleActive)
-    .add('formatText', formatTextCommand)
-    .add('formatBlock', formatBlockCommand)
-    .add('formatNative', formatNativeCommand)
-    .add('deleteText', deleteTextCommand);
-};
-
-export { textFormatConfigs } from './config.js';
-
-export {
-  FORMAT_BLOCK_SUPPORT_FLAVOURS,
-  FORMAT_NATIVE_SUPPORT_FLAVOURS,
-  FORMAT_TEXT_SUPPORT_FLAVOURS,
-} from './consts.js';
+import './text-style.js';
 export { isFormatSupported } from './utils.js';
 
-declare global {
-  namespace BlockSuite {
-    interface CommandContext {
-      textStyle?: AffineTextAttributes;
-    }
-    interface Commands {
-      deleteText: typeof deleteTextCommand;
-      formatBlock: typeof formatBlockCommand;
-      formatNative: typeof formatNativeCommand;
-      formatText: typeof formatTextCommand;
-      toggleBold: typeof toggleBold;
-      toggleItalic: typeof toggleItalic;
-      toggleUnderline: typeof toggleUnderline;
-      toggleStrike: typeof toggleStrike;
-      toggleCode: typeof toggleCode;
-      toggleLink: typeof toggleLink;
-      getTextStyle: typeof getTextStyle;
-      isTextStyleActive: typeof isTextStyleActive;
-    }
-  }
-}
+export const textCommands: BlockCommands = {
+  deleteText: deleteTextCommand,
+  formatBlock: formatBlockCommand,
+  formatNative: formatNativeCommand,
+  formatText: formatTextCommand,
+  toggleBold: toggleBold,
+  toggleItalic: toggleItalic,
+  toggleUnderline: toggleUnderline,
+  toggleStrike: toggleStrike,
+  toggleCode: toggleCode,
+  toggleLink: toggleLink,
+  isTextStyleActive: isTextStyleActive,
+  getTextStyle: getTextStyle,
+  getTextSelection: getTextSelectionCommand,
+};

--- a/packages/affine/components/src/rich-text/format/text-style.ts
+++ b/packages/affine/components/src/rich-text/format/text-style.ts
@@ -81,3 +81,22 @@ export const isTextStyleActive: Command<
 
   return next();
 };
+
+declare global {
+  namespace BlockSuite {
+    interface CommandContext {
+      textStyle?: AffineTextAttributes;
+    }
+
+    interface Commands {
+      toggleBold: typeof toggleBold;
+      toggleItalic: typeof toggleItalic;
+      toggleUnderline: typeof toggleUnderline;
+      toggleStrike: typeof toggleStrike;
+      toggleCode: typeof toggleCode;
+      toggleLink: typeof toggleLink;
+      getTextStyle: typeof getTextStyle;
+      isTextStyleActive: typeof isTextStyleActive;
+    }
+  }
+}

--- a/packages/affine/components/src/rich-text/index.ts
+++ b/packages/affine/components/src/rich-text/index.ts
@@ -12,7 +12,7 @@ export {
   FORMAT_NATIVE_SUPPORT_FLAVOURS,
   FORMAT_TEXT_SUPPORT_FLAVOURS,
   isFormatSupported,
-  registerTextStyleCommands,
+  textCommands,
   textFormatConfigs,
 } from './format/index.js';
 export {

--- a/packages/affine/shared/src/commands/index.ts
+++ b/packages/affine/shared/src/commands/index.ts
@@ -1,23 +1,3 @@
-import type { BlockStdScope } from '@blocksuite/block-std';
-
-import {
-  getBlockIndexCommand,
-  getNextBlockCommand,
-  getPrevBlockCommand,
-  getSelectedBlocksCommand,
-} from './block-crud/index.js';
-import {
-  copySelectedModelsCommand,
-  deleteSelectedModelsCommand,
-  draftSelectedModelsCommand,
-  getSelectedModelsCommand,
-} from './model-crud/index.js';
-import {
-  getBlockSelectionsCommand,
-  getImageSelectionsCommand,
-  getTextSelectionCommand,
-} from './selection/index.js';
-
 export {
   getBlockIndexCommand,
   getNextBlockCommand,
@@ -45,18 +25,3 @@ declare global {
     }
   }
 }
-
-export const registerCommands = (std: BlockStdScope) => {
-  std.command
-    .add('getBlockIndex', getBlockIndexCommand)
-    .add('getNextBlock', getNextBlockCommand)
-    .add('getPrevBlock', getPrevBlockCommand)
-    .add('getSelectedBlocks', getSelectedBlocksCommand)
-    .add('copySelectedModels', copySelectedModelsCommand)
-    .add('deleteSelectedModels', deleteSelectedModelsCommand)
-    .add('draftSelectedModels', draftSelectedModelsCommand)
-    .add('getSelectedModels', getSelectedModelsCommand)
-    .add('getBlockSelections', getBlockSelectionsCommand)
-    .add('getImageSelections', getImageSelectionsCommand)
-    .add('getTextSelection', getTextSelectionCommand);
-};

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -21,10 +21,8 @@ import { guard } from 'lit/directives/guard.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import type { DocMode } from '../_common/types.js';
-import type {
-  EdgelessRootService,
-  RootBlockComponent,
-} from '../root-block/index.js';
+import type { EdgelessRootService } from '../root-block/edgeless/edgeless-root-service.js';
+import type { RootBlockComponent } from '../root-block/types.js';
 import type { EmbedSyncedDocCard } from './components/embed-synced-doc-card.js';
 import type { EmbedSyncedDocBlockService } from './embed-synced-doc-service.js';
 
@@ -452,16 +450,18 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
       })
     );
 
-    this._syncedDocMode = this._rootService.docModeService.getMode(
-      this.model.pageId
-    );
-    this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this._syncedDocMode);
-    this.disposables.add(
-      this._rootService.docModeService.onModeChange(mode => {
-        this._syncedDocMode = mode;
-        this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, mode);
-      }, this.model.pageId)
-    );
+    if (this._rootService) {
+      this._syncedDocMode = this._rootService.docModeService.getMode(
+        this.model.pageId
+      );
+      this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this._syncedDocMode);
+      this.disposables.add(
+        this._rootService.docModeService.onModeChange(mode => {
+          this._syncedDocMode = mode;
+          this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, mode);
+        }, this.model.pageId)
+      );
+    }
 
     this.syncedDoc &&
       this.disposables.add(
@@ -486,13 +486,12 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
     // Forward docLinkClicked event from the synced doc
     const syncedDocRootService =
       this.syncedDocEditorHost?.std.spec.getService('affine:page');
-    if (syncedDocRootService) {
+    syncedDocRootService &&
       this.disposables.add(
         syncedDocRootService.slots.docLinkClicked.on(({ docId }) => {
-          this._rootService.slots.docLinkClicked.emit({ docId });
+          this._rootService?.slots.docLinkClicked.emit({ docId });
         })
       );
-    }
 
     this._initEdgelessFitEffect();
   }

--- a/packages/blocks/src/image-block/commands/index.ts
+++ b/packages/blocks/src/image-block/commands/index.ts
@@ -1,0 +1,7 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { getImageSelectionsCommand } from '@blocksuite/affine-shared/commands';
+
+export const commands: BlockCommands = {
+  getImageSelections: getImageSelectionsCommand,
+};

--- a/packages/blocks/src/image-block/image-spec.ts
+++ b/packages/blocks/src/image-block/image-spec.ts
@@ -3,6 +3,7 @@ import type { BlockSpec } from '@blocksuite/block-std';
 import { ImageBlockSchema } from '@blocksuite/affine-model';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands/index.js';
 import { ImageBlockService } from './image-service.js';
 
 export const ImageBlockSpec: BlockSpec = {
@@ -14,4 +15,5 @@ export const ImageBlockSpec: BlockSpec = {
       imageToolbar: literal`affine-image-toolbar-widget`,
     },
   },
+  commands,
 };

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -154,8 +154,6 @@ export {
   renderToolbarSeparator,
 } from '@blocksuite/affine-components/toolbar';
 export * from '@blocksuite/affine-model';
-// To provide the type for commands
-export { registerCommands } from '@blocksuite/affine-shared/commands';
 export {
   ColorVariables,
   FontFamilyVariables,

--- a/packages/blocks/src/list-block/commands/index.ts
+++ b/packages/blocks/src/list-block/commands/index.ts
@@ -1,0 +1,13 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { convertToNumberedListCommand } from './convert-to-numbered-list.js';
+import { indentListCommand } from './indent-list.js';
+import { splitListCommand } from './split-list.js';
+import { unindentListCommand } from './unindent-list.js';
+
+export const commands: BlockCommands = {
+  convertToNumberedList: convertToNumberedListCommand,
+  splitList: splitListCommand,
+  indentList: indentListCommand,
+  unindentList: unindentListCommand,
+};

--- a/packages/blocks/src/list-block/index.ts
+++ b/packages/blocks/src/list-block/index.ts
@@ -1,12 +1,2 @@
-import type { ListBlockService } from './list-service.js';
-
 export * from './list-block.js';
 export * from './list-service.js';
-
-declare global {
-  namespace BlockSuite {
-    interface BlockServices {
-      'affine:list': ListBlockService;
-    }
-  }
-}

--- a/packages/blocks/src/list-block/list-service.ts
+++ b/packages/blocks/src/list-block/list-service.ts
@@ -12,10 +12,6 @@ import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { BlockService } from '@blocksuite/block-std';
 
 import { AffineDragHandleWidget } from '../root-block/widgets/drag-handle/drag-handle.js';
-import { convertToNumberedListCommand } from './commands/convert-to-numbered-list.js';
-import { indentListCommand } from './commands/indent-list.js';
-import { splitListCommand } from './commands/split-list.js';
-import { unindentListCommand } from './commands/unindent-list.js';
 import { correctNumberedListsOrderToPrev } from './commands/utils.js';
 import { listPrefix, toggleStyles } from './styles.js';
 import { getListIcon } from './utils/get-list-icon.js';
@@ -35,11 +31,6 @@ export class ListBlockService<
 
   override mounted(): void {
     super.mounted();
-
-    this.std.command.add('convertToNumberedList', convertToNumberedListCommand);
-    this.std.command.add('splitList', splitListCommand);
-    this.std.command.add('unindentList', unindentListCommand);
-    this.std.command.add('indentList', indentListCommand);
 
     this.referenceNodeConfig.setDoc(this.doc);
 
@@ -75,5 +66,13 @@ export class ListBlockService<
         },
       })
     );
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockServices {
+      'affine:list': ListBlockService;
+    }
   }
 }

--- a/packages/blocks/src/list-block/list-spec.ts
+++ b/packages/blocks/src/list-block/list-spec.ts
@@ -3,6 +3,7 @@ import type { BlockSpec } from '@blocksuite/block-std';
 import { ListBlockSchema } from '@blocksuite/affine-model';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands/index.js';
 import { ListBlockService } from './list-service.js';
 
 export const ListBlockSpec: BlockSpec = {
@@ -10,5 +11,6 @@ export const ListBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-list`,
   },
+  commands,
   service: ListBlockService,
 };

--- a/packages/blocks/src/note-block/commands/index.ts
+++ b/packages/blocks/src/note-block/commands/index.ts
@@ -1,8 +1,32 @@
-import type { BlockComponent } from '@blocksuite/block-std';
+import type { BlockCommands, BlockComponent } from '@blocksuite/block-std';
 
-export * from './block-type.js';
-export * from './select-block.js';
-export * from './select-blocks-between.js';
+import {
+  getBlockIndexCommand,
+  getBlockSelectionsCommand,
+  getNextBlockCommand,
+  getPrevBlockCommand,
+  getSelectedBlocksCommand,
+} from '@blocksuite/affine-shared/commands';
+
+import { updateBlockType } from './block-type.js';
+import { focusBlockEnd } from './focus-block-end.js';
+import { focusBlockStart } from './focus-block-start.js';
+import { selectBlock } from './select-block.js';
+import { selectBlocksBetween } from './select-blocks-between.js';
+
+export const commands: BlockCommands = {
+  // block
+  getBlockIndex: getBlockIndexCommand,
+  getPrevBlock: getPrevBlockCommand,
+  getNextBlock: getNextBlockCommand,
+  getSelectedBlocks: getSelectedBlocksCommand,
+  getBlockSelections: getBlockSelectionsCommand,
+  selectBlock: selectBlock,
+  selectBlocksBetween: selectBlocksBetween,
+  focusBlockStart: focusBlockStart,
+  focusBlockEnd: focusBlockEnd,
+  updateBlockType: updateBlockType,
+};
 
 declare global {
   namespace BlockSuite {

--- a/packages/blocks/src/note-block/index.ts
+++ b/packages/blocks/src/note-block/index.ts
@@ -1,14 +1,4 @@
-import type { NoteBlockService } from './note-service.js';
-
 export * from './commands/index.js';
 export * from './note-block.js';
 export * from './note-edgeless-block.js';
 export * from './note-service.js';
-
-declare global {
-  namespace BlockSuite {
-    interface BlockServices {
-      'affine:note': NoteBlockService;
-    }
-  }
-}

--- a/packages/blocks/src/note-block/note-service.ts
+++ b/packages/blocks/src/note-block/note-service.ts
@@ -1,6 +1,5 @@
 import type { NoteBlockModel } from '@blocksuite/affine-model';
 
-import { registerTextStyleCommands } from '@blocksuite/affine-components/rich-text';
 import { NoteBlockSchema } from '@blocksuite/affine-model';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { BlockService } from '@blocksuite/block-std';
@@ -20,13 +19,6 @@ import {
   captureEventTarget,
   getDuplicateBlocks,
 } from '../root-block/widgets/drag-handle/utils.js';
-import { focusBlockEnd } from './commands/focus-block-end.js';
-import { focusBlockStart } from './commands/focus-block-start.js';
-import {
-  selectBlock,
-  selectBlocksBetween,
-  updateBlockType,
-} from './commands/index.js';
 
 export class NoteBlockService extends BlockService<NoteBlockModel> {
   private _dragHandleOption: DragHandleOption = {
@@ -122,17 +114,16 @@ export class NoteBlockService extends BlockService<NoteBlockModel> {
   override mounted() {
     super.mounted();
 
-    this.std.command
-      .add('selectBlocksBetween', selectBlocksBetween)
-      .add('selectBlock', selectBlock)
-      .add('focusBlockStart', focusBlockStart)
-      .add('focusBlockEnd', focusBlockEnd)
-      .add('updateBlockType', updateBlockType);
-
-    registerTextStyleCommands(this.std);
-
     this.disposables.add(
       AffineDragHandleWidget.registerOption(this._dragHandleOption)
     );
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockServices {
+      'affine:note': NoteBlockService;
+    }
   }
 }

--- a/packages/blocks/src/note-block/note-spec.ts
+++ b/packages/blocks/src/note-block/note-spec.ts
@@ -3,6 +3,7 @@ import type { BlockSpec } from '@blocksuite/block-std';
 import { NoteBlockSchema } from '@blocksuite/affine-model';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands/index.js';
 import { NoteBlockService } from './note-service.js';
 
 export const NoteBlockSpec: BlockSpec = {
@@ -11,6 +12,7 @@ export const NoteBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-note`,
   },
+  commands,
 };
 
 export const EdgelessNoteBlockSpec: BlockSpec = {
@@ -19,4 +21,5 @@ export const EdgelessNoteBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-edgeless-note`,
   },
+  commands,
 };

--- a/packages/blocks/src/root-block/commands/index.ts
+++ b/packages/blocks/src/root-block/commands/index.ts
@@ -1,0 +1,26 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import {
+  getSelectedPeekableBlocksCommand,
+  peekSelectedBlockCommand,
+} from '@blocksuite/affine-components/peek';
+import { textCommands } from '@blocksuite/affine-components/rich-text';
+import {
+  copySelectedModelsCommand,
+  deleteSelectedModelsCommand,
+  draftSelectedModelsCommand,
+  getSelectedModelsCommand,
+} from '@blocksuite/affine-shared/commands';
+
+export const commands: BlockCommands = {
+  // models
+  copySelectedModels: copySelectedModelsCommand,
+  deleteSelectedModels: deleteSelectedModelsCommand,
+  draftSelectedModels: draftSelectedModelsCommand,
+  getSelectedModels: getSelectedModelsCommand,
+  // text
+  ...textCommands,
+  // peekable
+  peekSelectedBlock: peekSelectedBlockCommand,
+  getSelectedPeekableBlocks: getSelectedPeekableBlocksCommand,
+};

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -8,8 +8,9 @@ import type {
 import { RootBlockSchema } from '@blocksuite/affine-model';
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
-import type { RootBlockConfig } from '../index.js';
+import type { RootBlockConfig } from '../root-config.js';
 
+import { commands } from '../commands/index.js';
 import { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from '../widgets/doc-remote-selection/doc-remote-selection.js';
 import { AFFINE_DRAG_HANDLE_WIDGET } from '../widgets/drag-handle/drag-handle.js';
 import { AFFINE_EDGELESS_AUTO_CONNECT_WIDGET } from '../widgets/edgeless-auto-connect/edgeless-auto-connect.js';
@@ -94,6 +95,7 @@ export const EdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
       )}`,
     },
   },
+  commands,
 };
 
 export const PreviewEdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
@@ -110,4 +112,5 @@ export const PreviewEdgelessRootBlockSpec: EdgelessRootBlockSpecType = {
       }
     );
   },
+  commands,
 };

--- a/packages/blocks/src/root-block/index.ts
+++ b/packages/blocks/src/root-block/index.ts
@@ -1,7 +1,3 @@
-import type { EdgelessRootService } from './edgeless/edgeless-root-service.js';
-import type { PageRootService } from './page/page-root-service.js';
-import type { RootBlockConfig } from './types.js';
-
 export * from './clipboard/index.js';
 export * from './edgeless/index.js';
 export * from './page/page-root-block.js';
@@ -17,14 +13,3 @@ export {
 export * from './types.js';
 export * from './utils/index.js';
 export * from './widgets/index.js';
-
-declare global {
-  namespace BlockSuite {
-    interface BlockServices {
-      'affine:page': PageRootService | EdgelessRootService;
-    }
-    interface BlockConfigs {
-      'affine:page': RootBlockConfig;
-    }
-  }
-}

--- a/packages/blocks/src/root-block/page/page-root-spec.ts
+++ b/packages/blocks/src/root-block/page/page-root-spec.ts
@@ -3,8 +3,9 @@ import type { BlockSpec } from '@blocksuite/block-std';
 import { RootBlockSchema } from '@blocksuite/affine-model';
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
-import type { RootBlockConfig } from '../index.js';
+import type { RootBlockConfig } from '../root-config.js';
 
+import { commands } from '../commands/index.js';
 import { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from '../widgets/doc-remote-selection/doc-remote-selection.js';
 import { AFFINE_DRAG_HANDLE_WIDGET } from '../widgets/drag-handle/drag-handle.js';
 import { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from '../widgets/embed-card-toolbar/embed-card-toolbar.js';
@@ -68,4 +69,5 @@ export const PageRootBlockSpec: PageRootBlockSpecType = {
       )}`,
     },
   },
+  commands,
 };

--- a/packages/blocks/src/root-block/root-config.ts
+++ b/packages/blocks/src/root-block/root-config.ts
@@ -1,0 +1,15 @@
+import type { DocRemoteSelectionConfig } from './widgets/doc-remote-selection/config.js';
+import type { LinkedWidgetConfig } from './widgets/linked-doc/index.js';
+
+export interface RootBlockConfig {
+  linkedWidget?: Partial<LinkedWidgetConfig>;
+  docRemoteSelectionWidget?: Partial<DocRemoteSelectionConfig>;
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockConfigs {
+      'affine:page': RootBlockConfig;
+    }
+  }
+}

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -1,18 +1,14 @@
+import type { PeekViewService } from '@blocksuite/affine-components/peek';
+import type { RefNodeSlots } from '@blocksuite/affine-components/rich-text';
 import type { RootBlockModel } from '@blocksuite/affine-model';
 import type { BlockComponent } from '@blocksuite/block-std';
 import type { BlockModel } from '@blocksuite/store';
 
 import {
-  type PeekViewService,
-  getSelectedPeekableBlocksCommand,
-  peekSelectedBlockCommand,
-} from '@blocksuite/affine-components/peek';
-import {
   type EmbedCardStyle,
   type NoteBlockModel,
   NoteDisplayMode,
 } from '@blocksuite/affine-model';
-import { registerCommands } from '@blocksuite/affine-shared/commands';
 import { ThemeObserver } from '@blocksuite/affine-shared/theme';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { BlockService } from '@blocksuite/block-std';
@@ -103,7 +99,7 @@ export interface TelemetryService {
   ): void;
 }
 
-export class RootService extends BlockService<RootBlockModel> {
+export abstract class RootService extends BlockService<RootBlockModel> {
   private _embedBlockRegistry = new Set<EmbedOptions>();
 
   private _exportOptions = {
@@ -348,11 +344,6 @@ export class RootService extends BlockService<RootBlockModel> {
   override mounted() {
     super.mounted();
 
-    registerCommands(this.std);
-    this.std.command
-      .add('peekSelectedBlock', peekSelectedBlockCommand)
-      .add('getSelectedPeekableBlocks', getSelectedPeekableBlocksCommand);
-
     this.loadFonts();
 
     this.disposables.addFromEvent(
@@ -410,5 +401,15 @@ export class RootService extends BlockService<RootBlockModel> {
     const viewportElement = rootComponent.viewportElement as HTMLElement | null;
     assertExists(viewportElement);
     return viewportElement;
+  }
+
+  abstract slots: RefNodeSlots;
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockServices {
+      'affine:page': RootService;
+    }
   }
 }

--- a/packages/blocks/src/root-block/types.ts
+++ b/packages/blocks/src/root-block/types.ts
@@ -1,9 +1,6 @@
 import type { EdgelessRootBlockComponent } from './edgeless/edgeless-root-block.js';
 import type { PageRootBlockComponent } from './page/page-root-block.js';
-import type {
-  AFFINE_DOC_REMOTE_SELECTION_WIDGET,
-  DocRemoteSelectionConfig,
-} from './widgets/doc-remote-selection/index.js';
+import type { AFFINE_DOC_REMOTE_SELECTION_WIDGET } from './widgets/doc-remote-selection/index.js';
 import type { AFFINE_DRAG_HANDLE_WIDGET } from './widgets/drag-handle/drag-handle.js';
 import type { AFFINE_EDGELESS_REMOTE_SELECTION_WIDGET } from './widgets/edgeless-remote-selection/index.js';
 import type { AFFINE_EDGELESS_ZOOM_TOOLBAR_WIDGET } from './widgets/edgeless-zoom-toolbar/index.js';
@@ -11,10 +8,7 @@ import type { EDGELESS_ELEMENT_TOOLBAR_WIDGET } from './widgets/element-toolbar/
 import type { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from './widgets/embed-card-toolbar/embed-card-toolbar.js';
 import type { AFFINE_FORMAT_BAR_WIDGET } from './widgets/format-bar/format-bar.js';
 import type { AFFINE_INNER_MODAL_WIDGET } from './widgets/inner-modal/inner-modal.js';
-import type {
-  AFFINE_LINKED_DOC_WIDGET,
-  LinkedWidgetConfig,
-} from './widgets/linked-doc/index.js';
+import type { AFFINE_LINKED_DOC_WIDGET } from './widgets/linked-doc/index.js';
 import type { AFFINE_MODAL_WIDGET } from './widgets/modal/modal.js';
 import type { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from './widgets/page-dragging-area/page-dragging-area.js';
 import type { AFFINE_PIE_MENU_ID_EDGELESS_TOOLS } from './widgets/pie-menu/config.js';
@@ -56,8 +50,3 @@ export type RootBlockComponent =
   | EdgelessRootBlockComponent;
 
 export type PieMenuId = typeof AFFINE_PIE_MENU_ID_EDGELESS_TOOLS;
-
-export interface RootBlockConfig {
-  linkedWidget?: Partial<LinkedWidgetConfig>;
-  docRemoteSelectionWidget?: Partial<DocRemoteSelectionConfig>;
-}

--- a/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
+++ b/packages/blocks/src/root-block/widgets/ai-panel/ai-panel.ts
@@ -21,6 +21,7 @@ import { customElement, property, query } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 
 import type { AIError } from '../../../_common/components/index.js';
+import type { EdgelessRootService } from '../../edgeless/edgeless-root-service.js';
 import type { AIPanelGenerating } from './components/index.js';
 import type { AffineAIPanelState, AffineAIPanelWidgetConfig } from './type.js';
 
@@ -329,7 +330,8 @@ export class AffineAIPanelWidget extends WidgetComponent {
       if (rootService instanceof PageRootService) {
         rootBoundary = undefined;
       } else {
-        const viewport = rootService.viewport;
+        // TODO circular dependency: instanceof EdgelessRootService
+        const viewport = (rootService as EdgelessRootService).viewport;
         rootBoundary = {
           x: viewport.left,
           y: viewport.top,

--- a/packages/blocks/src/surface-block/commands/index.ts
+++ b/packages/blocks/src/surface-block/commands/index.ts
@@ -1,0 +1,7 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { reassociateConnectorsCommand } from './reassociate-connectors.js';
+
+export const commands: BlockCommands = {
+  reassociateConnectors: reassociateConnectorsCommand,
+};

--- a/packages/blocks/src/surface-block/surface-service.ts
+++ b/packages/blocks/src/surface-block/surface-service.ts
@@ -2,7 +2,6 @@ import { BlockService } from '@blocksuite/block-std';
 
 import type { SurfaceBlockModel } from './surface-model.js';
 
-import { reassociateConnectorsCommand } from './commands/reassociate-connectors.js';
 import { LayerManager } from './managers/layer-manager.js';
 
 export class SurfaceBlockService extends BlockService<SurfaceBlockModel> {
@@ -12,8 +11,6 @@ export class SurfaceBlockService extends BlockService<SurfaceBlockModel> {
 
   override mounted(): void {
     super.mounted();
-
-    this.std.command.add('reassociateConnectors', reassociateConnectorsCommand);
 
     this.surface = this.doc.getBlockByFlavour(
       'affine:surface'

--- a/packages/blocks/src/surface-block/surface-spec.ts
+++ b/packages/blocks/src/surface-block/surface-spec.ts
@@ -2,6 +2,7 @@ import type { BlockSpec } from '@blocksuite/block-std';
 
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands/index.js';
 import './surface-block-void.js';
 import { SurfaceBlockSchema } from './surface-model.js';
 import { SurfaceBlockService } from './surface-service.js';
@@ -19,5 +20,6 @@ export const EdgelessSurfaceBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-surface`,
   },
+  commands,
   service: SurfaceBlockService,
 };

--- a/packages/framework/block-std/src/spec/type.ts
+++ b/packages/framework/block-std/src/spec/type.ts
@@ -2,7 +2,6 @@ import type { DisposableGroup } from '@blocksuite/global/utils';
 import type { BlockSchemaType } from '@blocksuite/store';
 import type { StaticValue } from 'lit/static-html.js';
 
-import type { Command } from '../command/types.js';
 import type { BlockService } from '../service/index.js';
 import type { BlockServiceConstructor } from '../service/index.js';
 import type { BlockSpecSlots } from './slots.js';
@@ -12,7 +11,7 @@ export interface BlockView<WidgetNames extends string = string> {
   widgets?: Record<WidgetNames, StaticValue>;
 }
 
-export type BlockCommands = Partial<Record<keyof BlockSuite.Commands, Command>>;
+export type BlockCommands = Partial<BlockSuite.Commands>;
 
 export interface BlockSpec<
   WidgetNames extends string = string,

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -18,6 +18,7 @@
     "@blocksuite/global": "workspace:*",
     "@blocksuite/inline": "workspace:*",
     "@blocksuite/store": "workspace:*",
+    "@blocksuite/affine-shared": "workspace:*",
     "@dotlottie/player-component": "^2.7.12",
     "@fal-ai/serverless-client": "^0.13.0",
     "@floating-ui/dom": "^1.6.8",

--- a/packages/presets/src/ai/chat-panel/actions/actions-handle.ts
+++ b/packages/presets/src/ai/chat-panel/actions/actions-handle.ts
@@ -6,7 +6,11 @@ import type {
 import type { EdgelessRootService, ImageSelection } from '@blocksuite/blocks';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
-import { BlocksUtils, NoteDisplayMode } from '@blocksuite/blocks';
+import {
+  BlocksUtils,
+  NoteDisplayMode,
+  PageRootService,
+} from '@blocksuite/blocks';
 import { Bound, getElementsBound } from '@blocksuite/global/utils';
 
 import {
@@ -105,7 +109,9 @@ export const PageEditorActions = [
       newDoc.addBlock('affine:surface', {}, rootId);
       const noteId = newDoc.addBlock('affine:note', {}, rootId);
 
-      host.spec.getService('affine:page').slots.docLinkClicked.emit({
+      const rootService = host.spec.getService('affine:page');
+      if (!(rootService instanceof PageRootService)) return;
+      rootService.slots.docLinkClicked.emit({
         docId: newDoc.id,
       });
       let complete = false;

--- a/packages/presets/src/index.ts
+++ b/packages/presets/src/index.ts
@@ -1,3 +1,5 @@
+import '@blocksuite/affine-shared/commands';
+
 export * from './blocks/index.js';
 export * from './editors/index.js';
 export * from './fragments/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,6 +723,9 @@ importers:
 
   packages/presets:
     dependencies:
+      '@blocksuite/affine-shared':
+        specifier: workspace:*
+        version: link:../affine/shared
       '@blocksuite/block-std':
         specifier: workspace:*
         version: link:../framework/block-std


### PR DESCRIPTION
### What changed?
- Move commands to block spec declarations
- Separate global declares

### What's next?
- Support `InlineSpec` customization
- Separate `@blocksuite/affine-shared/commands`
- Remove `slots` in RootService
