### PR TITLE
fix(playground): attachment e2e test failed cause by error-FILE_PATH

### DIFF
--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -39,7 +39,7 @@ import {
 import { test } from './utils/playwright.js';
 
 const FILE_NAME = 'test-card-1.png';
-const FILE_PATH = `../packages/playground/public/${FILE_NAME}`;
+const FILE_PATH = `packages/playground/public/${FILE_NAME}`;
 const FILE_ID = 'ejImogf-Tb7AuKY-v94uz1zuOJbClqK-tWBxVr_ksGA=';
 const FILE_SIZE = 45801;
 


### PR DESCRIPTION
fix the [issue](https://github.com/toeverything/blocksuite/issues/7967) cause by by error-FILE_PATH