### PR TITLE
feat: add gfx container symbol and interface

### DIFF
--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -15,12 +15,15 @@ export {
 } from './surface/decorators/index.js';
 export {
   type BaseElementProps,
+  type GfxContainerElement,
   type GfxElementGeometry,
   GfxGroupLikeElementModel,
   GfxLocalElementModel,
   GfxPrimitiveElementModel,
   type PointTestOptions,
   type SerializedElement,
+  gfxContainerSymbol,
+  isGfxContainerElm,
 } from './surface/element-model.js';
 export {
   SurfaceBlockModel,

--- a/packages/framework/block-std/src/gfx/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/element-model.ts
@@ -79,6 +79,18 @@ export interface GfxElementGeometry {
   intersectsBound(bound: Bound): boolean;
 }
 
+export const gfxContainerSymbol = Symbol('GfxContainerElement');
+
+export const isGfxContainerElm = (elm: unknown): elm is GfxContainerElement => {
+  return (elm as GfxContainerElement)[gfxContainerSymbol] === true;
+};
+
+export interface GfxContainerElement {
+  [gfxContainerSymbol]: true;
+  childIds: string[];
+  childElements: GfxModel[];
+}
+
 export abstract class GfxPrimitiveElementModel<
   Props extends BaseElementProps = BaseElementProps,
 > implements GfxElementGeometry
@@ -361,13 +373,18 @@ export abstract class GfxPrimitiveElementModel<
 }
 
 export abstract class GfxGroupLikeElementModel<
-  Props extends BaseElementProps = BaseElementProps,
-> extends GfxPrimitiveElementModel<Props> {
+    Props extends BaseElementProps = BaseElementProps,
+  >
+  extends GfxPrimitiveElementModel<Props>
+  implements GfxContainerElement
+{
   private _childBoundCacheKey: string = '';
 
   private _childIds: string[] = [];
 
   private _mutex = createMutex();
+
+  [gfxContainerSymbol] = true as const;
 
   private _updateXYWH() {
     let bound: Bound | undefined;


### PR DESCRIPTION
### Changed
- Add `gfxContainerSymbol` to mark a model as a container
- Add `GfxContainerElement` interface
- Add `isGfxContainerElm` function to determine whether an element is a container