### PR TITLE
chore(edgeless): field naming

### DIFF
--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -7,8 +7,8 @@ import {
   GfxPrimitiveElementModel,
   convert,
   derive,
+  field,
   watch,
-  yfield,
 } from '@blocksuite/block-std/gfx';
 import {
   Bound,
@@ -131,7 +131,7 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
     return 'brush';
   }
 
-  @yfield()
+  @field()
   accessor color: Color = '#000000';
 
   @watch((_, instance) => {
@@ -159,7 +159,7 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
       xywh: transformed.bound.serialize(),
     };
   })
-  @yfield()
+  @field()
   accessor lineWidth: number = 4;
 
   @watch((_, instance) => {
@@ -186,10 +186,10 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
 
     return relativePoints;
   })
-  @yfield()
+  @field()
   accessor points: (IVec | IVec3)[] = [];
 
-  @yfield(0)
+  @field(0)
   accessor rotate: number = 0;
 
   @derive((xywh: SerializedXYWH, instance: Instance) => {
@@ -214,7 +214,7 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
       ]),
     };
   })
-  @yfield()
+  @field()
   accessor xywh: SerializedXYWH = '[0,0,0,0]';
 }
 

--- a/packages/affine/model/src/elements/connector/connector.ts
+++ b/packages/affine/model/src/elements/connector/connector.ts
@@ -8,8 +8,8 @@ import type { IVec, SerializedXYWH, XYWH } from '@blocksuite/global/utils';
 import {
   GfxPrimitiveElementModel,
   derive,
+  field,
   local,
-  yfield,
 } from '@blocksuite/block-std/gfx';
 import {
   Bound,
@@ -420,13 +420,13 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   @local()
   accessor absolutePath: PointLocation[] = [];
 
-  @yfield('None' as PointStyle)
+  @field('None' as PointStyle)
   accessor frontEndpointStyle!: PointStyle;
 
   /**
    * Defines the size constraints of the label.
    */
-  @yfield({
+  @field({
     hasMaxWidth: true,
     maxWidth: CONNECTOR_LABEL_MAX_WIDTH,
   } as ConnectorLabelConstraintsProps)
@@ -435,13 +435,13 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   /**
    * Control display and hide.
    */
-  @yfield(true)
+  @field(true)
   accessor labelDisplay!: boolean;
 
   /**
    * The offset property specifies the label along the connector path.
    */
-  @yfield({
+  @field({
     distance: 0.5,
     anchor: ConnectorLabelOffsetAnchor.Center,
   } as ConnectorLabelOffsetProps)
@@ -450,7 +450,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   /**
    * Defines the style of the label.
    */
-  @yfield({
+  @field({
     color: '#000000',
     fontFamily: FontFamily.Inter,
     fontSize: 16,
@@ -464,7 +464,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
    * Returns a `XYWH` array providing information about the size of a label
    * and its position relative to the viewport.
    */
-  @yfield()
+  @field()
   accessor labelXYWH: XYWH | undefined = undefined;
 
   /**
@@ -473,7 +473,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   @local()
   accessor lableEditing: boolean = false;
 
-  @yfield()
+  @field()
   accessor mode: ConnectorMode = ConnectorMode.Orthogonal;
 
   @derive((path: PointLocation[], instance) => {
@@ -486,33 +486,33 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   @local()
   accessor path: PointLocation[] = [];
 
-  @yfield('Arrow' as PointStyle)
+  @field('Arrow' as PointStyle)
   accessor rearEndpointStyle!: PointStyle;
 
   @local()
   accessor rotate: number = 0;
 
-  @yfield()
+  @field()
   accessor rough: boolean | undefined = undefined;
 
-  @yfield()
+  @field()
   accessor roughness: number = DEFAULT_ROUGHNESS;
 
-  @yfield()
+  @field()
   accessor source: Connection = {
     position: [0, 0],
   };
 
-  @yfield()
+  @field()
   accessor stroke: Color = '#000000';
 
-  @yfield()
+  @field()
   accessor strokeStyle: StrokeStyle = StrokeStyle.Solid;
 
-  @yfield()
+  @field()
   accessor strokeWidth: number = 4;
 
-  @yfield()
+  @field()
   accessor target: Connection = {
     position: [0, 0],
   };
@@ -520,7 +520,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   /**
    * The content of the label.
    */
-  @yfield()
+  @field()
   accessor text: Y.Text | undefined = undefined;
 
   @local()

--- a/packages/affine/model/src/elements/group/group.ts
+++ b/packages/affine/model/src/elements/group/group.ts
@@ -6,9 +6,9 @@ import type { Y } from '@blocksuite/store';
 
 import {
   GfxGroupLikeElementModel,
+  field,
   local,
   observe,
-  yfield,
 } from '@blocksuite/block-std/gfx';
 import {
   Bound,
@@ -104,13 +104,13 @@ export class GroupElementModel extends GfxGroupLikeElementModel<GroupElementProp
       );
     }
   )
-  @yfield()
+  @field()
   accessor children: Y.Map<boolean> = new DocCollection.Y.Map<boolean>();
 
   @local()
   accessor showTitle: boolean = true;
 
-  @yfield()
+  @field()
   accessor title: Y.Text = new DocCollection.Y.Text();
 }
 

--- a/packages/affine/model/src/elements/shape/shape.ts
+++ b/packages/affine/model/src/elements/shape/shape.ts
@@ -23,8 +23,8 @@ import {
 } from '@blocksuite/affine-model';
 import {
   GfxPrimitiveElementModel,
+  field,
   local,
-  yfield,
 } from '@blocksuite/block-std/gfx';
 import { DocCollection, type Y } from '@blocksuite/store';
 
@@ -93,46 +93,46 @@ export class ShapeElementModel extends GfxPrimitiveElementModel<ShapeProps> {
     return 'shape';
   }
 
-  @yfield('#000000' as Color)
+  @field('#000000' as Color)
   accessor color!: Color;
 
-  @yfield()
+  @field()
   accessor fillColor: Color = '--affine-palette-shape-yellow';
 
-  @yfield()
+  @field()
   accessor filled: boolean = false;
 
-  @yfield(FontFamily.Inter as string)
+  @field(FontFamily.Inter as string)
   accessor fontFamily!: string;
 
-  @yfield(ShapeTextFontSize.MEDIUM)
+  @field(ShapeTextFontSize.MEDIUM)
   accessor fontSize!: number;
 
-  @yfield(FontStyle.Normal as FontStyle)
+  @field(FontStyle.Normal as FontStyle)
   accessor fontStyle!: FontStyle;
 
-  @yfield(FontWeight.Regular as FontWeight)
+  @field(FontWeight.Regular as FontWeight)
   accessor fontWeight!: FontWeight;
 
-  @yfield(false as false | number)
+  @field(false as false | number)
   accessor maxWidth: false | number = false;
 
-  @yfield([SHAPE_TEXT_VERTICAL_PADDING, SHAPE_TEXT_PADDING])
+  @field([SHAPE_TEXT_VERTICAL_PADDING, SHAPE_TEXT_PADDING])
   accessor padding: [number, number] = [
     SHAPE_TEXT_VERTICAL_PADDING,
     SHAPE_TEXT_PADDING,
   ];
 
-  @yfield()
+  @field()
   accessor radius: number = 0;
 
-  @yfield(0)
+  @field(0)
   accessor rotate: number = 0;
 
-  @yfield(DEFAULT_ROUGHNESS)
+  @field(DEFAULT_ROUGHNESS)
   accessor roughness: number = DEFAULT_ROUGHNESS;
 
-  @yfield()
+  @field()
   accessor shadow: {
     blur: number;
     offsetX: number;
@@ -140,40 +140,40 @@ export class ShapeElementModel extends GfxPrimitiveElementModel<ShapeProps> {
     color: string;
   } | null = null;
 
-  @yfield('General' as ShapeStyle)
+  @field('General' as ShapeStyle)
   accessor shapeStyle: ShapeStyle = 'General';
 
-  @yfield()
+  @field()
   accessor shapeType: ShapeType = 'rect';
 
-  @yfield()
+  @field()
   accessor strokeColor: Color = '--affine-palette-line-yellow';
 
-  @yfield()
+  @field()
   accessor strokeStyle: StrokeStyle = StrokeStyle.Solid;
 
-  @yfield()
+  @field()
   accessor strokeWidth: number = 4;
 
-  @yfield()
+  @field()
   accessor text: Y.Text | undefined = undefined;
 
-  @yfield(TextAlign.Center as TextAlign)
+  @field(TextAlign.Center as TextAlign)
   accessor textAlign!: TextAlign;
 
   @local()
   accessor textDisplay: boolean = true;
 
-  @yfield(TextAlign.Center as TextAlign)
+  @field(TextAlign.Center as TextAlign)
   accessor textHorizontalAlign!: TextAlign;
 
-  @yfield(TextResizing.AUTO_HEIGHT as TextResizing)
+  @field(TextResizing.AUTO_HEIGHT as TextResizing)
   accessor textResizing: TextResizing = TextResizing.AUTO_HEIGHT;
 
-  @yfield(TextVerticalAlign.Center as TextVerticalAlign)
+  @field(TextVerticalAlign.Center as TextVerticalAlign)
   accessor textVerticalAlign!: TextVerticalAlign;
 
-  @yfield()
+  @field()
   accessor xywh: SerializedXYWH = '[0,0,100,100]';
 }
 

--- a/packages/affine/model/src/elements/text/text.ts
+++ b/packages/affine/model/src/elements/text/text.ts
@@ -9,7 +9,7 @@ import {
   TextAlign,
   type TextStyleProps,
 } from '@blocksuite/affine-model';
-import { GfxPrimitiveElementModel, yfield } from '@blocksuite/block-std/gfx';
+import { GfxPrimitiveElementModel, field } from '@blocksuite/block-std/gfx';
 import {
   Bound,
   getPointsFromBoundsWithRotation,
@@ -60,34 +60,34 @@ export class TextElementModel extends GfxPrimitiveElementModel<TextElementProps>
     return 'text';
   }
 
-  @yfield()
+  @field()
   accessor color: Color = '#000000';
 
-  @yfield()
+  @field()
   accessor fontFamily: FontFamily = FontFamily.Inter;
 
-  @yfield()
+  @field()
   accessor fontSize: number = 16;
 
-  @yfield(FontStyle.Normal as FontStyle)
+  @field(FontStyle.Normal as FontStyle)
   accessor fontStyle: FontStyle = FontStyle.Normal;
 
-  @yfield(FontWeight.Regular as FontWeight)
+  @field(FontWeight.Regular as FontWeight)
   accessor fontWeight: FontWeight = FontWeight.Regular;
 
-  @yfield(false)
+  @field(false)
   accessor hasMaxWidth: boolean = false;
 
-  @yfield(0)
+  @field(0)
   accessor rotate: number = 0;
 
-  @yfield()
+  @field()
   accessor text: Y.Text = new DocCollection.Y.Text();
 
-  @yfield()
+  @field()
   accessor textAlign: TextAlign = TextAlign.Center;
 
-  @yfield()
+  @field()
   accessor xywh: SerializedXYWH = '[0,0,16,16]';
 }
 

--- a/packages/blocks/src/surface-block/element-model/mindmap.ts
+++ b/packages/blocks/src/surface-block/element-model/mindmap.ts
@@ -9,9 +9,9 @@ import { LocalConnectorElementModel } from '@blocksuite/affine-model';
 import {
   GfxGroupLikeElementModel,
   convert,
+  field,
   observe,
   watch,
-  yfield,
 } from '@blocksuite/block-std/gfx';
 import {
   assertType,
@@ -1037,7 +1037,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
       instance.connectors.clear();
     }
   )
-  @yfield()
+  @field()
   accessor children: Y.Map<NodeDetail> = new DocCollection.Y.Map();
 
   @watch((_, instance: MindmapElementModel, local) => {
@@ -1060,7 +1060,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
 
     instance.buildTree();
   })
-  @yfield()
+  @field()
   accessor layoutType: LayoutType = LayoutType.RIGHT;
 
   @watch((_, instance: MindmapElementModel, local) => {
@@ -1068,7 +1068,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
       instance.layout();
     }
   })
-  @yfield()
+  @field()
   accessor style: MindmapStyle = MindmapStyle.ONE;
 }
 

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -3,15 +3,15 @@ export {
   convert,
   convertProps,
   derive,
+  field,
   getDerivedProps,
-  getYFieldPropsSet,
+  getFieldPropsSet,
   initializeObservers,
   initializeWatchers,
   local,
   observe,
   updateDerivedProps,
   watch,
-  yfield,
 } from './surface/decorators/index.js';
 export {
   type BaseElementProps,

--- a/packages/framework/block-std/src/gfx/surface/decorators/common.ts
+++ b/packages/framework/block-std/src/gfx/surface/decorators/common.ts
@@ -48,6 +48,6 @@ export function createDecoratorState() {
   return {
     creating: false,
     deriving: false,
-    skipYfield: false,
+    skipField: false,
   };
 }

--- a/packages/framework/block-std/src/gfx/surface/decorators/field.ts
+++ b/packages/framework/block-std/src/gfx/surface/decorators/field.ts
@@ -7,7 +7,7 @@ import { startObserve } from './observer.js';
 
 const yPropsSetSymbol = Symbol('yProps');
 
-export function getYFieldPropsSet(target: unknown): Set<string | symbol> {
+export function getFieldPropsSet(target: unknown): Set<string | symbol> {
   const proto = Object.getPrototypeOf(target);
   // @ts-ignore
   if (!Object.hasOwn(proto, yPropsSetSymbol)) {
@@ -19,7 +19,7 @@ export function getYFieldPropsSet(target: unknown): Set<string | symbol> {
   return proto[yPropsSetSymbol] as Set<string | symbol>;
 }
 
-export function yfield<V, T extends GfxPrimitiveElementModel>(fallback?: V) {
+export function field<V, T extends GfxPrimitiveElementModel>(fallback?: V) {
   return function yDecorator(
     target: ClassAccessorDecoratorTarget<T, V>,
     context: ClassAccessorDecoratorContext
@@ -28,14 +28,14 @@ export function yfield<V, T extends GfxPrimitiveElementModel>(fallback?: V) {
 
     return {
       init(this: GfxPrimitiveElementModel, v: V) {
-        const yProps = getYFieldPropsSet(this);
+        const yProps = getFieldPropsSet(this);
 
         yProps.add(prop);
 
         if (
           getDecoratorState(
             this.surface ?? Object.getPrototypeOf(this).constructor
-          )?.skipYfield
+          )?.skipField
         ) {
           return;
         }
@@ -63,7 +63,7 @@ export function yfield<V, T extends GfxPrimitiveElementModel>(fallback?: V) {
       set(this: T, originalVal: V) {
         const isCreating = getDecoratorState(this.surface)?.creating;
 
-        if (getDecoratorState(this.surface)?.skipYfield) {
+        if (getDecoratorState(this.surface)?.skipField) {
           return;
         }
 

--- a/packages/framework/block-std/src/gfx/surface/decorators/index.ts
+++ b/packages/framework/block-std/src/gfx/surface/decorators/index.ts
@@ -1,6 +1,6 @@
 export { convert, convertProps } from './convert.js';
 export { derive, getDerivedProps, updateDerivedProps } from './derive.js';
+export { field, getFieldPropsSet } from './field.js';
 export { local } from './local.js';
 export { initializeObservers, observe } from './observer.js';
 export { initializeWatchers, watch } from './watch.js';
-export { getYFieldPropsSet, yfield } from './yfield.js';

--- a/packages/framework/block-std/src/gfx/surface/decorators/local.ts
+++ b/packages/framework/block-std/src/gfx/surface/decorators/local.ts
@@ -7,7 +7,7 @@ import { getDerivedProps, updateDerivedProps } from './derive.js';
 /**
  * A decorator to mark the property as a local property.
  *
- * The local property act like it is a yfield property, but it's not synced to the Y map.
+ * The local property act like it is a field property, but it's not synced to the Y map.
  * Updating local property will also trigger the `elementUpdated` slot of the surface model
  */
 export function local<V, T extends GfxPrimitiveElementModel>() {

--- a/packages/framework/block-std/src/gfx/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/element-model.ts
@@ -22,12 +22,12 @@ import type { SurfaceBlockModel } from './surface-model.js';
 
 import {
   convertProps,
+  field,
   getDerivedProps,
-  getYFieldPropsSet,
+  getFieldPropsSet,
   local,
   updateDerivedProps,
   watch,
-  yfield,
 } from './decorators/index.js';
 
 export type BaseElementProps = {
@@ -183,12 +183,12 @@ export abstract class GfxPrimitiveElementModel<
     // @ts-ignore
     delete this[prop];
 
-    if (getYFieldPropsSet(this).has(prop as string)) {
+    if (getFieldPropsSet(this).has(prop as string)) {
       this.surface.doc.transact(() => {
         this.yMap.set(prop as string, value);
       });
     } else {
-      console.warn('pop a prop that is not yfield or local:', prop);
+      console.warn('pop a prop that is not field or local:', prop);
     }
   }
 
@@ -201,7 +201,7 @@ export abstract class GfxPrimitiveElementModel<
       return;
     }
 
-    if (!getYFieldPropsSet(this).has(prop as string)) {
+    if (!getFieldPropsSet(this).has(prop as string)) {
       return;
     }
 
@@ -337,7 +337,7 @@ export abstract class GfxPrimitiveElementModel<
   @local()
   accessor externalXYWH: SerializedXYWH | undefined = undefined;
 
-  @yfield()
+  @field()
   accessor index!: string;
 
   @local()
@@ -345,7 +345,7 @@ export abstract class GfxPrimitiveElementModel<
 
   abstract rotate: number;
 
-  @yfield()
+  @field()
   accessor seed!: number;
 
   abstract get type(): string;
@@ -411,7 +411,7 @@ export abstract class GfxGroupLikeElementModel<
 
   /**
    * The actual field that stores the children of the group.
-   * It should be a ymap decorated with `@yfield`.
+   * It should be a ymap decorated with `@field`.
    */
   hasChild(element: string | GfxModel) {
     return (

--- a/packages/framework/block-std/src/gfx/surface/surface-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/surface-model.ts
@@ -152,7 +152,7 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
     const state = this._decoratorState;
 
     state.creating = true;
-    state.skipYfield = options.skipFieldInit ?? false;
+    state.skipField = options.skipFieldInit ?? false;
 
     let mounted = false;
     // @ts-ignore
@@ -169,7 +169,7 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
     // @ts-ignore
     delete Ctor['_decoratorState'];
     state.creating = false;
-    state.skipYfield = false;
+    state.skipField = false;
 
     const unmount = () => {
       mounted = false;

--- a/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
@@ -396,7 +396,7 @@ describe('stash/pop', () => {
     expect(elementModel.h).toBe(180 + elementModel.lineWidth);
   });
 
-  test('non-yfield property should not allow stash/pop, and should failed silently ', () => {
+  test('non-field property should not allow stash/pop, and should failed silently ', () => {
     const id = model.addElement({
       type: 'group',
     });


### PR DESCRIPTION
`yfield` -> `field` to reduce concepts of yjs entities
