### PR TITLE
fix(blocks): embed card overflow in mobile

### DIFF
--- a/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
+++ b/packages/blocks/src/_common/embed-block-helper/embed-block-element.ts
@@ -5,6 +5,7 @@ import type { BlockModel } from '@blocksuite/store';
 import type { TemplateResult } from 'lit';
 
 import { CaptionedBlockComponent } from '@blocksuite/affine-components/caption';
+import { DocModeProvider } from '@blocksuite/affine-shared/services';
 import { ThemeObserver } from '@blocksuite/affine-shared/theme';
 import {
   type BlockService,
@@ -156,7 +157,11 @@ export class EmbedBlockComponent<
       this._cardStyle === 'list'
     ) {
       this.style.display = 'block';
-      this.style.minWidth = `${BOOKMARK_MIN_WIDTH}px`;
+
+      const mode = this.std.get(DocModeProvider).getEditorMode();
+      if (mode === 'edgeless') {
+        this.style.minWidth = `${BOOKMARK_MIN_WIDTH}px`;
+      }
     }
 
     return html`

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -1,6 +1,7 @@
 import type { BookmarkBlockModel } from '@blocksuite/affine-model';
 
 import { CaptionedBlockComponent } from '@blocksuite/affine-components/caption';
+import { DocModeProvider } from '@blocksuite/affine-shared/services';
 import { html } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
@@ -18,11 +19,7 @@ export class BookmarkBlockComponent extends CaptionedBlockComponent<
 > {
   private _fetchAbortController?: AbortController;
 
-  protected containerStyleMap = styleMap({
-    position: 'relative',
-    width: '100%',
-    minWidth: `${BOOKMARK_MIN_WIDTH}px`,
-  });
+  protected containerStyleMap!: ReturnType<typeof styleMap>;
 
   open = () => {
     let link = this.model.url;
@@ -40,6 +37,15 @@ export class BookmarkBlockComponent extends CaptionedBlockComponent<
 
   override connectedCallback() {
     super.connectedCallback();
+
+    const mode = this.std.get(DocModeProvider).getEditorMode();
+    const miniWidth = `${BOOKMARK_MIN_WIDTH}px`;
+
+    this.containerStyleMap = styleMap({
+      position: 'relative',
+      width: '100%',
+      ...(mode === 'edgeless' ? { miniWidth } : {}),
+    });
 
     this._fetchAbortController = new AbortController();
 

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -3,12 +3,13 @@ import {
   WidgetViewMapIdentifier,
 } from '@blocksuite/block-std';
 import * as blocks from '@blocksuite/blocks';
-import { QuickSearchProvider } from '@blocksuite/blocks';
+import { DocModeProvider, QuickSearchProvider } from '@blocksuite/blocks';
 import * as globalUtils from '@blocksuite/global/utils';
 import * as editor from '@blocksuite/presets';
 import '@blocksuite/presets/themes/affine.css';
 import * as store from '@blocksuite/store';
 
+import { mockDocModeService } from '../_common/mock-services.js';
 import { setupEdgelessTemplate } from '../_common/setup.js';
 import '../dev-format.js';
 import {
@@ -37,9 +38,13 @@ async function main() {
         identifiers: {
           WidgetViewMapIdentifier,
           QuickSearchProvider,
+          DocModeProvider,
         },
         extensions: {
           WidgetViewMapExtension,
+        },
+        mockServices: {
+          mockDocModeService,
         },
       }),
     });

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -103,6 +103,17 @@ async function initEmptyEditor({
                 });
               },
             },
+            {
+              setup: di => {
+                di.override(
+                  window.$blocksuite.identifiers.DocModeProvider,
+                  window.$blocksuite.mockServices.mockDocModeService(
+                    () => editor.mode,
+                    mode => editor.switchEditor(mode)
+                  )
+                );
+              },
+            },
           ];
           editor.edgelessSpecs = [
             ...editor.edgelessSpecs,
@@ -111,6 +122,17 @@ async function initEmptyEditor({
                 di.addImpl(window.$blocksuite.identifiers.QuickSearchProvider, {
                   searchDoc: () => Promise.resolve(null),
                 });
+              },
+            },
+            {
+              setup: di => {
+                di.override(
+                  window.$blocksuite.identifiers.DocModeProvider,
+                  window.$blocksuite.mockServices.mockDocModeService(
+                    () => editor.mode,
+                    mode => editor.switchEditor(mode)
+                  )
+                );
               },
             },
           ];

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -8,7 +8,9 @@ import type { BlockModel, Doc, DocCollection } from '@store/index.js';
 
 declare global {
   interface Window {
-    /** Available on playground window */
+    /** Available on playground window
+     * the following instance are initialized in `packages/playground/apps/starter/main.ts`
+     */
     $blocksuite: {
       store: typeof import('../../packages/framework/store/src/index.js');
       blocks: typeof import('../../packages/blocks/src/index.js');
@@ -19,9 +21,13 @@ declare global {
       identifiers: {
         WidgetViewMapIdentifier: typeof WidgetViewMapIdentifier;
         QuickSearchProvider: typeof import('../../packages/affine/shared/src/services/quick-search-service.js').QuickSearchProvider;
+        DocModeProvider: typeof import('../../packages/affine/shared/src/services/doc-mode-service.js').DocModeProvider;
       };
       extensions: {
         WidgetViewMapExtension: typeof import('../../packages/framework/block-std/src/extension/widget-view-map.js').WidgetViewMapExtension;
+      };
+      mockServices: {
+        mockDocModeService: typeof import('../../packages/playground/apps/_common/mock-services.js').mockDocModeService;
       };
     };
     collection: DocCollection;


### PR DESCRIPTION
Close: [BS-1289](https://linear.app/affine-design/issue/BS-1289/linked-doc-block有个写死的min-width-450px-：-需要去除最小宽度的限制)

This fix based on `getEditorMode()`. There three cases:
- `edgeless mode > note or edgeless text > embed card`, apply `max-width`,
- `edgeless mode > embed card` no width limit, since the style is overrideed in `renderGfxBlock()`,
- `page mode > embed card` remove `max-width` since the page width may be small like in mobile.

In AFFiNE side, the `getEditorMode()` should be provide in `DocModeService`, related PR: #8110 

Other changes:
- add `mockDocModeService` for editor of playwright test

