### PR TITLE
feat: expand mind map dragging responsive area

### DIFF
--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -104,7 +104,7 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
       this.points as [number, number][],
       this.rotate,
       [px, py],
-      (options?.expand ?? 10) / Math.min(options?.zoom ?? 1, 1)
+      (options?.hitThreshold ?? 10) / Math.min(options?.zoom ?? 1, 1)
     );
     return hit;
   }

--- a/packages/affine/model/src/elements/connector/connector.ts
+++ b/packages/affine/model/src/elements/connector/connector.ts
@@ -276,7 +276,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
 
     return (
       Vec.dist(point, currentPoint) <
-      (options?.expand ? strokeWidth / 2 : 0) + 8
+      (options?.hitThreshold ? strokeWidth / 2 : 0) + 8
     );
   }
 

--- a/packages/affine/model/src/elements/shape/api/diamond.ts
+++ b/packages/affine/model/src/elements/shape/api/diamond.ts
@@ -59,7 +59,7 @@ export const diamond = {
     let hit = pointOnPolygonStoke(
       point,
       points,
-      (options?.expand ?? 1) / (options.zoom ?? 1)
+      (options?.hitThreshold ?? 1) / (options.zoom ?? 1)
     );
 
     if (!hit) {

--- a/packages/affine/model/src/elements/shape/api/ellipse.ts
+++ b/packages/affine/model/src/elements/shape/api/ellipse.ts
@@ -49,7 +49,7 @@ export const ellipse = {
     options: PointTestOptions
   ) {
     const point: IVec = [x, y];
-    const expand = (options?.expand ?? 1) / (options?.zoom ?? 1);
+    const expand = (options?.hitThreshold ?? 1) / (options?.zoom ?? 1);
     const rx = this.w / 2;
     const ry = this.h / 2;
     const center: IVec = [this.x + rx, this.y + ry];

--- a/packages/affine/model/src/elements/shape/api/rect.ts
+++ b/packages/affine/model/src/elements/shape/api/rect.ts
@@ -42,12 +42,16 @@ export const rect = {
     options: PointTestOptions
   ) {
     const point: IVec = [x, y];
-    const points = getPointsFromBoundsWithRotation(this);
+    const points = getPointsFromBoundsWithRotation(
+      this,
+      undefined,
+      options.responsePadding
+    );
 
     let hit = pointOnPolygonStoke(
       point,
       points,
-      (options?.expand ?? 1) / (options.zoom ?? 1)
+      (options?.hitThreshold ?? 1) / (options.zoom ?? 1)
     );
 
     if (!hit) {

--- a/packages/affine/model/src/elements/shape/api/triangle.ts
+++ b/packages/affine/model/src/elements/shape/api/triangle.ts
@@ -55,7 +55,7 @@ export const triangle = {
     let hit = pointOnPolygonStoke(
       point,
       points,
-      (options?.expand ?? 1) / (options?.zoom ?? 1)
+      (options?.hitThreshold ?? 1) / (options?.zoom ?? 1)
     );
 
     if (!hit) {

--- a/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/controllers/tools/default-tool.ts
@@ -445,7 +445,10 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
       this._clearMindMapHoverState = [];
 
       const hoveredMindmap = this._service
-        .pickElement(x, y, { all: true, expand: 40 })
+        .pickElement(x, y, {
+          all: true,
+          responsePadding: [25, 60],
+        })
         .filter(
           el =>
             el !== current &&
@@ -764,7 +767,7 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     }
 
     const selected = this._pick(e.x, e.y, {
-      expand: 10,
+      hitThreshold: 10,
     });
     if (!selected) {
       const textFlag = this._edgeless.doc.awarenessStore.getFlag(

--- a/packages/blocks/src/surface-block/element-model/utils/mindmap/utils.ts
+++ b/packages/blocks/src/surface-block/element-model/utils/mindmap/utils.ts
@@ -27,15 +27,21 @@ export function getHoveredArea(
  * @returns
  */
 export function showMergeIndicator(
-  mindmap: MindmapElementModel,
+  targetMindmap: MindmapElementModel,
   /**
    * The hovered node
    */
   target: string | MindmapNode,
+
+  /**
+   * The node that will be merged
+   */
   source: MindmapNode,
   position: [number, number]
 ) {
-  target = mindmap.getNode(typeof target === 'string' ? target : target.id)!;
+  target = targetMindmap.getNode(
+    typeof target === 'string' ? target : target.id
+  )!;
 
   if (!target) {
     return;
@@ -44,24 +50,24 @@ export function showMergeIndicator(
   assertType<MindmapNode>(target);
 
   // the target cannot be the child of source
-  const mergeCheck = (sourceTree: MindmapNode): boolean => {
-    if (!target || !sourceTree) return false;
-    if (target === sourceTree) return false;
+  const mergeCheck = (sourceNode: MindmapNode): boolean => {
+    if (!target || !sourceNode) return false;
+    if (target === sourceNode) return false;
 
-    if (sourceTree.children.length) {
-      return sourceTree.children.every(node => mergeCheck(node));
+    if (sourceNode.children.length) {
+      return sourceNode.children.every(node => mergeCheck(node));
     }
 
     return true;
   };
   const getMergeInfo = () => {
-    const layoutType = mindmap.getLayoutDir(target)!;
+    const layoutType = targetMindmap.getLayoutDir(target)!;
     const hoveredArea = getHoveredArea(
       target.element as ShapeElementModel,
       position,
       layoutType
     );
-    const isRoot = target.id === mindmap.tree.id;
+    const isRoot = target.id === targetMindmap.tree.id;
     const isSibling =
       !isRoot &&
       ((layoutType === LayoutType.RIGHT && hoveredArea.includes('left')) ||
@@ -81,7 +87,7 @@ export function showMergeIndicator(
         };
       }
 
-      const parentNode = mindmap.getParentNode(target.id)!;
+      const parentNode = targetMindmap.getParentNode(target.id)!;
 
       return {
         target: parentNode,
@@ -100,10 +106,10 @@ export function showMergeIndicator(
   }
 
   const mergeInfo = getMergeInfo();
-  const path = mindmap.getPath(mergeInfo.target);
+  const path = targetMindmap.getPath(mergeInfo.target);
   path.push(mergeInfo.index);
-  const style = mindmap.styleGetter.getNodeStyle(source, path);
-  const connector = mindmap['addConnector'](
+  const style = targetMindmap.styleGetter.getNodeStyle(source, path);
+  const connector = targetMindmap['addConnector'](
     mergeInfo.target,
     source,
     mergeInfo.layoutType,
@@ -115,7 +121,7 @@ export function showMergeIndicator(
 
   return {
     clear: () => {
-      mindmap.extraConnectors.delete(connector.id);
+      targetMindmap.extraConnectors.delete(connector.id);
       delete source.overriddenDir;
     },
     mergeInfo,

--- a/packages/framework/block-std/src/gfx/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/element-model.ts
@@ -44,7 +44,15 @@ export type SerializedElement = Record<string, unknown> & {
 };
 
 export interface PointTestOptions {
-  expand?: number;
+  /**
+   * The threshold of the hit test. The unit is pixel.
+   */
+  hitThreshold?: number;
+
+  /**
+   * The padding of the response area for each element when do the hit testing. The unit is pixel.
+   */
+  responsePadding?: [number, number];
 
   /**
    * If true, the transparent area of the element will be ignored during the point inclusion test.
@@ -54,7 +62,6 @@ export interface PointTestOptions {
    */
   ignoreTransparent?: boolean;
 
-  all?: boolean;
   zoom?: number;
 }
 

--- a/packages/framework/global/src/utils/math.ts
+++ b/packages/framework/global/src/utils/math.ts
@@ -72,10 +72,16 @@ export function getPointsFromBoundsWithRotation(
     [x + w, y + h],
     // left-bottom
     [x, y + h],
-  ]
+  ],
+  resPadding: [number, number] = [0, 0]
 ): IVec[] {
   const { rotate } = bounds;
-  let points = getPoints(bounds);
+  let points = getPoints({
+    x: bounds.x - resPadding[1],
+    y: bounds.y - resPadding[0],
+    w: bounds.w + resPadding[1] * 2,
+    h: bounds.h + resPadding[0] * 2,
+  });
 
   if (rotate) {
     const { x, y, w, h } = bounds;


### PR DESCRIPTION
Fixes [BS-1054](https://linear.app/affine-design/issue/BS-1054/mind-map-拖拽同级节点调整顺序的有效触发区域太小)

### Other changes
- rename `expand` to more reasonable `hitThreshold`
- add `responsePadding` on hit test options to allow to expand the elements response area