### PR TITLE
feat: each editor instance has its own independent local selection

### DIFF
--- a/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
+++ b/packages/blocks/src/root-block/remote-color-manager/remote-color-manager.ts
@@ -7,16 +7,16 @@ export class RemoteColorManager {
     const sessionColor =
       this.rootService.editPropsStore.getStorage('remoteColor');
     if (sessionColor) {
-      this.awareness.awareness.setLocalStateField('color', sessionColor);
+      this.awarenessStore.awareness.setLocalStateField('color', sessionColor);
       return;
     }
 
     const pickColor = multiPlayersColor.pick();
-    this.awareness.awareness.setLocalStateField('color', pickColor);
+    this.awarenessStore.awareness.setLocalStateField('color', pickColor);
     this.rootService.editPropsStore.setStorage('remoteColor', pickColor);
   }
 
-  private get awareness() {
+  private get awarenessStore() {
     return this.host.doc.collection.awarenessStore;
   }
 
@@ -25,22 +25,22 @@ export class RemoteColorManager {
   }
 
   get(id: number) {
-    const awarenessColor = this.awareness.getStates().get(id)?.color;
+    const awarenessColor = this.awarenessStore.getStates().get(id)?.color;
     if (awarenessColor) {
       return awarenessColor;
     }
 
-    if (id !== this.awareness.awareness.clientID) return null;
+    if (id !== this.awarenessStore.awareness.clientID) return null;
 
     const sessionColor =
       this.rootService.editPropsStore.getStorage('remoteColor');
     if (sessionColor) {
-      this.awareness.awareness.setLocalStateField('color', sessionColor);
+      this.awarenessStore.awareness.setLocalStateField('color', sessionColor);
       return sessionColor;
     }
 
     const pickColor = multiPlayersColor.pick();
-    this.awareness.awareness.setLocalStateField('color', pickColor);
+    this.awarenessStore.awareness.setLocalStateField('color', pickColor);
     this.rootService.editPropsStore.setStorage('remoteColor', pickColor);
     return pickColor;
   }

--- a/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
+++ b/packages/blocks/src/root-block/widgets/doc-remote-selection/doc-remote-selection.ts
@@ -70,6 +70,9 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
             'affine:code',
             'affine:database',
             'affine:image',
+            'affine:attachment',
+            'affine:bookmark',
+            'affine:surface-ref',
           ]) || /affine:embed-*/.test(block.flavour)
         );
       },

--- a/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/packages/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -182,6 +182,8 @@ export class AffineFormatBarWidget extends WidgetComponent {
       })
     );
     this.disposables.addFromEvent(document, 'selectionchange', () => {
+      if (!this.host.event.active) return;
+
       const databaseSelection = this.host.selection.find('database');
       if (!databaseSelection) {
         return;

--- a/packages/framework/store/src/yjs/awareness.ts
+++ b/packages/framework/store/src/yjs/awareness.ts
@@ -106,10 +106,10 @@ export class AwarenessStore<
   }
 
   getLocalSelection(
-    blockCollection: BlockCollection
+    selectionManagerId: string
   ): ReadonlyArray<Record<string, unknown>> {
     return (
-      (this.awareness.getLocalState()?.selectionV2 ?? {})[blockCollection.id] ??
+      (this.awareness.getLocalState()?.selectionV2 ?? {})[selectionManagerId] ??
       []
     );
   }
@@ -132,14 +132,11 @@ export class AwarenessStore<
     this.awareness.setLocalStateField('flags', { ...oldFlags, [field]: value });
   }
 
-  setLocalSelection(
-    blockCollection: BlockCollection,
-    selection: UserSelection
-  ) {
+  setLocalSelection(selectionManagerId: string, selection: UserSelection) {
     const oldSelection = this.awareness.getLocalState()?.selectionV2 ?? {};
     this.awareness.setLocalStateField('selectionV2', {
       ...oldSelection,
-      [blockCollection.id]: selection,
+      [selectionManagerId]: selection,
     });
   }
 


### PR DESCRIPTION
[BS-1079](https://linear.app/affine-design/issue/BS-1079/同一个页面中的不同-editor-需要区分选区)

1. selection manager adds a unique id identifier. Due to the need to identify selection operations on the same document, a composite ID is required.

   ```
    selectionManager._id = `${this.std.blockCollection.id}:${nanoid()}`;
   ```

2. The logic for distinguishing between local selection and remote selection needs to be changed. Only the selection in selectionV2 that corresponds to the current editor selection manager ID is considered local selection, while selections from other clients are remote selections. Selections managed by different selection managers of the same client, such as in a split view, are neither local nor remote. However, if multiple windows exist with selections, they will be synchronized together to other windows and treated as remote selections for those windows.

    The awareness store also needs to be modified, passing the selectionManagerId when calling getLocalSelection and setLocalSelection.

    ```
    getLocalSelection(
        selectionManagerId: string
     ): ReadonlyArray<Record<string, unknown>> {
        return (
      (this.awareness.getLocalState()?.selectionV2 ?? {})[selectionManagerId] ??
          []
        );
      }

      setLocalSelection(selectionManagerId: string, selection: UserSelection) {
        const oldSelection = this.awareness.getLocalState()?.selectionV2 ?? {};
        this.awareness.setLocalStateField('selectionV2', {
          ...oldSelection,
          [selectionManagerId]: selection,
        });
      }
    ```

3. In some places where the document selectionChange event is directly listened to, checks will be performed, and the selection of editors whose event dispatcher status is not active will not be updated.

4.  Collaboration between selection managers of the same version will not cause any issues. However, when collaborating across different versions, the new version will function normally, but the old version may not be able to properly display the selection from the new version.

    Previously, selectionV2 used blockCollectionId as the key.
Now it uses ${this.std.blockCollection.id}:${nanoid()}.

    Old version selection managers don't have an ID. When setting selection, the key is blockCollectionId.

    New version selection managers have an ID. Key is blockCollectionId:nanoId. Attempts to distinguish user instances by selectionManagerId.

    When old and new clients collaborate on the same blockCollection,
the awareness.state.selectionV2 data might look like this:

    ```
    {
      blockCollectionId: selectionJson,
      blockCollectionId:selection1: selectionJson,
      blockCollectionId:selection2: selectionJson,
    }
    ```

    For old clients, they will only get the selection with the key blockCollectionId under the same client in state selectionV2. Selections with different clientIds but the same blockCollectionId are treated as remoteSelections. In this case, since the new version's key is blockCollectionId:selection1, the old version cannot obtain the remote selection from the new version. 

    For the new version, using selectionManagerId as the key, selections with keys matching selectionManagerId under the same client in state selectionV2 are considered local. Selections from different clients but with keys starting with the same blockCollectionId, are considered remote selections. In this case, new version clients can normally obtain selections from old versions.

