### PR TITLE
refactor: separate RootService to commands and utils

### DIFF
--- a/packages/blocks/src/_common/edgeless/note/get-last-note.ts
+++ b/packages/blocks/src/_common/edgeless/note/get-last-note.ts
@@ -1,0 +1,21 @@
+import type { Doc } from '@blocksuite/store';
+
+import { type NoteBlockModel, NoteDisplayMode } from '@blocksuite/affine-model';
+import { matchFlavours } from '@blocksuite/affine-shared/utils';
+
+export function getLastNoteBlock(doc: Doc) {
+  let note: NoteBlockModel | null = null;
+  if (!doc.root) return null;
+  const { children } = doc.root;
+  for (let i = children.length - 1; i >= 0; i--) {
+    const child = children[i];
+    if (
+      matchFlavours(child, ['affine:note']) &&
+      child.displayMode !== NoteDisplayMode.EdgelessOnly
+    ) {
+      note = child as NoteBlockModel;
+      break;
+    }
+  }
+  return note;
+}

--- a/packages/blocks/src/_common/embed-block-helper/insert-embed-card.ts
+++ b/packages/blocks/src/_common/embed-block-helper/insert-embed-card.ts
@@ -1,0 +1,119 @@
+import type { EmbedCardStyle } from '@blocksuite/affine-model';
+import type { BlockStdScope } from '@blocksuite/block-std';
+import type { BlockModel, Doc } from '@blocksuite/store';
+
+import {
+  EMBED_CARD_HEIGHT,
+  EMBED_CARD_WIDTH,
+} from '@blocksuite/affine-shared/consts';
+import { Bound, Vec } from '@blocksuite/global/utils';
+
+import type { EdgelessRootBlockComponent } from '../../root-block/edgeless/index.js';
+import type { DocMode } from '../types.js';
+
+import { getLastNoteBlock } from '../edgeless/note/get-last-note.js';
+import { getRootByEditorHost } from '../utils/query.js';
+
+function getParentModelBySelection(
+  doc: Doc,
+  mode: DocMode,
+  selected?: BlockModel | null
+): {
+  index?: number;
+  model?: BlockModel | null;
+} {
+  const currentMode = mode;
+  const root = doc.root;
+  if (!root)
+    return {
+      index: undefined,
+      model: null,
+    };
+
+  if (currentMode === 'edgeless') {
+    const surface =
+      root.children.find(child => child.flavour === 'affine:surface') ?? null;
+    return { index: undefined, model: surface };
+  }
+
+  if (currentMode === 'page') {
+    let selectedBlock = selected;
+    let index: undefined | number = undefined;
+
+    if (!selectedBlock) {
+      // if no block is selected, append to the last note block
+      selectedBlock = getLastNoteBlock(doc);
+    }
+
+    while (selectedBlock && selectedBlock.flavour !== 'affine:note') {
+      // selectedBlock = this.doc.getParent(selectedBlock.id);
+      const parent = doc.getParent(selectedBlock.id);
+      index = parent?.children.indexOf(selectedBlock);
+      selectedBlock = parent;
+    }
+
+    return { index, model: selectedBlock };
+  }
+
+  return {
+    index: undefined,
+    model: null,
+  };
+}
+
+interface EmbedCardProperties {
+  flavour: string;
+  targetStyle: EmbedCardStyle;
+  props: Record<string, unknown>;
+}
+
+export function insertEmbedCard(
+  std: BlockStdScope,
+  properties: EmbedCardProperties
+) {
+  const { doc, host, spec } = std;
+  const rootService = spec.getService('affine:page');
+  const mode = rootService.docModeService.getMode();
+  const selectedBlock = rootService.selectedBlocks[0]?.model;
+
+  const { model, index } = getParentModelBySelection(doc, mode, selectedBlock);
+  const { flavour, targetStyle, props } = properties;
+
+  if (mode === 'page') {
+    host.doc.addBlock(flavour as never, props, model, index);
+    return;
+  }
+  if (mode === 'edgeless') {
+    const edgelessRoot = getRootByEditorHost(
+      host
+    ) as EdgelessRootBlockComponent | null;
+    if (!edgelessRoot) return;
+
+    edgelessRoot.service.viewport.smoothZoom(1);
+    const surface = edgelessRoot.surface;
+    const center = Vec.toVec(surface.renderer.viewport.center);
+    const cardId = edgelessRoot.service.addBlock(
+      flavour,
+      {
+        ...props,
+        xywh: Bound.fromCenter(
+          center,
+          EMBED_CARD_WIDTH[targetStyle],
+          EMBED_CARD_HEIGHT[targetStyle]
+        ).serialize(),
+        style: targetStyle,
+      },
+      surface.model
+    );
+
+    edgelessRoot.service.selection.set({
+      elements: [cardId],
+      editing: false,
+    });
+
+    edgelessRoot.tools.setEdgelessTool({
+      type: 'default',
+    });
+    return;
+  }
+}

