### PR TITLE
fix: split view edit status conflict

### DIFF
--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -316,7 +316,8 @@ export class AffineFormatBarWidget extends WidgetComponent {
     const readonly = this.doc.awarenessStore.isReadonly(
       this.doc.blockCollection
     );
-    if (readonly) return false;
+    const active = this.host.event.active;
+    if (readonly || !active) return false;
 
     if (
       this.displayType === 'block' &&

--- a/packages/playground/apps/_common/components/debug-menu.ts
+++ b/packages/playground/apps/_common/components/debug-menu.ts
@@ -2,7 +2,6 @@
 import type { DocMode, EdgelessRootService } from '@blocksuite/blocks';
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 import type { DeltaInsert } from '@blocksuite/inline/types';
-import type { AffineEditorContainer, CommentPanel } from '@blocksuite/presets';
 import type { SlDropdown } from '@shoelace-style/shoelace';
 import type { Pane } from 'tweakpane';
 
@@ -24,6 +23,7 @@ import {
   toast,
 } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
+import { AffineEditorContainer, type CommentPanel } from '@blocksuite/presets';
 import { type DocCollection, Job, Text } from '@blocksuite/store';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/button-group/button-group.js';
@@ -399,6 +399,34 @@ export class DebugMenu extends ShadowlessElement {
     this.framePanel.toggleDisplay();
   }
 
+  private _toggleMultipleEditors() {
+    const app = document.querySelector('#app');
+    if (app) {
+      const currentEditorCount = app.querySelectorAll(
+        'affine-editor-container'
+      ).length;
+      if (currentEditorCount === 1) {
+        // Add a second editor
+        const newEditor = document.createElement('affine-editor-container');
+        newEditor.doc = this.doc;
+        app.append(newEditor);
+        app.childNodes.forEach(child => {
+          if (child instanceof AffineEditorContainer) {
+            child.style.flex = '1';
+          }
+        });
+        (app as HTMLElement).style.display = 'flex';
+      } else {
+        // Remove the second editor
+        const secondEditor = app.querySelectorAll('affine-editor-container')[1];
+        if (secondEditor) {
+          secondEditor.remove();
+        }
+        (app as HTMLElement).style.display = 'block';
+      }
+    }
+  }
+
   private _toggleOutlinePanel() {
     this.outlinePanel.toggleDisplay();
   }
@@ -606,6 +634,9 @@ export class DebugMenu extends ShadowlessElement {
                 Toggle Comment Panel
               </sl-menu-item>
               <sl-menu-item @click="${this._addNote}"> Add Note </sl-menu-item>
+              <sl-menu-item @click="${this._toggleMultipleEditors}">
+                Toggle Multiple Editors
+              </sl-menu-item>
             </sl-menu>
           </sl-dropdown>
 

--- a/packages/playground/apps/starter/data/multiple-editor.ts
+++ b/packages/playground/apps/starter/data/multiple-editor.ts
@@ -33,14 +33,10 @@ export const multiEditor: InitFn = (collection: DocCollection, id: string) => {
       target.load();
       editor.doc = target;
     });
+    editor.style.borderRight = '1px solid var(--affine-border-color)';
 
     app.append(editor);
     app.style.display = 'flex';
-    app.childNodes.forEach(node => {
-      if (node instanceof AffineEditorContainer) {
-        node.style.flex = '1';
-      }
-    });
   }
 };
 
@@ -81,7 +77,11 @@ export const multiEditorVertical: InitFn = (
       target.load();
       editor.doc = target;
     });
+    editor.style.borderBottom = '1px solid var(--affine-border-color)';
+
     app.append(editor);
+    app.style.display = 'flex';
+    app.style.flexDirection = 'column';
   }
 };
 

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -129,6 +129,20 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   document.body.append(debugMenu);
   document.body.append(chatPanel);
 
+  // for multiple editor
+  const params = new URLSearchParams(location.search);
+  const init = params.get('init');
+  if (init && init.startsWith('multiple-editor')) {
+    app.childNodes.forEach(node => {
+      if (node instanceof AffineEditorContainer) {
+        node.style.flex = '1';
+        if (init === 'multiple-editor-vertical') {
+          node.style.overflow = 'auto';
+        }
+      }
+    });
+  }
+
   // debug info
   window.editor = editor;
   window.doc = doc;

--- a/tests/multiple-editors/selection.spec.ts
+++ b/tests/multiple-editors/selection.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+
+import { dragBetweenCoords } from '../utils/actions/drag.js';
+import { toggleMultipleEditors } from '../utils/actions/edgeless.js';
+import {
+  enterPlaygroundRoom,
+  initEmptyParagraphState,
+  initThreeParagraphs,
+} from '../utils/actions/misc.js';
+import { getRichTextBoundingBox } from '../utils/actions/selection.js';
+import { test } from '../utils/playwright.js';
+
+test('should only show one format bar when multiple editors are toggled', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await initThreeParagraphs(page);
+  await toggleMultipleEditors(page);
+
+  // Select some text
+  const box123 = await getRichTextBoundingBox(page, '2');
+  const above123 = { x: box123.left + 10, y: box123.top + 2 };
+
+  const box789 = await getRichTextBoundingBox(page, '4');
+  const bottomRight789 = { x: box789.right - 10, y: box789.bottom - 2 };
+
+  await dragBetweenCoords(page, above123, bottomRight789, { steps: 10 });
+
+  // should only show one format bar
+  const formatBar = page.locator('.affine-format-bar-widget');
+  await expect(formatBar).toHaveCount(1);
+});

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -114,6 +114,12 @@ export async function toggleFramePanel(page: Page) {
   await waitNextFrame(page);
 }
 
+export async function toggleMultipleEditors(page: Page) {
+  await page.click('sl-button:text("Test Operations")');
+  await page.click('sl-menu-item:text("Toggle Multiple Editors")');
+  await waitNextFrame(page);
+}
+
 export async function switchEditorMode(page: Page) {
   await page.click('sl-tooltip[content="Switch Editor"]');
   // FIXME: listen to editor loaded event


### PR DESCRIPTION
Fix: [BS-1077](https://linear.app/affine-design/issue/BS-1077/split-view-下编辑器状态冲突)

And:
1. Fix starter playground multiple editors init function.
2. Add a button to toggle multiple editors in playground.