### PR TITLE
feat(blocks): configure more menu on image toolbar

### DIFF
--- a/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/components/image-toolbar.ts
@@ -63,6 +63,8 @@ export class AffineImageToolbar extends LitElement {
 
     assertExists(this._moreButton);
 
+    const groups = this.context.config.configure(this.moreMenuConfig);
+
     createLitPortal({
       template: html`
         <editor-menu-content
@@ -74,7 +76,7 @@ export class AffineImageToolbar extends LitElement {
           })}
         >
           <div data-size="large" data-orientation="vertical">
-            ${renderGroups(this.moreMenuConfig, this.context)}
+            ${renderGroups(groups, this.context)}
           </div>
         </editor-menu-content>
       `,

--- a/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/image-toolbar/index.ts
@@ -65,8 +65,8 @@ export class AffineImageToolbarWidget extends WidgetComponent<
         return {
           template: html`<affine-image-toolbar
             .context=${context}
-            .config=${this.config}
-            .moreMenuConfig=${this.moreMenuConfig}
+            .config=${cloneGroups(this.config)}
+            .moreMenuConfig=${cloneGroups(this.moreMenuConfig)}
             .onActiveStatusChange=${(active: boolean) => {
               this._isActivated = active;
               if (!active && !this._hoverController?.isHovering) {


### PR DESCRIPTION
Closes [BS-1247](https://linear.app/affine-design/issue/BS-1247/image-options-copy-link-to-block-button)
<img width="450" alt="Screenshot 2024-08-28 at 21 33 43" src="https://github.com/user-attachments/assets/9b8d9c67-feed-4da6-97bb-f8238a60e732">
