### PR TITLE
fix: edgeless viewport pan and zoom when readonly

### DIFF
--- a/packages/framework/block-std/src/event/dispatcher.ts
+++ b/packages/framework/block-std/src/event/dispatcher.ts
@@ -263,8 +263,6 @@ export class UIEventDispatcher extends LifeCycleWatcher {
   }
 
   private _setActive(active: boolean) {
-    if (this.host.doc.readonly) return;
-
     if (active) {
       if (UIEventDispatcher._activeDispatcher !== this) {
         if (UIEventDispatcher._activeDispatcher) {

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -18,6 +18,7 @@ import {
   optionMouseDrag,
   shiftClickView,
   switchEditorMode,
+  toggleEditorReadonly,
   zoomByMouseWheel,
   zoomResetByKeyboard,
 } from '../utils/actions/edgeless.js';
@@ -147,6 +148,32 @@ test('zoom by pinch', async ({ page }) => {
   await assertZoomLevel(page, 50);
   const zoomed = [265, 426.25, 0.5 * NOTE_WIDTH, 46];
   await assertEdgelessSelectedRect(page, zoomed);
+});
+
+test('zoom by pinch when edgeless is readonly', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyEdgelessState(page);
+
+  await switchEditorMode(page);
+  await zoomResetByKeyboard(page);
+  await assertZoomLevel(page, 100);
+
+  await toggleEditorReadonly(page);
+
+  const from = [
+    { x: CENTER_X - 100, y: CENTER_Y },
+    { x: CENTER_X + 100, y: CENTER_Y },
+  ];
+  const to = [
+    { x: CENTER_X - 50, y: CENTER_Y },
+    { x: CENTER_X + 50, y: CENTER_Y },
+  ];
+  await multiTouchDown(page, from);
+  await multiTouchMove(page, from, to);
+  await multiTouchUp(page, to);
+
+  await toggleEditorReadonly(page);
+  await assertZoomLevel(page, 50);
 });
 
 test('move by pan', async ({ page }) => {

--- a/tests/edgeless/presentation.spec.ts
+++ b/tests/edgeless/presentation.spec.ts
@@ -42,6 +42,7 @@ test.describe('presentation', () => {
     await prevButton.click();
     await expect(edgelessNote).toBeHidden();
 
+    await waitNextFrame(page, 300);
     await nextButton.click();
     await expect(edgelessNote).toBeVisible();
   });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -136,6 +136,12 @@ export async function enterPresentationMode(page: Page) {
   await waitNextFrame(page);
 }
 
+export async function toggleEditorReadonly(page: Page) {
+  await page.click('sl-button:text("Test Operations")');
+  await page.click('sl-menu-item:text("Toggle Readonly")');
+  await waitNextFrame(page);
+}
+
 type EdgelessTool =
   | 'default'
   | 'pan'


### PR DESCRIPTION
Fix: [BS-1315](https://linear.app/affine-design/issue/BS-1315/bug：edgeless-mode-无法移动)