--- a/packages/blocks/src/bookmark-block/bookmark-spec.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-spec.ts
@@ -4,11 +4,13 @@ import { BookmarkBlockSchema } from '@blocksuite/affine-model';
 import { literal } from 'lit/static-html.js';
 
 import { BookmarkBlockService } from './bookmark-service.js';
+import { commands } from './commands/index.js';
 
 export const BookmarkBlockSpec: BlockSpec = {
   schema: BookmarkBlockSchema,
   view: {
     component: literal`affine-bookmark`,
   },
+  commands,
   service: BookmarkBlockService,
 };

--- a/packages/blocks/src/bookmark-block/commands/index.ts
+++ b/packages/blocks/src/bookmark-block/commands/index.ts
@@ -1,0 +1,7 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { insertBookmarkCommand } from './insert-bookmark.js';
+
+export const commands: BlockCommands = {
+  insertBookmark: insertBookmarkCommand,
+};

--- a/packages/blocks/src/bookmark-block/commands/insert-bookmark.ts
+++ b/packages/blocks/src/bookmark-block/commands/insert-bookmark.ts
@@ -1,0 +1,32 @@
+import type { EmbedCardStyle } from '@blocksuite/affine-model';
+import type { Command } from '@blocksuite/block-std';
+
+import { insertEmbedCard } from '../../_common/embed-block-helper/insert-embed-card.js';
+
+export const insertBookmarkCommand: Command<
+  never,
+  'insertedLinkType',
+  { url: string }
+> = (ctx, next) => {
+  const { url, std } = ctx;
+  const rootService = std.spec.getService('affine:page');
+  const embedOptions = rootService.getEmbedBlockOptions(url);
+
+  let flavour = 'affine:bookmark';
+  let targetStyle: EmbedCardStyle = 'vertical';
+  const props: Record<string, unknown> = { url };
+  if (embedOptions) {
+    flavour = embedOptions.flavour;
+    targetStyle = embedOptions.styles[0];
+  }
+  insertEmbedCard(std, { flavour, targetStyle, props });
+  next();
+};
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      insertBookmark: typeof insertBookmarkCommand;
+    }
+  }
+}

--- a/packages/blocks/src/edgeless-text/commands/index.ts
+++ b/packages/blocks/src/edgeless-text/commands/index.ts
@@ -1,7 +1,7 @@
 import type { BlockCommands } from '@blocksuite/block-std';
 
-import { addEdgelessTextBlockCommand } from './insert-edgeless-text.js';
+import { insertEdgelessTextCommand } from './insert-edgeless-text.js';
 
 export const commands: BlockCommands = {
-  addEdgelessTextBlock: addEdgelessTextBlockCommand,
+  insertEdgelessText: insertEdgelessTextCommand,
 };

--- a/packages/blocks/src/edgeless-text/commands/insert-edgeless-text.ts
+++ b/packages/blocks/src/edgeless-text/commands/insert-edgeless-text.ts
@@ -10,7 +10,7 @@ import {
   EDGELESS_TEXT_BLOCK_MIN_WIDTH,
 } from '../edgeless-text-block.js';
 
