### PR TITLE
fix(edgeless): select all should not select doc only notes

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -1,4 +1,8 @@
-import { EdgelessTextBlockModel, ShapeType } from '@blocksuite/affine-model';
+import {
+  EdgelessTextBlockModel,
+  NoteDisplayMode,
+  ShapeType,
+} from '@blocksuite/affine-model';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { IS_MAC } from '@blocksuite/global/env';
 import { Bound } from '@blocksuite/global/utils';
@@ -274,7 +278,14 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this.rootComponent.service.selection.set({
             elements: [
               ...service.blocks
-                .filter(block => block.group === null)
+                .filter(
+                  block =>
+                    block.group === null &&
+                    !(
+                      matchFlavours(block, ['affine:note']) &&
+                      block.displayMode === NoteDisplayMode.DocOnly
+                    )
+                )
                 .map(block => block.id),
               ...service.elements
                 .filter(el => el.group === null)

--- a/tests/edgeless/selection/keyboard.spec.ts
+++ b/tests/edgeless/selection/keyboard.spec.ts
@@ -1,19 +1,28 @@
+import { NoteDisplayMode } from '@blocksuite/affine-model';
 import { expect } from '@playwright/test';
 
 import * as actions from '../../utils/actions/edgeless.js';
-import { setEdgelessTool } from '../../utils/actions/edgeless.js';
+import {
+  addNote,
+  changeNoteDisplayModeWithId,
+  setEdgelessTool,
+  zoomResetByKeyboard,
+} from '../../utils/actions/edgeless.js';
 import {
   addBasicBrushElement,
   addBasicRectShapeElement,
   dragBetweenCoords,
   enterPlaygroundRoom,
   initEmptyEdgelessState,
+  selectAllByKeyboard,
   switchEditorMode,
 } from '../../utils/actions/index.js';
 import {
   assertEdgelessDraggingArea,
   assertEdgelessNonSelectedRect,
+  assertEdgelessSelectedElementHandleCount,
   assertEdgelessSelectedRect,
+  assertVisibleBlockCount,
 } from '../../utils/asserts.js';
 import { test } from '../../utils/playwright.js';
 
@@ -230,4 +239,27 @@ test('should be able to update selection dragging area after releasing space', a
       },
     }
   );
+});
+
+test('cmd+a should not select doc only note', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+  const note2 = await addNote(page, 'note2', 100, 200);
+  await addNote(page, 'note3', 200, 300);
+  await page.mouse.click(200, 500);
+  // assert add note success, there should be 2 notes in edgeless page
+  await assertVisibleBlockCount(page, 'edgeless-note', 3);
+
+  // change note display mode to doc only
+  await changeNoteDisplayModeWithId(page, note2, NoteDisplayMode.DocOnly);
+  // there should still be 2 notes in edgeless page
+  await assertVisibleBlockCount(page, 'edgeless-note', 2);
+
+  // cmd+a should not select doc only note
+  await selectAllByKeyboard(page);
+  // there should be only 2 notes in selection
+  await assertEdgelessSelectedElementHandleCount(page, 2);
 });

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -298,6 +298,22 @@ export async function assertRowCount(page: Page, count: number) {
   await expect(page.locator('.affine-database-block-row')).toHaveCount(count);
 }
 
+export async function assertVisibleBlockCount(
+  page: Page,
+  flavour: string,
+  count: number
+) {
+  // not only count, but also check if all the blocks are visible
+  const locator = page.locator(`affine-${flavour}`);
+  let visibleCount = 0;
+  for (let i = 0; i < count; i++) {
+    if (await locator.nth(i).isVisible()) {
+      visibleCount++;
+    }
+  }
+  expect(visibleCount).toEqual(count);
+}
+
 export async function assertRichTextInlineRange(
   page: Page,
   richTextIndex: number,
@@ -912,6 +928,15 @@ export async function assertEdgelessSelectedRect(page: Page, xywh: number[]) {
   expect(box.y).toBeCloseTo(y, 0);
   expect(box.width).toBeCloseTo(w, 0);
   expect(box.height).toBeCloseTo(h, 0);
+}
+
+export async function assertEdgelessSelectedElementHandleCount(
+  page: Page,
+  count: number
+) {
+  const editor = getEditorLocator(page);
+  const handles = editor.locator('.element-handle');
+  await expect(handles).toHaveCount(count);
 }
 
 export async function assertEdgelessRemoteSelectedRect(


### PR DESCRIPTION
[BS-1267](https://linear.app/affine-design/issue/BS-1267/在-edgeless-里面全选复制，粘贴到一篇空白的文档，page-only-的内容也会被一起复制)