### PR TITLE
feat: split lastProps$ of different shape types

### DIFF
--- a/packages/affine/block-surface/src/index.ts
+++ b/packages/affine/block-surface/src/index.ts
@@ -1,6 +1,8 @@
 import type { SurfaceBlockModel } from './surface-model.js';
 import type { SurfaceBlockService } from './surface-service.js';
 
+import './commands/reassociate-connectors.js';
+
 export { type IModelCoord, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from './consts.js';
 export {
   AffineCanvasTextFonts,

--- a/packages/affine/shared/src/utils/zod-schema.ts
+++ b/packages/affine/shared/src/utils/zod-schema.ts
@@ -21,8 +21,6 @@ import {
   NoteShadowsSchema,
   PointStyle,
   ShapeStyle,
-  ShapeTextFontSize,
-  ShapeType,
   StrokeColorsSchema,
   StrokeStyle,
   TextAlign,
@@ -34,13 +32,11 @@ const ConnectorEndpointSchema = z.nativeEnum(PointStyle);
 const StrokeStyleSchema = z.nativeEnum(StrokeStyle);
 const LineWidthSchema = z.nativeEnum(LineWidth);
 const ShapeStyleSchema = z.nativeEnum(ShapeStyle);
-const ShapeTextFontSizeSchema = z.nativeEnum(ShapeTextFontSize);
 const FontFamilySchema = z.nativeEnum(FontFamily);
 const FontWeightSchema = z.nativeEnum(FontWeight);
 const FontStyleSchema = z.nativeEnum(FontStyle);
 const TextAlignSchema = z.nativeEnum(TextAlign);
 const TextVerticalAlignSchema = z.nativeEnum(TextVerticalAlign);
-const ShapeTypeSchema = z.nativeEnum(ShapeType);
 const NoteDisplayModeSchema = z.nativeEnum(NoteDisplayMode);
 const ConnectorModeSchema = z.nativeEnum(ConnectorMode);
 
@@ -95,37 +91,46 @@ export const BrushSchema = z
     lineWidth: LineWidth.Four,
   });
 
-export const ShapeSchema = z
-  .object({
-    color: TextColorSchema,
-    shapeType: ShapeTypeSchema,
-    fillColor: ShapeFillColorSchema,
-    strokeColor: ShapeStrokeColorSchema,
-    strokeStyle: StrokeStyleSchema,
-    strokeWidth: z.number(),
-    shapeStyle: ShapeStyleSchema,
-    filled: z.boolean(),
-    radius: z.number(),
-    fontSize: ShapeTextFontSizeSchema.optional(),
-    fontFamily: FontFamilySchema.optional(),
-    fontWeight: FontWeightSchema.optional(),
-    fontStyle: FontStyleSchema.optional(),
-    textAlign: TextAlignSchema.optional(),
-    textHorizontalAlign: TextAlignSchema.optional(),
-    textVerticalAlign: TextVerticalAlignSchema.optional(),
-    roughness: z.number().optional(),
-  })
-  .default({
-    color: DEFAULT_SHAPE_TEXT_COLOR,
-    shapeType: ShapeType.Rect,
-    fillColor: DEFAULT_SHAPE_FILL_COLOR,
-    strokeColor: DEFAULT_SHAPE_STROKE_COLOR,
-    strokeStyle: StrokeStyle.Solid,
-    strokeWidth: LineWidth.Two,
-    shapeStyle: ShapeStyle.General,
-    filled: true,
-    radius: 0,
-  });
+const DEFAULT_SHAPE = {
+  color: DEFAULT_SHAPE_TEXT_COLOR,
+  fillColor: DEFAULT_SHAPE_FILL_COLOR,
+  strokeColor: DEFAULT_SHAPE_STROKE_COLOR,
+  strokeStyle: StrokeStyle.Solid,
+  strokeWidth: LineWidth.Two,
+  shapeStyle: ShapeStyle.General,
+  filled: true,
+  radius: 0,
+  fontSize: 20,
+  fontFamily: FontFamily.Inter,
+  fontWeight: FontWeight.Regular,
+  fontStyle: FontStyle.Normal,
+  textAlign: TextAlign.Center,
+};
+
+const ShapeObject = {
+  color: TextColorSchema,
+  fillColor: ShapeFillColorSchema,
+  strokeColor: ShapeStrokeColorSchema,
+  strokeStyle: StrokeStyleSchema,
+  strokeWidth: z.number(),
+  shapeStyle: ShapeStyleSchema,
+  filled: z.boolean(),
+  radius: z.number(),
+  fontSize: z.number(),
+  fontFamily: FontFamilySchema,
+  fontWeight: FontWeightSchema,
+  fontStyle: FontStyleSchema,
+  textAlign: TextAlignSchema,
+  textHorizontalAlign: TextAlignSchema.optional(),
+  textVerticalAlign: TextVerticalAlignSchema.optional(),
+  roughness: z.number().optional(),
+};
+
+export const ShapeSchema = z.object(ShapeObject).default(DEFAULT_SHAPE);
+
+export const RoundedShapeSchema = z
+  .object(ShapeObject)
+  .default({ ...DEFAULT_SHAPE, radius: 0.1 });
 
 export const TextSchema = z
   .object({
@@ -176,7 +181,7 @@ export const NoteSchema = z
   })
   .default({
     background: DEFAULT_NOTE_BACKGROUND_COLOR,
-    displayMode: NoteDisplayMode.DocAndEdgeless,
+    displayMode: NoteDisplayMode.EdgelessOnly,
     edgeless: {
       style: {
         borderRadius: 0,
@@ -186,3 +191,19 @@ export const NoteSchema = z
       },
     },
   });
+
+export const NodePropsSchema = z.object({
+  connector: ConnectorSchema,
+  brush: BrushSchema,
+  text: TextSchema,
+  'affine:edgeless-text': EdgelessTextSchema,
+  'affine:note': NoteSchema,
+  // shapes
+  'shape:diamond': ShapeSchema,
+  'shape:ellipse': ShapeSchema,
+  'shape:rect': ShapeSchema,
+  'shape:triangle': ShapeSchema,
+  'shape:roundedRect': RoundedShapeSchema,
+});
+
+export type NodeProps = z.infer<typeof NodePropsSchema>;

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -42,6 +42,7 @@
     "fractional-indexing": "^3.2.0",
     "html2canvas": "^1.4.1",
     "lit": "^3.2.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.2",
     "mdast-util-gfm-autolink-literal": "^2.0.1",
@@ -97,6 +98,7 @@
   ],
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
+    "@types/lodash.clonedeep": "^4.5.9",
     "@types/lodash.isplainobject": "^4.0.9",
     "@types/lodash.merge": "^4.6.9"
   }

