### PR TITLE
fix(page): remote cursor is invisible at the line wrap position

### DIFF
--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -123,8 +123,11 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
       const container = this._container;
       const containerRect = this._containerRect;
       const rangeRects = Array.from(range.getClientRects());
-      if (rangeRects.length === 1) {
-        const rect = rangeRects[0];
+      if (rangeRects.length > 0) {
+        const rect =
+          rangeRects.length === 1
+            ? rangeRects[0]
+            : rangeRects[rangeRects.length - 1];
         return {
           width: 2,
           height: rect.height,


### PR DESCRIPTION
During collaboration, the remote cursor is not displayed at the line wrap position. The reason is that in this case, 'range.getClientRects()' returns two 'DOMRect' objects that are not handled in the code.

before:

https://github.com/user-attachments/assets/774ff434-19cd-48da-83ee-b36244902957

after:


https://github.com/user-attachments/assets/29972ae2-6367-4f9f-9ca3-3868dd12c579



