### PR TITLE
fix: edgeless pressShiftKeyUpdated slot never trigger

### DIFF
--- a/packages/blocks/src/note-block/keymap-controller.ts
+++ b/packages/blocks/src/note-block/keymap-controller.ts
@@ -481,7 +481,7 @@ export class KeymapController implements ReactiveController {
   bind = () => {
     this.host.handleEvent('keyDown', ctx => {
       const state = ctx.get('keyboardState');
-      if (state.raw.key === 'Shift') {
+      if (['Control', 'Meta', 'Shift'].includes(state.raw.key)) {
         return;
       }
       this._reset();

--- a/packages/framework/block-std/src/event/control/keyboard.ts
+++ b/packages/framework/block-std/src/event/control/keyboard.ts
@@ -39,9 +39,6 @@ export class KeyboardControl {
     ) {
       return false;
     }
-    if (['Control', 'Meta', 'Shift'].includes(event.key)) {
-      return false;
-    }
     return true;
   };
 


### PR DESCRIPTION
[BS-1226](https://linear.app/affine-design/issue/BS-1226/edgeless-下无法触发-shift-keydown-事件)

edgeless pressShiftKeyUpdated slot never triger, which will cause some functions that depend on this slot to not work properly, such as holding down shift to scale certain elements proportionally, like note and embed synced doc.