--- a/packages/blocks/src/root-block/configs/editor-settings.ts
+++ b/packages/blocks/src/root-block/configs/editor-settings.ts
@@ -1,18 +1,7 @@
-import {
-  BrushSchema,
-  ConnectorSchema,
-  EdgelessTextSchema,
-  NoteSchema,
-  ShapeSchema,
-} from '@blocksuite/affine-shared/utils';
-import { z } from 'zod';
+import type { z } from 'zod';
 
-export const EditorSettingSchema = z.object({
-  connector: ConnectorSchema,
-  brush: BrushSchema,
-  shape: ShapeSchema,
-  'affine:edgeless-text': EdgelessTextSchema,
-  'affine:note': NoteSchema,
-});
+import { NodePropsSchema } from '@blocksuite/affine-shared/utils';
+
+export const EditorSettingSchema = NodePropsSchema;
 
 export type EditorSetting = z.infer<typeof EditorSettingSchema>;

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -514,7 +514,9 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
     const { shapeStyle, strokeColor, fillColor, strokeWidth, roughness } =
       isShape(this.currentSource)
         ? this.currentSource
-        : this.edgeless.service.editPropsStore.getLastProps('shape');
+        : this.edgeless.service.editPropsStore.lastProps$.value[
+            `shape:${targetType}`
+          ];
 
     const stroke = ThemeObserver.getColorValue(
       strokeColor,

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/utils.ts
@@ -320,7 +320,7 @@ export function createShapeElement(
 
   const props = isShape(current)
     ? current.serialize()
-    : edgeless.service.editPropsStore.getLastProps('shape');
+    : edgeless.service.editPropsStore.lastProps$.value[`shape:${targetType}`];
 
   const id = service.addElement('shape', {
     ...props,

--- a/packages/blocks/src/root-block/edgeless/components/panel/shape-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/panel/shape-panel.ts
@@ -21,10 +21,10 @@ export class EdgelessShapePanel extends LitElement {
   `;
 
   slots = {
-    select: new Slot<ShapeTool['shapeType']>(),
+    select: new Slot<ShapeTool['shapeName']>(),
   };
 
-  private _onSelect(value: ShapeTool['shapeType']) {
+  private _onSelect(value: ShapeTool['shapeName']) {
     this.selectedShape = value;
     this.slots.select.emit(value);
   }
@@ -57,7 +57,7 @@ export class EdgelessShapePanel extends LitElement {
   }
 
   @property({ attribute: false })
-  accessor selectedShape: ShapeTool['shapeType'] | null | undefined = undefined;
+  accessor selectedShape: ShapeTool['shapeName'] | null | undefined = undefined;
 
   @property({ attribute: false })
   accessor shapeStyle: ShapeStyle = ShapeStyle.Scribbled;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/common/create-popper.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/common/create-popper.ts
@@ -26,6 +26,7 @@ export function createPopper<T extends keyof HTMLElementTagNameMap>(
     /** transition duration in ms */
     duration?: number;
     onDispose?: () => void;
+    setProps?: (ele: HTMLElementTagNameMap[T]) => void;
   }
 ) {
   const duration = options?.duration ?? 230;
@@ -44,6 +45,7 @@ export function createPopper<T extends keyof HTMLElementTagNameMap>(
 
   const clipWrapper = document.createElement('div');
   const menu = document.createElement(tagName);
+  options?.setProps?.(menu);
   assertExists(reference.shadowRoot);
   clipWrapper.append(menu);
   reference.shadowRoot.append(clipWrapper);

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-dense-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/connector/connector-dense-menu.ts
@@ -10,8 +10,7 @@ import type { DenseMenuBuilder } from '../common/type.js';
 
 export const buildConnectorDenseMenu: DenseMenuBuilder = edgeless => {
   const prevMode =
-    edgeless.service.editPropsStore.getLastProps('connector').mode ??
-    ConnectorMode.Curve;
+    edgeless.service.editPropsStore.lastProps$.value.connector.mode;
 
   const isSelected = edgeless.tools.edgelessTool.type === 'connector';
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-draggable.ts
@@ -10,7 +10,9 @@ import {
   getShapeType,
 } from '@blocksuite/affine-model';
 import { TelemetryProvider } from '@blocksuite/affine-shared/services';
+import { ThemeObserver } from '@blocksuite/affine-shared/theme';
 import { assertExists } from '@blocksuite/global/utils';
+import { SignalWatcher } from '@lit-labs/preact-signals';
 import { LitElement, css, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -64,7 +66,7 @@ shapes.forEach(s => {
 
 @customElement('edgeless-toolbar-shape-draggable')
 export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
-  LitElement
+  SignalWatcher(LitElement)
 ) {
   static override styles = css`
     :host {
@@ -152,9 +154,24 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
       standardWidth: 100,
       clickToDrag: true,
       onOverlayCreated: (overlay, element) => {
+        const shapeName =
+          this.draggableController.states.draggingElement?.data.name;
+        if (!shapeName) return;
+
+        this.setEdgelessTool({
+          type: 'shape',
+          shapeName,
+        });
+
+        const shape$ =
+          this.edgeless.service.editPropsStore.lastProps$.value[
+            `shape:${shapeName}`
+          ];
+        const color = ThemeObserver.generateColorProperty(shape$.fillColor);
+        const stroke = ThemeObserver.generateColorProperty(shape$.strokeColor);
         Object.assign(overlay.element.style, {
-          color: this.color,
-          stroke: this.stroke,
+          color,
+          stroke,
         });
         const controller = this.edgeless.tools.currentController;
         if (controller instanceof ShapeToolController) {
@@ -253,9 +270,19 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
         s => s.name,
         shape => {
           const isBeingDragged = draggingShape?.name === shape.name;
+          const shape$ =
+            this.edgeless.service.editPropsStore.lastProps$.value[
+              `shape:${shape.name}`
+            ];
+          const color = ThemeObserver.generateColorProperty(shape$.fillColor);
+          const stroke = ThemeObserver.generateColorProperty(
+            shape$.strokeColor
+          );
           const baseStyle = {
             ...buildVariablesObject(shape.style),
             filter: `drop-shadow(${this.shapeShadow})`,
+            color,
+            stroke,
           };
           const currStyle = styleMap({
             ...baseStyle,
@@ -317,9 +344,6 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
   }
 
   @property({ attribute: false })
-  accessor color!: string;
-
-  @property({ attribute: false })
   accessor onShapeClick: (shape: DraggableShape) => void = () => {};
 
   @state()
@@ -327,9 +351,6 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
 
   @query('.edgeless-shape-draggable')
   accessor shapeContainer!: HTMLDivElement;
-
-  @property({ attribute: false })
-  accessor stroke!: string;
 }
 
 declare global {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu-config.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/shape-menu-config.ts
@@ -12,66 +12,46 @@ import {
   SquareIcon,
   TriangleIcon,
 } from '@blocksuite/affine-components/icons';
-import {
-  ShapeType,
-  getShapeRadius,
-  getShapeType,
-} from '@blocksuite/affine-model';
+import { ShapeType } from '@blocksuite/affine-model';
 
 import type { ShapeTool } from '../../../tools/shape-tool.js';
 
-const { Rect, Ellipse, Triangle, Diamond } = ShapeType;
-
 type Config = {
-  name: ShapeTool['shapeType'];
+  name: ShapeTool['shapeName'];
   generalIcon: TemplateResult<1>;
   scribbledIcon: TemplateResult<1>;
   tooltip: string;
   disabled: boolean;
-  value: Record<string, unknown>;
 };
 
 export const ShapeComponentConfig: Config[] = [
   {
-    name: Rect,
+    name: ShapeType.Rect,
     generalIcon: SquareIcon,
     scribbledIcon: ScribbledSquareIcon,
     tooltip: 'Square',
     disabled: false,
-    value: {
-      shapeType: Rect,
-      radius: 0,
-    },
   },
   {
-    name: Ellipse,
+    name: ShapeType.Ellipse,
     generalIcon: EllipseIcon,
     scribbledIcon: ScribbledEllipseIcon,
     tooltip: 'Ellipse',
     disabled: false,
-    value: {
-      shapeType: Ellipse,
-    },
   },
   {
-    name: Diamond,
+    name: ShapeType.Diamond,
     generalIcon: DiamondIcon,
     scribbledIcon: ScribbledDiamondIcon,
     tooltip: 'Diamond',
     disabled: false,
-    value: {
-      shapeType: Diamond,
-    },
   },
   {
-    name: Triangle,
+    name: ShapeType.Triangle,
     generalIcon: TriangleIcon,
     scribbledIcon: ScribbledTriangleIcon,
     tooltip: 'Triangle',
     disabled: false,
-    value: {
-      shapeType: Triangle,
-    },
   },
   {
     name: 'roundedRect',
@@ -79,10 +59,6 @@ export const ShapeComponentConfig: Config[] = [
     scribbledIcon: ScribbledRoundedRectangleIcon,
     tooltip: 'Rounded rectangle',
     disabled: false,
-    value: {
-      shapeType: getShapeType('roundedRect'),
-      radius: getShapeRadius('roundedRect'),
-    },
   },
 ];
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/shape/utils.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/shape/utils.ts
@@ -14,7 +14,7 @@ type TransformState = {
 };
 
 export type DraggableShape = {
-  name: ShapeTool['shapeType'];
+  name: ShapeTool['shapeName'];
   svg: TemplateResult;
   style: {
     default?: TransformState;

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -10,7 +10,6 @@ import {
 import {
   EdgelessTextBlockModel,
   NoteDisplayMode,
-  getShapeName,
 } from '@blocksuite/affine-model';
 import { TelemetryProvider } from '@blocksuite/affine-shared/services';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
@@ -38,7 +37,7 @@ import {
   DEFAULT_NOTE_TIP,
 } from './utils/consts.js';
 import { deleteElements } from './utils/crud.js';
-import { getNextShapeType, updateShapeProps } from './utils/hotkey-utils.js';
+import { getNextShapeType } from './utils/hotkey-utils.js';
 import { isCanvasElement, isNoteBlock } from './utils/query.js';
 import {
   mountConnectorLabelEditor,
@@ -217,30 +216,20 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         },
         'Shift-s': () => {
           if (this.rootComponent.service.locked) return;
+          const controller = rootComponent.tools.currentController;
           if (
             this.rootComponent.service.selection.editing ||
-            !(
-              rootComponent.tools.currentController instanceof
-              ShapeToolController
-            )
+            !(controller instanceof ShapeToolController)
           ) {
             return;
           }
-
-          const attr =
-            rootComponent.service.editPropsStore.getLastProps('shape');
-
-          const shapeName = getShapeName(attr.shapeType, attr.radius);
+          const { shapeName } = controller.tool;
           const nextShapeName = getNextShapeType(shapeName);
           this._setEdgelessTool(rootComponent, {
             type: 'shape',
-            shapeType: nextShapeName,
+            shapeName: nextShapeName,
           });
 
-          updateShapeProps(nextShapeName, rootComponent);
-
-          const controller = rootComponent.tools
-            .currentController as ShapeToolController;
           controller.createOverlay();
         },
         'Mod-g': ctx => {

--- a/packages/blocks/src/root-block/edgeless/tools/note-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/note-tool.ts
@@ -105,7 +105,7 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     if (newTool.type !== 'affine:note') return;
 
     const attributes =
-      this._edgeless.service.editPropsStore.getLastProps('affine:note');
+      this._edgeless.service.editPropsStore.lastProps$.value['affine:note'];
     const background = attributes.background;
     this._noteOverlay = new NoteOverlay(this._edgeless, background);
     this._noteOverlay.text = newTool.tip;
@@ -179,7 +179,7 @@ export class NoteToolController extends EdgelessToolController<NoteTool> {
     this._clearOverlay();
 
     const attributes =
-      this._edgeless.service.editPropsStore.getLastProps('affine:note');
+      this._edgeless.service.editPropsStore.lastProps$.value['affine:note'];
     const background = attributes.background;
     this._draggingNoteOverlay = new DraggingNoteOverlay(
       this._edgeless,

--- a/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/hotkey-utils.ts
@@ -1,31 +1,16 @@
-import {
-  ShapeType,
-  getShapeRadius,
-  getShapeType,
-} from '@blocksuite/affine-model';
+import { ShapeType } from '@blocksuite/affine-model';
 
-import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 import type { ShapeTool } from '../tools/shape-tool.js';
 
-const shapeMap: Record<ShapeTool['shapeType'], number> = {
+const shapeMap: Record<ShapeTool['shapeName'], number> = {
   [ShapeType.Rect]: 0,
   [ShapeType.Ellipse]: 1,
   [ShapeType.Diamond]: 2,
   [ShapeType.Triangle]: 3,
   roundedRect: 4,
 };
-const shapes = Object.keys(shapeMap) as ShapeTool['shapeType'][];
+const shapes = Object.keys(shapeMap) as ShapeTool['shapeName'][];
 
-export function getNextShapeType(cur: ShapeTool['shapeType']) {
+export function getNextShapeType(cur: ShapeTool['shapeName']) {
   return shapes[(shapeMap[cur] + 1) % shapes.length];
-}
-
-export function updateShapeProps(
-  shapeName: ShapeTool['shapeType'],
-  edgeless: EdgelessRootBlockComponent
-) {
-  edgeless.service.editPropsStore.recordLastProps('shape', {
-    shapeType: getShapeType(shapeName),
-    radius: getShapeRadius(shapeName),
-  });
 }

--- a/packages/blocks/src/root-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/text.ts
@@ -12,8 +12,7 @@ import {
   type GroupElementModel,
   ShapeElementModel,
 } from '@blocksuite/affine-model';
-import { FontFamily, TextElementModel } from '@blocksuite/affine-model';
-import { ThemeObserver } from '@blocksuite/affine-shared/theme';
+import { TextElementModel } from '@blocksuite/affine-model';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import {
   Bound,
@@ -24,20 +23,12 @@ import { DocCollection } from '@blocksuite/store';
 
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
-import {
-  GET_DEFAULT_LINE_COLOR,
-  isTransparent,
-} from '../components/panel/color-panel.js';
+import { GET_DEFAULT_LINE_COLOR } from '../components/panel/color-panel.js';
 import { EdgelessConnectorLabelEditor } from '../components/text/edgeless-connector-label-editor.js';
 import { EdgelessFrameTitleEditor } from '../components/text/edgeless-frame-title-editor.js';
 import { EdgelessGroupTitleEditor } from '../components/text/edgeless-group-title-editor.js';
 import { EdgelessShapeTextEditor } from '../components/text/edgeless-shape-text-editor.js';
 import { EdgelessTextEditor } from '../components/text/edgeless-text-editor.js';
-import {
-  SHAPE_FILL_COLOR_BLACK,
-  SHAPE_TEXT_COLOR_PURE_BLACK,
-  SHAPE_TEXT_COLOR_PURE_WHITE,
-} from './consts.js';
 
 export function mountTextElementEditor(
   textElement: TextElementModel,
@@ -89,23 +80,7 @@ export function mountShapeTextEditor(
 
   if (!shapeElement.text) {
     const text = new DocCollection.Y.Text();
-    let color = ThemeObserver.getColorValue(
-      shapeElement.fillColor,
-      GET_DEFAULT_LINE_COLOR()
-    );
-    color = isTransparent(color)
-      ? GET_DEFAULT_LINE_COLOR()
-      : color === SHAPE_FILL_COLOR_BLACK
-        ? SHAPE_TEXT_COLOR_PURE_WHITE
-        : SHAPE_TEXT_COLOR_PURE_BLACK;
-    edgeless.service.updateElement(shapeElement.id, {
-      text,
-      color,
-      fontFamily:
-        shapeElement.shapeStyle === 'General'
-          ? FontFamily.Inter
-          : FontFamily.Kalam,
-    });
+    edgeless.service.updateElement(shapeElement.id, { text });
   }
 
   const updatedElement = edgeless.service.getElementById(shapeElement.id);

--- a/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
@@ -303,24 +303,24 @@ export class ShapeOverlay extends ToolOverlay {
     this.disposables.add(
       this.edgeless.slots.edgelessToolUpdated.on(edgelessTool => {
         if (edgelessTool.type !== 'shape') return;
-        const shapeType = edgelessTool.shapeType;
+        const { shapeName } = edgelessTool;
         const newOptions = {
           ...options,
         };
 
         let { x, y } = this;
-        if (shapeType === 'roundedRect' || shapeType === 'rect') {
+        if (shapeName === 'roundedRect' || shapeName === 'rect') {
           x += SHAPE_OVERLAY_OFFSET_X;
           y += SHAPE_OVERLAY_OFFSET_Y;
         }
         const w =
-          shapeType === 'roundedRect'
+          shapeName === 'roundedRect'
             ? SHAPE_OVERLAY_WIDTH + 40
             : SHAPE_OVERLAY_WIDTH;
         const xywh = [x, y, w, SHAPE_OVERLAY_HEIGHT] as XYWH;
         this.shape = ShapeFactory.createShape(
           xywh,
-          shapeType,
+          shapeName,
           newOptions,
           shapeStyle
         );

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-shape-button.ts
@@ -121,12 +121,12 @@ function getMostCommonStrokeColor(
 
 function getMostCommonShape(
   elements: ShapeElementModel[]
-): ShapeTool['shapeType'] | null {
+): ShapeTool['shapeName'] | null {
   const shapeTypes = countBy(elements, (ele: ShapeElementModel) => {
     return getShapeName(ele.shapeType, ele.radius);
   });
   const max = maxBy(Object.entries(shapeTypes), ([_k, count]) => count);
-  return max ? (max[0] as ShapeTool['shapeType']) : null;
+  return max ? (max[0] as ShapeTool['shapeName']) : null;
 }
 
 function getMostCommonLineSize(elements: ShapeElementModel[]): LineWidth {

--- a/packages/blocks/src/root-block/widgets/pie-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/config.ts
@@ -264,17 +264,16 @@ shapes.forEach(shape => {
     label: shape.label,
     icon: ({ rootComponent }) => {
       const attributes =
-        rootComponent.service.editPropsStore.getLastProps('shape');
+        rootComponent.service.editPropsStore.lastProps$.value[
+          `shape:${shape.type}`
+        ];
       return shape.icon(attributes.shapeStyle);
     },
 
     action: ({ rootComponent }) => {
       rootComponent.service.tool.setEdgelessTool({
         type: 'shape',
-        shapeType: shape.type,
-      });
-      rootComponent.service.editPropsStore.recordLastProps('shape', {
-        shapeType: shape.type,
+        shapeName: shape.type,
       });
       updateShapeOverlay(rootComponent);
     },
@@ -285,7 +284,9 @@ pie.command({
   label: 'Toggle Style',
   icon: ({ rootComponent }) => {
     const { shapeStyle } =
-      rootComponent.service.editPropsStore.getLastProps('shape');
+      rootComponent.service.editPropsStore.lastProps$.value[
+        'shape:roundedRect'
+      ];
     return shapeStyle === ShapeStyle.General
       ? ScribbledStyleIcon
       : GeneralStyleIcon;
@@ -293,13 +294,15 @@ pie.command({
 
   action: ({ rootComponent }) => {
     const { shapeStyle } =
-      rootComponent.service.editPropsStore.getLastProps('shape');
+      rootComponent.service.editPropsStore.lastProps$.value[
+        'shape:roundedRect'
+      ];
     const toggleType =
       shapeStyle === ShapeStyle.General
         ? ShapeStyle.Scribbled
         : ShapeStyle.General;
 
-    rootComponent.service.editPropsStore.recordLastProps('shape', {
+    rootComponent.service.editPropsStore.recordLastProps('shape:roundedRect', {
       shapeStyle: toggleType,
     });
 
@@ -311,8 +314,8 @@ pie.colorPicker({
   label: 'Fill',
   active: getActiveShapeColor('fill'),
   onChange: (color: string, { rootComponent }: PieMenuContext) => {
-    rootComponent.service.editPropsStore.recordLastProps('shape', {
-      fillColor: color as LastProps['shape']['fillColor'],
+    rootComponent.service.editPropsStore.recordLastProps('shape:roundedRect', {
+      fillColor: color as LastProps['shape:roundedRect']['fillColor'],
     });
     updateShapeOverlay(rootComponent);
   },
@@ -324,8 +327,8 @@ pie.colorPicker({
   hollow: true,
   active: getActiveShapeColor('stroke'),
   onChange: (color: string, { rootComponent }: PieMenuContext) => {
-    rootComponent.service.editPropsStore.recordLastProps('shape', {
-      strokeColor: color as LastProps['shape']['strokeColor'],
+    rootComponent.service.editPropsStore.recordLastProps('shape:roundedRect', {
+      strokeColor: color as LastProps['shape:roundedRect']['strokeColor'],
     });
     updateShapeOverlay(rootComponent);
   },

--- a/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/pie-menu/utils.ts
@@ -28,7 +28,10 @@ export function updateShapeOverlay(rootComponent: EdgelessRootBlockComponent) {
 export function getActiveShapeColor(type: 'fill' | 'stroke') {
   return ({ rootComponent }: PieMenuContext) => {
     if (rootComponent instanceof EdgelessRootBlockComponent) {
-      const props = rootComponent.service.editPropsStore.getLastProps('shape');
+      const props =
+        rootComponent.service.editPropsStore.lastProps$.value[
+          'shape:roundedRect'
+        ];
       const color = type == 'fill' ? props.fillColor : props.strokeColor;
       return ThemeObserver.getColorValue(color);
     }
@@ -41,7 +44,7 @@ export function getActiveConnectorStrokeColor({
 }: PieMenuContext) {
   if (rootComponent instanceof EdgelessRootBlockComponent) {
     const props =
-      rootComponent.service.editPropsStore.getLastProps('connector');
+      rootComponent.service.editPropsStore.lastProps$.value.connector;
     const color = props.stroke;
     return ThemeObserver.getColorValue(color);
   }

--- a/packages/framework/store/package.json
+++ b/packages/framework/store/package.json
@@ -23,6 +23,7 @@
     "@types/lodash.ismatch": "^4.4.9",
     "flexsearch": "0.7.43",
     "lib0": "^0.2.97",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.ismatch": "^4.4.0",
     "lodash.merge": "^4.6.2",
     "minimatch": "^10.0.1",
@@ -31,6 +32,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.9",
     "@types/lodash.merge": "^4.6.9",
     "lit": "^3.2.0",
     "yjs": "^13.6.18"

--- a/packages/framework/store/src/store/collection.ts
+++ b/packages/framework/store/src/store/collection.ts
@@ -10,6 +10,7 @@ import {
   MemoryBlobSource,
   NoopDocSource,
 } from '@blocksuite/sync';
+import clonedeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import { Awareness } from 'y-protocols/awareness.js';
 import * as Y from 'yjs';
@@ -118,7 +119,7 @@ export class DocCollection extends DocCollectionAddonType {
     this.doc = new BlockSuiteDoc({ guid: id });
     this.awarenessStore = new AwarenessStore(
       new Awareness<RawAwarenessState>(this.doc),
-      merge({ ...FLAGS_PRESET }, defaultFlags)
+      merge(clonedeep(FLAGS_PRESET), defaultFlags)
     );
 
     this.awarenessSync = new AwarenessEngine(

--- a/packages/framework/store/src/yjs/awareness.ts
+++ b/packages/framework/store/src/yjs/awareness.ts
@@ -2,6 +2,7 @@ import type { Awareness as YAwareness } from 'y-protocols/awareness.js';
 
 import { Slot } from '@blocksuite/global/utils';
 import { type Signal, signal } from '@preact/signals-core';
+import clonedeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 
 import type { BlockCollection } from '../store/index.js';
@@ -87,7 +88,7 @@ export class AwarenessStore<
 
   private _initFlags(defaultFlags: Flags) {
     const upstreamFlags = this.awareness.getLocalState()?.flags;
-    const flags = { ...defaultFlags };
+    const flags = clonedeep(defaultFlags);
     if (upstreamFlags) {
       merge(flags, upstreamFlags);
     }

--- a/packages/presets/src/__tests__/edgeless/last-props.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/last-props.spec.ts
@@ -1,11 +1,11 @@
-import type {
-  BrushElementModel,
-  ConnectorElementModel,
-  EdgelessRootBlockComponent,
-  ShapeElementModel,
-  TextElementModel,
+import {
+  ShapeType,
+  type BrushElementModel,
+  type ConnectorElementModel,
+  type EdgelessRootBlockComponent,
+  type ShapeElementModel,
+  type TextElementModel,
 } from '@blocksuite/blocks';
-
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { getDocRootBlock } from '../utils/edgeless.js';
@@ -23,17 +23,70 @@ describe('apply last props', () => {
     return cleanup;
   });
 
-  test('shape', () => {
-    const id = service.addElement('shape', { shapeType: 'rect' });
-    const shape = service.getElementById(id) as ShapeElementModel;
-    expect(shape.fillColor).toBe('--affine-palette-shape-yellow');
-    expect(shape.strokeColor).toBe('--affine-palette-line-yellow');
-    expect(shape.shapeStyle).toBe('General');
-    service.updateElement(id, { fillColor: '--affine-palette-shape-orange' });
-    const secondShape = service.getElementById(
-      service.addElement('shape', { shapeType: 'rect' })
+  test('shapes', () => {
+    // rect shape
+    const rectId = service.addElement('shape', { shapeType: ShapeType.Rect });
+    const rectShape = service.getElementById(rectId) as ShapeElementModel;
+    expect(rectShape.fillColor).toBe('--affine-palette-shape-yellow');
+    service.updateElement(rectId, {
+      fillColor: '--affine-palette-shape-orange',
+    });
+    expect(
+      service.editPropsStore.lastProps$.value[`shape:${ShapeType.Rect}`]
+        .fillColor
+    ).toBe('--affine-palette-shape-orange');
+
+    // diamond shape
+    const diamondId = service.addElement('shape', {
+      shapeType: ShapeType.Diamond,
+    });
+    const diamondShape = service.getElementById(diamondId) as ShapeElementModel;
+    expect(diamondShape.fillColor).toBe('--affine-palette-shape-yellow');
+    service.updateElement(diamondId, {
+      fillColor: '--affine-palette-shape-blue',
+    });
+    expect(
+      service.editPropsStore.lastProps$.value[`shape:${ShapeType.Diamond}`]
+        .fillColor
+    ).toBe('--affine-palette-shape-blue');
+
+    // rounded rect shape
+    const roundedRectId = service.addElement('shape', {
+      shapeType: ShapeType.Rect,
+      radius: 0.1,
+    });
+    const roundedRectShape = service.getElementById(
+      roundedRectId
     ) as ShapeElementModel;
-    expect(secondShape.fillColor).toBe('--affine-palette-shape-orange');
+    expect(roundedRectShape.fillColor).toBe('--affine-palette-shape-yellow');
+    service.updateElement(roundedRectId, {
+      fillColor: '--affine-palette-shape-green',
+    });
+    expect(
+      service.editPropsStore.lastProps$.value['shape:roundedRect'].fillColor
+    ).toBe('--affine-palette-shape-green');
+
+    // apply last props
+    const rectId2 = service.addElement('shape', { shapeType: ShapeType.Rect });
+    const rectShape2 = service.getElementById(rectId2) as ShapeElementModel;
+    expect(rectShape2.fillColor).toBe('--affine-palette-shape-orange');
+
+    const diamondId2 = service.addElement('shape', {
+      shapeType: ShapeType.Diamond,
+    });
+    const diamondShape2 = service.getElementById(
+      diamondId2
+    ) as ShapeElementModel;
+    expect(diamondShape2.fillColor).toBe('--affine-palette-shape-blue');
+
+    const roundedRectId2 = service.addElement('shape', {
+      shapeType: ShapeType.Rect,
+      radius: 0.1,
+    });
+    const droundedRectShape2 = service.getElementById(
+      roundedRectId2
+    ) as ShapeElementModel;
+    expect(droundedRectShape2.fillColor).toBe('--affine-palette-shape-green');
   });
 
   test('connector', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,9 @@ importers:
       lit:
         specifier: ^3.2.0
         version: 3.2.0
+      lodash.clonedeep:
+        specifier: ^4.5.0
+        version: 4.5.0
       lodash.isplainobject:
         specifier: ^4.0.6
         version: 4.0.6
@@ -630,6 +633,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.0.5
         version: 3.0.5
+      '@types/lodash.clonedeep':
+        specifier: ^4.5.9
+        version: 4.5.9
       '@types/lodash.isplainobject':
         specifier: ^4.0.9
         version: 4.0.9
@@ -768,6 +774,9 @@ importers:
       lib0:
         specifier: ^0.2.97
         version: 0.2.97
+      lodash.clonedeep:
+        specifier: ^4.5.0
+        version: 4.5.0
       lodash.ismatch:
         specifier: ^4.4.0
         version: 4.4.0
@@ -787,6 +796,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@types/lodash.clonedeep':
+        specifier: ^4.5.9
+        version: 4.5.9
       '@types/lodash.merge':
         specifier: ^4.6.9
         version: 4.6.9
@@ -2972,6 +2984,9 @@ packages:
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/lodash.clonedeep@4.5.9':
+    resolution: {integrity: sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==}
 
   '@types/lodash.ismatch@4.4.9':
     resolution: {integrity: sha512-qWihnStOPKH8urljLGm6ZOEdN/5Bt4vxKR81tL3L4ArUNLvcf9RW3QSnPs21eix5BiqioSWq4aAXD4Iep+d0fw==}
@@ -5687,6 +5702,9 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.clonedeepwith@4.5.0:
     resolution: {integrity: sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==}
@@ -11071,6 +11089,10 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
+  '@types/lodash.clonedeep@4.5.9':
+    dependencies:
+      '@types/lodash': 4.17.7
+
   '@types/lodash.ismatch@4.4.9':
     dependencies:
       '@types/lodash': 4.17.7
@@ -14145,6 +14167,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.clonedeep@4.5.0: {}
 
   lodash.clonedeepwith@4.5.0: {}
 

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -368,14 +368,7 @@ export async function assertEdgelessShapeType(page: Page, type: ShapeName) {
     if (container.edgelessTool.type !== 'shape')
       throw new Error('Expected shape tool');
 
-    const shapeType = container.edgelessTool.shapeType;
-    if (
-      shapeType === 'rect' &&
-      container.service.editPropsStore.getLastProps('shape').radius > 0
-    )
-      return 'roundedRect';
-
-    return container.edgelessTool.shapeType;
+    return container.edgelessTool.shapeName;
   });
 
   expect(type).toEqual(curType);


### PR DESCRIPTION
### What Changed?
- Split lastProps$ of different shape types.
```typescript
export const NodePropsSchema = z.object({
  'shape:diamond': ShapeSchema,
  'shape:ellipse': ShapeSchema,
  'shape:rect': ShapeSchema,
  'shape:triangle': ShapeSchema,
  'shape:roundedRect': RoundedShapeSchema,
});
```
- Refactor toolbar menu components.
- Rename `shapeType` to `shapeName` in toolbar.
- Remove `getLastProps` API.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/0f035089-1dfa-4e9d-b654-85ea5c91a821.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/0f035089-1dfa-4e9d-b654-85ea5c91a821.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/0f035089-1dfa-4e9d-b654-85ea5c91a821.mov">录屏2024-09-03 19.01.08.mov</video>

