### PR TITLE
fix: no need to query portal when convert edgeless block to canvas

### DIFF
--- a/packages/blocks/src/_common/export-manager/export-manager.ts
+++ b/packages/blocks/src/_common/export-manager/export-manager.ts
@@ -1,6 +1,6 @@
 import type { BlockService, EditorHost } from '@blocksuite/block-std';
 import type { IBound } from '@blocksuite/global/utils';
-import type { BlockModel, Doc } from '@blocksuite/store';
+import type { Doc } from '@blocksuite/store';
 
 import {
   GroupElementModel,
@@ -18,7 +18,6 @@ import type { GfxBlockModel } from '../../root-block/edgeless/block-model.js';
 import type { EdgelessRootBlockComponent } from '../../root-block/edgeless/edgeless-root-block.js';
 
 import {
-  blockComponentGetter,
   getBlockComponentByModel,
   getRootByEditorHost,
 } from '../../_common/utils/index.js';
@@ -390,13 +389,7 @@ export class ExportManager {
       ) as EdgelessRootBlockComponent;
       const bound = edgeless.getElementsBound();
       assertExists(bound);
-      return this.edgelessToCanvas(
-        edgeless.surface.renderer,
-        bound,
-        (model: BlockModel) =>
-          blockComponentGetter(model, this.editorHost.view),
-        edgeless
-      );
+      return this.edgelessToCanvas(edgeless.surface.renderer, bound, edgeless);
     }
   }
 
@@ -404,7 +397,6 @@ export class ExportManager {
   async edgelessToCanvas(
     surfaceRenderer: Renderer,
     bound: IBound,
-    blockComponentGetter: (model: BlockModel) => Element | null = () => null,
     edgeless?: EdgelessRootBlockComponent,
     nodes?: GfxBlockModel[],
     surfaces?: BlockSuite.SurfaceElementModel[],
@@ -475,11 +467,7 @@ export class ExportManager {
           blockBound.h
         );
       }
-      let blockComponent = blockComponentGetter(block)?.parentElement;
-      if (matchFlavours(block, ['affine:note'])) {
-        blockComponent = blockComponent?.closest('.edgeless-block-portal-note');
-      }
-
+      const blockComponent = this.editorHost.view.getBlock(block.id);
       if (blockComponent) {
         const blockBound = xywhArrayToObject(block);
         const canvasData = await this._html2canvas(
@@ -500,7 +488,7 @@ export class ExportManager {
 
         for (let i = 0; i < blocksInsideFrame.length; i++) {
           const element = blocksInsideFrame[i];
-          const htmlElement = blockComponentGetter(element);
+          const htmlElement = this.editorHost.view.getBlock(block.id);
           const blockBound = xywhArrayToObject(element);
           const canvasData = await html2canvas(htmlElement as HTMLElement);
 

--- a/packages/blocks/src/_common/utils/query.ts
+++ b/packages/blocks/src/_common/utils/query.ts
@@ -1,8 +1,4 @@
-import type {
-  BlockComponent,
-  EditorHost,
-  ViewStore,
-} from '@blocksuite/block-std';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
 import type { Point } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
@@ -28,25 +24,6 @@ export function buildPath(model: BlockModel | null): string[] {
     current = current.doc.getParent(current);
   }
   return path;
-}
-
-export function blockComponentGetter(model: BlockModel, view: ViewStore) {
-  if (matchFlavours(model, ['affine:image', 'affine:frame'])) {
-    let current: BlockModel | null = model;
-    let id: string | null = null;
-    while (current) {
-      // Top level image render under root block not surface block
-      if (!matchFlavours(current, ['affine:surface'])) {
-        id = current.id;
-        break;
-      }
-      current = current.doc.getParent(current);
-    }
-
-    return view.getBlock(id || model.id);
-  } else {
-    return view.getBlock(model.id);
-  }
 }
 
 export function getRootByEditorHost(

--- a/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/clipboard.ts
@@ -14,6 +14,7 @@ import {
   isUrlInClipboard,
   matchFlavours,
 } from '@blocksuite/affine-shared/utils';
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import {
   Bound,
   DisposableGroup,
@@ -40,10 +41,7 @@ import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
 } from '../../../_common/consts.js';
-import {
-  blockComponentGetter,
-  getRootByEditorHost,
-} from '../../../_common/utils/query.js';
+import { getRootByEditorHost } from '../../../_common/utils/query.js';
 import { SurfaceGroupLikeModel } from '../../../surface-block/element-model/base.js';
 import { CanvasElementType } from '../../../surface-block/element-model/index.js';
 import { splitIntoLines } from '../../../surface-block/elements/text/utils.js';
@@ -953,17 +951,12 @@ export class EdgelessClipboardController extends PageClipboard {
       block: BlockSuite.EdgelessBlockModelType,
       isInFrame = false
     ) => {
-      let blockComponent = blockComponentGetter(
-        block,
-        this.std.view
-      )?.parentElement;
-      const blockPortalSelector = block.flavour.replace(
-        'affine:',
-        '.edgeless-block-portal-'
-      );
-      blockComponent = blockComponent?.closest(blockPortalSelector);
+      const blockComponent = this.std.view.getBlock(block.id);
       if (!blockComponent) {
-        throw new Error('Could not find edgeless block portal.');
+        throw new BlockSuiteError(
+          ErrorCode.EdgelessExportError,
+          'Could not find edgeless block component.'
+        );
       }
 
       const blockBound = Bound.deserialize(block.xywh);

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/utils.ts
@@ -6,7 +6,6 @@ import { assertExists } from '@blocksuite/global/utils';
 import type { Renderer } from '../../../surface-block/canvas-renderer/renderer.js';
 import type { SurfaceRefBlockComponent } from '../../../surface-ref-block/surface-ref-block.js';
 
-import { blockComponentGetter } from '../../../_common/utils/query.js';
 import { isTopLevelBlock } from '../../../root-block/edgeless/utils/query.js';
 
 export const edgelessToBlob = async (
@@ -17,7 +16,7 @@ export const edgelessToBlob = async (
     edgelessElement: BlockSuite.EdgelessModel;
   }
 ): Promise<Blob> => {
-  const { edgelessElement, surfaceRefBlock } = options;
+  const { edgelessElement } = options;
   const rootService = host.spec.getService('affine:page');
   const exportManager = rootService.exportManager;
   const bound = Bound.deserialize(edgelessElement.xywh);
@@ -27,7 +26,6 @@ export const edgelessToBlob = async (
     .edgelessToCanvas(
       options.surfaceRenderer,
       bound,
-      model => blockComponentGetter(model, surfaceRefBlock.host.view),
       undefined,
       isBlock ? [edgelessElement] : undefined,
       isBlock ? undefined : [edgelessElement],


### PR DESCRIPTION
To fix: [PD-1632](https://linear.app/affine-design/issue/PD-1632/edgeless-make-it-real-报错)

The to canvas function is still relied on in some whiteboard-related AI functions like make it real and needs to be fixed before switching to the new to png method.

In this pr, remove edgeless portal query and block query function.