### PR TITLE
fix(blocks): tracking logic should not be triggered when the result is null

### DIFF
--- a/packages/blocks/src/embed-linked-doc-block/commands/insert-link-by-quick-search.ts
+++ b/packages/blocks/src/embed-linked-doc-block/commands/insert-link-by-quick-search.ts
@@ -37,7 +37,8 @@ export const insertLinkByQuickSearchCommand: Command<
           flavour: 'affine:bookmark',
         };
       }
-      return {};
+
+      return null;
     });
 
   next({ insertedLinkType });
@@ -49,7 +50,7 @@ declare global {
       insertedLinkType?: Promise<{
         flavour?: string;
         isNewDoc?: boolean;
-      }>;
+      } | null>;
     }
 
     interface Commands {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
@@ -14,23 +14,23 @@ export const buildLinkDenseMenu: DenseMenuBuilder = edgeless => ({
 
     insertedLinkType
       ?.then(type => {
-        if (type) {
-          edgeless.std
-            .getOptional(TelemetryProvider)
-            ?.track('CanvasElementAdded', {
-              control: 'toolbar:general',
-              page: 'whiteboard editor',
-              module: 'toolbar',
-              type: type.flavour?.split(':')[1],
-            });
-          if (type.isNewDoc) {
-            edgeless.std.getOptional(TelemetryProvider)?.track('DocCreated', {
-              control: 'toolbar:general',
-              page: 'whiteboard editor',
-              module: 'edgeless toolbar',
-              type: type.flavour?.split(':')[1],
-            });
-          }
+        if (!type) return;
+
+        edgeless.std
+          .getOptional(TelemetryProvider)
+          ?.track('CanvasElementAdded', {
+            control: 'toolbar:general',
+            page: 'whiteboard editor',
+            module: 'toolbar',
+            type: type.flavour?.split(':')[1],
+          });
+        if (type.isNewDoc) {
+          edgeless.std.getOptional(TelemetryProvider)?.track('DocCreated', {
+            control: 'toolbar:general',
+            page: 'whiteboard editor',
+            module: 'edgeless toolbar',
+            type: type.flavour?.split(':')[1],
+          });
         }
       })
       .catch(console.error);

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
@@ -24,49 +24,49 @@ export class EdgelessLinkToolButton extends QuickToolMixin(LitElement) {
     );
     insertedLinkType
       ?.then(type => {
-        if (type) {
+        if (!type) return;
+
+        this.edgeless.std
+          .getOptional(TelemetryProvider)
+          ?.track('CanvasElementAdded', {
+            control: 'toolbar:general',
+            page: 'whiteboard editor',
+            module: 'toolbar',
+            segment: 'toolbar',
+            type: type.flavour?.split(':')[1],
+          });
+
+        if (type.isNewDoc) {
           this.edgeless.std
             .getOptional(TelemetryProvider)
-            ?.track('CanvasElementAdded', {
+            ?.track('DocCreated', {
               control: 'toolbar:general',
               page: 'whiteboard editor',
-              module: 'toolbar',
-              segment: 'toolbar',
+              module: 'edgeless toolbar',
+              segment: 'whiteboard',
               type: type.flavour?.split(':')[1],
             });
-
-          if (type.isNewDoc) {
-            this.edgeless.std
-              .getOptional(TelemetryProvider)
-              ?.track('DocCreated', {
-                control: 'toolbar:general',
-                page: 'whiteboard editor',
-                module: 'edgeless toolbar',
-                segment: 'whiteboard',
-                type: type.flavour?.split(':')[1],
-              });
-            this.edgeless.std
-              .getOptional(TelemetryProvider)
-              ?.track('LinkedDocCreated', {
-                control: 'links',
-                page: 'whiteboard editor',
-                module: 'edgeless toolbar',
-                segment: 'whiteboard',
-                type: type.flavour?.split(':')[1],
-                other: 'new doc',
-              });
-          } else {
-            this.edgeless.std
-              .getOptional(TelemetryProvider)
-              ?.track('LinkedDocCreated', {
-                control: 'links',
-                page: 'whiteboard editor',
-                module: 'edgeless toolbar',
-                segment: 'whiteboard',
-                type: type.flavour?.split(':')[1],
-                other: 'existing doc',
-              });
-          }
+          this.edgeless.std
+            .getOptional(TelemetryProvider)
+            ?.track('LinkedDocCreated', {
+              control: 'links',
+              page: 'whiteboard editor',
+              module: 'edgeless toolbar',
+              segment: 'whiteboard',
+              type: type.flavour?.split(':')[1],
+              other: 'new doc',
+            });
+        } else {
+          this.edgeless.std
+            .getOptional(TelemetryProvider)
+            ?.track('LinkedDocCreated', {
+              control: 'links',
+              page: 'whiteboard editor',
+              module: 'edgeless toolbar',
+              segment: 'whiteboard',
+              type: type.flavour?.split(':')[1],
+              other: 'existing doc',
+            });
         }
       })
       .catch(console.error);

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
@@ -72,25 +72,25 @@ export class EdgelessNoteMenu extends EdgelessToolbarToolMixin(LitElement) {
 
     insertedLinkType
       ?.then(type => {
-        if (type) {
+        if (!type) return;
+
+        this.edgeless.std
+          .getOptional(TelemetryProvider)
+          ?.track('CanvasElementAdded', {
+            control: 'toolbar:general',
+            page: 'whiteboard editor',
+            module: 'toolbar',
+            type: type.flavour?.split(':')[1],
+          });
+        if (type.isNewDoc) {
           this.edgeless.std
             .getOptional(TelemetryProvider)
-            ?.track('CanvasElementAdded', {
+            ?.track('DocCreated', {
               control: 'toolbar:general',
               page: 'whiteboard editor',
-              module: 'toolbar',
+              module: 'edgeless toolbar',
               type: type.flavour?.split(':')[1],
             });
-          if (type.isNewDoc) {
-            this.edgeless.std
-              .getOptional(TelemetryProvider)
-              ?.track('DocCreated', {
-                control: 'toolbar:general',
-                page: 'whiteboard editor',
-                module: 'edgeless toolbar',
-                type: type.flavour?.split(':')[1],
-              });
-          }
         }
       })
       .catch(console.error);

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -188,26 +188,26 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
 
           insertedLinkType
             ?.then(type => {
-              if (type) {
+              if (!type) return;
+
+              rootComponent.std
+                .getOptional(TelemetryProvider)
+                ?.track('CanvasElementAdded', {
+                  control: 'shortcut',
+                  page: 'whiteboard editor',
+                  module: 'toolbar',
+                  segment: 'toolbar',
+                  type: type.flavour?.split(':')[1],
+                });
+              if (type.isNewDoc) {
                 rootComponent.std
                   .getOptional(TelemetryProvider)
-                  ?.track('CanvasElementAdded', {
+                  ?.track('DocCreated', {
                     control: 'shortcut',
                     page: 'whiteboard editor',
-                    module: 'toolbar',
-                    segment: 'toolbar',
+                    segment: 'whiteboard',
                     type: type.flavour?.split(':')[1],
                   });
-                if (type.isNewDoc) {
-                  rootComponent.std
-                    .getOptional(TelemetryProvider)
-                    ?.track('DocCreated', {
-                      control: 'shortcut',
-                      page: 'whiteboard editor',
-                      segment: 'whiteboard',
-                      type: type.flavour?.split(':')[1],
-                    });
-                }
               }
             })
             .catch(console.error);


### PR DESCRIPTION
Closes [BS-1333](https://linear.app/affine-design/issue/BS-1333/需要修复一个-linked-doc-添加行为的埋点逻辑)