### PR TITLE
fix(edgeless): xywh missing in mindmap serialized data

### DIFF
--- a/packages/affine/model/src/elements/group/group.ts
+++ b/packages/affine/model/src/elements/group/group.ts
@@ -92,7 +92,6 @@ export class GroupElementModel extends GfxGroupLikeElementModel<GroupElementProp
 
   override serialize() {
     const result = super.serialize();
-    result.xywh = this.xywh;
     return result as SerializedGroupElement;
   }
 

--- a/packages/framework/block-std/src/gfx/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/surface/element-model.ts
@@ -294,7 +294,9 @@ export abstract class GfxPrimitiveElementModel<
   }
 
   serialize() {
-    return this.yMap.toJSON() as SerializedElement;
+    const result = this.yMap.toJSON();
+    result.xywh = this.xywh;
+    return result as SerializedElement;
   }
 
   stash(prop: keyof Props | string) {


### PR DESCRIPTION
move export `xywh` from `GroupModel` to `GroupLikeModel` for covering mindmap