### PR TITLE
refactor(edgeless): support configuring overlays and elementRenders

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -116,10 +116,11 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
         assertExists(connector);
         const otherSideId = connector.source.id;
 
-        connector.target = this._surface.overlays.connector.renderConnector(
-          point,
-          otherSideId ? [otherSideId] : []
-        );
+        connector.target =
+          this.edgeless.service.connectorOverlay.renderConnector(
+            point,
+            otherSideId ? [otherSideId] : []
+          );
       }
     });
 
@@ -132,7 +133,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
       }
 
       this._isMoving = false;
-      this._surface.overlays.connector.clear();
+      this.edgeless.service.connectorOverlay.clear();
       this._disposables.dispose();
       this._disposables = new DisposableGroup();
     });
@@ -641,10 +642,6 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
       shapeMethods[targetType].draw(ctx, { ...bound, rotate: current.rotate });
     };
     surface.refresh();
-  }
-
-  private get _surface() {
-    return this.edgeless.surface;
   }
 
   override connectedCallback(): void {

--- a/packages/blocks/src/root-block/edgeless/components/connector/connector-handle.ts
+++ b/packages/blocks/src/root-block/edgeless/components/connector/connector-handle.ts
@@ -52,20 +52,20 @@ export class EdgelessConnectorHandle extends WithDisposable(LitElement) {
       this._capPointerDown(e, 'target');
     });
     this._disposables.add(() => {
-      edgeless.surface.overlays.connector.clear();
+      edgeless.service.connectorOverlay.clear();
     });
   }
 
   private _capPointerDown(e: PointerEvent, connection: 'target' | 'source') {
     const { edgeless, connector, _disposables } = this;
-    const { service, surface } = edgeless;
+    const { service } = edgeless;
     e.stopPropagation();
     _disposables.addFromEvent(document, 'pointermove', e => {
       const point = service.viewport.toModelCoordFromClientCoord([e.x, e.y]);
       const isStartPointer = connection === 'source';
       const otherSideId = connector[isStartPointer ? 'target' : 'source'].id;
 
-      connector[connection] = surface.overlays.connector.renderConnector(
+      connector[connection] = edgeless.service.connectorOverlay.renderConnector(
         point,
         otherSideId ? [otherSideId] : []
       );
@@ -73,7 +73,7 @@ export class EdgelessConnectorHandle extends WithDisposable(LitElement) {
     });
 
     _disposables.addFromEvent(document, 'pointerup', () => {
-      surface.overlays.connector.clear();
+      edgeless.service.overlays.connector.clear();
       edgeless.doc.captureSync();
       _disposables.dispose();
       this._disposables = new DisposableGroup();

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -393,6 +393,7 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
     y: number,
     options: { all: true } & PointTestOptions
   ): BlockSuite.EdgelessModel[];
+
   pickElement(
     x: number,
     y: number,
@@ -706,6 +707,10 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
     return (this.frames as GfxBlockModel[]).concat(this._layer.blocks);
   }
 
+  get connectorOverlay() {
+    return this.overlays.connector as ConnectionOverlay;
+  }
+
   /**
    * sorted edgeless elements
    */
@@ -726,6 +731,10 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
 
   get frame() {
     return this._frame;
+  }
+
+  get frameOverlay() {
+    return this.overlays.frame as FrameOverlay;
   }
 
   get frames() {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -18,7 +18,7 @@ import type {
   CanvasElementType,
   ConnectorElementModel,
 } from '../../surface-block/element-model/index.js';
-import type { SurfaceBlockModel } from '../../surface-block/index.js';
+import type { Overlay, SurfaceBlockModel } from '../../surface-block/index.js';
 import type { ReorderingDirection } from '../../surface-block/managers/layer-manager.js';
 import type { SurfaceContext } from '../../surface-block/surface-block.js';
 import type { EdgelessToolConstructor } from './services/tools-manager.js';
@@ -26,12 +26,17 @@ import type { EdgelessTool } from './types.js';
 
 import { SurfaceGroupLikeModel } from '../../surface-block/element-model/base.js';
 import { MindmapElementModel } from '../../surface-block/index.js';
+import { ConnectionOverlay } from '../../surface-block/managers/connector-manager.js';
 import { LayerManager } from '../../surface-block/managers/layer-manager.js';
 import { compare } from '../../surface-block/managers/layer-utils.js';
+import {
+  type ElementRenderer,
+  elementRenderers,
+} from '../../surface-block/renderer/elements/index.js';
 import { getSurfaceBlock } from '../../surface-ref-block/utils.js';
 import { RootService, type TelemetryEvent } from '../root-service.js';
 import { GfxBlockModel } from './block-model.js';
-import { EdgelessFrameManager } from './frame-manager.js';
+import { EdgelessFrameManager, FrameOverlay } from './frame-manager.js';
 import { EdgelessSelectionManager } from './services/selection-manager.js';
 import { TemplateJob } from './services/template.js';
 import {
@@ -97,6 +102,13 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
   static override readonly flavour = RootBlockSchema.model.flavour;
 
   TemplateJob = TemplateJob;
+
+  elementRenderers: Record<string, ElementRenderer> = elementRenderers;
+
+  overlays: Record<string, Overlay> = {
+    connector: new ConnectionOverlay(this),
+    frame: new FrameOverlay(),
+  };
 
   slots = {
     edgelessToolUpdated: new Slot<EdgelessTool>(),

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -28,7 +28,7 @@ export function removeContainedFrames(frames: FrameBlockModel[]) {
 export class FrameOverlay extends Overlay {
   bound: Bound | null = null;
 
-  clear() {
+  override clear() {
     this.bound = null;
     this._renderer?.refresh();
   }

--- a/packages/blocks/src/root-block/edgeless/tools/connector-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/connector-tool.ts
@@ -5,6 +5,7 @@ import { ShapeType } from '@blocksuite/affine-model';
 import { Bound, noop } from '@blocksuite/global/utils';
 
 import type { ConnectorMode } from '../../../surface-block/index.js';
+import type { ConnectionOverlay } from '../../../surface-block/managers/connector-manager.js';
 import type { EdgelessTool } from '../types.js';
 
 import {
@@ -98,7 +99,7 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
       this._edgeless.service.removeElement(id);
     }
 
-    this._surface.overlays.connector.clear();
+    this._edgeless.service.overlays.connector.clear();
     this._mode = ConnectorToolMode.Dragging;
     this._connector = null;
     this._source = null;
@@ -112,7 +113,6 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
     const {
       _connector,
       _edgeless,
-      _surface: { overlays },
       _service: { viewport },
     } = this;
 
@@ -123,7 +123,7 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
       excludedIds.push(_connector.source.id);
     }
 
-    const target = overlays.connector.renderConnector(point, excludedIds);
+    const target = this.connector.renderConnector(point, excludedIds);
     _edgeless.service.updateElement(_connector.id, { target });
   }
 
@@ -182,9 +182,7 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
     if (!sourceId) return;
 
     const point = this._service.viewport.toModelCoord(e.x, e.y);
-    const target = this._surface.overlays.connector.renderConnector(point, [
-      sourceId,
-    ]);
+    const target = this.connector.renderConnector(point, [sourceId]);
 
     this._allowCancel = !target.id;
     this._connector.source.position = calculateNearestLocation(
@@ -204,9 +202,7 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
 
   onContainerPointerDown(e: PointerEventState) {
     this._startPoint = this._service.viewport.toModelCoord(e.x, e.y);
-    this._source = this._surface.overlays.connector.renderConnector(
-      this._startPoint
-    );
+    this._source = this.connector.renderConnector(this._startPoint);
   }
 
   onContainerTripleClick() {
@@ -245,10 +241,14 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
     this._createConnector();
 
     if (element instanceof GroupElementModel) {
-      this._surface.overlays.connector.sourceBounds = this._sourceBounds;
+      this.connector.sourceBounds = this._sourceBounds;
     }
 
     this.findTargetByPoint(point);
+  }
+
+  get connector() {
+    return this._edgeless.service.overlays.connector as ConnectionOverlay;
   }
 }
 

--- a/packages/blocks/src/root-block/edgeless/tools/connector-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/connector-tool.ts
@@ -5,7 +5,6 @@ import { ShapeType } from '@blocksuite/affine-model';
 import { Bound, noop } from '@blocksuite/global/utils';
 
 import type { ConnectorMode } from '../../../surface-block/index.js';
-import type { ConnectionOverlay } from '../../../surface-block/managers/connector-manager.js';
 import type { EdgelessTool } from '../types.js';
 
 import {
@@ -248,7 +247,7 @@ export class ConnectorToolController extends EdgelessToolController<ConnectorToo
   }
 
   get connector() {
-    return this._edgeless.service.overlays.connector as ConnectionOverlay;
+    return this._edgeless.service.connectorOverlay;
   }
 }
 

--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -505,8 +505,8 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
 
     const frame = this._service.frame.selectFrame(this._toBeMoved);
     frame
-      ? this._surface.overlays.frame.highlight(frame as FrameBlockModel)
-      : this._surface.overlays.frame.clear();
+      ? this._service.frameOverlay.highlight(frame as FrameBlockModel)
+      : this._service.frameOverlay.clear();
   }
 
   private _moveLabel(delta: IVec) {
@@ -880,15 +880,13 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
       this._lock = false;
     }
 
-    if (this.edgelessSelectionManager.editing) {
-      return;
-    }
-    const { surface } = this._edgeless;
+    if (this.edgelessSelectionManager.editing) return;
+
     this._dragStartPos = [0, 0];
     this._dragLastPos = [0, 0];
     this._selectedBounds = [];
     this._service.snap.cleanupAlignables();
-    surface.overlays.frame.clear();
+    this._service.frameOverlay.clear();
     this._toBeMoved = [];
     this._selectedConnector = null;
     this._selectedConnectorLabelBounds = null;

--- a/packages/blocks/src/root-block/font-loader/font-loader.ts
+++ b/packages/blocks/src/root-block/font-loader/font-loader.ts
@@ -1,11 +1,6 @@
 import { IS_FIREFOX } from '@blocksuite/global/env';
 
-export interface FontConfig {
-  font: string;
-  weight: string;
-  url: string;
-  style: string;
-}
+import type { FontConfig } from '../../surface-block/consts.js';
 
 const initFontFace = IS_FIREFOX
   ? ({ font, weight, url, style }: FontConfig) =>

--- a/packages/blocks/src/surface-block/consts.ts
+++ b/packages/blocks/src/surface-block/consts.ts
@@ -1,6 +1,11 @@
 import { FontFamily, FontStyle, FontWeight } from '@blocksuite/affine-model';
 
-import type { FontConfig } from '../root-block/font-loader/font-loader.js';
+export interface FontConfig {
+  font: string;
+  weight: string;
+  url: string;
+  style: string;
+}
 
 export const ZOOM_MAX = 6.0;
 export const ZOOM_MIN = 0.1;

--- a/packages/blocks/src/surface-block/managers/connector-manager.ts
+++ b/packages/blocks/src/surface-block/managers/connector-manager.ts
@@ -836,7 +836,7 @@ export class ConnectionOverlay extends Overlay {
     return context.pickElementsByBound(bound).filter(ele => ele.connectable);
   }
 
-  clear() {
+  override clear() {
     this.sourceBounds = null;
     this.targetBounds = null;
     this._clearRect();

--- a/packages/blocks/src/surface-block/renderer/canvas-renderer.ts
+++ b/packages/blocks/src/surface-block/renderer/canvas-renderer.ts
@@ -26,6 +26,8 @@ export abstract class Overlay {
 
   constructor() {}
 
+  clear() {}
+
   setRenderer(renderer: CanvasRenderer | null) {
     this._renderer = renderer;
   }

--- a/packages/blocks/src/surface-block/surface-block.ts
+++ b/packages/blocks/src/surface-block/surface-block.ts
@@ -231,7 +231,6 @@ export class SurfaceBlockComponent extends BlockComponent<
 
     this.setAttribute(RANGE_SYNC_EXCLUDE_ATTR, 'true');
 
-    console.log(this.service);
     this._initThemeObserver();
     this._initRenderer();
     this._initOverlays();


### PR DESCRIPTION
This removes the existence of `root-block` in the `block/surface-block`.