### PR TITLE
fix(edgeless): externalXYWH is undefined when frame out of viewport after enter edgeless editor

### DIFF
--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -223,6 +223,13 @@ export class EdgelessFrameTitle extends SignalWatcher(
     this._xywh = this.model.xywh;
   }
 
+  override firstUpdated() {
+    if (!this._frameTitleEl) return;
+    this._cachedWidth = this._frameTitleEl.clientWidth;
+    this._cachedHeight = this._frameTitleEl.clientHeight;
+    this._updateFrameTitleSize();
+  }
+
   override render() {
     const model = this.model;
     const bound = Bound.deserialize(model.xywh);
@@ -291,7 +298,6 @@ export class EdgelessFrameTitle extends SignalWatcher(
       this._cachedHeight = this._frameTitleEl.clientHeight;
       sizeChanged = true;
     }
-
     if (sizeChanged || _changedProperties.has('_zoom')) {
       this._updateFrameTitleSize();
     }

--- a/packages/presets/src/__tests__/edgeless/frame.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/frame.spec.ts
@@ -1,5 +1,9 @@
-import type { EdgelessRootBlockComponent } from '@blocksuite/blocks';
+import type {
+  EdgelessRootBlockComponent,
+  FrameBlockComponent,
+} from '@blocksuite/blocks';
 
+import { assertType } from '@blocksuite/global/utils';
 import { Text } from '@blocksuite/store';
 import { beforeEach, describe, expect, test } from 'vitest';
 
@@ -82,7 +86,7 @@ describe('frame', () => {
       service.surface.id
     );
     service.zoomToFit();
-    await wait();
+    await wait(500); // fit has a transition animation
 
     const frameTitle = document.querySelector(
       `[data-block-id="${frameId}"] .affine-frame-title`
@@ -96,11 +100,11 @@ describe('frame', () => {
     const pointDom1 = document.elementFromPoint(
       titleRect.x + titleRect.width / 2,
       titleRect.y + titleRect.height / 2
-    ) as HTMLElement;
+    );
     const pointDom2 = document.elementFromPoint(
       bodyRect.x + bodyRect.width / 2,
       bodyRect.y + bodyRect.height / 2
-    ) as HTMLElement;
+    );
 
     expect(
       frameTitle.contains(pointDom1),
@@ -111,5 +115,25 @@ describe('frame', () => {
       frameBody.contains(pointDom2),
       'Frame body should be on bottom'
     ).toBeFalsy();
+  });
+
+  test('frame should have externalXYWH after moving viewport to contains frame', async () => {
+    const frameId = service.doc.addBlock(
+      'affine:frame',
+      {
+        xywh: '[1800,1800,200,200]',
+        title: new Text('Frame 1'),
+      },
+      service.surface.id
+    );
+    await wait();
+
+    const frame = service.doc.getBlock(frameId);
+    expect(frame).toBeTruthy();
+
+    assertType<FrameBlockComponent>(frame);
+
+    service.viewport.setCenter(900, 900);
+    expect(frame?.model.externalXYWH).toBeDefined();
   });
 });


### PR DESCRIPTION
Close [BS-1353](https://linear.app/affine-design/issue/BS-1353/externalxywh-is-undefined-when-frame-out-of-viewport-when-enter)

If a frame is out of viewport after enter edgeless editor, the title of frame will be un-clickable when move viewport to the position of frame. The reason is `externalXYWH` is not initialized by `<edgeless-frame-title>` in this case.


### Before

https://github.com/user-attachments/assets/2b0e9979-c8cc-4207-843c-65786656f487


### After

https://github.com/user-attachments/assets/fc3875cc-dd7a-46c4-925f-fd01779cb945

