### PR TITLE
chore: add editor mode related service on doc mode service

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/insert-embed-card.ts
+++ b/packages/blocks/src/_common/embed-block-helper/insert-embed-card.ts
@@ -74,7 +74,7 @@ export function insertEmbedCard(
 ) {
   const { doc, host } = std;
   const rootService = std.getService('affine:page');
-  const mode = std.get(DocModeProvider).getMode();
+  const mode = rootService.std.get(DocModeProvider).getEditorMode() ?? 'page';
   const selectedBlock = rootService.selectedBlocks[0]?.model;
 
   const { model, index } = getParentModelBySelection(doc, mode, selectedBlock);

--- a/packages/blocks/src/_common/utils/render-linked-doc.ts
+++ b/packages/blocks/src/_common/utils/render-linked-doc.ts
@@ -598,6 +598,7 @@ export function createLinkedDocFromEdgelessElements(
       ids.set(model.id, newId);
     });
   });
-  host.std.get(DocModeProvider).setMode('edgeless', linkedDoc.id);
+
+  host.std.get(DocModeProvider).setPrimaryMode('edgeless', linkedDoc.id);
   return linkedDoc;
 }

--- a/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/blocks/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -263,9 +263,9 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<
         this._linkedDocMode = this.model.params?.mode ?? 'page';
       } else {
         const docMode = this.std.get(DocModeProvider);
-        this._linkedDocMode = docMode.getMode(this.model.pageId);
+        this._linkedDocMode = docMode.getPrimaryMode(this.model.pageId);
         this.disposables.add(
-          docMode.onModeChange(mode => {
+          docMode.onPrimaryModeChange(mode => {
             this._linkedDocMode = mode;
           }, this.model.pageId)
         );

--- a/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/blocks/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -396,10 +396,10 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<
 
     if (this._rootService) {
       const docMode = this._rootService.std.get(DocModeProvider);
-      this.syncedDocMode = docMode.getMode(this.model.pageId);
+      this.syncedDocMode = docMode.getPrimaryMode(this.model.pageId);
       this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this.syncedDocMode);
       this.disposables.add(
-        docMode.onModeChange(mode => {
+        docMode.onPrimaryModeChange(mode => {
           this.syncedDocMode = mode;
           this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, mode);
         }, this.model.pageId)

--- a/packages/blocks/src/image-block/image-resize-manager.ts
+++ b/packages/blocks/src/image-block/image-resize-manager.ts
@@ -78,7 +78,8 @@ export class ImageResizeManager {
     const rootComponent = getClosestRootBlockComponent(this._activeComponent);
     if (
       rootComponent &&
-      rootComponent.service.std.get(DocModeProvider).getMode() === 'edgeless'
+      rootComponent.service.std.get(DocModeProvider).getEditorMode() ===
+        'edgeless'
     ) {
       this._zoom = (
         rootComponent as EdgelessRootBlockComponent

--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -64,7 +64,8 @@ export function createLinkedDocMenuGroup(
       key: doc.id,
       name: doc.title || DEFAULT_DOC_NAME,
       icon:
-        editorHost.std.get(DocModeProvider).getMode(doc.id) === 'edgeless'
+        editorHost.std.get(DocModeProvider).getPrimaryMode(doc.id) ===
+        'edgeless'
           ? LinkedEdgelessIcon
           : LinkedDocIcon,
       action: () => {

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -591,7 +591,8 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     const pageService = this.std.getService('affine:page');
 
     pageService.editPropsStore.setStorage('viewport', viewport);
-    this.std.get(DocModeProvider).setMode('edgeless');
+
+    this.std.get(DocModeProvider).setEditorMode('edgeless');
   }
 
   override willUpdate(_changedProperties: Map<PropertyKey, unknown>): void {

--- a/packages/playground/apps/_common/components/debug-menu.ts
+++ b/packages/playground/apps/_common/components/debug-menu.ts
@@ -7,7 +7,7 @@ import { type EditorHost, ShadowlessElement } from '@blocksuite/block-std';
 import {
   type DocMode,
   DocModeProvider,
-  type EdgelessRootService,
+  EdgelessRootService,
 } from '@blocksuite/blocks';
 import {
   type AffineTextAttributes,
@@ -319,8 +319,7 @@ export class DebugMenu extends ShadowlessElement {
   private _present() {
     if (!this.editor.std || !this.editor.host) return;
     const rootService = this.editor.std.getService('affine:page');
-    const mode = this.editor.std.get(DocModeProvider).getMode();
-    if (mode !== 'edgeless') {
+    if (!(rootService instanceof EdgelessRootService)) {
       toast(
         this.editor.host,
         'The presentation mode is only available on edgeless mode.',
@@ -373,7 +372,12 @@ export class DebugMenu extends ShadowlessElement {
 
   private _switchEditorMode() {
     if (!this.editor.host) return;
-    this.mode = this.editor.host.std.get(DocModeProvider).toggleMode();
+    const newMode = this.mode === 'page' ? 'edgeless' : 'page';
+    const docModeService = this.editor.host.std.get(DocModeProvider);
+    if (docModeService) {
+      docModeService.setPrimaryMode(newMode, this.editor.doc.id);
+    }
+    this.mode = newMode;
   }
 
   private _switchOffsetMode() {

--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -1,9 +1,9 @@
-import {
-  DocModeProvider,
-  type EdgelessRootBlockComponent,
-  type SurfaceRefBlockComponent,
+import type {
+  EdgelessRootBlockComponent,
+  SurfaceRefBlockComponent,
 } from '@blocksuite/blocks';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { beforeEach, describe, expect, test } from 'vitest';
 
 import { wait } from '../utils/common.js';
 import { addNote, getDocRootBlock } from '../utils/edgeless.js';
@@ -177,13 +177,8 @@ describe('basic', () => {
       `affine-surface-ref[data-block-id="${surfaceRefId}"]`
     ) as HTMLElement;
 
-    const switchEditor = vi.fn(() => {});
-    const pageService = editor.host!.std.getService('affine:page');
-    pageService.std.get(DocModeProvider).onModeChange(switchEditor);
-
     expect(surfaceRef).instanceOf(Element);
     (surfaceRef as SurfaceRefBlockComponent).viewInEdgeless();
-    expect(switchEditor).toBeCalledWith('edgeless');
     await wait();
   });
 });

--- a/packages/presets/src/editors/editor-container.ts
+++ b/packages/presets/src/editors/editor-container.ts
@@ -189,7 +189,7 @@ export class AffineEditorContainer
     this._disposables.add(
       effect(() => {
         const std = this._std.value;
-        const mode = std.get(DocModeProvider).getMode();
+        const mode = std.get(DocModeProvider).getPrimaryMode(this.doc.id);
         this._forwardRef(mode);
       })
     );

--- a/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
+++ b/packages/presets/src/fragments/frame-panel/body/frame-panel-body.ts
@@ -221,7 +221,7 @@ export class FramePanelBody extends WithDisposable(ShadowlessElement) {
 
       const rootService = this.editorHost.std.getService('affine:page');
       rootService.editPropsStore.setStorage('viewport', viewport);
-      rootService.std.get(DocModeProvider).setMode('edgeless');
+      rootService.std.get(DocModeProvider).setEditorMode('edgeless');
     } else {
       this.edgeless.service.viewport.setViewportByBound(
         bound,

--- a/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frame-panel-header.ts
@@ -112,7 +112,7 @@ export class FramePanelHeader extends WithDisposable(LitElement) {
 
   private _enterPresentationMode = () => {
     if (!this.edgeless) {
-      this.rootService.std.get(DocModeProvider).setMode('edgeless');
+      this.rootService.std.get(DocModeProvider).setEditorMode('edgeless');
     }
 
     setTimeout(() => {


### PR DESCRIPTION
Fix: [BS-1292](https://linear.app/affine-design/issue/BS-1292/无法通过-docmodeservicesetmode-切换-mode)

rename:

before:

```
  setMode: (mode: DocMode, docId?: string) => void;
  getMode: (docId?: string) => DocMode;
  toggleMode: (docId?: string) => DocMode;
  onModeChange: (
    handler: (mode: DocMode) => void,
    docId?: string
  ) => Disposable;
```

after:

```
  /**
   * Set the primary mode of the doc.
   * This would not affect the current editor mode.
   * If you want to switch the editor mode, use `setEditorMode` instead.
   * @param mode - The mode to set.
   * @param docId - The id of the doc.
   */
  setPrimaryMode: (mode: DocMode, docId: string) => void;
  /**
   * Get the primary mode of the doc.
   * Normally, it would be used to query the mode of other doc.
   * @param docId - The id of the doc.
   * @returns The primary mode of the document.
   */
  getPrimaryMode: (docId: string) => DocMode;
  /**
   * Toggle the primary mode of the doc.
   * @param docId - The id of the doc.
   * @returns The new primary mode of the doc.
   */
  togglePrimaryMode: (docId: string) => DocMode;
  /**
   * Subscribe to changes in the primary mode of the doc.
   * For example:
   * Embed-linked-doc-block will subscribe to the primary mode of the linked doc,
   * and will display different UI according to the primary mode of the linked doc.
   * @param handler - The handler to call when the primary mode of certain doc changes.
   * @param docId - The id of the doc.
   * @returns A disposable to stop the subscription.
   */
  onPrimaryModeChange: (
    handler: (mode: DocMode) => void,
    docId: string
  ) => Disposable;
```

add:

```
  /**
   * Set the editor mode. Normally, it would be used to set the mode of the current editor.
   * When patch or override the doc mode service, can pass a callback to set the editor mode.
   * @param mode - The mode to set.
   */
  setEditorMode: (mode: DocMode) => void;
  /**
   * Get current editor mode.
   * @returns The editor mode.
   */
  getEditorMode: () => DocMode | null;
```

mock docModeService like this

```
export function mockDocModeService(
  getEditorModeCallback: () => DocMode,
  setEditorModeCallback: (mode: DocMode) => void
) {
  const docModeService: DocModeProvider = {
    getPrimaryMode: (docId: string) => {
      try {
        const modeMap = getModeFromStorage();
        return modeMap.get(docId) ?? DEFAULT_MODE;
      } catch (_e) {
        return DEFAULT_MODE;
      }
    },
    onPrimaryModeChange: (handler: (mode: DocMode) => void, docId: string) => {
      if (!slotMap.get(docId)) {
        slotMap.set(docId, new Slot());
      }
      return slotMap.get(docId)!.on(handler);
    },
    getEditorMode: () => {
      return getEditorModeCallback();
    },
    setEditorMode: (mode: DocMode) => {
      setEditorModeCallback(mode);
    },
    setPrimaryMode: (mode: DocMode, docId: string) => {
      const modeMap = getModeFromStorage();
      modeMap.set(docId, mode);
      saveModeToStorage(modeMap);
      slotMap.get(docId)?.emit(mode);
    },
    togglePrimaryMode: (docId: string) => {
      const mode =
        docModeService.getPrimaryMode(docId) === 'page' ? 'edgeless' : 'page';
      docModeService.setPrimaryMode(mode, docId);
      return mode;
    },
  };
  return docModeService;
}
```

And override docModeService implementation

```
  function patchPageRootSpec(spec: ExtensionType[]) {
    class PatchPageServiceWatcher extends BlockServiceWatcher {
      static override readonly flavour = 'affine:page';

    ...

    const setEditorModeCallBack = editor.switchEditor.bind(editor);
    const getEditorModeCallback = () => editor.mode;
    const newSpec: typeof spec = [
      ...spec,
      {
        setup: di => {
          di.override(DocModeProvider, () =>
            mockDocModeService(getEditorModeCallback, setEditorModeCallBack)
          );
        },
      },
    ];

    return newSpec;
  }
```