### PR TITLE
feat: add gfx api entry point

### DIFF
--- a/packages/affine/block-surface/src/renderer/canvas-renderer.ts
+++ b/packages/affine/block-surface/src/renderer/canvas-renderer.ts
@@ -221,13 +221,11 @@ export class CanvasRenderer {
   }
 
   private _render() {
-    const { viewportBounds, zoom, cumulativeParentScale } = this.viewport;
+    const { viewportBounds, zoom } = this.viewport;
     const { ctx } = this;
     const dpr = window.devicePixelRatio;
     const scale = zoom * dpr;
-    const matrix = new DOMMatrix()
-      .scaleSelf(scale)
-      .scaleSelf(cumulativeParentScale);
+    const matrix = new DOMMatrix().scaleSelf(scale);
     /**
      * if a layer does not have a corresponding canvas
      * its element will be add to this array and drawing on the

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -392,7 +392,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
   private _initViewport() {
     const { service } = this;
 
-    service.viewport.setContainer(this);
+    service.viewport.setViewportElement(this);
 
     const run = () => {
       const viewport =

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
@@ -163,7 +163,7 @@ export class EdgelessRootPreviewBlockComponent extends BlockComponent<
   }
 
   private _initViewport() {
-    this.service.viewport.setContainer(this);
+    this.service.viewport.setViewportElement(this);
   }
 
   override connectedCallback() {

--- a/packages/blocks/src/root-block/edgeless/utils/panning-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/panning-utils.ts
@@ -10,10 +10,8 @@ export function calPanDelta(
   edgeDistance = 20
 ): IVec | null {
   // Get viewport edge
-  const { left, top, cumulativeParentScale } = viewport;
-  let { width, height } = viewport;
-  width /= cumulativeParentScale;
-  height /= cumulativeParentScale;
+  const { left, top } = viewport;
+  const { width, height } = viewport;
   // Get pointer position
   let { x, y } = e;
   const { containerOffset } = e;

--- a/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
@@ -106,7 +106,7 @@ export class MindmapSurfaceBlock extends BlockComponent<SurfaceBlockModel> {
 
   override firstUpdated(_changedProperties: Map<PropertyKey, unknown>): void {
     this._renderer?.attach(this.editorContainer);
-    this._viewport.setContainer(this.editorContainer);
+    this._viewport.setViewportElement(this.editorContainer);
 
     this._resizeEffect();
     this._setupCenterEffect();

--- a/packages/framework/block-std/src/gfx/controller.ts
+++ b/packages/framework/block-std/src/gfx/controller.ts
@@ -1,0 +1,183 @@
+import type { BlockModel } from '@blocksuite/store';
+
+import {
+  Bound,
+  DisposableGroup,
+  type IBound,
+  last,
+} from '@blocksuite/global/utils';
+
+import type { BlockStdScope } from '../scope/block-std-scope.js';
+import type { SurfaceBlockModel } from './surface/surface-model.js';
+
+import { onSurfaceAdded } from '../utils/gfx.js';
+import { GfxBlockElementModel, type GfxModel } from './gfx-block-model.js';
+import { GridManager } from './grid.js';
+import { LayerManager } from './layer.js';
+import {
+  GfxPrimitiveElementModel,
+  type PointTestOptions,
+} from './surface/element-model.js';
+import { Viewport } from './viewport.js';
+
+export class GfxController {
+  private _disposables: DisposableGroup = new DisposableGroup();
+
+  private _surface: SurfaceBlockModel | null = null;
+
+  readonly grid: GridManager;
+
+  readonly layer: LayerManager;
+
+  std: BlockStdScope;
+
+  readonly viewport: Viewport = new Viewport();
+
+  constructor(std: BlockStdScope) {
+    this.std = std;
+
+    this._disposables.add(
+      onSurfaceAdded(this.doc, surface => {
+        this._surface = surface;
+
+        if (surface) {
+          this._disposables.add(this.grid.watch({ surface }));
+          this.layer.watch({ surface });
+        }
+      })
+    );
+
+    this.grid = new GridManager();
+    this.layer = new LayerManager(this.doc, this.surface);
+
+    this._disposables.add(this.grid.watch({ doc: this.doc }));
+    this._disposables.add(this.layer);
+    this._disposables.add(this.viewport);
+  }
+
+  /**
+   * Get a block or element by its id.
+   * Note that non-gfx block can also be queried in this method.
+   * @param id
+   * @returns
+   */
+  getElementById<
+    T extends GfxModel | BlockModel<object> = GfxModel | BlockModel<object>,
+  >(id: string): T | null {
+    // @ts-ignore
+    return (
+      this.surface?.getElementById(id) ?? this.doc.getBlock(id)?.model ?? null
+    );
+  }
+
+  /**
+   * Get elements on a specific point.
+   * @param x
+   * @param y
+   * @param options
+   */
+  getElementByPoint(
+    x: number,
+    y: number,
+    options: { all: true } & PointTestOptions
+  ): GfxModel[];
+  getElementByPoint(
+    x: number,
+    y: number,
+    options?: { all?: false } & PointTestOptions
+  ): GfxModel | null;
+  getElementByPoint(
+    x: number,
+    y: number,
+    options: PointTestOptions & {
+      all?: boolean;
+    } = { all: false, hitThreshold: 10 }
+  ): GfxModel | GfxModel[] | null {
+    options.zoom = this.viewport.zoom;
+    options.hitThreshold ??= 10;
+
+    const hitThreshold = options.hitThreshold;
+    const responsePadding = options.responsePadding ?? [
+      hitThreshold / 2,
+      hitThreshold / 2,
+    ];
+    const all = options.all ?? false;
+    const hitTestBound = {
+      x: x - responsePadding[1],
+      y: y - responsePadding[0],
+      w: responsePadding[1] * 2,
+      h: responsePadding[0] * 2,
+    };
+
+    const candidates = this.grid.search(hitTestBound);
+    const picked = candidates.filter(
+      elm =>
+        elm.includesPoint(x, y, options as PointTestOptions, this.std.host) ||
+        elm.externalBound?.isPointInBound([x, y])
+    );
+
+    picked.sort(this.layer.compare);
+
+    if (all) {
+      return picked;
+    }
+
+    return last(picked) ?? null;
+  }
+
+  /**
+   * Query all elements in an area.
+   * @param bound
+   * @param options
+   */
+  getElementsByBound(
+    bound: IBound,
+    options: { type: 'canvas' }
+  ): GfxPrimitiveElementModel[];
+  getElementsByBound(
+    bound: IBound,
+    options: { type: 'block' }
+  ): GfxBlockElementModel[];
+  getElementsByBound(
+    bound: IBound,
+    options: { type: 'block' | 'canvas' | 'all' } = {
+      type: 'all',
+    }
+  ): GfxModel[] {
+    bound = bound instanceof Bound ? bound : Bound.from(bound);
+
+    let candidates = this.grid.search(bound);
+
+    if (options.type !== 'all') {
+      const filter =
+        options.type === 'block'
+          ? (elm: GfxModel) => elm instanceof GfxBlockElementModel
+          : (elm: GfxModel) => elm instanceof GfxPrimitiveElementModel;
+
+      candidates = candidates.filter(filter);
+    }
+
+    candidates.sort(this.layer.compare);
+
+    return candidates;
+  }
+
+  getElementsByType(type: string): (GfxModel | BlockModel<object>)[] {
+    return (
+      this.surface?.getElementsByType(type) ??
+      this.doc.getBlocksByFlavour(type).map(b => b.model)
+    );
+  }
+
+  umount() {
+    this._disposables.dispose();
+  }
+
+  get doc() {
+    return this.std.doc;
+  }
+
+  get surface() {
+    return this._surface;
+  }
+}

