### PR TITLE
fix: embed block remote selection background should be transparent

### DIFF
--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -70,7 +70,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
             'affine:code',
             'affine:database',
             'affine:image',
-          ]) || !/affine:embed-*/.test(block.flavour)
+          ]) || /affine:embed-*/.test(block.flavour)
         );
       },
       ...config,


### PR DESCRIPTION
fix: [BS-1089](https://linear.app/affine-design/issue/BS-1089/center-peek-的协同选中状态有问题：打开center-peek-后选中状态变成了全选center-peek-视图里的内容)

related: [BS-993](https://linear.app/affine-design/issue/BS-993/协同用户选择整个block时，不需要显示背景色，只需要显示光标铭牌)