### PR TITLE
refactor(edgeless): remove public usage of `surface.edgeless`

### DIFF
--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -137,7 +137,7 @@ export class EdgelessClipboardController extends PageClipboard {
 
     const elements = getCloneElements(
       this.selectionManager.selectedElements,
-      this.surface.edgeless.service.frame
+      this.edgeless.service.frame
     );
 
     // when note active, handle copy like page mode
@@ -178,10 +178,10 @@ export class EdgelessClipboardController extends PageClipboard {
 
     const elements = getCloneElements(
       this.selectionManager.selectedElements,
-      this.surface.edgeless.service.frame
+      this.edgeless.service.frame
     );
     this.doc.transact(() => {
-      deleteElements(this.surface, elements);
+      deleteElements(this.edgeless, elements);
     });
 
     this.selectionManager.set({
@@ -1205,7 +1205,7 @@ export class EdgelessClipboardController extends PageClipboard {
   }
 
   private get edgeless() {
-    return this.surface.edgeless;
+    return this.host;
   }
 
   private get selectionManager() {

--- a/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
@@ -305,11 +305,11 @@ export class NoteSlicer extends WithDisposable(LitElement) {
       })
     );
 
-    const { surface } = this.edgeless;
+    const { surface } = edgeless;
     requestAnimationFrame(() => {
-      if (surface.isConnected && surface.edgeless.dispatcher) {
+      if (surface.isConnected && edgeless.dispatcher) {
         disposables.add(
-          surface.edgeless.dispatcher.add('click', ctx => {
+          edgeless.dispatcher.add('click', ctx => {
             const event = ctx.get('pointerState');
             const { raw } = event;
             const target = raw.target as HTMLElement;

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-text-editor.ts
@@ -188,7 +188,7 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
           element.display = true;
 
           if (element.text.length === 0) {
-            deleteElements(edgeless.surface, [element]);
+            deleteElements(edgeless, [element]);
           }
 
           edgeless.service.selection.set({

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -559,9 +559,9 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         });
       }
 
-      deleteElements(edgeless.surface, selectedElements);
+      deleteElements(edgeless, selectedElements);
     } else {
-      deleteElements(edgeless.surface, selectedElements);
+      deleteElements(edgeless, selectedElements);
       edgeless.service.selection.clear();
     }
   }

--- a/packages/blocks/src/root-block/edgeless/tools/eraser-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/eraser-tool.ts
@@ -128,7 +128,7 @@ export class EraserToolController extends EdgelessToolController<EraserTool> {
   }
 
   override onContainerDragEnd(): void {
-    deleteElements(this._surface, Array.from(this._eraseTargets));
+    deleteElements(this._edgeless, Array.from(this._eraseTargets));
     this._reset();
     this._doc.captureSync();
   }

--- a/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/clipboard-utils.ts
@@ -28,10 +28,7 @@ export async function duplicate(
   select = true
 ) {
   const { clipboardController } = edgeless;
-  const copyElements = getCloneElements(
-    elements,
-    edgeless.surface.edgeless.service.frame
-  );
+  const copyElements = getCloneElements(elements, edgeless.service.frame);
   const totalBound = edgelessElementsBound(copyElements);
   totalBound.x += totalBound.w + offset;
 

--- a/packages/blocks/src/root-block/edgeless/utils/crud.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/crud.ts
@@ -1,14 +1,14 @@
 import type { Connectable } from '../../../_common/utils/index.js';
-import type { SurfaceBlockComponent } from '../../../surface-block/surface-block.js';
+import type { EdgelessRootBlockComponent } from '../index.js';
 
 import { isConnectable, isNoteBlock } from './query.js';
 
 export function deleteElements(
-  surface: SurfaceBlockComponent,
+  edgeless: EdgelessRootBlockComponent,
   elements: BlockSuite.EdgelessModel[]
 ) {
   const set = new Set(elements);
-  const service = surface.edgeless.service;
+  const { service } = edgeless;
 
   elements.forEach(element => {
     if (isConnectable(element)) {
@@ -19,10 +19,10 @@ export function deleteElements(
 
   set.forEach(element => {
     if (isNoteBlock(element)) {
-      const children = surface.doc.root?.children ?? [];
+      const children = edgeless.doc.root?.children ?? [];
       // FIXME: should always keep at least 1 note
       if (children.length > 1) {
-        surface.doc.deleteBlock(element);
+        edgeless.doc.deleteBlock(element);
       }
     } else {
       service.removeElement(element.id);

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-brush-button.ts
@@ -162,7 +162,7 @@ export class EdgelessChangeBrushButton extends WithDisposable(LitElement) {
   }
 
   get service() {
-    return this.surface.edgeless.service;
+    return this.edgeless.service;
   }
 
   get surface() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/config.ts
@@ -301,7 +301,7 @@ export const conversionsGroup: MenuItemGroup<ElementToolbarMoreMenuContext> = {
       icon: LinkedPageIcon({ width: '20', height: '20' }),
       label: 'Create linked doc',
       type: 'create-linked-doc',
-      action: async ({ doc, selection, service, surface, host }) => {
+      action: async ({ doc, selection, service, surface, edgeless, host }) => {
         const title = await promptDocTitle(host);
         if (title === null) return;
 
@@ -349,7 +349,7 @@ export const conversionsGroup: MenuItemGroup<ElementToolbarMoreMenuContext> = {
         });
         // delete selected elements
         doc.transact(() => {
-          deleteElements(surface, elements);
+          deleteElements(edgeless, elements);
         });
         selection.set({
           elements: [cardId],
@@ -371,9 +371,9 @@ export const deleteGroup: MenuItemGroup<ElementToolbarMoreMenuContext> = {
       icon: DeleteIcon({ width: '20', height: '20' }),
       label: 'Delete',
       type: 'delete',
-      action: ({ doc, selection, selectedElements, surface }) => {
+      action: ({ doc, selection, selectedElements, edgeless }) => {
         doc.captureSync();
-        deleteElements(surface, selectedElements);
+        deleteElements(edgeless, selectedElements);
 
         selection.set({
           elements: [],

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -10,7 +10,6 @@ import type { EdgelessRootBlockComponent } from '../root-block/edgeless/edgeless
 import type { SurfaceBlockModel } from './surface-model.js';
 import type { SurfaceBlockService } from './surface-service.js';
 
-import { isShape } from '../root-block/edgeless/components/auto-complete/utils.js';
 import { FrameOverlay } from '../root-block/edgeless/frame-manager.js';
 import { ConnectorElementModel } from './element-model/index.js';
 import { ConnectionOverlay } from './managers/connector-manager.js';
@@ -33,7 +32,7 @@ export class SurfaceBlockComponent extends BlockComponent<
     };
 
     this._disposables.add(
-      this.edgeless.service.viewport.viewportUpdated.on(() => {
+      this._edgeless.service.viewport.viewportUpdated.on(() => {
         refresh();
       })
     );
@@ -52,8 +51,6 @@ export class SurfaceBlockComponent extends BlockComponent<
   static isConnector = (element: unknown): element is ConnectorElementModel => {
     return element instanceof ConnectorElementModel;
   };
-
-  static isShape = isShape;
 
   static override styles = css`
     .affine-edgeless-surface-block-container {
@@ -118,7 +115,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   `;
 
   fitToViewport = (bound: Bound) => {
-    const { viewport } = this.edgeless.service;
+    const { viewport } = this._edgeless.service;
     bound = bound.expand(30);
     if (Date.now() - this._lastTime > 200)
       this._cachedViewport = viewport.viewportBounds;
@@ -139,15 +136,20 @@ export class SurfaceBlockComponent extends BlockComponent<
     this._renderer?.refresh();
   };
 
+  /** @deprecated */
+  private get _edgeless() {
+    return this.parentComponent as EdgelessRootBlockComponent;
+  }
+
   private _getReversedTransform() {
-    const { translateX, translateY, zoom } = this.edgeless.service.viewport;
+    const { translateX, translateY, zoom } = this._edgeless.service.viewport;
 
     return `scale(${1 / zoom}) translate(${-translateX}px, ${-translateY}px)`;
   }
 
   private _initOverlay() {
     this.overlays = {
-      connector: new ConnectionOverlay(this.edgeless.service),
+      connector: new ConnectionOverlay(this._edgeless.service),
       frame: new FrameOverlay(),
     };
 
@@ -157,7 +159,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   }
 
   private _initRenderer() {
-    const service = this.edgeless.service!;
+    const service = this._edgeless.service!;
 
     this._renderer = new CanvasRenderer({
       viewport: service.viewport,
@@ -241,10 +243,6 @@ export class SurfaceBlockComponent extends BlockComponent<
         <!-- attach canvas later in renderer -->
       </div>
     `;
-  }
-
-  get edgeless() {
-    return this.parentComponent as EdgelessRootBlockComponent;
   }
 
   get renderer() {

--- a/packages/presets/src/__tests__/edgeless/layer.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/layer.spec.ts
@@ -811,7 +811,7 @@ test('indexed canvas should be inserted into edgeless portal when switch to edge
   const edgeless = getDocRootBlock(doc, editor, 'edgeless');
   expect(edgeless.querySelectorAll('.indexable-canvas').length).toBe(1);
 
-  const indexedCanvas = getSurface(doc, editor).edgeless.querySelectorAll(
+  const indexedCanvas = edgeless.querySelectorAll(
     '.indexable-canvas'
   )[0] as HTMLCanvasElement;
 


### PR DESCRIPTION
`surface.edgeless` would be removed after the viewport is migrated under surface.