--- a/packages/framework/block-std/src/gfx/viewport.ts
+++ b/packages/framework/block-std/src/gfx/viewport.ts
@@ -19,8 +19,6 @@ export const ZOOM_MIN = 0.1;
 export class Viewport {
   protected _center: IPoint = { x: 0, y: 0 };
 
-  protected _cumulativeParentScale = 1;
-
   protected _el!: HTMLElement;
 
   protected _height = 0;
@@ -30,8 +28,6 @@ export class Viewport {
   protected _locked = false;
 
   protected _rafId: number | null = null;
-
-  private _syncFlag = false;
 
   protected _top = 0;
 
@@ -93,14 +89,6 @@ export class Viewport {
     });
   }
 
-  setContainer(container: HTMLElement) {
-    const rect = container.getBoundingClientRect();
-
-    this._el = container;
-
-    this.setRect(rect.left, rect.top, rect.width, rect.height);
-  }
-
   setRect(left: number, top: number, width: number, height: number) {
     this._left = left;
     this._top = top;
@@ -156,6 +144,14 @@ export class Viewport {
     ] as IVec;
 
     this.setViewport(zoom, center, smooth);
+  }
+
+  setViewportElement(elm: HTMLElement) {
+    const rect = elm.getBoundingClientRect();
+
+    this._el = elm;
+
+    this.setRect(rect.left, rect.top, rect.width, rect.height);
   }
 
   setZoom(zoom: number, focusPoint?: IPoint) {
@@ -217,45 +213,6 @@ export class Viewport {
     innerSmoothZoom();
   }
 
-  sync(viewport: Viewport) {
-    const syncViewport = (from: Viewport, to: Viewport) => {
-      to._syncFlag = true;
-      to.setZoom(from.zoom);
-      to.setCenter(from.centerX, from.centerY);
-      to._syncFlag = false;
-    };
-    const syncSize = (from: Viewport, to: Viewport) => {
-      to._syncFlag = true;
-      to.setRect(from.left, from.top, from.width, from.height);
-      to._syncFlag = false;
-    };
-
-    const disposables = [
-      viewport.viewportUpdated.on(() => {
-        if (viewport._syncFlag) return;
-        syncViewport(viewport, this);
-      }),
-      this.viewportUpdated.on(() => {
-        if (this._syncFlag) return;
-        syncViewport(this, viewport);
-      }),
-      viewport.sizeUpdated.on(() => {
-        if (viewport._syncFlag) return;
-        syncSize(viewport, this);
-      }),
-      this.sizeUpdated.on(() => {
-        if (this._syncFlag) return;
-        syncSize(this, viewport);
-      }),
-    ];
-
-    syncViewport(viewport, this);
-
-    return () => {
-      disposables.forEach(disposable => disposable.dispose());
-    };
-  }
-
   toModelBound(bound: Bound) {
     const { w, h } = bound;
     const [x, y] = this.toModelCoord(bound.x, bound.y);
@@ -309,13 +266,6 @@ export class Viewport {
     return this._center.y;
   }
 
-  /**
-   * @deprecated
-   */
-  get cumulativeParentScale() {
-    return this._cumulativeParentScale;
-  }
-
   get height() {
     return this._height;
   }
@@ -359,8 +309,8 @@ export class Viewport {
 
     return Bound.from({
       ...viewportMinXY,
-      w: (viewportMaxXY.x - viewportMinXY.x) / this._cumulativeParentScale,
-      h: (viewportMaxXY.y - viewportMinXY.y) / this._cumulativeParentScale,
+      w: viewportMaxXY.x - viewportMinXY.x,
+      h: viewportMaxXY.y - viewportMinXY.y,
     });
   }
 

--- a/packages/framework/block-std/src/utils/gfx.ts
+++ b/packages/framework/block-std/src/utils/gfx.ts
@@ -1,0 +1,33 @@
+import type { Doc } from '@blocksuite/store';
+
+import { effect } from '@lit-labs/preact-signals';
+
+import { SurfaceBlockModel } from '../gfx/index.js';
+
+export function onSurfaceAdded(
+  doc: Doc,
+  callback: (model: SurfaceBlockModel | null) => void
+) {
+  let found = false;
+  let foundId = '';
+
+  const dispose = effect(() => {
+    // if the surface is already found, no need to search again
+    if (found && doc.getBlock(foundId)) {
+      return;
+    }
+
+    for (const block of Object.values(doc.blocks.value)) {
+      if (block.model instanceof SurfaceBlockModel) {
+        callback(block.model);
+        found = true;
+        foundId = block.id;
+      }
+      return;
+    }
+
+    callback(null);
+  });
+
+  return dispose;
+}


### PR DESCRIPTION
### Changed
All basic edgeless APIs should be moved to `GfxController`. Currently, all edgeless APIs are in EdgelessRootService, and they should be progressively migrated.

Now the edgeless APIs can be accessed through `std.gfx.xxx` .