### PR TITLE
chore(playground): remove legacy share url entry

### DIFF
--- a/packages/framework/store/src/utils/utils.ts
+++ b/packages/framework/store/src/utils/utils.ts
@@ -1,13 +1,9 @@
 import type { z } from 'zod';
 
-import { toBase64 } from 'lib0/buffer.js';
-import * as Y from 'yjs';
-
 import type { BlockModel } from '../schema/base.js';
 import type { BlockSchema } from '../schema/base.js';
 import type { YBlock } from '../store/doc/block/index.js';
 import type { BlockProps } from '../store/doc/block-collection.js';
-import type { DocCollection } from '../store/index.js';
 
 import { SYS_KEYS } from '../consts.js';
 import { native2Y } from '../reactive/index.js';
@@ -40,12 +36,6 @@ export function syncBlockProps(
     // @ts-ignore
     model[key] = native2Y(value);
   });
-}
-
-export function encodeCollectionAsYjsUpdateV2(
-  collection: DocCollection
-): string {
-  return toBase64(Y.encodeStateAsUpdateV2(collection.doc));
 }
 
 export const hash = (str: string) => {

--- a/packages/playground/apps/_common/components/debug-menu.ts
+++ b/packages/playground/apps/_common/components/debug-menu.ts
@@ -24,7 +24,7 @@ import {
   toast,
 } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
-import { type DocCollection, Job, Text, Utils } from '@blocksuite/store';
+import { type DocCollection, Job, Text } from '@blocksuite/store';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
 import '@shoelace-style/shoelace/dist/components/color-picker/color-picker.js';
@@ -369,13 +369,6 @@ export class DebugMenu extends ShadowlessElement {
     window.history.pushState({}, '', url);
   }
 
-  private _shareUrl() {
-    const base64 = Utils.encodeCollectionAsYjsUpdateV2(this.collection);
-    const url = new URL(window.location.toString());
-    url.searchParams.set('init', base64);
-    window.history.pushState({}, '', url);
-  }
-
   private _switchEditorMode() {
     if (!this.editor.host) return;
     const { docModeService } = this.editor.host.spec.getService('affine:page');
@@ -584,9 +577,6 @@ export class DebugMenu extends ShadowlessElement {
               </sl-menu-item>
               <sl-menu-item @click="${this._importNotionHTML}">
                 Import Notion HTML
-              </sl-menu-item>
-              <sl-menu-item @click="${this._shareUrl}">
-                Share URL
               </sl-menu-item>
               <sl-menu-item @click="${this._toggleStyleDebugMenu}">
                 Toggle CSS Debug Menu

--- a/packages/playground/apps/_common/components/quick-edgeless-menu.ts
+++ b/packages/playground/apps/_common/components/quick-edgeless-menu.ts
@@ -6,7 +6,7 @@ import type { AffineEditorContainer } from '@blocksuite/presets';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
 import { EdgelessRootService, printToPdf } from '@blocksuite/blocks';
-import { type DocCollection, Text, Utils } from '@blocksuite/store';
+import { type DocCollection, Text } from '@blocksuite/store';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
@@ -241,13 +241,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
     }
   }
 
-  private _shareUrl() {
-    const base64 = Utils.encodeCollectionAsYjsUpdateV2(this.collection);
-    const url = new URL(window.location.toString());
-    url.searchParams.set('init', base64);
-    window.history.pushState({}, '', url);
-  }
-
   private _switchEditorMode() {
     if (!this.rootService) return;
     this._docMode = this.rootService.docModeService.toggleMode();
@@ -404,9 +397,6 @@ export class QuickEdgelessMenu extends ShadowlessElement {
                     <sl-menu-item @click=${this._importSnapshot}>
                       Import Snapshot
                     </sl-menu-item>
-                    <sl-menu-item @click=${this._shareUrl}>
-                      Share URL</sl-menu-item
-                    >
                     ${this.chatPanel
                       ? html`<sl-menu-item @click=${this._toggleChatPanel}>
                           Toggle Chat Panel


### PR DESCRIPTION
The legacy `Share URL` feature in playground is not maintained to my knowledge.
