### PR TITLE
fix: edgeless auto connect label position

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
@@ -154,7 +154,7 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
   };
 
   static override styles = css`
-    .edgeless-index-label {
+    .page-visible-index-label {
       box-sizing: border-box;
       padding: 0px 6px;
       border: 1px solid #0000001a;
@@ -240,7 +240,7 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
           alignItems: 'center',
         });
 
-        return html`<div style=${style}>
+        return html`<div style=${style} class="edgeless-only-index-label">
           ${HiddenIcon}
           <affine-tooltip tip-position="bottom">
             ${getIndexLabelTooltip(SmallDocIcon, 'Hidden on page')}
@@ -338,7 +338,7 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
                 transition: 'all 0.1s linear',
               })}
               index=${i}
-              class="edgeless-index-label"
+              class="page-visible-index-label"
               @pointerdown=${(e: PointerEvent) => {
                 stopPropagation(e);
                 this._index = this._index === i ? -1 : i;
@@ -524,10 +524,31 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
         }
       })
     );
+
+    _disposables.add(
+      service.uiEventDispatcher.add('dragStart', () => {
+        this._dragging = true;
+      })
+    );
+    _disposables.add(
+      service.uiEventDispatcher.add('dragEnd', () => {
+        this._dragging = false;
+      })
+    );
+    _disposables.add(
+      service.slots.elementResizeStart.on(() => {
+        this._dragging = true;
+      })
+    );
+    _disposables.add(
+      service.slots.elementResizeEnd.on(() => {
+        this._dragging = false;
+      })
+    );
   }
 
   override render() {
-    if (!this._show) return nothing;
+    if (!this._show || this._dragging) return nothing;
 
     this._updateLabels();
 
@@ -539,6 +560,9 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
       ? this._NavigatorComponent(elements)
       : nothing} `;
   }
+
+  @state()
+  private accessor _dragging = false;
 
   @state()
   private accessor _edgelessOnlyNotesSet = new Set<NoteBlockModel>();

--- a/tests/edgeless/auto-connect.spec.ts
+++ b/tests/edgeless/auto-connect.spec.ts
@@ -1,13 +1,16 @@
-import type { Page } from '@playwright/test';
-
 import { NoteDisplayMode } from '@blocksuite/affine-model';
