### PR TITLE
fix(inline): show point styles in link node

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/affine-link.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/affine-link.ts
@@ -61,6 +61,13 @@ export class AffineLink extends ShadowlessElement {
     }
   `;
 
+  // Workaround for links not working in contenteditable div
+  // see also https://stackoverflow.com/questions/12059211/how-to-make-clickable-anchor-in-contenteditable-div
+  //
+  // Note: We cannot use JS to directly open a new page as this may be blocked by the browser.
+  //
+  // Please also note that when readonly mode active,
+  // this workaround is not necessary and links work normally.
   // see https://github.com/toeverything/AFFiNE/issues/1540
   private _onMouseUp() {
     const anchorElement = this.querySelector('a');
@@ -138,13 +145,6 @@ export class AffineLink extends ShadowlessElement {
     return selfInlineRange;
   }
 
-  // Workaround for links not working in contenteditable div
-  // see also https://stackoverflow.com/questions/12059211/how-to-make-clickable-anchor-in-contenteditable-div
-  //
-  // Note: We cannot use JS to directly open a new page as this may be blocked by the browser.
-  //
-  // Please also note that when readonly mode active,
-  // this workaround is not necessary and links work normally.
   get std() {
     const std = this.block.std;
     assertExists(std);

--- a/packages/framework/inline/src/components/v-text.ts
+++ b/packages/framework/inline/src/components/v-text.ts
@@ -18,7 +18,6 @@ export class VText extends LitElement {
         'word-break': 'break-word',
         'text-wrap': 'wrap',
         'white-space-collapse': 'break-spaces',
-        cursor: 'text',
       })}
       data-v-text="true"
       >${this.str}</span


### PR DESCRIPTION
This PR has NOT been thoroughly tested.

Before

<img width="540" alt="Screenshot 2024-08-27 at 18 59 07" src="https://github.com/user-attachments/assets/4df01d13-d0cc-4c11-8989-f8a805c12fdd">


After

https://github.com/user-attachments/assets/600f5e7c-ba87-470d-8c4b-e98901863572