-export const addEdgelessTextBlockCommand: Command<
+export const insertEdgelessTextCommand: Command<
   never,
   'textId',
   {
@@ -23,8 +23,10 @@ export const addEdgelessTextBlockCommand: Command<
   const doc = host.doc;
   const edgelessService = std.spec.getService('affine:page');
   const surface = getSurfaceBlock(doc);
-  if (!(edgelessService instanceof EdgelessRootService)) return;
-  if (!surface) return;
+  if (!(edgelessService instanceof EdgelessRootService) || !surface) {
+    next();
+    return;
+  }
 
   const zoom = edgelessService.zoom;
   const textId = edgelessService.addBlock(
@@ -88,7 +90,7 @@ declare global {
     }
 
     interface Commands {
-      addEdgelessTextBlock: typeof addEdgelessTextBlockCommand;
+      insertEdgelessText: typeof insertEdgelessTextCommand;
     }
   }
 }

--- a/packages/blocks/src/embed-linked-doc-block/commands/index.ts
+++ b/packages/blocks/src/embed-linked-doc-block/commands/index.ts
@@ -1,7 +1,9 @@
 import type { BlockCommands } from '@blocksuite/block-std';
 
+import { insertEmbedLinkedDocCommand } from './insert-embed-linked-doc.js';
 import { insertLinkByQuickSearchCommand } from './insert-link-by-quick-search.js';
 
 export const commands: BlockCommands = {
+  insertEmbedLinkedDoc: insertEmbedLinkedDocCommand,
   insertLinkByQuickSearch: insertLinkByQuickSearchCommand,
 };

--- a/packages/blocks/src/embed-linked-doc-block/commands/insert-embed-linked-doc.ts
+++ b/packages/blocks/src/embed-linked-doc-block/commands/insert-embed-linked-doc.ts
@@ -1,0 +1,25 @@
+import type { EmbedCardStyle } from '@blocksuite/affine-model';
+import type { Command } from '@blocksuite/block-std';
+
+import { insertEmbedCard } from '../../_common/embed-block-helper/insert-embed-card.js';
+
+export const insertEmbedLinkedDocCommand: Command<
+  never,
+  'insertedLinkType',
+  { docId: string }
+> = (ctx, next) => {
+  const { docId, std } = ctx;
+  const flavour = 'affine:embed-linked-doc';
+  const targetStyle: EmbedCardStyle = 'vertical';
+  const props: Record<string, unknown> = { pageId: docId };
+  insertEmbedCard(std, { flavour, targetStyle, props });
+  next();
+};
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      insertEmbedLinkedDoc: typeof insertEmbedLinkedDocCommand;
+    }
+  }
+}

--- a/packages/blocks/src/paragraph-block/commands/append-paragraph.ts
+++ b/packages/blocks/src/paragraph-block/commands/append-paragraph.ts
@@ -1,0 +1,37 @@
+import type { Command } from '@blocksuite/block-std';
+
+import { focusTextModel } from '@blocksuite/affine-components/rich-text';
+
+import { getLastNoteBlock } from '../../_common/edgeless/note/get-last-note.js';
+
+export const appendParagraphCommand: Command<
+  never,
+  never,
+  { text?: string }
+> = (ctx, next) => {
+  const { std, text = '' } = ctx;
+  const { doc } = std;
+  if (!doc.root) return;
+
+  const note = getLastNoteBlock(doc);
+  let noteId = note?.id;
+  if (!noteId) {
+    noteId = doc.addBlock('affine:note', {}, doc.root.id);
+  }
+  const id = doc.addBlock(
+    'affine:paragraph',
+    { text: new doc.Text(text) },
+    noteId
+  );
+
+  focusTextModel(std, id, text.length);
+  next();
+};
+
+declare global {
+  namespace BlockSuite {
+    interface Commands {
+      appendParagraph: typeof appendParagraphCommand;
+    }
+  }
+}

--- a/packages/blocks/src/paragraph-block/commands/index.ts
+++ b/packages/blocks/src/paragraph-block/commands/index.ts
@@ -1,0 +1,7 @@
+import type { BlockCommands } from '@blocksuite/block-std';
+
+import { appendParagraphCommand } from './append-paragraph.js';
+
+export const commands: BlockCommands = {
+  appendParagraph: appendParagraphCommand,
+};