+import { assertExists } from '@blocksuite/global/utils';
+import { type Page, expect } from '@playwright/test';
 
 import {
   addNote,
   changeNoteDisplayModeWithId,
+  dragBetweenViewCoords,
   edgelessCommonSetup,
+  getNoteBoundBoxInEdgeless,
   getSelectedBound,
   selectNoteInEdgeless,
+  zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
 import { assertSelectedBound } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
@@ -43,7 +46,7 @@ test.describe('auto-connect', () => {
 
     await selectNoteInEdgeless(page, id1);
     const bound = await getSelectedBound(page, 0);
-    await page.locator('.edgeless-index-label').nth(0).click();
+    await page.locator('.page-visible-index-label').nth(0).click();
     await assertSelectedBound(page, bound);
 
     await page.locator('.edgeless-auto-connect-next-button').click();
@@ -55,5 +58,123 @@ test.describe('auto-connect', () => {
     bound[0] += 100;
     bound[1] += 200;
     await assertSelectedBound(page, bound);
+  });
+
+  test('should display index label when select note', async ({ page }) => {
+    await init(page);
+    const id1 = await addNote(page, 'page1', 200, 300);
+    const id2 = await addNote(page, 'page2', 300, 500);
+
+    await page.mouse.click(200, 50);
+
+    await changeNoteDisplayModeWithId(
+      page,
+      id1,
+      NoteDisplayMode.DocAndEdgeless
+    );
+
+    await selectNoteInEdgeless(page, id2);
+    const edgelessOnlyIndexLabel = page.locator('.edgeless-only-index-label');
+    await expect(edgelessOnlyIndexLabel).toBeVisible();
+    await expect(edgelessOnlyIndexLabel).toHaveCount(1);
+
+    await selectNoteInEdgeless(page, id1);
+    const pageVisibleIndexLabel = page.locator('.page-visible-index-label');
+    await expect(pageVisibleIndexLabel).toBeVisible();
+    await expect(pageVisibleIndexLabel).toHaveCount(1);
+  });
+
+  test('should hide index label when dragging note', async ({ page }) => {
+    await init(page);
+    const id1 = await addNote(page, 'page1', 200, 300);
+
+    await page.mouse.click(200, 50);
+
+    await changeNoteDisplayModeWithId(
+      page,
+      id1,
+      NoteDisplayMode.DocAndEdgeless
+    );
+
+    const pageVisibleIndexLabel = page.locator('.page-visible-index-label');
+    await expect(pageVisibleIndexLabel).toBeVisible();
+    await expect(pageVisibleIndexLabel).toHaveCount(1);
+
+    const bound = await getNoteBoundBoxInEdgeless(page, id1);
+    await page.mouse.move(
+      bound.x + bound.width / 2,
+      bound.y + bound.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      bound.x + bound.width * 2,
+      bound.y + bound.height * 2
+    );
+
+    await expect(pageVisibleIndexLabel).not.toBeVisible();
+
+    await page.mouse.up();
+    await expect(pageVisibleIndexLabel).toBeVisible();
+  });
+
+  test('should update index label position after dragging', async ({
+    page,
+  }) => {
+    await init(page);
+    await zoomResetByKeyboard(page);
+
+    const id1 = await addNote(page, 'page1', 200, 300);
+    const id2 = await addNote(page, 'page2', 300, 500);
+
+    await page.mouse.click(200, 50);
+
+    await changeNoteDisplayModeWithId(
+      page,
+      id1,
+      NoteDisplayMode.DocAndEdgeless
+    );
+
+    await selectNoteInEdgeless(page, id2);
+    const edgelessOnlyIndexLabel = page.locator('.edgeless-only-index-label');
+    await expect(edgelessOnlyIndexLabel).toBeVisible();
+
+    // check initial index label position
+    const noteBound = await getNoteBoundBoxInEdgeless(page, id2);
+    const edgelessOnlyIndexLabelBound =
+      await edgelessOnlyIndexLabel.boundingBox();
+    assertExists(edgelessOnlyIndexLabelBound);
+    const border = 1;
+    const offset = 16;
+    expect(edgelessOnlyIndexLabelBound.x).toBeCloseTo(
+      noteBound.x +
+        noteBound.width / 2 -
+        edgelessOnlyIndexLabelBound.width / 2 +
+        border
+    );
+    expect(edgelessOnlyIndexLabelBound.y).toBeCloseTo(
+      noteBound.y + noteBound.height + offset
+    );
+
+    // move note
+    await dragBetweenViewCoords(
+      page,
+      [noteBound.x + noteBound.width / 2, noteBound.y + noteBound.height / 2],
+      [noteBound.x + noteBound.width, noteBound.y + noteBound.height]
+    );
+
+    // check new index label position
+    const newNoteBound = await getNoteBoundBoxInEdgeless(page, id2);
+    const newEdgelessOnlyIndexLabelBound =
+      await edgelessOnlyIndexLabel.boundingBox();
+    assertExists(newEdgelessOnlyIndexLabelBound);
+    expect(newEdgelessOnlyIndexLabelBound.x).toBeCloseTo(
+      newNoteBound.x +
+        newNoteBound.width / 2 -
+        newEdgelessOnlyIndexLabelBound.width / 2 +
+        border
+    );
+    expect(newEdgelessOnlyIndexLabelBound.y).toBeCloseTo(
+      newNoteBound.y + newNoteBound.height + offset
+    );
   });
 });

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -1248,7 +1248,7 @@ export async function assertNotHasClass(locator: Locator, className: string) {
 }
 
 export async function assertNoteSequence(page: Page, expected: string) {
-  const actual = await page.locator('.edgeless-index-label').innerText();
+  const actual = await page.locator('.page-visible-index-label').innerText();
   expect(expected).toBe(actual);
 }
 


### PR DESCRIPTION
[BS-1283](https://linear.app/affine-design/issue/BS-1283/edgeless-only-note-下的-label-没有跟随-note-移动)