### PR TITLE
feat: add editorSetting config

### DIFF
--- a/packages/blocks/src/root-block/config/editor-settings.ts
+++ b/packages/blocks/src/root-block/config/editor-settings.ts
@@ -1,0 +1,18 @@
+import {
+  BrushSchema,
+  ConnectorSchema,
+  EdgelessTextSchema,
+  NoteSchema,
+  ShapeSchema,
+} from '@blocksuite/affine-shared/utils';
+import { z } from 'zod';
+
+export const EditorSettingSchema = z.object({
+  connector: ConnectorSchema,
+  brush: BrushSchema,
+  shape: ShapeSchema,
+  'affine:edgeless-text': EdgelessTextSchema,
+  'affine:note': NoteSchema,
+});
+
+export type EditorSetting = z.infer<typeof EditorSettingSchema>;

--- a/packages/blocks/src/root-block/config/index.ts
+++ b/packages/blocks/src/root-block/config/index.ts
@@ -1,0 +1,1 @@
+export * from './editor-settings.js';

--- a/packages/blocks/src/root-block/root-config.ts
+++ b/packages/blocks/src/root-block/root-config.ts
@@ -1,8 +1,13 @@
+import type { DeepPartial } from '@blocksuite/global/utils';
+import type { Signal } from '@lit-labs/preact-signals';
+
+import type { EditorSetting } from './config/index.js';
 import type { ToolbarMoreMenuConfig } from './configs/toolbar.js';
 import type { DocRemoteSelectionConfig } from './widgets/doc-remote-selection/config.js';
 import type { LinkedWidgetConfig } from './widgets/linked-doc/index.js';
 
 export interface RootBlockConfig {
+  editorSetting?: Signal<DeepPartial<EditorSetting>>;
   linkedWidget?: Partial<LinkedWidgetConfig>;
   docRemoteSelectionWidget?: Partial<DocRemoteSelectionConfig>;
   toolbarMoreMenu: Partial<ToolbarMoreMenuConfig>;

--- a/packages/framework/global/src/utils/types.ts
+++ b/packages/framework/global/src/utils/types.ts
@@ -2,3 +2,12 @@
 export type Constructor<T = object, Arguments extends any[] = any[]> = new (
   ...args: Arguments
 ) => T;
+
+// Recursive type to make all properties optional
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object
+    ? T[P] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : DeepPartial<T[P]>
+    : T[P];
+};


### PR DESCRIPTION
### What Changed?
- Add `editorSetting` config in root-block
- `lastProps$` is computed from initProps, editorSetting$ and innerProps$
  - `initProps` is a defalut value
  - `editorSetting$` is a signal passed from AFFiNE
  - `innerProps$` is a signal of internal changes in BlockSuite

Test Config in AFFiNE like:
```typescript
config: {
  editorSetting: signal({
    shape: {
      fillColor: '--affine-palette-shape-purple',
    }
  })
}
```

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/97a2a2d3-2cba-4cf1-98bb-ddafc30f4570.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/97a2a2d3-2cba-4cf1-98bb-ddafc30f4570.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/97a2a2d3-2cba-4cf1-98bb-ddafc30f4570.mov">录屏2024-08-27 19.36.04.mov</video>

