### PR TITLE
fix(playground): dark mode style inconsistence

### DIFF
--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -144,7 +144,6 @@ export class AffineEditorContainer
     .playground-page-editor-container {
       flex-grow: 1;
       font-family: var(--affine-font-family);
-      background: var(--affine-background-primary-color);
       display: block;
     }
 


### PR DESCRIPTION
Before:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/71ce25dd-5cca-4bdd-9a64-1795ec5193a8">

After:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/a8913d47-e935-46b0-b0b3-5c23e67363bc">
