### PR TITLE
refactor(edgeless): remove circular deps from surface to edgeless root

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../surface-block/element-model/index.js';
 import type { SurfaceBlockModel } from '../../surface-block/index.js';
 import type { ReorderingDirection } from '../../surface-block/managers/layer-manager.js';
+import type { SurfaceContext } from '../../surface-block/surface-block.js';
 import type { EdgelessToolConstructor } from './services/tools-manager.js';
 import type { EdgelessTool } from './types.js';
 
@@ -76,7 +77,7 @@ declare module '@blocksuite/blocks' {
   }
 }
 
-export class EdgelessRootService extends RootService {
+export class EdgelessRootService extends RootService implements SurfaceContext {
   private _frame: EdgelessFrameManager;
 
   private _layer: LayerManager;

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -32,7 +32,7 @@ import {
 } from '@blocksuite/global/utils';
 
 import type { Connectable } from '../../_common/types.js';
-import type { EdgelessRootService } from '../../root-block/edgeless/edgeless-root-service.js';
+import type { SurfaceContext } from '../surface-block.js';
 
 import { isConnectorWithLabel } from '../element-model/utils/connector.js';
 import { Overlay } from '../renderer/canvas-renderer.js';
@@ -820,7 +820,7 @@ export class ConnectionOverlay extends Overlay {
 
   targetBounds: IBound | null = null;
 
-  constructor(private _service: EdgelessRootService) {
+  constructor(private _context: SurfaceContext) {
     super();
   }
 
@@ -831,9 +831,9 @@ export class ConnectionOverlay extends Overlay {
   }
 
   private _findConnectablesInViews() {
-    const service = this._service;
-    const bound = this._service.viewport.viewportBounds;
-    return service.pickElementsByBound(bound).filter(ele => ele.connectable);
+    const context = this._context;
+    const bound = context.viewport.viewportBounds;
+    return context.pickElementsByBound(bound).filter(ele => ele.connectable);
   }
 
   clear() {
@@ -843,9 +843,9 @@ export class ConnectionOverlay extends Overlay {
   }
 
   override render(ctx: CanvasRenderingContext2D): void {
-    const zoom = this._service.viewport.zoom;
+    const zoom = this._context.viewport.zoom;
     const radius = 5 / zoom;
-    const color = getComputedStyle(this._service.host).getPropertyValue(
+    const color = getComputedStyle(this._context.host).getPropertyValue(
       '--affine-text-emphasis-color'
     );
 
@@ -894,7 +894,7 @@ export class ConnectionOverlay extends Overlay {
    */
   renderConnector(point: IVec, excludedIds: string[] = []) {
     const connectables = this._findConnectablesInViews();
-    const service = this._service;
+    const context = this._context;
     const target = [];
 
     this._clearRect();
@@ -916,7 +916,7 @@ export class ConnectionOverlay extends Overlay {
       // then check if closes to anchors
       const anchors = getAnchors(connectable);
       const len = anchors.length;
-      const pointerViewCoord = service.viewport.toViewCoord(point[0], point[1]);
+      const pointerViewCoord = context.viewport.toViewCoord(point[0], point[1]);
 
       let shortestDistance = Number.POSITIVE_INFINITY;
       let j = 0;
@@ -925,7 +925,7 @@ export class ConnectionOverlay extends Overlay {
 
       for (; j < len; j++) {
         const anchor = anchors[j];
-        const anchorViewCoord = service.viewport.toViewCoord(
+        const anchorViewCoord = context.viewport.toViewCoord(
           anchor.point[0],
           anchor.point[1]
         );
@@ -972,7 +972,7 @@ export class ConnectionOverlay extends Overlay {
           {
             ignoreTransparent: false,
           },
-          this._service.host
+          this._context.host
         )
       ) {
         target.push(connectable);

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -1,4 +1,7 @@
 import type { Color } from '@blocksuite/affine-model';
+import type { EditorHost, SurfaceSelection } from '@blocksuite/block-std';
+import type { GfxModel, Viewport } from '@blocksuite/block-std/gfx';
+import type { Slot } from '@blocksuite/global/utils';
 
 import { ThemeObserver } from '@blocksuite/affine-shared/theme';
 import { BlockComponent, RANGE_SYNC_EXCLUDE_ATTR } from '@blocksuite/block-std';
@@ -6,7 +9,7 @@ import { Bound, values } from '@blocksuite/global/utils';
 import { css, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 
-import type { EdgelessRootBlockComponent } from '../root-block/edgeless/edgeless-root-block.js';
+import type { LayerManager } from './managers/layer-manager.js';
 import type { SurfaceBlockModel } from './surface-model.js';
 import type { SurfaceBlockService } from './surface-service.js';
 
@@ -15,6 +18,19 @@ import { ConnectorElementModel } from './element-model/index.js';
 import { ConnectionOverlay } from './managers/connector-manager.js';
 import { CanvasRenderer } from './renderer/canvas-renderer.js';
 import { elementRenderers } from './renderer/elements/index.js';
+
+export interface SurfaceContext {
+  viewport: Viewport;
+  layer: LayerManager;
+  host: EditorHost;
+  selection: {
+    selectedIds: string[];
+    slots: {
+      updated: Slot<SurfaceSelection[]>;
+    };
+  };
+  pickElementsByBound: (bound: Bound) => GfxModel[];
+}
 
 @customElement('affine-surface')
 export class SurfaceBlockComponent extends BlockComponent<
@@ -32,7 +48,7 @@ export class SurfaceBlockComponent extends BlockComponent<
     };
 
     this._disposables.add(
-      this._edgeless.service.viewport.viewportUpdated.on(() => {
+      this._context.viewport.viewportUpdated.on(() => {
         refresh();
       })
     );
@@ -115,7 +131,7 @@ export class SurfaceBlockComponent extends BlockComponent<
   `;
 
   fitToViewport = (bound: Bound) => {
-    const { viewport } = this._edgeless.service;
+    const { viewport } = this._context;
     bound = bound.expand(30);
     if (Date.now() - this._lastTime > 200)
       this._cachedViewport = viewport.viewportBounds;
@@ -136,20 +152,19 @@ export class SurfaceBlockComponent extends BlockComponent<
     this._renderer?.refresh();
   };
 
-  /** @deprecated */
-  private get _edgeless() {
-    return this.parentComponent as EdgelessRootBlockComponent;
+  private get _context(): SurfaceContext {
+    return this.parentComponent?.service as unknown as SurfaceContext;
   }
 
   private _getReversedTransform() {
-    const { translateX, translateY, zoom } = this._edgeless.service.viewport;
+    const { translateX, translateY, zoom } = this._context.viewport;
 
     return `scale(${1 / zoom}) translate(${-translateX}px, ${-translateY}px)`;
   }
 
   private _initOverlay() {
     this.overlays = {
-      connector: new ConnectionOverlay(this._edgeless.service),
+      connector: new ConnectionOverlay(this._context),
       frame: new FrameOverlay(),
     };
 
@@ -159,11 +174,9 @@ export class SurfaceBlockComponent extends BlockComponent<
   }
 
   private _initRenderer() {
-    const service = this._edgeless.service!;
-
     this._renderer = new CanvasRenderer({
-      viewport: service.viewport,
-      layerManager: service.layer,
+      viewport: this._context.viewport,
+      layerManager: this._context.layer,
       enableStackingCanvas: true,
       provider: {
         generateColorProperty: (color: Color, fallback: string) =>
@@ -173,7 +186,7 @@ export class SurfaceBlockComponent extends BlockComponent<
         getColorScheme: () => ThemeObserver.mode,
         getPropertyValue: (property: string) =>
           ThemeObserver.getPropertyValue(property),
-        selectedElements: () => service.selection.selectedIds,
+        selectedElements: () => this._context.selection.selectedIds,
       },
       onStackingCanvasCreated(canvas) {
         canvas.className = 'indexable-canvas';
@@ -215,7 +228,7 @@ export class SurfaceBlockComponent extends BlockComponent<
       })
     );
     this._disposables.add(
-      service.selection.slots.updated.on(() => {
+      this._context.selection.slots.updated.on(() => {
         this._renderer.refresh();
       })
     );

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -174,9 +174,10 @@ export class SurfaceBlockComponent extends BlockComponent<
   }
 
   private _initRenderer() {
+    const context = this._context;
     this._renderer = new CanvasRenderer({
-      viewport: this._context.viewport,
-      layerManager: this._context.layer,
+      viewport: context.viewport,
+      layerManager: context.layer,
       enableStackingCanvas: true,
       provider: {
         generateColorProperty: (color: Color, fallback: string) =>
@@ -186,7 +187,7 @@ export class SurfaceBlockComponent extends BlockComponent<
         getColorScheme: () => ThemeObserver.mode,
         getPropertyValue: (property: string) =>
           ThemeObserver.getPropertyValue(property),
-        selectedElements: () => this._context.selection.selectedIds,
+        selectedElements: () => context.selection.selectedIds,
       },
       onStackingCanvasCreated(canvas) {
         canvas.className = 'indexable-canvas';
@@ -228,7 +229,7 @@ export class SurfaceBlockComponent extends BlockComponent<
       })
     );
     this._disposables.add(
-      this._context.selection.slots.updated.on(() => {
+      context.selection.slots.updated.on(() => {
         this._renderer.refresh();
       })
     );


### PR DESCRIPTION
The `SurfaceContext` is added as boundary between surface block and `EdgelessRootService`.

After removing some legacy deps from surface block to root block, we should be able to migrate surface block to a standalone package.
