### PR TITLE
fix: mind map radial layout rules

### DIFF
--- a/packages/blocks/src/surface-block/element-model/mindmap.ts
+++ b/packages/blocks/src/surface-block/element-model/mindmap.ts
@@ -156,6 +156,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
       return;
     }
 
+    let splitDir: LayoutType | undefined = undefined;
     const tree = this._tree;
     const splitPoint = tree.children.findIndex((child, index) => {
       if (
@@ -163,13 +164,17 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
         (child.detail.preferredDir === LayoutType.RIGHT &&
           child.children[index + 1]?.detail.preferredDir !== LayoutType.RIGHT)
       ) {
+        splitDir = child.detail.preferredDir;
         return true;
       }
 
       return false;
     });
 
-    if (splitPoint === -1) {
+    if (
+      splitPoint === -1 ||
+      (splitDir === LayoutType.LEFT && splitPoint >= tree.children.length / 2)
+    ) {
       const mid = Math.ceil(tree.children.length / 2);
 
       tree.right.push(...tree.children.slice(0, mid));


### PR DESCRIPTION
Fixes [BS-1229](https://linear.app/affine-design/issue/BS-1229/mind-map-雷达-radial-layout-添加新节点后，布局和顺序都是错误的)
