### PR TITLE
fix: new creating mind map node order

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -409,9 +409,10 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           }
 
           const mindmap = elements[0].group as MindmapElementModel;
+          const currentNode = mindmap.getNode(elements[0].id)!;
           const node = mindmap.getNode(elements[0].id)!;
           const parent = mindmap.getParentNode(node.id) ?? node;
-          const id = mindmap.addNode(parent.id);
+          const id = mindmap.addNode(parent.id, currentNode.id, 'after');
           const target = service.getElementById(id) as ShapeElementModel;
 
           requestAnimationFrame(() => {


### PR DESCRIPTION
Fixes [BS-877](https://linear.app/affine-design/issue/BS-877/在-mind-map-子节点上回车创建的-new-node-位置顺序不对)