### PR TITLE
fix: multiple editor event dispatcher active status

### DIFF
--- a/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/services/tools-manager.ts
@@ -68,6 +68,7 @@ export class EdgelessToolsManager {
   private _mounted = false;
 
   private _onContainerClick = (e: PointerEventState) => {
+    this._updateLastMousePos(e);
     return this.currentController.onContainerClick(e);
   };
 


### PR DESCRIPTION
1. Introduction of a static variable for active Event Dispatcher management
- Added a static variable _activeDispatcher to identify the currently active event dispatcher.
- Ensures that only one event dispatcher is active at any given time.

2. More accurate determination of the current active element's state
 - _isActiveElementOutsideHost and _isEditableElementActive method for better recognition of editable elements outside of current editor host.
- Enhanced conditions for setting the active state in the _setActive method, considering more edge cases

3. Remove deprecated slots.

Fix: 
[BS-713](https://linear.app/affine-design/issue/BS-713/cursor-游离在-edgeless-面板会跟-ai-chat-输入冲突)
[BS-1261](https://linear.app/affine-design/issue/BS-1261/cmd-k-面板搜索时，即使光标不在白板，也会触发白板快捷键)
[BS-1262](https://linear.app/affine-design/issue/BS-1262/全选-block-时，光标移动到编辑区域外，再次-cmda，会选中编辑区域外的文字)