### PR TITLE
fix: some keydown handlers not trigger when multiple editors

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
@@ -195,7 +195,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
       },
     });
 
-    const dispose = this.edgeless.bindHotKey(
+    this.edgeless.bindHotKey(
       {
         m: () => {
           const service = this.edgeless.service;
@@ -229,7 +229,6 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
       },
       { global: true }
     );
-    this.disposables.add(dispose);
   }
 
   override render() {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
@@ -203,39 +203,37 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
       },
     });
 
-    this._disposables.add(
-      this.edgeless.bindHotKey(
-        {
-          s: ctx => {
-            // `page.keyboard.press('Shift+s')` in playwright will also trigger this 's' key event
-            if (ctx.get('keyboardState').raw.shiftKey) return;
+    this.edgeless.bindHotKey(
+      {
+        s: ctx => {
+          // `page.keyboard.press('Shift+s')` in playwright will also trigger this 's' key event
+          if (ctx.get('keyboardState').raw.shiftKey) return;
 
-            const service = this.edgeless.service;
-            if (service.locked || service.selection.editing) return;
+          const service = this.edgeless.service;
+          if (service.locked || service.selection.editing) return;
 
-            if (this.readyToDrop) {
-              const activeIndex = shapes.findIndex(
-                s => s.name === this.draggingShape
-              );
-              const nextIndex = (activeIndex + 1) % shapes.length;
-              const next = shapes[nextIndex];
-              this.draggingShape = next.name;
+          if (this.readyToDrop) {
+            const activeIndex = shapes.findIndex(
+              s => s.name === this.draggingShape
+            );
+            const nextIndex = (activeIndex + 1) % shapes.length;
+            const next = shapes[nextIndex];
+            this.draggingShape = next.name;
 
-              this.draggableController.cancelWithoutAnimation();
-            }
+            this.draggableController.cancelWithoutAnimation();
+          }
 
-            const el = this.shapeContainer.querySelector(
-              `.shape.${this.draggingShape}`
-            ) as HTMLElement;
-            assertExists(el, 'Edgeless toolbar Shape element not found');
-            const { x, y } = service.tool.lastMousePos;
-            const { left, top } = this.edgeless.viewport;
-            const clientPos = { x: x + left, y: y + top };
-            this.draggableController.clickToDrag(el, clientPos);
-          },
+          const el = this.shapeContainer.querySelector(
+            `.shape.${this.draggingShape}`
+          ) as HTMLElement;
+          assertExists(el, 'Edgeless toolbar Shape element not found');
+          const { x, y } = service.tool.lastMousePos;
+          const { left, top } = this.edgeless.viewport;
+          const clientPos = { x: x + left, y: y + top };
+          this.draggableController.clickToDrag(el, clientPos);
         },
-        { global: true }
-      )
+      },
+      { global: true }
     );
   }
 


### PR DESCRIPTION
Fix: [BS-1256](https://linear.app/affine-design/issue/BS-1256/split-view-时打开-center-peek-再关闭，无法再激活任意一个-editor，白板快捷键会失效)

Remove some redundant disposable group, because they have been added once in packages/framework/block-std/src/view/element/block-component.ts bindHotkeys funtion.
