### PR TITLE
feat: mindmap remembers last settings

### DIFF
--- a/packages/affine/block-surface/src/element-model/mindmap.ts
+++ b/packages/affine/block-surface/src/element-model/mindmap.ts
@@ -6,7 +6,9 @@ import type {
 import type { SerializedXYWH, XYWH } from '@blocksuite/global/utils';
 
 import {
+  LayoutType,
   LocalConnectorElementModel,
+  MindmapStyle,
   TextResizing,
 } from '@blocksuite/affine-model';
 import {
@@ -37,15 +39,8 @@ import type {
   MindmapStyleGetter,
 } from './utils/mindmap/style.js';
 
-import { layout, LayoutType } from './utils/mindmap/layout.js';
-import {
-  applyNodeStyle,
-  MindmapStyle,
-  mindmapStyleGetters,
-} from './utils/mindmap/style.js';
-
-export { LayoutType } from './utils/mindmap/layout.js';
-export { MindmapStyle } from './utils/mindmap/style.js';
+import { layout } from './utils/mindmap/layout.js';
+import { applyNodeStyle, mindmapStyleGetters } from './utils/mindmap/style.js';
 
 const baseNodeSchema = z.object({
   text: z.string(),

--- a/packages/affine/block-surface/src/element-model/utils/mindmap/layout.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/layout.ts
@@ -1,5 +1,6 @@
 import type { SerializedXYWH } from '@blocksuite/global/utils';
 
+import { LayoutType } from '@blocksuite/affine-model';
 import { Bound } from '@blocksuite/global/utils';
 
 import type { MindmapElementModel } from '../../mindmap.js';
@@ -40,12 +41,6 @@ export type MindmapRoot = MindmapNode & {
   left: MindmapNode[];
   right: MindmapNode[];
 };
-
-export enum LayoutType {
-  BALANCE = 2,
-  LEFT = 1,
-  RIGHT = 0,
-}
 
 type TreeSize = {
   /**

--- a/packages/affine/block-surface/src/element-model/utils/mindmap/style.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/style.ts
@@ -5,6 +5,7 @@ import {
   FontFamily,
   FontWeight,
   LineColor,
+  MindmapStyle,
   ShapeFillColor,
   StrokeStyle,
 } from '@blocksuite/affine-model';
@@ -345,13 +346,6 @@ export class StyleFour extends MindmapStyleGetter {
   }
 }
 export const styleFour = new StyleFour();
-
-export enum MindmapStyle {
-  FOUR = 4,
-  ONE = 1,
-  THREE = 3,
-  TWO = 2,
-}
 
 export const mindmapStyleGetters: {
   [key in MindmapStyle]: MindmapStyleGetter;

--- a/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
@@ -1,12 +1,12 @@
-import type { ShapeElementModel } from '@blocksuite/affine-model';
 import type { GfxModel } from '@blocksuite/block-std/gfx';
 
+import { LayoutType, type ShapeElementModel } from '@blocksuite/affine-model';
 import { assertType } from '@blocksuite/global/utils';
 
 import type { MindmapElementModel } from '../../mindmap.js';
+import type { MindmapNode } from './layout.js';
 
 import { ConnectorPathGenerator } from '../../../managers/connector-manager.js';
-import { LayoutType, type MindmapNode } from './layout.js';
 
 export function getHoveredArea(
   target: ShapeElementModel,

--- a/packages/affine/block-surface/src/index.ts
+++ b/packages/affine/block-surface/src/index.ts
@@ -11,11 +11,7 @@ export {
 } from './element-model/base.js';
 
 export { CanvasElementType } from './element-model/index.js';
-export {
-  LayoutType,
-  MindmapElementModel,
-  MindmapStyle,
-} from './element-model/mindmap.js';
+export { MindmapElementModel } from './element-model/mindmap.js';
 export type { SerializedMindmapElement } from './element-model/mindmap.js';
 export { MindmapUtils } from './element-model/utils/mindmap/index.js';
 import { isConnectorWithLabel } from './element-model/utils/connector.js';

--- a/packages/affine/model/src/consts/index.ts
+++ b/packages/affine/model/src/consts/index.ts
@@ -1,6 +1,7 @@
 export * from './connector.js';
 export * from './doc.js';
 export * from './line.js';
+export * from './mindmap.js';
 export * from './note.js';
 export * from './shape.js';
 export * from './text.js';

--- a/packages/affine/model/src/consts/mindmap.ts
+++ b/packages/affine/model/src/consts/mindmap.ts
@@ -1,0 +1,12 @@
+export enum LayoutType {
+  BALANCE = 2,
+  LEFT = 1,
+  RIGHT = 0,
+}
+
+export enum MindmapStyle {
+  FOUR = 4,
+  ONE = 1,
+  THREE = 3,
+  TWO = 2,
+}

--- a/packages/affine/shared/src/utils/zod-schema.ts
+++ b/packages/affine/shared/src/utils/zod-schema.ts
@@ -13,9 +13,11 @@ import {
   FontFamily,
   FontStyle,
   FontWeight,
+  LayoutType,
   LineColor,
   LineColorsSchema,
   LineWidth,
+  MindmapStyle,
   NoteBackgroundColorsSchema,
   NoteDisplayMode,
   NoteShadowsSchema,
@@ -39,6 +41,8 @@ const TextAlignSchema = z.nativeEnum(TextAlign);
 const TextVerticalAlignSchema = z.nativeEnum(TextVerticalAlign);
 const NoteDisplayModeSchema = z.nativeEnum(NoteDisplayMode);
 const ConnectorModeSchema = z.nativeEnum(ConnectorMode);
+const LayoutTypeSchema = z.nativeEnum(LayoutType);
+const MindmapStyleSchema = z.nativeEnum(MindmapStyle);
 
 export const ColorSchema = z.union([
   z.object({
@@ -192,10 +196,21 @@ export const NoteSchema = z
     },
   });
 
+export const MindmapSchema = z
+  .object({
+    layoutType: LayoutTypeSchema,
+    style: MindmapStyleSchema,
+  })
+  .default({
+    layoutType: LayoutType.RIGHT,
+    style: MindmapStyle.ONE,
+  });
+
 export const NodePropsSchema = z.object({
   connector: ConnectorSchema,
   brush: BrushSchema,
   text: TextSchema,
+  mindmap: MindmapSchema,
   'affine:edgeless-text': EdgelessTextSchema,
   'affine:note': NoteSchema,
   // shapes

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -14,7 +14,6 @@ import {
 } from '@blocksuite/affine-block-surface';
 import {
   ConnectorPathGenerator,
-  LayoutType,
   MindmapElementModel,
 } from '@blocksuite/affine-block-surface';
 import {
@@ -27,6 +26,7 @@ import {
   ConnectorMode,
   DEFAULT_CONNECTOR_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
+  LayoutType,
   ShapeElementModel,
   shapeMethods,
 } from '@blocksuite/affine-model';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/assets.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/assets.ts
@@ -1,7 +1,6 @@
 import type { TemplateResult } from 'lit';
 
-import { MindmapStyle } from '@blocksuite/affine-block-surface';
-import { ColorScheme } from '@blocksuite/affine-model';
+import { ColorScheme, MindmapStyle } from '@blocksuite/affine-model';
 
 import { type DraggableTool, getMindmapRender } from './basket-elements.js';
 import {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
@@ -3,10 +3,10 @@ import type { TemplateResult } from 'lit';
 import {
   CanvasElementType,
   type MindmapElementModel,
-  type MindmapStyle,
 } from '@blocksuite/affine-block-surface';
-import { LayoutType } from '@blocksuite/affine-block-surface';
 import {
+  LayoutType,
+  type MindmapStyle,
   type ShapeElementModel,
   TextElementModel,
 } from '@blocksuite/affine-model';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-tool-button.ts
@@ -1,8 +1,8 @@
 import type { MindmapElementModel } from '@blocksuite/affine-block-surface';
+import type { MindmapStyle } from '@blocksuite/affine-model';
 import type { Bound } from '@blocksuite/global/utils';
 
-import { MindmapStyle } from '@blocksuite/affine-block-surface';
-import { assertExists } from '@blocksuite/global/utils';
+import { computed, SignalWatcher } from '@lit-labs/preact-signals';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -28,7 +28,7 @@ import { importMindmap } from './utils/import-mindmap.js';
 
 @customElement('edgeless-mindmap-tool-button')
 export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
-  LitElement
+  SignalWatcher(LitElement)
 ) {
   static override styles = css`
     :host {
@@ -121,6 +121,12 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
     }
   `;
 
+  private _style$ = computed(() => {
+    const { style } =
+      this.edgeless.service.editPropsStore.lastProps$.value.mindmap;
+    return style;
+  });
+
   draggableController!: EdgelessDraggableElementController<DraggableTool>;
 
   override enableActiveBackground = true;
@@ -128,7 +134,9 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
   override type: EdgelessTool['type'][] = ['mindmap', 'text'];
 
   get draggableTools(): DraggableTool[] {
-    const mindmap = this.mindmaps.find(m => m.style === this.activeStyle)!;
+    const style = this._style$.value;
+    const mindmap =
+      this.mindmaps.find(m => m.style === style) || this.mindmaps[0];
     return [
       {
         name: 'text',
@@ -142,7 +150,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
         icon: mindmap.icon,
         config: mindmapConfig,
         standardWidth: 350,
-        render: getMindmapRender(this.activeStyle),
+        render: getMindmapRender(style),
       },
     ];
   }
@@ -158,9 +166,10 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
     const menu = this.createPopper('edgeless-mindmap-menu', this);
     Object.assign(menu.element, {
       edgeless: this.edgeless,
-      activeStyle: this.activeStyle,
       onActiveStyleChange: (style: MindmapStyle) => {
-        this.activeStyle = style;
+        this.edgeless.service.editPropsStore.recordLastProps('mindmap', {
+          style,
+        });
       },
       onImportMindMap: (bound: Bound) => {
         return importMindmap(bound).then(mindmap => {
@@ -253,13 +262,14 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
           if (this.readyToDrop) {
             // change the style
             const activeIndex = this.mindmaps.findIndex(
-              m => m.style === this.activeStyle
+              m => m.style === this._style$.value
             );
             const nextIndex = (activeIndex + 1) % this.mindmaps.length;
             const next = this.mindmaps[nextIndex];
-            this.activeStyle = next.style;
+            this.edgeless.service.editPropsStore.recordLastProps('mindmap', {
+              style: next.style,
+            });
             const tool = this.draggableTools.find(t => t.name === 'mindmap');
-            assertExists(tool);
             this.draggableController.updateElementInfo({
               data: tool,
               preview: next.icon,
@@ -268,7 +278,6 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
           }
           this.setEdgelessTool({ type: 'mindmap' });
           const icon = this.mindmapElement;
-          assertExists(icon);
           const { x, y } = service.tool.lastMousePos;
           const { left, top } = this.edgeless.viewport;
           const clientPos = { x: x + left, y: y + top };
@@ -396,9 +405,6 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
       this.initDragController();
     }
   }
-
-  @state()
-  accessor activeStyle: MindmapStyle = MindmapStyle.ONE;
 
   @property({ type: Boolean })
   accessor enableBlur = true;

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -1,9 +1,5 @@
-import type { ShapeElementModel } from '@blocksuite/affine-model';
-
-import {
-  LayoutType,
-  MindmapElementModel,
-} from '@blocksuite/affine-block-surface';
+import { MindmapElementModel } from '@blocksuite/affine-block-surface';
+import { LayoutType, type ShapeElementModel } from '@blocksuite/affine-model';
 import {
   ConnectorElementModel,
   ConnectorMode,

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-mindmap-button.ts
@@ -1,7 +1,6 @@
 import type { MindmapElementModel } from '@blocksuite/affine-block-surface';
 import type { ShapeElementModel } from '@blocksuite/affine-model';
 
-import { LayoutType, MindmapStyle } from '@blocksuite/affine-block-surface';
 import {
   MindmapBalanceLayoutIcon,
   MindmapLeftLayoutIcon,
@@ -14,6 +13,7 @@ import {
   SmallArrowDownIcon,
 } from '@blocksuite/affine-components/icons';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
+import { LayoutType, MindmapStyle } from '@blocksuite/affine-model';
 import { WithDisposable } from '@blocksuite/block-std';
 import { countBy, maxBy } from '@blocksuite/global/utils';
 import { css, html, LitElement, nothing, type TemplateResult } from 'lit';
@@ -157,6 +157,9 @@ class EdgelessChangeMindmapLayoutPanel extends LitElement {
 @customElement('edgeless-change-mindmap-button')
 export class EdgelessChangeMindmapButton extends WithDisposable(LitElement) {
   private _updateLayoutType = (layoutType: LayoutType) => {
+    this.edgeless.service.editPropsStore.recordLastProps('mindmap', {
+      layoutType,
+    });
     this.elements.forEach(element => {
       element.layoutType = layoutType;
       element.layout();
@@ -165,6 +168,7 @@ export class EdgelessChangeMindmapButton extends WithDisposable(LitElement) {
   };
 
   private _updateStyle = (style: MindmapStyle) => {
+    this.edgeless.service.editPropsStore.recordLastProps('mindmap', { style });
     this._mindmaps.forEach(element => (element.style = style));
   };
 

--- a/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.ts
@@ -3,13 +3,13 @@ import type {
   SurfaceBlockModel,
 } from '@blocksuite/affine-block-surface';
 
-import { MindmapStyle } from '@blocksuite/affine-block-surface';
 import {
   MindmapStyleFour,
   MindmapStyleOne,
   MindmapStyleThree,
   MindmapStyleTwo,
 } from '@blocksuite/affine-components/icons';
+import { MindmapStyle } from '@blocksuite/affine-model';
 import {
   BlockStdScope,
   type EditorHost,

--- a/packages/presets/src/__tests__/edgeless/group.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/group.spec.ts
@@ -1,9 +1,9 @@
 import type { MindmapElementModel } from '@blocksuite/affine-block-surface';
 
-import { LayoutType } from '@blocksuite/affine-block-surface';
 import {
   type EdgelessRootBlockComponent,
   type GroupElementModel,
+  LayoutType,
   NoteDisplayMode,
 } from '@blocksuite/blocks';
 import { DocCollection } from '@blocksuite/store';


### PR DESCRIPTION
Close issue [BS-1219](https://linear.app/affine-design/issue/BS-1219).

### What changed?
- Add `MindmapSchema` in `zod-schema`.
- Use signal `style$` instead of state `style`.
- Update import references.


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/69b46171-5258-4377-b94c-841f45025d5a.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/69b46171-5258-4377-b94c-841f45025d5a.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/69b46171-5258-4377-b94c-841f45025d5a.mov">录屏2024-09-09 15.24.10.mov</video>

