### PR TITLE
fix: scale input copy paste on edgeless

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/panel/scale-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/scale-panel.ts
@@ -81,15 +81,18 @@ export class EdgelessScalePanel extends LitElement {
       ${repeat(
         this.scaleList,
         scale => scale,
-        scale =>
-          html`<edgeless-tool-icon-button
+        scale => {
+          const classes = `scale-${scale}`;
+          return html`<edgeless-tool-icon-button
+            class=${classes}
             .iconContainerPadding=${[4, 8]}
             .activeMode=${'background'}
             .active=${this.scale === scale}
             @click=${() => this._onSelect(scale)}
           >
             ${format(scale)}
-          </edgeless-tool-icon-button>`
+          </edgeless-tool-icon-button>`;
+        }
       )}
 
       <input
@@ -103,6 +106,9 @@ export class EdgelessScalePanel extends LitElement {
         @input=${stopPropagation}
         @click=${stopPropagation}
         @pointerdown=${stopPropagation}
+        @cut=${stopPropagation}
+        @copy=${stopPropagation}
+        @paste=${stopPropagation}
       />
     `;
   }

--- a/packages/blocks/src/root-block/edgeless/components/panel/size-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/size-panel.ts
@@ -127,6 +127,9 @@ export class EdgelessSizePanel extends LitElement {
         @input=${stopPropagation}
         @click=${stopPropagation}
         @pointerdown=${stopPropagation}
+        @cut=${stopPropagation}
+        @copy=${stopPropagation}
+        @paste=${stopPropagation}
       />
     `;
   }

--- a/tests/edgeless/note/scale.spec.ts
+++ b/tests/edgeless/note/scale.spec.ts
@@ -1,0 +1,98 @@
+import { type Page, expect } from '@playwright/test';
+import {
+  addNote,
+  locatorScalePanelButton,
+  selectNoteInEdgeless,
+  switchEditorMode,
+  triggerComponentToolbarAction,
+  zoomResetByKeyboard,
+} from 'utils/actions/edgeless.js';
+import {
+  copyByKeyboard,
+  pasteByKeyboard,
+  selectAllByKeyboard,
+} from 'utils/actions/keyboard.js';
+import {
+  enterPlaygroundRoom,
+  initEmptyEdgelessState,
+  waitNextFrame,
+} from 'utils/actions/misc.js';
+import { test } from 'utils/playwright.js';
+
+async function setupAndAddNote(page: Page) {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+  const noteId = await addNote(page, 'hello world', 100, 200);
+  await page.mouse.click(0, 0);
+  return noteId;
+}
+
+async function openScalePanel(page: Page, noteId: string) {
+  await selectNoteInEdgeless(page, noteId);
+  await triggerComponentToolbarAction(page, 'changeNoteScale');
+  await waitNextFrame(page);
+  const scalePanel = page.locator('edgeless-scale-panel');
+  await expect(scalePanel).toBeVisible();
+  return scalePanel;
+}
+
+async function checkNoteScale(
+  page: Page,
+  noteId: string,
+  expectedScale: number
+) {
+  const edgelessNote = page.locator(
+    `affine-edgeless-note[data-block-id="${noteId}"]`
+  );
+  const noteContainer = edgelessNote.locator('.edgeless-note-container');
+  const style = await noteContainer.getAttribute('style');
+  expect(style).toContain(`transform: scale(${expectedScale})`);
+}
+
+test.describe('note scale', () => {
+  test('Note scale can be changed by scale panel button', async ({ page }) => {
+    const noteId = await setupAndAddNote(page);
+    await openScalePanel(page, noteId);
+
+    const scale150 = locatorScalePanelButton(page, 50);
+    await scale150.click();
+
+    await checkNoteScale(page, noteId, 0.5);
+  });
+
+  test('Note scale can be changed by scale panel input', async ({ page }) => {
+    const noteId = await setupAndAddNote(page);
+    const scalePanel = await openScalePanel(page, noteId);
+
+    const scaleInput = scalePanel.locator('.scale-input');
+    await scaleInput.click();
+    await page.keyboard.type('50');
+    await page.keyboard.press('Enter');
+
+    await checkNoteScale(page, noteId, 0.5);
+  });
+
+  test('Note scale input support copy paste', async ({ page }) => {
+    const noteId = await setupAndAddNote(page);
+    const scalePanel = await openScalePanel(page, noteId);
+
+    const scaleInput = scalePanel.locator('.scale-input');
+    await scaleInput.click();
+    await page.keyboard.type('50');
+    await selectAllByKeyboard(page);
+    await copyByKeyboard(page);
+    await page.mouse.click(0, 0);
+
+    await selectNoteInEdgeless(page, noteId);
+    await triggerComponentToolbarAction(page, 'changeNoteScale');
+    await waitNextFrame(page);
+
+    await scaleInput.click();
+    await pasteByKeyboard(page);
+    await page.keyboard.press('Enter');
+
+    await checkNoteScale(page, noteId, 0.5);
+  });
+});

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -721,6 +721,10 @@ export function locatorNoteDisplayModeButton(
     .locator(`.item.${mode}`);
 }
 
+export function locatorScalePanelButton(page: Page, scale: number) {
+  return page.locator('edgeless-scale-panel').locator(`.scale-${scale}`);
+}
+
 export async function changeNoteDisplayMode(page: Page, mode: NoteDisplayMode) {
   const button = locatorNoteDisplayModeButton(page, mode);
   await button.click();
@@ -1001,6 +1005,7 @@ type Action =
   | 'autoSize'
   | 'changeNoteDisplayMode'
   | 'changeNoteSlicerSetting'
+  | 'changeNoteScale'
   | 'addText'
   | 'quickConnect'
   | 'turnIntoLinkedDoc'
@@ -1219,6 +1224,13 @@ export async function triggerComponentToolbarAction(
       const button = locatorComponentToolbar(page)
         .locator('edgeless-change-note-button')
         .getByRole('button', { name: 'Slicer' });
+      await button.click();
+      break;
+    }
+    case 'changeNoteScale': {
+      const button = locatorComponentToolbar(page)
+        .locator('edgeless-change-note-button')
+        .getByRole('button', { name: 'Scale' });
       await button.click();
       break;
     }


### PR DESCRIPTION
[BS-866](https://linear.app/affine-design/issue/BS-866/edgeless-input中的内容无法复制)
[BS-779](https://linear.app/affine-design/issue/BS-779/edgeless-复制手动输入的缩放参数后，粘贴到目标时，会原地创建一个-linked-doc)