--- a/packages/blocks/src/paragraph-block/paragraph-spec.ts
+++ b/packages/blocks/src/paragraph-block/paragraph-spec.ts
@@ -3,6 +3,7 @@ import type { BlockSpec } from '@blocksuite/block-std';
 import { ParagraphBlockSchema } from '@blocksuite/affine-model';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands/index.js';
 import { ParagraphBlockService } from './paragraph-service.js';
 
 export const ParagraphBlockSpec: BlockSpec = {
@@ -10,5 +11,6 @@ export const ParagraphBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-paragraph`,
   },
+  commands,
   service: ParagraphBlockService,
 };

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -260,13 +260,10 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
       'enable_edgeless_text'
     );
     if (textFlag) {
-      const { textId } = this.edgeless.std.command.exec(
-        'addEdgelessTextBlock',
-        {
-          x: bound.x,
-          y: bound.y,
-        }
-      );
+      const { textId } = this.edgeless.std.command.exec('insertEdgelessText', {
+        x: bound.x,
+        y: bound.y,
+      });
       if (!textId) return;
       edgelessService.updateElement(this.connector.id, {
         target: { id: textId, position },

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
@@ -7,7 +7,7 @@ export const buildLinkDenseMenu: DenseMenuBuilder = edgeless => ({
   name: 'Link',
   icon: LinkIcon,
   select: () => {
-    const { insertedLinkType } = edgeless.service.std.command.exec(
+    const { insertedLinkType } = edgeless.std.command.exec(
       'insertLinkByQuickSearch'
     );
 
@@ -18,14 +18,14 @@ export const buildLinkDenseMenu: DenseMenuBuilder = edgeless => ({
             control: 'toolbar:general',
             page: 'whiteboard editor',
             module: 'toolbar',
-            type: type.flavour.split(':')[1],
+            type: type.flavour?.split(':')[1],
           });
           if (type.isNewDoc) {
             edgeless.service.telemetryService?.track('DocCreated', {
               control: 'toolbar:general',
               page: 'whiteboard editor',
               module: 'edgeless toolbar',
-              type: type.flavour.split(':')[1],
+              type: type.flavour?.split(':')[1],
             });
           }
         }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
@@ -18,16 +18,18 @@ export class EdgelessLinkToolButton extends QuickToolMixin(LitElement) {
   override type = 'default' as const;
 
   private _onClick() {
-    this.edgeless.service
-      .insertLinkByQuickSearch()
-      .then(type => {
+    const { insertedLinkType } = this.edgeless.std.command.exec(
+      'insertLinkByQuickSearch'
+    );
+    insertedLinkType
+      ?.then(type => {
         if (type) {
           this.edgeless.service.telemetryService?.track('CanvasElementAdded', {
             control: 'toolbar:general',
             page: 'whiteboard editor',
             module: 'toolbar',
             segment: 'toolbar',
-            type: type.flavour.split(':')[1],
+            type: type.flavour?.split(':')[1],
           });
 
           if (type.isNewDoc) {
@@ -36,14 +38,14 @@ export class EdgelessLinkToolButton extends QuickToolMixin(LitElement) {
               page: 'whiteboard editor',
               module: 'edgeless toolbar',
               segment: 'whiteboard',
-              type: type.flavour.split(':')[1],
+              type: type.flavour?.split(':')[1],
             });
             this.edgeless.service.telemetryService?.track('LinkedDocCreated', {
               control: 'links',
               page: 'whiteboard editor',
               module: 'edgeless toolbar',
               segment: 'whiteboard',
-              type: type.flavour.split(':')[1],
+              type: type.flavour?.split(':')[1],
               other: 'new doc',
             });
           } else {
@@ -52,7 +54,7 @@ export class EdgelessLinkToolButton extends QuickToolMixin(LitElement) {
               page: 'whiteboard editor',
               module: 'edgeless toolbar',
               segment: 'whiteboard',
-              type: type.flavour.split(':')[1],
+              type: type.flavour?.split(':')[1],
               other: 'existing doc',
             });
           }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
@@ -119,7 +119,7 @@ export const textRender: DraggableTool['render'] = (
   const flag = edgeless.doc.awarenessStore.getFlag('enable_edgeless_text');
   let id: string;
   if (flag) {
-    const { textId } = edgeless.std.command.exec('addEdgelessTextBlock', {
+    const { textId } = edgeless.std.command.exec('insertEdgelessText', {
       x: bound.x,
       y: vCenter - h / 2,
     });

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
@@ -76,14 +76,14 @@ export class EdgelessNoteMenu extends EdgelessToolbarToolMixin(LitElement) {
             control: 'toolbar:general',
             page: 'whiteboard editor',
             module: 'toolbar',
-            type: type.flavour.split(':')[1],
+            type: type.flavour?.split(':')[1],
           });
           if (type.isNewDoc) {
             this.edgeless.service.telemetryService?.track('DocCreated', {
               control: 'toolbar:general',
               page: 'whiteboard editor',
               module: 'edgeless toolbar',
-              type: type.flavour.split(':')[1],
+              type: type.flavour?.split(':')[1],
             });
           }
         }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -775,7 +775,7 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
 
       if (textFlag) {
         const [x, y] = this._service.viewport.toModelCoord(e.x, e.y);
-        this._edgeless.std.command.exec('addEdgelessTextBlock', { x, y });
+        this._edgeless.std.command.exec('insertEdgelessText', { x, y });
       } else {
         addText(this._edgeless, e);
       }

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/text-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/text-tool.ts
@@ -29,7 +29,7 @@ export class TextToolController extends EdgelessToolController<TextTool> {
 
     if (textFlag) {
       const [x, y] = this._service.viewport.toModelCoord(e.x, e.y);
-      this._edgeless.std.command.exec('addEdgelessTextBlock', { x, y });
+      this._edgeless.std.command.exec('insertEdgelessText', { x, y });
       this._service.tool.setEdgelessTool({
         type: 'default',
       });

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -196,7 +196,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                     page: 'whiteboard editor',
                     module: 'toolbar',
                     segment: 'toolbar',
-                    type: type.flavour.split(':')[1],
+                    type: type.flavour?.split(':')[1],
                   }
                 );
                 if (type.isNewDoc) {
@@ -204,7 +204,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                     control: 'shortcut',
                     page: 'whiteboard editor',
                     segment: 'whiteboard',
-                    type: type.flavour.split(':')[1],
+                    type: type.flavour?.split(':')[1],
                   });
                 }
               }

--- a/packages/blocks/src/root-block/root-service.ts
+++ b/packages/blocks/src/root-block/root-service.ts
@@ -1,22 +1,12 @@
 import type { PeekViewService } from '@blocksuite/affine-components/peek';
 import type { RefNodeSlots } from '@blocksuite/affine-components/rich-text';
 import type { RootBlockModel } from '@blocksuite/affine-model';
+import type { EmbedCardStyle } from '@blocksuite/affine-model';
 import type { BlockComponent } from '@blocksuite/block-std';
-import type { BlockModel } from '@blocksuite/store';
 
-import { focusTextModel } from '@blocksuite/affine-components/rich-text';
-import {
-  type EmbedCardStyle,
-  type NoteBlockModel,
-  NoteDisplayMode,
-} from '@blocksuite/affine-model';
 import { ThemeObserver } from '@blocksuite/affine-shared/theme';
-import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { BlockService } from '@blocksuite/block-std';
-import { Bound, Vec } from '@blocksuite/global/utils';
-import { assertExists } from '@blocksuite/global/utils';
 
-import type { EdgelessRootBlockComponent } from './edgeless/edgeless-root-block.js';
 import type { RootBlockComponent } from './types.js';
 
 import {
@@ -28,18 +18,13 @@ import {
   type NotificationService,
   createDocModeService,
 } from '../_common/components/index.js';
-import {
-  DEFAULT_IMAGE_PROXY_ENDPOINT,
-  EMBED_CARD_HEIGHT,
-  EMBED_CARD_WIDTH,
-} from '../_common/consts.js';
+import { DEFAULT_IMAGE_PROXY_ENDPOINT } from '../_common/consts.js';
 import { ExportManager } from '../_common/export-manager/export-manager.js';
 import {
   HtmlTransformer,
   MarkdownTransformer,
   ZipTransformer,
 } from '../_common/transformers/index.js';
-import { getRootByEditorHost } from '../_common/utils/index.js';
 import { CommunityCanvasTextFonts } from '../surface-block/consts.js';
 import { EditPropsStore } from '../surface-block/managers/edit-session.js';
 import { FontLoader } from './font-loader/font-loader.js';
@@ -110,139 +95,6 @@ export abstract class RootService extends BlockService<RootBlockModel> {
     flavour: this.flavour,
   };
 
-  private _getParentModelBySelection = (): {
-    index: number | undefined;
-    model: BlockModel | null;
-  } => {
-    const currentMode = this.docModeService.getMode();
-    const root = this.doc.root;
-    if (!root)
-      return {
-        index: undefined,
-        model: null,
-      };
-
-    if (currentMode === 'edgeless') {
-      const surface =
-        root.children.find(child => child.flavour === 'affine:surface') ?? null;
-      return { index: undefined, model: surface };
-    }
-
-    if (currentMode === 'page') {
-      let selectedBlock: BlockModel | null = this.selectedBlocks[0]?.model;
-      let index: undefined | number = undefined;
-
-      if (!selectedBlock) {
-        // if no block is selected, append to the last note block
-        selectedBlock = this._getLastNoteBlock();
-      }
-
-      while (selectedBlock && selectedBlock.flavour !== 'affine:note') {
-        // selectedBlock = this.doc.getParent(selectedBlock.id);
-        const parent = this.doc.getParent(selectedBlock.id);
-        index = parent?.children.indexOf(selectedBlock);
-        selectedBlock = parent;
-      }
-
-      return { index, model: selectedBlock };
-    }
-
-    return {
-      index: undefined,
-      model: null,
-    };
-  };
-
-  private _insertCard = (
-    flavour: string,
-    targetStyle: EmbedCardStyle,
-    props: Record<string, unknown>
-  ) => {
-    const host = this.host;
-
-    const mode = this.docModeService.getMode();
-    const { model, index } = this._getParentModelBySelection();
-
-    if (mode === 'page') {
-      host.doc.addBlock(flavour as never, props, model, index);
-      return;
-    }
-    if (mode === 'edgeless') {
-      const edgelessRoot = getRootByEditorHost(
-        host
-      ) as EdgelessRootBlockComponent | null;
-      if (!edgelessRoot) return;
-
-      edgelessRoot.service.viewport.smoothZoom(1);
-      const surface = edgelessRoot.surface;
-      const center = Vec.toVec(surface.renderer.viewport.center);
-      const cardId = edgelessRoot.service.addBlock(
-        flavour,
-        {
-          ...props,
-          xywh: Bound.fromCenter(
-            center,
-            EMBED_CARD_WIDTH[targetStyle],
-            EMBED_CARD_HEIGHT[targetStyle]
-          ).serialize(),
-          style: targetStyle,
-        },
-        surface.model
-      );
-
-      edgelessRoot.service.selection.set({
-        elements: [cardId],
-        editing: false,
-      });
-
-      edgelessRoot.tools.setEdgelessTool({
-        type: 'default',
-      });
-      return;
-    }
-  };
-
-  private _insertDoc = (docId: string) => {
-    const flavour = 'affine:embed-linked-doc';
-    const targetStyle: EmbedCardStyle = 'vertical';
-    const props: Record<string, unknown> = { pageId: docId };
-
-    this._insertCard(flavour, targetStyle, props);
-    return flavour;
-  };
-
-  private _insertLink = (url: string) => {
-    const embedOptions = this.getEmbedBlockOptions(url);
-
-    let flavour = 'affine:bookmark';
-    let targetStyle: EmbedCardStyle = 'vertical';
-    const props: Record<string, unknown> = { url };
-    if (embedOptions) {
-      flavour = embedOptions.flavour;
-      targetStyle = embedOptions.styles[0];
-    }
-
-    this._insertCard(flavour, targetStyle, props);
-    return flavour;
-  };
-
-  appendParagraph = (text: string = '') => {
-    const { doc } = this;
-    if (!doc.root) return;
-    if (doc.readonly) return;
-    let noteId = this._getLastNoteBlock()?.id;
-    if (!noteId) {
-      noteId = doc.addBlock('affine:note', {}, doc.root.id);
-    }
-    const id = doc.addBlock(
-      'affine:paragraph',
-      { text: new doc.Text(text) },
-      noteId
-    );
-
-    focusTextModel(this.host.std, id, text.length);
-  };
-
   docModeService: DocModeService = createDocModeService(this.doc.id);
 
   readonly editPropsStore: EditPropsStore = new EditPropsStore(this);
@@ -260,42 +112,6 @@ export abstract class RootService extends BlockService<RootBlockModel> {
       if (regex.test(url)) return options;
     }
     return null;
-  };
-
-  insertLinkByQuickSearch = async (
-    userInput?: string,
-    skipSelection?: boolean
-  ): Promise<
-    | {
-        flavour: string;
-        isNewDoc?: boolean;
-      }
-    | undefined
-  > => {
-    if (!this.quickSearchService) return;
-
-    const result = await this.quickSearchService.searchDoc({
-      action: 'insert',
-      userInput,
-      skipSelection,
-    });
-    if (!result) return;
-
-    // add linked doc
-    if ('docId' in result) {
-      this._insertDoc(result.docId);
-      return { flavour: 'affine:embed-linked-doc', isNewDoc: result.isNewDoc };
-    }
-
-    // add normal link;
-    if ('userInput' in result) {
-      this._insertLink(result.userInput);
-      return {
-        flavour: 'affine:bookmark',
-      };
-    }
-
-    return;
   };
 
   // implements provided by affine
@@ -318,24 +134,6 @@ export abstract class RootService extends BlockService<RootBlockModel> {
     html: HtmlTransformer,
     zip: ZipTransformer,
   };
-
-  private _getLastNoteBlock() {
-    const { doc } = this;
-    let note: NoteBlockModel | null = null;
-    if (!doc.root) return null;
-    const { children } = doc.root;
-    for (let i = children.length - 1; i >= 0; i--) {
-      const child = children[i];
-      if (
-        matchFlavours(child, ['affine:note']) &&
-        child.displayMode !== NoteDisplayMode.EdgelessOnly
-      ) {
-        note = child as NoteBlockModel;
-        break;
-      }
-    }
-    return note;
-  }
 
   loadFonts() {
     this.fontLoader.load(CommunityCanvasTextFonts);
@@ -397,9 +195,8 @@ export abstract class RootService extends BlockService<RootBlockModel> {
     const rootComponent = this.std.view.viewFromPath('block', [
       this.std.doc.root?.id ?? '',
     ]) as RootBlockComponent | null;
-    assertExists(rootComponent);
-    const viewportElement = rootComponent.viewportElement as HTMLElement | null;
-    assertExists(viewportElement);
+    if (!rootComponent) return null;
+    const viewportElement = rootComponent.viewportElement;
     return viewportElement;
   }
 

--- a/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
+++ b/packages/blocks/src/surface-block/commands/reassociate-connectors.ts
@@ -1,7 +1,5 @@
 import type { Command } from '@blocksuite/block-std';
 
-import { assertExists } from '@blocksuite/global/utils';
-
 /**
  * Re-associate bindings for block that have been converted.
  *
@@ -14,11 +12,11 @@ export const reassociateConnectorsCommand: Command<
   { oldId: string; newId: string }
 > = (ctx, next) => {
   const { oldId, newId } = ctx;
-  assertExists(oldId, 'The old block ID is required!');
-  assertExists(newId, 'The new block ID is required!');
-
   const service = ctx.std.spec.getService('affine:surface');
-  assertExists(service);
+  if (!oldId || !newId || !service) {
+    next();
+    return;
+  }
 
   const surface = service.surface;
   const connectors = surface.getConnectors(oldId);

--- a/packages/blocks/src/surface-block/surface-spec.ts
+++ b/packages/blocks/src/surface-block/surface-spec.ts
@@ -12,6 +12,7 @@ export const PageSurfaceBlockSpec: BlockSpec = {
   view: {
     component: literal`affine-surface-void`,
   },
+  commands,
   service: SurfaceBlockService,
 };
 


### PR DESCRIPTION
### What Changed?
- In `RootService`
  - Refactor `_getLastNoteBlock ` to `getLastNoteBlock` utils
  - Refactor `_insertCard` to `insertEmbedCard` utils
  - Refactor `insertLinkByQuickSearch` to `insertLinkByQuickSearch` command
  - Refactor `appendParagraph` to `appendParagraph` command
  - Refactor `_insertLink` to `insertBookmark` command
  - Refactor `_insertDoc` to `insertEmbedLinkedDoc` command