### PR TITLE
feat(edgeless): only select top level in element tree during drag selecting

### DIFF
--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -220,7 +220,7 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     const h = Math.abs(startY - curY);
     const bound = new Bound(x, y, w, h);
 
-    const elements = service.gfx.getElementsByBound(bound);
+    const elements = getTopElements(service.gfx.getElementsByBound(bound));
 
     const set = new Set(
       tools.shiftKey ? [...elements, ...selection.selectedElements] : elements


### PR DESCRIPTION
Close [BS-1285](https://linear.app/affine-design/issue/BS-1285/group全选时，对齐会对齐group内部yuan素)

This PR changes the behavior of dragging selection that only select top level element in **element tree** in dragging area. See below.

### Before
inner elements are also selected

![CleanShot 2024-09-05 at 17.42.04@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/b804aa86-aeb9-43e9-b88d-9e50baa8753d.png)

### After
only selected outer elements

![CleanShot 2024-09-05 at 17.41.10@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/0e0a06c7-c11c-4d82-8df1-e99b37b9d083.png)

