### PR TITLE
fix(blocks): should drop alpha value when dragging endpoint

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -234,6 +234,19 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
       }
     }
 
+    // needs to drop `alpha` value
+    if (typeof stroke === 'object') {
+      if (stroke.normal?.endsWith('00')) {
+        stroke.normal = stroke.normal.substring(0, 7);
+      }
+      if (stroke.light?.endsWith('00')) {
+        stroke.light = stroke.light.substring(0, 7);
+      }
+      if (stroke.dark?.endsWith('00')) {
+        stroke.dark = stroke.dark.substring(0, 7);
+      }
+    }
+
     const id = edgeless.service.addElement(CanvasElementType.CONNECTOR, {
       mode: ConnectorMode.Orthogonal,
       strokeWidth: 2,


### PR DESCRIPTION
Closes [BS-1163](https://linear.app/affine-design/issue/BS-1163/[bug]：通过端点拖拽新的-shape-时-connector-不显示)