### PR TITLE
refactor: use .default() to set default value of zod schema

### DIFF
--- a/packages/affine/model/src/consts/connector.ts
+++ b/packages/affine/model/src/consts/connector.ts
@@ -1,0 +1,28 @@
+export enum ConnectorEndpoint {
+  Front = 'Front',
+  Rear = 'Rear',
+}
+
+export enum PointStyle {
+  Arrow = 'Arrow',
+  Circle = 'Circle',
+  Diamond = 'Diamond',
+  None = 'None',
+  Triangle = 'Triangle',
+}
+
+export const DEFAULT_FRONT_END_POINT_STYLE = PointStyle.None;
+export const DEFAULT_REAR_END_POINT_STYLE = PointStyle.Arrow;
+export const CONNECTOR_LABEL_MAX_WIDTH = 280;
+
+export enum ConnectorLabelOffsetAnchor {
+  Bottom = 'bottom',
+  Center = 'center',
+  Top = 'top',
+}
+
+export enum ConnectorMode {
+  Straight,
+  Orthogonal,
+  Curve,
+}

--- a/packages/affine/model/src/consts/index.ts
+++ b/packages/affine/model/src/consts/index.ts
@@ -1,3 +1,4 @@
+export * from './connector.js';
 export * from './line.js';
 export * from './note.js';
 export * from './shape.js';

--- a/packages/affine/model/src/consts/line.ts
+++ b/packages/affine/model/src/consts/line.ts
@@ -1,5 +1,16 @@
 import { createZodUnion } from '../utils/zod.js';
 
