### PR TITLE
fix(edgeless): empty group names should not break copy-paste actions

### DIFF
--- a/packages/affine/model/src/elements/group/group.ts
+++ b/packages/affine/model/src/elements/group/group.ts
@@ -31,7 +31,7 @@ export type SerializedGroupElement = SerializedElement & {
 
 export class GroupElementModel extends GfxGroupLikeElementModel<GroupElementProps> {
   static override propsToY(props: Record<string, unknown>) {
-    if (props.title && !(props.title instanceof DocCollection.Y.Text)) {
+    if ('title' in props && !(props.title instanceof DocCollection.Y.Text)) {
       props.title = new DocCollection.Y.Text(props.title as string);
     }
 

--- a/packages/blocks/src/surface-block/renderer/elements/group/utils.ts
+++ b/packages/blocks/src/surface-block/renderer/elements/group/utils.ts
@@ -15,7 +15,7 @@ const TITLE_FONT_SIZE = 16;
 const TITLE_PADDING = [10, 4];
 
 export function titleRenderParams(group: GroupElementModel, zoom: number) {
-  let text = group.title.toJSON();
+  let text = group.title.toString();
   const font = getGroupTitleFont(zoom);
   const lineWidth = getLineWidth(text, font);
   const lineHeight = getLineHeight(


### PR DESCRIPTION
User can edit group name removing the title totally, leaving the input field blank.
Copy-Paste action would deserialize the field into the empty string, not the Y.Text instance and the call of toJson over string type variable would result in "call on undefined" error.
Additionally, the initial fromYProps implementation should consider transforming of the zero length string to the Y.Text instance, because the inline editor expects it to function properly.

<img width="401" alt="image" src="https://github.com/user-attachments/assets/f4d61e15-81b5-45df-aee0-b6560b8d7018">

https://github.com/user-attachments/assets/d1f84b47-f68f-426b-880e-b5500542c04b

