### PR TITLE
fix(blocks): should clone groups when creating a new image toolbar instance

### DIFF
--- a/packages/affine/components/src/toolbar/index.ts
+++ b/packages/affine/components/src/toolbar/index.ts
@@ -20,6 +20,7 @@ export type {
   MenuItemGroup,
 } from './types.js';
 export {
+  cloneGroups,
   groupsToActions,
   renderActions,
   renderGroups,

--- a/packages/affine/components/src/toolbar/utils.ts
+++ b/packages/affine/components/src/toolbar/utils.ts
@@ -90,6 +90,10 @@ export function renderActions(
   );
 }
 
+export function cloneGroups<T>(groups: MenuItemGroup<T>[]) {
+  return groups.map(group => ({ ...group, items: [...group.items] }));
+}
+
 export function renderGroups<T>(groups: MenuItemGroup<T>[], context: T) {
   return renderActions(groupsToActions(groups, context));
 }

--- a/packages/blocks/src/attachment-block/components/options.ts
+++ b/packages/blocks/src/attachment-block/components/options.ts
@@ -14,6 +14,7 @@ import {
 import { createLitPortal } from '@blocksuite/affine-components/portal';
 import {
   type MenuItemGroup,
+  cloneGroups,
   renderGroups,
   renderToolbarSeparator,
 } from '@blocksuite/affine-components/toolbar';
@@ -164,9 +165,7 @@ export function AttachmentOptionsTemplate({
     model,
     abortController
   );
-  const groups = context.config.configure(
-    BUILT_IN_GROUPS.map(group => ({ ...group, items: [...group.items] }))
-  );
+  const groups = context.config.configure(cloneGroups(BUILT_IN_GROUPS));
   const moreMenuActions = renderGroups(groups, context);
 
   const buttons = [

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/button.ts
@@ -1,4 +1,7 @@
-import { renderGroups } from '@blocksuite/affine-components/toolbar';
+import {
+  cloneGroups,
+  renderGroups,
+} from '@blocksuite/affine-components/toolbar';
 import { WithDisposable } from '@blocksuite/block-std';
 import { MoreHorizontalIcon, MoreVerticalIcon } from '@blocksuite/icons/lit';
 import { LitElement, html } from 'lit';
@@ -29,9 +32,7 @@ const BUILT_IN_GROUPS = [
 export class EdgelessMoreButton extends WithDisposable(LitElement) {
   override render() {
     const context = new ElementToolbarMoreMenuContext(this.edgeless);
-    const groups = context.config.configure(
-      BUILT_IN_GROUPS.map(group => ({ ...group, items: [...group.items] }))
-    );
+    const groups = context.config.configure(cloneGroups(BUILT_IN_GROUPS));
     const actions = renderGroups(groups, context);
 
     return html`

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -19,6 +19,7 @@ import { toast } from '@blocksuite/affine-components/toast';
 import {
   type MenuItem,
   type MenuItemGroup,
+  cloneGroups,
   renderGroups,
   renderToolbarSeparator,
 } from '@blocksuite/affine-components/toolbar';
@@ -400,9 +401,7 @@ export class EmbedCardToolbar extends WidgetComponent<
 
   private _moreActions() {
     const context = new EmbedCardToolbarContext(this);
-    const groups = context.config.configure(
-      BUILT_IN_GROUPS.map(group => ({ ...group, items: [...group.items] }))
-    );
+    const groups = context.config.configure(cloneGroups(BUILT_IN_GROUPS));
     return renderGroups(groups, context);
   }
 

--- a/packages/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/config.ts
@@ -32,7 +32,10 @@ import {
 } from '@blocksuite/affine-components/icons';
 import { createSimplePortal } from '@blocksuite/affine-components/portal';
 import { toast } from '@blocksuite/affine-components/toast';
-import { renderGroups } from '@blocksuite/affine-components/toolbar';
+import {
+  cloneGroups,
+  renderGroups,
+} from '@blocksuite/affine-components/toolbar';
 import { assertExists } from '@blocksuite/global/utils';
 import { Slice } from '@blocksuite/store';
 import { type TemplateResult, html } from 'lit';
@@ -478,9 +481,7 @@ const BUILT_IN_GROUPS: MenuItemGroup<FormatBarContext>[] = [
 
 export function toolbarMoreButton(toolbar: AffineFormatBarWidget) {
   const context = new FormatBarContext(toolbar);
-  const groups = context.config.configure(
-    BUILT_IN_GROUPS.map(group => ({ ...group, items: [...group.items] }))
-  );
+  const groups = context.config.configure(cloneGroups(BUILT_IN_GROUPS));
   const actions = renderGroups(groups, context);
 
   return html`

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -5,6 +5,7 @@ import type {
 import type { ImageBlockModel } from '@blocksuite/affine-model';
 
 import { HoverController } from '@blocksuite/affine-components/hover';
+import { cloneGroups } from '@blocksuite/affine-components/toolbar';
 import { WidgetComponent } from '@blocksuite/block-std';
 import { limitShift, shift } from '@floating-ui/dom';
 import { html } from 'lit';
@@ -144,9 +145,10 @@ export class AffineImageToolbarWidget extends WidgetComponent<
     return this;
   };
 
-  config: MenuItemGroup<ImageToolbarContext>[] = COMMON_GROUPS;
+  config: MenuItemGroup<ImageToolbarContext>[] = cloneGroups(COMMON_GROUPS);
 
-  moreMenuConfig: MenuItemGroup<ImageToolbarContext>[] = MORE_GROUPS;
+  moreMenuConfig: MenuItemGroup<ImageToolbarContext>[] =
+    cloneGroups(MORE_GROUPS);
 
   override firstUpdated() {
     if (this.doc.getParent(this.model.id)?.flavour === 'affine:surface') {

--- a/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/surface-ref-toolbar/surface-ref-toolbar.ts
@@ -17,6 +17,7 @@ import { toast } from '@blocksuite/affine-components/toast';
 import {
   type MenuItem,
   type MenuItemGroup,
+  cloneGroups,
   renderGroups,
   renderToolbarSeparator,
 } from '@blocksuite/affine-components/toolbar';
@@ -253,9 +254,7 @@ function SurfaceRefToolbarOptions(options: {
   }
 
   const context = new SurfaceRefToolbarContext(block, abortController);
-  const groups = context.config.configure(
-    BUILT_IN_GROUPS.map(group => ({ ...group, items: [...group.items] }))
-  );
+  const groups = context.config.configure(cloneGroups(BUILT_IN_GROUPS));
   const moreMenuActions = renderGroups(groups, context);
 
   const buttons = [


### PR DESCRIPTION
<img width="612" alt="Screenshot 2024-08-28 at 21 05 49" src="https://github.com/user-attachments/assets/5f6503b8-0a1e-448a-89cb-c2f6f97b0ce6">
