### PR TITLE
feat(edgeless): update frame ui

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-dragging-area-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-dragging-area-rect.ts
@@ -1,5 +1,6 @@
 import { WithDisposable } from '@blocksuite/block-std';
-import { LitElement, css, html, nothing } from 'lit';
+import { cssVarV2 } from '@toeverything/theme/v2';
+import { LitElement, css, html, nothing, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -10,7 +11,16 @@ export class EdgelessDraggingAreaRect extends WithDisposable(LitElement) {
   static override styles = css`
     .affine-edgeless-dragging-area {
       position: absolute;
-      background: var(--affine-hover-color);
+      background: ${unsafeCSS(
+        cssVarV2('edgeless/selection/selectionMarqueeBackground', '#1E96EB14')
+      )};
+      box-sizing: border-box;
+      border-width: 1px;
+      border-style: solid;
+      border-color: ${unsafeCSS(
+        cssVarV2('edgeless/selection/selectionMarqueeBorder', '#1E96EB')
+      )};
+
       z-index: 1;
       pointer-events: none;
     }

--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -147,6 +147,8 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
     this._updateMode();
 
     this.edgeless.slots.elementResizeEnd.emit();
+
+    this.edgeless.service.frameOverlay.clear();
   };
 
   private _onDragMove = (
@@ -1003,6 +1005,7 @@ export class EdgelessSelectedRect extends WithDisposable(LitElement) {
 
     frameManager.removeAllChildrenFromFrame(frame);
     frameManager.addElementsToFrame(frame, newChildren);
+    this.edgeless.service.frameOverlay.highlight(frame, true);
   }
 
   #adjustNote(

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-frame-title-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-frame-title-editor.ts
@@ -8,17 +8,39 @@ import {
 } from '@blocksuite/block-std';
 import { Bound } from '@blocksuite/global/utils';
 import { assertExists } from '@blocksuite/global/utils';
-import { html } from 'lit';
+import { cssVarV2 } from '@toeverything/theme/v2';
+import { css, html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { FrameBlockComponent } from '../../../../frame-block/index.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
+
+import {
+  frameTitleStyleVars,
+  type FrameBlockComponent,
+} from '../../../../frame-block/index.js';
 
 @customElement('edgeless-frame-title-editor')
 export class EdgelessFrameTitleEditor extends WithDisposable(
   ShadowlessElement
 ) {
+  static override styles = css`
+    .frame-title-editor {
+      display: flex;
+      align-items: center;
+      transform-origin: top left;
+      border-radius: 4px;
+      width: fit-content;
+      padding: 0 4px;
+      outline: none;
+      z-index: 1;
+      border: 1px solid var(--affine-primary-color);
+      box-shadow: 0px 0px 0px 2px rgba(30, 150, 235, 0.3);
+      overflow: hidden;
+      font-family: var(--affine-font-family);
+    }
+  `;
+
   private _unmount() {
     // dispose in advance to avoid execute `this.remove()` twice
     this.disposables.dispose();
@@ -94,37 +116,34 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
       model => model !== this.frameModel && model instanceof FrameBlockModel
     );
 
+    const colors = this.frameBlock?.titleElement?.colors ?? {
+      background: cssVarV2('edgeless/frame/background/white'),
+      text: 'var(--affine-text-primary-color)',
+    };
+
     const inlineEditorStyle = styleMap({
-      transformOrigin: 'top left',
-      borderRadius: '4px',
-      width: 'fit-content',
-      maxHeight: '30px',
-      lineHeight: '20px',
-      padding: '4px 10px',
-      fontSize: '14px',
+      fontSize: frameTitleStyleVars.fontSize + 'px',
       position: 'absolute',
-      left: (isInner ? x + 8 : x) + 'px',
-      top: (isInner ? y + 8 : y - 38) + 'px',
+      left: (isInner ? x + 4 : x) + 'px',
+      top: (isInner ? y + 4 : y - (frameTitleStyleVars.height + 8 / 2)) + 'px',
       minWidth: '8px',
-      fontFamily: 'var(--affine-font-family)',
-      background: isInner
-        ? 'var(--affine-white)'
-        : 'var(--affine-text-primary-color)',
-      color: isInner
-        ? 'var(--affine-text-secondary-color)'
-        : 'var(--affine-white)',
-      outline: 'none',
-      zIndex: '1',
-      border: `1px solid
-        var(--affine-primary-color)`,
-      boxShadow: `0px 0px 0px 2px rgba(30, 150, 235, 0.3)`,
+      height: frameTitleStyleVars.height + 'px',
+      background: colors.background,
+      color: colors.text,
     });
-    return html`<rich-text
-      .yText=${this.frameModel.title.yText}
-      .enableFormat=${false}
-      .enableAutoScrollHorizontally=${false}
-      style=${inlineEditorStyle}
-    ></rich-text>`;
+
+    const richTextStyle = styleMap({
+      height: 'fit-content',
+    });
+
+    return html`<div class="frame-title-editor" style=${inlineEditorStyle}>
+      <rich-text
+        .yText=${this.frameModel.title.yText}
+        .enableFormat=${false}
+        .enableAutoScrollHorizontally=${false}
+        style=${richTextStyle}
+      ></rich-text>
+    </div>`;
   }
 
   get editorHost() {
@@ -135,7 +154,6 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
     const block = this.editorHost.view.getBlock(
       this.frameModel.id
     ) as FrameBlockComponent | null;
-    assertExists(block);
     return block;
   }
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -82,7 +82,7 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
 
   overlays: Record<string, Overlay> = {
     connector: new ConnectionOverlay(this.gfx),
-    frame: new FrameOverlay(),
+    frame: new FrameOverlay(this),
   };
 
   slots = {

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -3,15 +3,16 @@ import type { FrameBlockModel } from '@blocksuite/affine-model';
 import type { NoteBlockModel } from '@blocksuite/affine-model';
 import type { Doc } from '@blocksuite/store';
 
-import {
-  GroupElementModel,
-  Overlay,
-  type RoughCanvas,
-} from '@blocksuite/affine-block-surface';
+import { GroupElementModel, Overlay } from '@blocksuite/affine-block-surface';
 import { renderableInEdgeless } from '@blocksuite/affine-block-surface';
 import { isGfxContainerElm } from '@blocksuite/block-std/gfx';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
-import { Bound, DisposableGroup, type IVec } from '@blocksuite/global/utils';
+import {
+  Bound,
+  DisposableGroup,
+  type IVec,
+  deserializeXYWH,
+} from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
 
 import type { EdgelessRootService } from '../../index.js';
@@ -26,27 +27,81 @@ const MIN_FRAME_HEIGHT = 640;
 const FRAME_PADDING = 40;
 
 export class FrameOverlay extends Overlay {
-  bound: Bound | null = null;
+  private _disposable = new DisposableGroup();
+
+  private _frame: FrameBlockModel | null = null;
+
+  private _innerElements: BlockSuite.EdgelessModel[] = [];
+
+  constructor(private _edgelessService: EdgelessRootService) {
+    super();
+  }
+
+  private get _frameManager() {
+    return this._edgelessService.frame;
+  }
+
+  private _reset() {
+    this._disposable.dispose();
+    this._disposable = new DisposableGroup();
+
+    this._frame = null;
+    this._innerElements = [];
+  }
 
   override clear() {
-    this.bound = null;
+    this._reset();
     this._renderer?.refresh();
   }
 
-  highlight(frame: FrameBlockModel) {
-    const bound = Bound.deserialize(frame.xywh);
-    this.bound = bound;
+  highlight(frame: FrameBlockModel, highlightInnerElements: boolean = false) {
+    this._reset();
+    this._disposable.add(
+      frame.deleted.once(() => {
+        this.clear();
+      })
+    );
+
+    this._frame = frame;
+
+    if (highlightInnerElements) {
+      const innerElements = new Set(
+        getTopElements(
+          this._frameManager.getElementsInFrameBound(frame)
+        ).concat(
+          this._frameManager.getChildElementsInFrame(frame).filter(child => {
+            return frame.intersectsBound(child.elementBound);
+          })
+        )
+      );
+
+      this._innerElements = [...innerElements];
+    }
+
     this._renderer?.refresh();
   }
 
-  override render(ctx: CanvasRenderingContext2D, _rc: RoughCanvas): void {
-    if (!this.bound) return;
-    const { x, y, w, h } = this.bound;
+  override render(ctx: CanvasRenderingContext2D): void {
+    if (!this._frame) return;
     ctx.beginPath();
     ctx.strokeStyle = '#1E96EB';
-    ctx.lineWidth = 2;
-    ctx.roundRect(x, y, w, h, 8);
-    ctx.stroke();
+    ctx.lineWidth = 2 / this._edgelessService.viewport.zoom;
+    const radius = 2 / this._edgelessService.viewport.zoom;
+
+    {
+      const { x, y, w, h } = this._frame.elementBound;
+      ctx.roundRect(x, y, w, h, radius);
+      ctx.stroke();
+    }
+
+    this._innerElements.forEach(element => {
+      const [x, y, w, h] = deserializeXYWH(element.xywh);
+      ctx.translate(x + w / 2, y + h / 2);
+      ctx.rotate(element.rotate);
+      ctx.roundRect(-w / 2, -h / 2, w, h, radius);
+      ctx.translate(-x - w / 2, -y - h / 2);
+      ctx.stroke();
+    });
   }
 }
 

--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -1047,8 +1047,20 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     }
   }
 
-  onContainerMouseMove() {
-    noop();
+  onContainerMouseMove(e: PointerEventState) {
+    const hovered = this._pick(e.x, e.y, {
+      hitThreshold: 10,
+    });
+    if (
+      isFrameBlock(hovered) &&
+      hovered.externalBound?.isPointInBound(
+        this._service.viewport.toModelCoord(e.x, e.y)
+      )
+    ) {
+      this._service.frameOverlay.highlight(hovered);
+    } else {
+      this._service.frameOverlay.clear();
+    }
   }
 
   onContainerMouseOut(_: PointerEventState) {

--- a/packages/blocks/src/root-block/edgeless/tools/frame-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/frame-tool.ts
@@ -54,19 +54,22 @@ export class FrameToolController extends EdgelessToolController<FrameTool> {
       });
       this._edgeless.tools.setEdgelessTool({ type: 'default' });
       this._edgeless.service.selection.set({
-        elements: [this._frame.id],
+        elements: [frame.id],
         editing: false,
       });
 
       const frameManager = this._edgeless.service.frame;
-      const elements = frameManager.getElementsInFrameBound(frame);
-
-      frameManager.addElementsToFrame(frame, getTopElements(elements));
+      frameManager.addElementsToFrame(
+        frame,
+        getTopElements(frameManager.getElementsInFrameBound(frame))
+      );
 
       this._doc.captureSync();
     }
+
     this._frame = null;
     this._startPoint = null;
+    this._service.frameOverlay.clear();
   }
 
   override onContainerDragMove(e: PointerEventState): void {
@@ -102,6 +105,8 @@ export class FrameToolController extends EdgelessToolController<FrameTool> {
     this._service.updateElement(this._frame.id, {
       xywh: Bound.fromPoints([this._startPoint, currentPoint]).serialize(),
     });
+
+    this._service.frameOverlay.highlight(this._frame, true);
   }
 
   override onContainerDragStart(e: PointerEventState): void {

--- a/packages/presets/src/__tests__/edgeless/frame.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/frame.spec.ts
@@ -102,11 +102,14 @@ describe('frame', () => {
       bodyRect.y + bodyRect.height / 2
     ) as HTMLElement;
 
-    expect(pointDom1.className, 'Frame title should be on top').toBe(
-      'affine-frame-title'
-    );
-    expect(pointDom2.className, 'Frame body should be on bottom').toBe(
-      'affine-note-mask'
-    );
+    expect(
+      frameTitle.contains(pointDom1),
+      'Frame title should be on top'
+    ).toBeTruthy();
+
+    expect(
+      frameBody.contains(pointDom2),
+      'Frame body should be on bottom'
+    ).toBeFalsy();
   });
 });

--- a/tests/edgeless/frame.spec.ts
+++ b/tests/edgeless/frame.spec.ts
@@ -1,0 +1,665 @@
+import { type Page, expect } from '@playwright/test';
+import { waitNextFrame } from 'utils/actions/misc.js';
+
+import { clickView, dblclickView, moveView } from '../utils/actions/click.js';
+import {
+  Shape,
+  addNote,
+  autoFit,
+  createShapeElement,
+  dragBetweenViewCoords,
+  edgelessCommonSetup,
+  getSelectedBound,
+  getSelectedBoundCount,
+  setEdgelessTool,
+  shiftClickView,
+  toViewCoord,
+  triggerComponentToolbarAction,
+  zoomInByKeyboard,
+  zoomOutByKeyboard,
+  zoomResetByKeyboard,
+} from '../utils/actions/edgeless.js';
+import {
+  SHORT_KEY,
+  copyByKeyboard,
+  pasteByKeyboard,
+  pressBackspace,
+  pressEnter,
+  pressEscape,
+  selectAllByKeyboard,
+  type,
+} from '../utils/actions/keyboard.js';
+import {
+  assertEdgelessCanvasText,
+  assertRichTexts,
+  assertSelectedBound,
+} from '../utils/asserts.js';
+import { test } from '../utils/playwright.js';
+
+test.beforeEach(async ({ page }) => {
+  await edgelessCommonSetup(page);
+  await zoomResetByKeyboard(page);
+});
+
+test.describe('frame', () => {
+  test.describe('add a frame then drag to move', () => {
+    const createThreeShapesAndSelectTowShape = async (page: Page) => {
+      await createShapeElement(page, [0, 0], [100, 100], Shape.Square);
+      await createShapeElement(page, [100, 0], [200, 100], Shape.Square);
+      await createShapeElement(page, [200, 0], [300, 100], Shape.Square);
+
+      await clickView(page, [50, 50]);
+      await shiftClickView(page, [150, 50]);
+    };
+
+    const assertFrameHasTwoShapeChildren = async (page: Page) => {
+      await page.waitForTimeout(500);
+      await dragBetweenViewCoords(page, [50, 50], [100, 50]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [50, 0, 100, 100], 0);
+      await assertSelectedBound(page, [150, 0, 100, 100], 1);
+      // the third shape should not be moved
+      await assertSelectedBound(page, [200, 0, 100, 100], 2);
+    };
+
+    test('multi select and add frame by shortcut F', async ({ page }) => {
+      await createThreeShapesAndSelectTowShape(page);
+      await page.keyboard.press('f');
+
+      await expect(page.locator('affine-frame')).toHaveCount(1);
+      await assertSelectedBound(page, [-300, -270, 800, 640]);
+
+      await assertFrameHasTwoShapeChildren(page);
+    });
+
+    test('multi select and add frame by component toolbar', async ({
+      page,
+    }) => {
+      await createThreeShapesAndSelectTowShape(page);
+      await triggerComponentToolbarAction(page, 'addFrame');
+
+      await expect(page.locator('affine-frame')).toHaveCount(1);
+      await assertSelectedBound(page, [-300, -270, 800, 640]);
+
+      await assertFrameHasTwoShapeChildren(page);
+    });
+
+    test('multi select and add frame by more option create frame', async ({
+      page,
+    }) => {
+      await createThreeShapesAndSelectTowShape(page);
+      await triggerComponentToolbarAction(page, 'createFrameOnMoreOption');
+
+      await expect(page.locator('affine-frame')).toHaveCount(1);
+      await assertSelectedBound(page, [-300, -270, 800, 640]);
+
+      await assertFrameHasTwoShapeChildren(page);
+    });
+
+    test('multi select add frame by edgeless toolbar', async ({ page }) => {
+      await createThreeShapesAndSelectTowShape(page);
+      await autoFit(page);
+      await setEdgelessTool(page, 'frame');
+      const frameMenu = page.locator('edgeless-frame-menu');
+      await expect(frameMenu).toBeVisible();
+      const button = page.locator('.frame-add-button[data-name="1:1"]');
+      await button.click();
+      await assertSelectedBound(page, [-450, -550, 1200, 1200]);
+
+      await dragBetweenViewCoords(page, [50, 50], [100, 50]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [50, 0, 100, 100], 0);
+      await assertSelectedBound(page, [150, 0, 100, 100], 1);
+      // the third shape should be moved
+      await assertSelectedBound(page, [250, 0, 100, 100], 2);
+    });
+
+    test('add frame by dragging with shortcut F', async ({ page }) => {
+      await createThreeShapesAndSelectTowShape(page);
+      await pressEscape(page); // unselect
+
+      await page.keyboard.press('f');
+      await dragBetweenViewCoords(page, [-10, -10], [210, 110]);
+      await waitNextFrame(page, 100);
+
+      await expect(page.locator('affine-frame')).toHaveCount(1);
+      await assertSelectedBound(page, [-10, -10, 220, 120]);
+
+      await assertFrameHasTwoShapeChildren(page);
+    });
+  });
+
+  const createFrame = async (
+    page: Page,
+    coord1: [number, number],
+    coord2: [number, number]
+  ) => {
+    await page.keyboard.press('f');
+    await dragBetweenViewCoords(page, coord1, coord2);
+    await waitNextFrame(page, 100);
+    await autoFit(page);
+  };
+
+  test.describe('edit frame title', () => {
+    const enterFrameTitleEditor = async (page: Page) => {
+      const frameTitle = page.locator('.affine-frame-title');
+      await frameTitle.dblclick();
+
+      const frameTitleEditor = page.locator('edgeless-frame-title-editor');
+      await frameTitleEditor.waitFor({
+        state: 'attached',
+      });
+      return frameTitleEditor;
+    };
+
+    test('edit frame title by db-click title', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+
+      await enterFrameTitleEditor(page);
+
+      await type(page, 'ABC');
+      await assertEdgelessCanvasText(page, 'ABC');
+    });
+
+    test('should not display frame title component when title is empty', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await enterFrameTitleEditor(page);
+
+      await type(page, '');
+      const frameTitle = page.locator('.affine-frame-title');
+      await expect(frameTitle).toHaveCount(0);
+    });
+
+    test('edit frame after zoom', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await autoFit(page);
+      await zoomOutByKeyboard(page);
+      await enterFrameTitleEditor(page);
+      await type(page, 'ABC');
+      await assertEdgelessCanvasText(page, 'ABC');
+
+      await pressEnter(page);
+
+      await zoomInByKeyboard(page);
+      await zoomInByKeyboard(page);
+      await zoomInByKeyboard(page);
+      await enterFrameTitleEditor(page);
+      await type(page, 'DEF');
+      await assertEdgelessCanvasText(page, 'DEF');
+    });
+
+    test('edit frame title after drag', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await dragBetweenViewCoords(page, [50 + 10, 50 + 10], [50 + 20, 50 + 20]);
+      await waitNextFrame(page, 100);
+      await enterFrameTitleEditor(page);
+      await type(page, 'ABC');
+      await assertEdgelessCanvasText(page, 'ABC');
+    });
+
+    test('blur unmount frame editor', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      const frameTitleEditor = await enterFrameTitleEditor(page);
+      await page.mouse.click(10, 10);
+      await expect(frameTitleEditor).toHaveCount(0);
+    });
+
+    test('enter unmount frame editor', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      const frameTitleEditor = await enterFrameTitleEditor(page);
+      await pressEnter(page);
+      await expect(frameTitleEditor).toHaveCount(0);
+    });
+  });
+
+  test.describe('add element to frame and then move frame', () => {
+    test.describe('add single element', () => {
+      test('element should be moved since it is created in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+        const noteCoord = await toViewCoord(page, [200, 200]);
+        await addNote(page, '', noteCoord[0], noteCoord[1]);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+        await assertSelectedBound(page, [220, 210, 448, 92], 2); // note
+      });
+
+      test('element should be not moved since it is created not in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await createShapeElement(page, [600, 600], [500, 500], Shape.Square);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [500, 500, 100, 100], 0); // shape
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+      });
+    });
+
+    test.describe('add group', () => {
+      // Group
+      // |<150px>|
+      // ┌────┐    ─
+      // │  ┌─┼──┐ 150 px
+      // └──┼─┘  │ |
+      //    └────┘ ─
+
+      test('group should be moved since it is fully contained in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+        await createShapeElement(page, [150, 150], [250, 250], Shape.Square);
+        await pressEscape(page);
+
+        await shiftClickView(page, [110, 110]);
+        await shiftClickView(page, [160, 160]);
+        await page.keyboard.press(`${SHORT_KEY}+g`);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [150, 150, 150, 150], 0); // group
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+      });
+      test('group should be moved since its center is in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await createShapeElement(page, [450, 450], [550, 550], Shape.Square);
+        await createShapeElement(page, [500, 500], [600, 600], Shape.Square);
+        await pressEscape(page);
+
+        await shiftClickView(page, [460, 460]);
+        await shiftClickView(page, [510, 510]);
+        await page.keyboard.press(`${SHORT_KEY}+g`);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        // since the new group center is in the frame, so the group is not child of frame
+        await assertSelectedBound(page, [500, 500, 150, 150], 0); // group
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+      });
+
+      test('group should not be moved since its center is not in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await createShapeElement(page, [500, 500], [600, 600], Shape.Square);
+        await createShapeElement(page, [550, 550], [650, 650], Shape.Square);
+        await pressEscape(page);
+
+        await shiftClickView(page, [510, 510]);
+        await shiftClickView(page, [560, 560]);
+        await page.keyboard.press(`${SHORT_KEY}+g`);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        // since the new group center is not in the frame, so the group is not child of frame
+        await assertSelectedBound(page, [500, 500, 150, 150], 0); // group
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+      });
+    });
+
+    test.describe('add inner frame', () => {
+      test('the inner frame and its children should be moved since it is fully contained in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await pressEscape(page);
+        await createFrame(page, [100, 100], [300, 300]);
+        await pressEscape(page);
+        await createShapeElement(page, [150, 150], [250, 250], Shape.Square);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [200, 200, 100, 100], 0); // shape
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+        await assertSelectedBound(page, [150, 150, 200, 200], 2); // inner frame
+      });
+
+      test('the inner frame and its children should  be moved since its center is in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await pressEscape(page);
+        await createFrame(page, [400, 400], [600, 600]);
+        await pressEscape(page);
+        await createShapeElement(page, [550, 550], [600, 600], Shape.Square);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [600, 600, 50, 50], 0); // shape
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+        await assertSelectedBound(page, [450, 450, 200, 200], 2); // inner frame
+      });
+
+      test('the inner frame and its children should also be moved even though its center is not in frame', async ({
+        page,
+      }) => {
+        await createFrame(page, [50, 50], [550, 550]);
+        await pressEscape(page);
+        await createFrame(page, [500, 500], [600, 600]);
+        await pressEscape(page);
+        await createShapeElement(page, [550, 550], [600, 600], Shape.Square);
+        await pressEscape(page);
+
+        await clickView(page, [60, 60]);
+        await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+        await waitNextFrame(page, 100);
+
+        await selectAllByKeyboard(page);
+        await assertSelectedBound(page, [600, 600, 50, 50], 0); // shape
+        await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+        await assertSelectedBound(page, [550, 550, 100, 100], 2); // inner frame
+      });
+    });
+
+    test('add mindmap root node and move frame', async ({ page }) => {
+      await createFrame(page, [50, 50], [550, 550]);
+      await pressEscape(page);
+      await triggerComponentToolbarAction(page, 'addMindmap');
+      let mindmapBound = await getSelectedBound(page);
+      await clickView(page, [
+        mindmapBound[0] + 10,
+        mindmapBound[1] + 0.5 * mindmapBound[3],
+      ]);
+      await dragBetweenViewCoords(
+        page,
+        [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+        [mindmapBound[0] + 10 + 50, mindmapBound[1] + 0.5 * mindmapBound[3]]
+      );
+      await waitNextFrame(page, 100);
+      await pressEscape(page);
+      await selectAllByKeyboard(page);
+      mindmapBound = await getSelectedBound(page);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(
+        page,
+        [
+          mindmapBound[0] + 50,
+          mindmapBound[1] + 50,
+          mindmapBound[2],
+          mindmapBound[3],
+        ],
+        0
+      ); // mindmap
+      await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+    });
+  });
+
+  test.describe('frame selection', () => {
+    test('frame can be selected by click blank area of frame', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await pressEscape(page);
+      expect(await getSelectedBoundCount(page)).toBe(0);
+
+      await clickView(page, [100, 100]);
+      expect(await getSelectedBoundCount(page)).toBe(1);
+      await assertSelectedBound(page, [50, 50, 100, 100]);
+    });
+
+    test('shape inside frame can be selected and edited', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [150, 150]);
+      expect(await getSelectedBoundCount(page)).toBe(1);
+      await assertSelectedBound(page, [100, 100, 100, 100]);
+
+      await dblclickView(page, [150, 150]);
+      await type(page, 'hello');
+      await assertEdgelessCanvasText(page, 'hello');
+    });
+
+    test('dom inside frame can be selected and edited', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      const noteCoord = await toViewCoord(page, [100, 100]);
+      await addNote(page, '', noteCoord[0], noteCoord[1]);
+      await page.mouse.click(noteCoord[0] - 80, noteCoord[1]);
+
+      await dblclickView(page, [150, 150]);
+      await type(page, 'hello');
+      await assertRichTexts(page, ['hello']);
+    });
+  });
+
+  test.describe('resize frame then move ', () => {
+    test('resize frame for warping shape', async ({ page }) => {
+      await createFrame(page, [50, 50], [150, 150]);
+      await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [150, 150], [450, 450]);
+      await waitNextFrame(page, 100);
+      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [250, 250, 100, 100], 0); // shape
+      await assertSelectedBound(page, [100, 100, 400, 400], 1); // frame
+    });
+
+    test('resize frame for unwrapping shape', async ({ page }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [450, 450], [150, 150]);
+      await waitNextFrame(page, 100);
+      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [200, 200, 100, 100], 0); // shape
+      await assertSelectedBound(page, [100, 100, 100, 100], 1); // frame
+    });
+  });
+
+  test('delete frame', async ({ page }) => {
+    await createFrame(page, [50, 50], [450, 450]);
+    await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
+    await pressEscape(page);
+
+    await clickView(page, [60, 60]);
+    await pressBackspace(page);
+    await expect(page.locator('affine-frame')).toHaveCount(0);
+
+    await selectAllByKeyboard(page);
+    await assertSelectedBound(page, [200, 200, 100, 100], 0);
+  });
+
+  test.describe('frame copy and paste', () => {
+    test('copy of frame should keep relationship of child elements', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await copyByKeyboard(page);
+
+      await moveView(page, [500, 500]); // center copy
+      await pasteByKeyboard(page);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [200, 200, 100, 100], 0); // shape
+      await assertSelectedBound(page, [450, 450, 100, 100], 1); // shape
+      await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
+      await assertSelectedBound(page, [300, 300, 400, 400], 3); // frame
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [60, 60], [10, 10]);
+      await waitNextFrame(page, 100);
+
+      await clickView(page, [360, 360]);
+      await dragBetweenViewCoords(page, [360, 360], [310, 310]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
+      await assertSelectedBound(page, [400, 400, 100, 100], 1); // shape
+      await assertSelectedBound(page, [0, 0, 400, 400], 2); // frame
+      await assertSelectedBound(page, [250, 250, 400, 400], 3); // frame
+    });
+
+    test('copy of frame by alt/option dragging should keep relationship of child elements', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await page.keyboard.down('Alt');
+      await dragBetweenViewCoords(page, [60, 60], [460, 460]);
+      await waitNextFrame(page, 100);
+      await page.keyboard.up('Alt');
+      await pressEscape(page);
+
+      await shiftClickView(page, [60, 60]);
+      await shiftClickView(page, [250, 250]);
+      await pressBackspace(page);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [600, 600, 100, 100], 0); // shape
+      await assertSelectedBound(page, [450, 450, 400, 400], 1); // frame
+
+      await clickView(page, [460, 460]);
+      await dragBetweenViewCoords(page, [460, 460], [510, 510]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [650, 650, 100, 100], 0); // shape
+      await assertSelectedBound(page, [500, 500, 400, 400], 1); // frame
+    });
+
+    test('duplicate element in frame', async ({ page }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [60, 60]);
+      await page.locator('edgeless-more-button').click();
+      await page
+        .locator('editor-menu-action', { hasText: 'Duplicate' })
+        .click();
+      await pressEscape(page);
+
+      await shiftClickView(page, [60, 60]);
+      await shiftClickView(page, [150, 150]);
+      await pressBackspace(page);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [510, 100, 100, 100], 0); // shape
+      await assertSelectedBound(page, [460, 50, 400, 400], 1); // frame
+    });
+
+    test('copy of element by alt/option dragging in frame should belong to frame', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [150, 150]);
+      await page.keyboard.down('Alt');
+      await dragBetweenViewCoords(page, [150, 150], [250, 250]);
+      await waitNextFrame(page, 100);
+      await page.keyboard.up('Alt');
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [100, 100, 100, 100], 0); // shape
+      await assertSelectedBound(page, [200, 200, 100, 100], 1); // shape
+      await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
+      await assertSelectedBound(page, [250, 250, 100, 100], 1); // shape
+      await assertSelectedBound(page, [100, 100, 400, 400], 2); // frame
+    });
+
+    test('copy of element by alt/option dragging out of frame should not belong to frame', async ({
+      page,
+    }) => {
+      await createFrame(page, [50, 50], [450, 450]);
+      await createShapeElement(page, [100, 100], [200, 200], Shape.Square);
+      await pressEscape(page);
+
+      await clickView(page, [150, 150]);
+      await page.keyboard.down('Alt');
+      await dragBetweenViewCoords(page, [150, 150], [550, 550]);
+      await waitNextFrame(page, 100);
+      await page.keyboard.up('Alt');
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [100, 100, 100, 100], 0); // shape
+      await assertSelectedBound(page, [500, 500, 100, 100], 1); // shape
+      await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
+
+      await clickView(page, [60, 60]);
+      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+      await waitNextFrame(page, 100);
+
+      await selectAllByKeyboard(page);
+      await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
+      await assertSelectedBound(page, [500, 500, 100, 100], 1); // shape
+      await assertSelectedBound(page, [100, 100, 400, 400], 2); // frame
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Improved frame UI in the edgeless mode. [BS-1112](https://linear.app/affine-design/issue/BS-1112/[frame-and-group-improvement]-ui-update)

### What changed?
- UI changes:
  - Colorize frame title background and reverse text color based on it. [BS-1114](https://linear.app/affine-design/issue/BS-1114/[frame-improvement]-frame-标签文字颜色需要根据-color-picker-选定的颜色自动反色)
  - Hide frame title when frame is small or text is empty. [BS-1111](https://linear.app/affine-design/issue/BS-1111/[frame-improvement]-标签的宽度受-frame-宽度的影响，标签内容进行省略处理，缩放直到内容全部省略后消失), [BS-1306](https://linear.app/affine-design/issue/BS-1306/[ui]-使用空格-hack-标签，标签不渲染)
  - Highlight frame border when hover frame title. [BS-1110](https://linear.app/affine-design/issue/BS-1110/[frame-improvement]-frame-通过-hover-标签进入-hover-态)
  - Mask frame title when hover it. [BS-1307](https://linear.app/affine-design/issue/BS-1307/[ui]-hover-标签时应该有-000000-透明度的黑色的-hover-态)
  - Highlight child elements when resize frame.
  - Update style of dragging rect. [BS-1294](https://linear.app/affine-design/issue/BS-1294/[improvement]-修改-edgeless-鼠标选区的-ui)
- UI bug fixes:
  - Fixed incorrect border of frame in `<affine-surface-ref>` in page mode. [BS-1217](https://linear.app/affine-design/issue/BS-1217/embed-frame-出现双边框)
  - Fixed jitter when enter frame title editor. [BS-1304](https://linear.app/affine-design/issue/BS-1304/[bug]-frame-标签-rename-时抖动)
  - Fixed viewport of <affine-surface-ref> not changed after resize frame. [BS-1212](https://linear.app/affine-design/issue/BS-1212/通过peekview调整frame的大小后，文档中的frame的viewport没有更新)