### PR TITLE
refactor(edgeless): decouple `ConnectorPathGenerator` from mindmap model

### DIFF
--- a/packages/affine/block-surface/src/element-model/mindmap.ts
+++ b/packages/affine/block-surface/src/element-model/mindmap.ts
@@ -1,6 +1,5 @@
 import type {
   BaseElementProps,
-  GfxModel,
   SerializedElement,
   SurfaceBlockModel,
 } from '@blocksuite/block-std/gfx';
@@ -36,7 +35,6 @@ import type {
 } from './utils/mindmap/style.js';
 
 import { TextResizing } from '../consts.js';
-import { ConnectorPathGenerator } from '../managers/connector-manager.js';
 import { LayoutType, layout } from './utils/mindmap/layout.js';
 import {
   MindmapStyle,
@@ -86,12 +84,6 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
   connectors = new Map<string, LocalConnectorElementModel>();
 
   extraConnectors = new Map<string, LocalConnectorElementModel>();
-
-  pathGenerator: ConnectorPathGenerator = new ConnectorPathGenerator({
-    getElementById: (id: string) =>
-      this.surface.getElementById(id) ??
-      (this.surface.doc.getBlockById(id) as GfxModel),
-  });
 
   static createFromTree(
     tree: MindmapNode,
@@ -264,8 +256,6 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
       // @ts-ignore
       connector[key as unknown] = value;
     });
-
-    this.pathGenerator.updatePath(connector);
 
     return connector;
   }

--- a/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
@@ -1,9 +1,11 @@
 import type { ShapeElementModel } from '@blocksuite/affine-model';
+import type { GfxModel } from '@blocksuite/block-std/gfx';
 
 import { assertType } from '@blocksuite/global/utils';
 
 import type { MindmapElementModel } from '../../mindmap.js';
 
+import { ConnectorPathGenerator } from '../../../managers/connector-manager.js';
 import { LayoutType, type MindmapNode } from './layout.js';
 
 export function getHoveredArea(
@@ -116,6 +118,10 @@ export function showMergeIndicator(
     style.connector,
     true
   );
+  const elementGetter = (id: string) =>
+    targetMindmap.surface.getElementById(id) ??
+    (targetMindmap.surface.doc.getBlockById(id) as GfxModel);
+  ConnectorPathGenerator.updatePath(connector, null, elementGetter);
 
   source.overriddenDir = mergeInfo.layoutType;
 

--- a/packages/affine/block-surface/src/managers/connector-manager.ts
+++ b/packages/affine/block-surface/src/managers/connector-manager.ts
@@ -1330,11 +1330,15 @@ export class ConnectorPathGenerator {
     return true;
   }
 
-  updatePath(
+  static updatePath(
     connector: ConnectorElementModel | LocalConnectorElementModel,
-    path?: PointLocation[]
+    path: PointLocation[] | null | null,
+    elementGetter?: (id: string) => GfxModel | null
   ) {
-    const points = path ?? this._generateConnectorPath(connector) ?? [];
+    const instance = new ConnectorPathGenerator({
+      getElementById: elementGetter ?? (() => null),
+    });
+    const points = path ?? instance._generateConnectorPath(connector) ?? [];
     const bound =
       connector.mode === ConnectorMode.Curve
         ? getBezierCurveBoundingBox(getBezierParameters(points))

--- a/packages/affine/block-surface/src/middlewares/connector.ts
+++ b/packages/affine/block-surface/src/middlewares/connector.ts
@@ -10,11 +10,8 @@ export const connectorMiddleware: SurfaceMiddleware = (
 ) => {
   const hasElementById = (id: string) =>
     surface.hasElementById(id) || surface.doc.hasBlockById(id);
-  const getElementById = (id: string) =>
+  const elementGetter = (id: string) =>
     surface.getElementById(id) ?? (surface.doc.getBlockById(id) as GfxModel);
-  const pathGenerator = new ConnectorPathGenerator({
-    getElementById: getElementById,
-  });
   const updateConnectorPath = (connector: ConnectorElementModel) => {
     if (
       ((connector.source?.id && hasElementById(connector.source.id)) ||
@@ -22,7 +19,7 @@ export const connectorMiddleware: SurfaceMiddleware = (
       ((connector.target?.id && hasElementById(connector.target.id)) ||
         (!connector.target?.id && connector.target?.position))
     ) {
-      pathGenerator.updatePath(connector);
+      ConnectorPathGenerator.updatePath(connector, null, elementGetter);
     }
   };
   const pendingList = new Set<ConnectorElementModel>();
@@ -42,7 +39,7 @@ export const connectorMiddleware: SurfaceMiddleware = (
 
   const disposables = [
     surface.elementAdded.on(({ id }) => {
-      const element = getElementById(id);
+      const element = elementGetter(id);
 
       if (!element) return;
 
@@ -53,7 +50,7 @@ export const connectorMiddleware: SurfaceMiddleware = (
       }
     }),
     surface.elementUpdated.on(({ id, props }) => {
-      const element = getElementById(id);
+      const element = elementGetter(id);
 
       if (props['xywh'] || props['rotate']) {
         surface.getConnectors(id).forEach(addToUpdateList);

--- a/packages/affine/block-surface/src/renderer/elements/mindmap.ts
+++ b/packages/affine/block-surface/src/renderer/elements/mindmap.ts
@@ -1,9 +1,11 @@
+import type { GfxModel } from '@blocksuite/block-std/gfx';
 import type { IBound } from '@blocksuite/global/utils';
 
 import type { MindmapElementModel } from '../../element-model/mindmap.js';
 import type { RoughCanvas } from '../../utils/rough/canvas.js';
 import type { CanvasRenderer } from '../canvas-renderer.js';
 
+import { ConnectorPathGenerator } from '../../managers/connector-manager.js';
 import { connector as renderConnector } from './connector/index.js';
 
 export function mindmap(
@@ -22,6 +24,12 @@ export function mindmap(
   model.traverse((to, from) => {
     if (from) {
       const connector = model.getConnector(from, to);
+      if (!connector) return;
+
+      const elementGetter = (id: string) =>
+        model.surface.getElementById(id) ??
+        (model.surface.doc.getBlockById(id) as GfxModel);
+      ConnectorPathGenerator.updatePath(connector, null, elementGetter);
 
       if (connector) {
         const dx = connector.x - bound.x;


### PR DESCRIPTION
This removes `this.pathGenerator` on `MindmapElementModel`.

After landing this PR, `MindmapElementModel` should be available to be moved to the `affine-model` package.