+export enum LineWidth {
+  Eight = 8,
+  // Thin
+  Four = 4,
+  Six = 6,
+  // Thick
+  Ten = 10,
+  Twelve = 12,
+  Two = 2,
+}
+
 export enum LineColor {
   Black = '--affine-palette-line-black',
   Blue = '--affine-palette-line-blue',

--- a/packages/affine/model/src/elements/connector/connector.ts
+++ b/packages/affine/model/src/elements/connector/connector.ts
@@ -27,26 +27,19 @@ import {
 import { DocCollection, type Y } from '@blocksuite/store';
 
 import {
+  CONNECTOR_LABEL_MAX_WIDTH,
   type Color,
+  ConnectorLabelOffsetAnchor,
+  ConnectorMode,
   DEFAULT_ROUGHNESS,
   FontFamily,
   FontStyle,
   FontWeight,
+  type PointStyle,
   StrokeStyle,
   TextAlign,
   type TextStyleProps,
 } from '../../consts/index.js';
-
-export enum ConnectorEndpoint {
-  Front = 'Front',
-  Rear = 'Rear',
-}
-
-export type PointStyle = 'None' | 'Arrow' | 'Triangle' | 'Circle' | 'Diamond';
-
-export const DEFAULT_FRONT_END_POINT_STYLE = 'None' as const;
-export const DEFAULT_REAR_END_POINT_STYLE = 'Arrow' as const;
-export const CONNECTOR_LABEL_MAX_WIDTH = 280;
 
 export type SerializedConnection = {
   id?: string;
@@ -60,11 +53,6 @@ export type Connection = {
   position?: [number, number];
 };
 
-export enum ConnectorMode {
-  Straight,
-  Orthogonal,
-  Curve,
-}
 export const getConnectorModeName = (mode: ConnectorMode) => {
   return {
     [ConnectorMode.Straight]: 'Straight',
@@ -72,12 +60,6 @@ export const getConnectorModeName = (mode: ConnectorMode) => {
     [ConnectorMode.Curve]: 'Curve',
   }[mode];
 };
-
-export enum ConnectorLabelOffsetAnchor {
-  Bottom = 'bottom',
-  Center = 'center',
-  Top = 'top',
-}
 
 export type ConnectorLabelOffsetProps = {
   // [0, 1], `0.5` by default

--- a/packages/affine/model/src/elements/connector/local-connector.ts
+++ b/packages/affine/model/src/elements/connector/local-connector.ts
@@ -3,16 +3,15 @@ import type { SerializedXYWH } from '@blocksuite/global/utils';
 
 import { GfxLocalElementModel } from '@blocksuite/block-std/gfx';
 
+import type { PointStyle } from '../../consts/index.js';
+import type { Connection } from './connector.js';
+
 import {
   type Color,
+  ConnectorMode,
   DEFAULT_ROUGHNESS,
   StrokeStyle,
 } from '../../consts/index.js';
-import {
-  type Connection,
-  ConnectorMode,
-  type PointStyle,
-} from './connector.js';
 
 export class LocalConnectorElementModel extends GfxLocalElementModel {
   private _path: PointLocation[] = [];

--- a/packages/affine/shared/src/types/index.ts
+++ b/packages/affine/shared/src/types/index.ts
@@ -11,17 +11,6 @@ export interface EditingState {
 
 export type SelectionPosition = 'start' | 'end' | Point;
 
-export enum LineWidth {
-  Eight = 8,
-  // Thin
-  Four = 4,
-  Six = 6,
-  // Thick
-  Ten = 10,
-  Twelve = 12,
-  Two = 2,
-}
-
 export enum LassoMode {
   FreeHand,
   Polygonal,

--- a/packages/affine/shared/src/utils/index.ts
+++ b/packages/affine/shared/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './reordering.js';
 export * from './string.js';
 export * from './title.js';
 export * from './url.js';
+export * from './zod-schema.js';

--- a/packages/affine/shared/src/utils/zod-schema.ts
+++ b/packages/affine/shared/src/utils/zod-schema.ts
@@ -1,0 +1,187 @@
+import {
+  ConnectorMode,
+  DEFAULT_CONNECTOR_COLOR,
+  DEFAULT_FRONT_END_POINT_STYLE,
+  DEFAULT_NOTE_BACKGROUND_COLOR,
+  DEFAULT_NOTE_SHADOW,
+  DEFAULT_REAR_END_POINT_STYLE,
+  DEFAULT_SHAPE_FILL_COLOR,
+  DEFAULT_SHAPE_STROKE_COLOR,
+  DEFAULT_SHAPE_TEXT_COLOR,
+  DEFAULT_TEXT_COLOR,
+  FillColorsSchema,
+  FontFamily,
+  FontStyle,
+  FontWeight,
+  LineColor,
+  LineColorsSchema,
+  LineWidth,
+  NoteBackgroundColorsSchema,
+  NoteDisplayMode,
+  NoteShadowsSchema,
+  PointStyle,
+  ShapeStyle,
+  ShapeTextFontSize,
+  ShapeType,
+  StrokeColorsSchema,
+  StrokeStyle,
+  TextAlign,
+  TextVerticalAlign,
+} from '@blocksuite/affine-model';
+import { z } from 'zod';
+
+const ConnectorEndpointSchema = z.nativeEnum(PointStyle);
+const StrokeStyleSchema = z.nativeEnum(StrokeStyle);
+const LineWidthSchema = z.nativeEnum(LineWidth);
+const ShapeStyleSchema = z.nativeEnum(ShapeStyle);
+const ShapeTextFontSizeSchema = z.nativeEnum(ShapeTextFontSize);
+const FontFamilySchema = z.nativeEnum(FontFamily);
+const FontWeightSchema = z.nativeEnum(FontWeight);
+const FontStyleSchema = z.nativeEnum(FontStyle);
+const TextAlignSchema = z.nativeEnum(TextAlign);
+const TextVerticalAlignSchema = z.nativeEnum(TextVerticalAlign);
+const ShapeTypeSchema = z.nativeEnum(ShapeType);
+const NoteDisplayModeSchema = z.nativeEnum(NoteDisplayMode);
+
+export const ColorSchema = z.union([
+  z.object({
+    normal: z.string(),
+  }),
+  z.object({
+    light: z.string(),
+    dark: z.string(),
+  }),
+]);
+const LineColorSchema = z.union([LineColorsSchema, ColorSchema]);
+const ShapeFillColorSchema = z.union([FillColorsSchema, ColorSchema]);
+const ShapeStrokeColorSchema = z.union([StrokeColorsSchema, ColorSchema]);
+const TextColorSchema = z.union([z.string(), ColorSchema]);
+const NoteBackgroundColorSchema = z.union([
+  NoteBackgroundColorsSchema,
+  ColorSchema,
+]);
+
+export const ConnectorSchema = z
+  .object({
+    frontEndpointStyle: ConnectorEndpointSchema,
+    rearEndpointStyle: ConnectorEndpointSchema,
+    stroke: LineColorSchema,
+    strokeStyle: StrokeStyleSchema,
+    strokeWidth: LineWidthSchema,
+    rough: z.boolean(),
+    mode: z.number(),
+  })
+  .default({
+    frontEndpointStyle: DEFAULT_FRONT_END_POINT_STYLE,
+    rearEndpointStyle: DEFAULT_REAR_END_POINT_STYLE,
+    stroke: DEFAULT_CONNECTOR_COLOR,
+    strokeStyle: StrokeStyle.Solid,
+    strokeWidth: LineWidth.Two,
+    rough: false,
+    mode: ConnectorMode.Curve,
+  });
+
+export const BrushSchema = z
+  .object({
+    color: LineColorSchema,
+    lineWidth: LineWidthSchema,
+  })
+  .default({
+    color: {
+      dark: LineColor.White,
+      light: LineColor.Black,
+    },
+    lineWidth: LineWidth.Four,
+  });
+
+export const ShapeSchema = z
+  .object({
+    color: TextColorSchema,
+    shapeType: ShapeTypeSchema,
+    fillColor: ShapeFillColorSchema,
+    strokeColor: ShapeStrokeColorSchema,
+    strokeStyle: StrokeStyleSchema,
+    strokeWidth: z.number(),
+    shapeStyle: ShapeStyleSchema,
+    filled: z.boolean(),
+    radius: z.number(),
+    fontSize: ShapeTextFontSizeSchema.optional(),
+    fontFamily: FontFamilySchema.optional(),
+    fontWeight: FontWeightSchema.optional(),
+    fontStyle: FontStyleSchema.optional(),
+    textAlign: TextAlignSchema.optional(),
+    textHorizontalAlign: TextAlignSchema.optional(),
+    textVerticalAlign: TextVerticalAlignSchema.optional(),
+    roughness: z.number().optional(),
+  })
+  .default({
+    color: DEFAULT_SHAPE_TEXT_COLOR,
+    shapeType: ShapeType.Rect,
+    fillColor: DEFAULT_SHAPE_FILL_COLOR,
+    strokeColor: DEFAULT_SHAPE_STROKE_COLOR,
+    strokeStyle: StrokeStyle.Solid,
+    strokeWidth: LineWidth.Two,
+    shapeStyle: ShapeStyle.General,
+    filled: true,
+    radius: 0,
+  });
+
+export const TextSchema = z
+  .object({
+    color: TextColorSchema,
+    fontFamily: FontFamilySchema,
+    textAlign: TextAlignSchema,
+    fontWeight: FontWeightSchema,
+    fontStyle: FontStyleSchema,
+    fontSize: z.number(),
+  })
+  .default({
+    color: DEFAULT_TEXT_COLOR,
+    fontFamily: FontFamily.Inter,
+    textAlign: TextAlign.Left,
+    fontWeight: FontWeight.Regular,
+    fontStyle: FontStyle.Normal,
+    fontSize: 24,
+  });
+
+export const EdgelessTextSchema = z
+  .object({
+    color: TextColorSchema,
+    fontFamily: FontFamilySchema,
+    textAlign: TextAlignSchema,
+    fontWeight: FontWeightSchema,
+    fontStyle: FontStyleSchema,
+  })
+  .default({
+    color: DEFAULT_TEXT_COLOR,
+    fontFamily: FontFamily.Inter,
+    textAlign: TextAlign.Left,
+    fontWeight: FontWeight.Regular,
+    fontStyle: FontStyle.Normal,
+  });
+
+export const NoteSchema = z
+  .object({
+    background: NoteBackgroundColorSchema,
+    displayMode: NoteDisplayModeSchema,
+    edgeless: z.object({
+      style: z.object({
+        borderRadius: z.number(),
+        borderSize: z.number(),
+        borderStyle: StrokeStyleSchema,
+        shadowType: NoteShadowsSchema,
+      }),
+    }),
+  })
+  .default({
+    background: DEFAULT_NOTE_BACKGROUND_COLOR,
+    displayMode: NoteDisplayMode.DocAndEdgeless,
+    edgeless: {
+      style: {
+        borderRadius: 0,
+        borderSize: 4,
+        borderStyle: StrokeStyle.None,
+        shadowType: DEFAULT_NOTE_SHADOW,
+      },
+    },
+  });

--- a/packages/blocks/src/_common/mind-map/draw.ts
+++ b/packages/blocks/src/_common/mind-map/draw.ts
@@ -1,5 +1,6 @@
 import {
   LineColor,
+  PointStyle,
   SHAPE_TEXT_PADDING,
   ShapeFillColor,
   ShapeStyle,
@@ -45,8 +46,8 @@ export const DEFAULT_CONNECTOR_PROPS: Partial<ConnectorElementModel> = {
   mode: ConnectorMode.Orthogonal,
   strokeWidth: 2,
   strokeStyle: StrokeStyle.Solid,
-  frontEndpointStyle: 'None',
-  rearEndpointStyle: 'None',
+  frontEndpointStyle: PointStyle.None,
+  rearEndpointStyle: PointStyle.None,
 };
 export type TreeNode = {
   // element id in edgeless if it already exists

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -80,7 +80,6 @@ export {
   MindmapService,
   MindmapStyle,
   MindmapSurfaceBlock,
-  type PointStyle,
   ShapeElementModel,
   SurfaceBlockModel,
   TextElementModel,

--- a/packages/blocks/src/root-block/edgeless/components/panel/line-styles-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/line-styles-panel.ts
@@ -3,12 +3,11 @@ import {
   DashLineIcon,
   StraightLineIcon,
 } from '@blocksuite/affine-components/icons';
-import { StrokeStyle } from '@blocksuite/affine-model';
+import { type LineWidth, StrokeStyle } from '@blocksuite/affine-model';
 import { html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { LineWidth } from '../../../../_common/types.js';
 import type { LineWidthEvent } from './line-width-panel.js';
 
 export type LineStyleEvent =

--- a/packages/blocks/src/root-block/edgeless/components/panel/line-width-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/line-width-panel.ts
@@ -1,9 +1,8 @@
+import { LineWidth } from '@blocksuite/affine-model';
 import { requestConnectedFrame } from '@blocksuite/affine-shared/utils';
 import { WithDisposable } from '@blocksuite/block-std';
 import { LitElement, type PropertyValues, css, html, nothing } from 'lit';
 import { customElement, property, query, queryAll } from 'lit/decorators.js';
-
-import { LineWidth } from '../../../../_common/types.js';
 
 type DragConfig = {
   stepWidth: number;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/brush/brush-tool-button.ts
@@ -2,7 +2,7 @@ import {
   EdgelessPenDarkIcon,
   EdgelessPenLightIcon,
 } from '@blocksuite/affine-components/icons';
-import { DEFAULT_BRUSH_COLOR } from '@blocksuite/affine-model';
+import { DEFAULT_BRUSH_COLOR, LineWidth } from '@blocksuite/affine-model';
 import { ThemeObserver } from '@blocksuite/affine-shared/theme';
 import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -10,7 +10,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { LastProps } from '../../../../../surface-block/managers/edit-session.js';
 
-import { LineWidth } from '../../../../../_common/utils/index.js';
 import '../../buttons/toolbar-button.js';
 import { getTooltipWithShortcut } from '../../utils.js';
 import {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-tool-button.ts
@@ -4,6 +4,7 @@ import {
 } from '@blocksuite/affine-components/icons';
 import {
   DEFAULT_CONNECTOR_COLOR,
+  LineWidth,
   getConnectorModeName,
 } from '@blocksuite/affine-model';
 import { LitElement, css, html } from 'lit';
@@ -12,7 +13,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import type { LastProps } from '../../../../../surface-block/managers/edit-session.js';
 
-import { LineWidth } from '../../../../../_common/utils/index.js';
 import { ConnectorMode } from '../../../../../surface-block/index.js';
 import '../../buttons/toolbar-button.js';
 import { getTooltipWithShortcut } from '../../utils.js';

--- a/packages/blocks/src/root-block/edgeless/utils/consts.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/consts.ts
@@ -1,11 +1,10 @@
 import {
   DEFAULT_ROUGHNESS,
   LineColor,
+  LineWidth,
   ShapeFillColor,
   StrokeStyle,
 } from '@blocksuite/affine-model';
-
-import { LineWidth } from '../../../_common/types.js';
 
 export const BOOKMARK_MIN_WIDTH = 450;
 

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
@@ -2,6 +2,7 @@ import {
   type BrushProps,
   type ColorScheme,
   LINE_COLORS,
+  LineWidth,
 } from '@blocksuite/affine-model';
 import { WithDisposable } from '@blocksuite/block-std';
 import { countBy, maxBy } from '@blocksuite/global/utils';
@@ -16,7 +17,6 @@ import type { ColorEvent } from '../../edgeless/components/panel/color-panel.js'
 import type { LineWidthEvent } from '../../edgeless/components/panel/line-width-panel.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
-import { LineWidth } from '../../../_common/types.js';
 import {
   packColor,
   packColorsWithColorScheme,

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-connector-button.ts
@@ -1,9 +1,3 @@
-import type {
-  ColorScheme,
-  ConnectorElementProps,
-  ConnectorLabelProps,
-} from '@blocksuite/affine-model';
-
 import {
   AddTextIcon,
   ConnectorCWithArrowIcon,
@@ -24,7 +18,13 @@ import {
   SmallArrowDownIcon,
 } from '@blocksuite/affine-components/icons';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
-import { LINE_COLORS, StrokeStyle } from '@blocksuite/affine-model';
+import {
+  type ColorScheme,
+  type ConnectorElementProps,
+  type ConnectorLabelProps,
+  PointStyle,
+} from '@blocksuite/affine-model';
+import { LINE_COLORS, LineWidth, StrokeStyle } from '@blocksuite/affine-model';
 import { WithDisposable } from '@blocksuite/block-std';
 import { countBy, maxBy } from '@blocksuite/global/utils';
 import { LitElement, type TemplateResult, html, nothing } from 'lit';
@@ -35,12 +35,10 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 
-import type { PointStyle } from '../../../surface-block/index.js';
 import type { EdgelessColorPickerButton } from '../../edgeless/components/color-picker/button.js';
 import type { PickColorEvent } from '../../edgeless/components/color-picker/types.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
-import { LineWidth } from '../../../_common/types.js';
 import {
   type ConnectorElementModel,
   ConnectorEndpoint,
@@ -160,46 +158,46 @@ const STYLE_CHOOSE: [boolean, () => TemplateResult<1>][] = [
 
 const FRONT_ENDPOINT_STYLE_LIST: EndpointStyle[] = [
   {
-    value: 'None',
+    value: PointStyle.None,
     icon: ConnectorEndpointNoneIcon,
   },
   {
-    value: 'Arrow',
+    value: PointStyle.Arrow,
     icon: FrontEndpointArrowIcon,
   },
   {
-    value: 'Triangle',
+    value: PointStyle.Triangle,
     icon: FrontEndpointTriangleIcon,
   },
   {
-    value: 'Circle',
+    value: PointStyle.Circle,
     icon: FrontEndpointCircleIcon,
   },
   {
-    value: 'Diamond',
+    value: PointStyle.Diamond,
     icon: FrontEndpointDiamondIcon,
   },
 ] as const;
 
 const REAR_ENDPOINT_STYLE_LIST: EndpointStyle[] = [
   {
-    value: 'Diamond',
+    value: PointStyle.Diamond,
     icon: RearEndpointDiamondIcon,
   },
   {
-    value: 'Circle',
+    value: PointStyle.Circle,
     icon: RearEndpointCircleIcon,
   },
   {
-    value: 'Triangle',
+    value: PointStyle.Triangle,
     icon: RearEndpointTriangleIcon,
   },
   {
-    value: 'Arrow',
+    value: PointStyle.Arrow,
     icon: RearEndpointArrowIcon,
   },
   {
-    value: 'None',
+    value: PointStyle.None,
     icon: ConnectorEndpointNoneIcon,
   },
 ] as const;

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
   FontFamily,
+  LineWidth,
   SHAPE_FILL_COLORS,
   SHAPE_STROKE_COLORS,
   ShapeStyle,
@@ -35,7 +36,6 @@ import type { EdgelessShapePanel } from '../../edgeless/components/panel/shape-p
 import type { ShapeTool } from '../../edgeless/controllers/tools/shape-tool.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
-import { LineWidth } from '../../../_common/types.js';
 import '../../edgeless/components/color-picker/index.js';
 import {
   packColor,

--- a/packages/blocks/src/surface-block/managers/edit-session.ts
+++ b/packages/blocks/src/surface-block/managers/edit-session.ts
@@ -1,136 +1,25 @@
 import type { BlockService } from '@blocksuite/block-std';
 
 import {
-  ConnectorMode,
-  DEFAULT_CONNECTOR_COLOR,
-  DEFAULT_FRONT_END_POINT_STYLE,
-  DEFAULT_NOTE_BACKGROUND_COLOR,
-  DEFAULT_NOTE_SHADOW,
-  DEFAULT_REAR_END_POINT_STYLE,
-  DEFAULT_SHAPE_FILL_COLOR,
-  DEFAULT_SHAPE_STROKE_COLOR,
-  DEFAULT_SHAPE_TEXT_COLOR,
-  DEFAULT_TEXT_COLOR,
-  FillColorsSchema,
-  FontFamily,
-  FontStyle,
-  FontWeight,
-  LineColorsSchema,
-  NoteBackgroundColorsSchema,
-  NoteDisplayMode,
-  NoteShadowsSchema,
-  ShapeStyle,
-  ShapeTextFontSize,
-  ShapeType,
-  StrokeColorsSchema,
-  StrokeStyle,
-  TextAlign,
-  TextVerticalAlign,
-} from '@blocksuite/affine-model';
-import { LineWidth } from '@blocksuite/affine-shared/types';
+  BrushSchema,
+  ColorSchema,
+  ConnectorSchema,
+  EdgelessTextSchema,
+  NoteSchema,
+  ShapeSchema,
+  TextSchema,
+} from '@blocksuite/affine-shared/utils';
 import { DisposableGroup, Slot } from '@blocksuite/global/utils';
 import { isPlainObject, merge } from 'merge';
 import { z } from 'zod';
 
-import { GET_DEFAULT_LINE_COLOR } from '../../root-block/edgeless/components/panel/color-panel.js';
-
-const ConnectorEndpointSchema = z.enum([
-  'None',
-  'Arrow',
-  'Triangle',
-  'Circle',
-  'Diamond',
-]);
-const StrokeStyleSchema = z.nativeEnum(StrokeStyle);
-const LineWidthSchema = z.nativeEnum(LineWidth);
-const ShapeStyleSchema = z.nativeEnum(ShapeStyle);
-const ShapeTextFontSizeSchema = z.nativeEnum(ShapeTextFontSize);
-const FontFamilySchema = z.nativeEnum(FontFamily);
-const FontWeightSchema = z.nativeEnum(FontWeight);
-const FontStyleSchema = z.nativeEnum(FontStyle);
-const TextAlignSchema = z.nativeEnum(TextAlign);
-const TextVerticalAlignSchema = z.nativeEnum(TextVerticalAlign);
-const ShapeTypeSchema = z.nativeEnum(ShapeType);
-const NoteDisplayModeSchema = z.nativeEnum(NoteDisplayMode);
-
-const ColorSchema = z.union([
-  z.object({
-    normal: z.string(),
-  }),
-  z.object({
-    light: z.string(),
-    dark: z.string(),
-  }),
-]);
-const LineColorSchema = z.union([LineColorsSchema, ColorSchema]);
-const ShapeFillColorSchema = z.union([FillColorsSchema, ColorSchema]);
-const ShapeStrokeColorSchema = z.union([StrokeColorsSchema, ColorSchema]);
-const TextColorSchema = z.union([z.string(), ColorSchema]);
-const NoteBackgroundColorSchema = z.union([
-  NoteBackgroundColorsSchema,
-  ColorSchema,
-]);
-
 const LastPropsSchema = z.object({
-  connector: z.object({
-    frontEndpointStyle: ConnectorEndpointSchema,
-    rearEndpointStyle: ConnectorEndpointSchema,
-    strokeStyle: StrokeStyleSchema,
-    stroke: LineColorSchema,
-    strokeWidth: LineWidthSchema,
-    rough: z.boolean(),
-    mode: z.number().optional(),
-  }),
-  brush: z.object({
-    color: LineColorSchema,
-    lineWidth: LineWidthSchema,
-  }),
-  shape: z.object({
-    shapeType: ShapeTypeSchema,
-    fillColor: ShapeFillColorSchema,
-    strokeColor: ShapeStrokeColorSchema,
-    shapeStyle: ShapeStyleSchema,
-    filled: z.boolean(),
-    radius: z.number(),
-    strokeWidth: z.number().optional(),
-    strokeStyle: StrokeStyleSchema.optional(),
-    color: TextColorSchema.optional(),
-    fontSize: ShapeTextFontSizeSchema.optional(),
-    fontFamily: FontFamilySchema.optional(),
-    fontWeight: FontWeightSchema.optional(),
-    fontStyle: FontStyleSchema.optional(),
-    textAlign: TextAlignSchema.optional(),
-    textHorizontalAlign: TextAlignSchema.optional(),
-    textVerticalAlign: TextVerticalAlignSchema.optional(),
-    roughness: z.number().optional(),
-  }),
-  text: z.object({
-    color: TextColorSchema,
-    fontFamily: FontFamilySchema,
-    textAlign: TextAlignSchema,
-    fontWeight: FontWeightSchema,
-    fontStyle: FontStyleSchema,
-    fontSize: z.number(),
-  }),
-  'affine:edgeless-text': z.object({
-    color: TextColorSchema,
-    fontFamily: FontFamilySchema,
-    textAlign: TextAlignSchema,
-    fontWeight: FontWeightSchema,
-    fontStyle: FontStyleSchema,
-  }),
-  'affine:note': z.object({
-    background: NoteBackgroundColorSchema,
-    displayMode: NoteDisplayModeSchema.optional(),
-    edgeless: z.object({
-      style: z.object({
-        borderRadius: z.number(),
-        borderSize: z.number(),
-        borderStyle: StrokeStyleSchema,
-        shadowType: NoteShadowsSchema,
-      }),
-    }),
-  }),
+  connector: ConnectorSchema,
+  brush: BrushSchema,
+  shape: ShapeSchema,
+  text: TextSchema,
+  'affine:edgeless-text': EdgelessTextSchema,
+  'affine:note': NoteSchema,
 });
 
 export type LastProps = z.infer<typeof LastPropsSchema>;
@@ -185,59 +74,14 @@ export type SerializedViewport = z.infer<
 export class EditPropsStore {
   private _disposables = new DisposableGroup();
 
-  private _lastProps: LastProps = {
-    connector: {
-      frontEndpointStyle: DEFAULT_FRONT_END_POINT_STYLE,
-      rearEndpointStyle: DEFAULT_REAR_END_POINT_STYLE,
-      stroke: DEFAULT_CONNECTOR_COLOR,
-      strokeStyle: StrokeStyle.Solid,
-      strokeWidth: LineWidth.Two,
-      rough: false,
-      mode: ConnectorMode.Curve,
-    },
-    brush: {
-      color: GET_DEFAULT_LINE_COLOR(),
-      lineWidth: LineWidth.Four,
-    },
-    shape: {
-      color: DEFAULT_SHAPE_TEXT_COLOR,
-      shapeType: ShapeType.Rect,
-      fillColor: DEFAULT_SHAPE_FILL_COLOR,
-      strokeColor: DEFAULT_SHAPE_STROKE_COLOR,
-      strokeStyle: StrokeStyle.Solid,
-      strokeWidth: LineWidth.Two,
-      shapeStyle: ShapeStyle.General,
-      filled: true,
-      radius: 0,
-    },
-    text: {
-      color: DEFAULT_TEXT_COLOR,
-      fontFamily: FontFamily.Inter,
-      textAlign: TextAlign.Left,
-      fontWeight: FontWeight.Regular,
-      fontStyle: FontStyle.Normal,
-      fontSize: 24,
-    },
-    'affine:edgeless-text': {
-      color: DEFAULT_TEXT_COLOR,
-      fontFamily: FontFamily.Inter,
-      textAlign: TextAlign.Left,
-      fontWeight: FontWeight.Regular,
-      fontStyle: FontStyle.Normal,
-    },
-    'affine:note': {
-      background: DEFAULT_NOTE_BACKGROUND_COLOR,
-      displayMode: NoteDisplayMode.DocAndEdgeless,
-      edgeless: {
-        style: {
-          borderRadius: 0,
-          borderSize: 4,
-          borderStyle: StrokeStyle.None,
-          shadowType: DEFAULT_NOTE_SHADOW,
-        },
-      },
-    },
-  };
+  private _lastProps: LastProps = LastPropsSchema.parse(
+    Object.entries(LastPropsSchema.shape).reduce((value, [key, schema]) => {
+      return {
+        ...value,
+        [key]: schema.parse(undefined),
+      };
+    }, {})
+  );
 
   slots = {
     lastPropsUpdated: new Slot<{
@@ -337,7 +181,7 @@ export class EditPropsStore {
     const props = this._lastProps[type];
     const overrideProps = extractProps(
       recordProps,
-      LastPropsSchema.shape[type]
+      LastPropsSchema.shape[type]._def.innerType
     );
     if (Object.keys(overrideProps).length === 0) return;
 

--- a/packages/presets/src/__tests__/edgeless/last-props.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/last-props.spec.ts
@@ -54,7 +54,10 @@ describe('apply last props', () => {
   test('brush', () => {
     const id = service.addElement('brush', {});
     const brush = service.getElementById(id) as BrushElementModel;
-    expect(brush.color).toBe('--affine-palette-line-black');
+    expect(brush.color).toEqual({
+      dark: '--affine-palette-line-white',
+      light: '--affine-palette-line-black',
+    });
     expect(brush.lineWidth).toBe(4);
     service.updateElement(id, { lineWidth: 10 });
     const secondBrush = service.getElementById(


### PR DESCRIPTION
### What changed?
- Use `.default()` to set the default value of zod schema.
- Refactor `_lastProps` initialize logic in `edit-session`.
- Move zod schemas to separate `zod-schema` file.
- Move consts to `model/consts` folder.