### PR TITLE
fix: text does not remember current settings

### DIFF
--- a/packages/affine/model/src/consts/brush.ts
+++ b/packages/affine/model/src/consts/brush.ts
@@ -1,0 +1,3 @@
+import { LineColor } from './line.js';
+
+export const DEFAULT_BRUSH_COLOR = LineColor.Blue;

--- a/packages/affine/model/src/consts/connector.ts
+++ b/packages/affine/model/src/consts/connector.ts
@@ -1,4 +1,5 @@
 import { createEnumMap } from '../utils/enum.js';
+import { LineColor } from './line.js';
 
 export enum ConnectorEndpoint {
   Front = 'Front',
@@ -15,8 +16,14 @@ export enum PointStyle {
 
 export const PointStyleMap = createEnumMap(PointStyle);
 
+export const DEFAULT_CONNECTOR_COLOR = LineColor.Grey;
+
+export const DEFAULT_CONNECTOR_TEXT_COLOR = LineColor.Black;
+
 export const DEFAULT_FRONT_END_POINT_STYLE = PointStyle.None;
+
 export const DEFAULT_REAR_END_POINT_STYLE = PointStyle.Arrow;
+
 export const CONNECTOR_LABEL_MAX_WIDTH = 280;
 
 export enum ConnectorLabelOffsetAnchor {

--- a/packages/affine/model/src/consts/index.ts
+++ b/packages/affine/model/src/consts/index.ts
@@ -1,3 +1,4 @@
+export * from './brush.js';
 export * from './connector.js';
 export * from './doc.js';
 export * from './line.js';

--- a/packages/affine/model/src/consts/line.ts
+++ b/packages/affine/model/src/consts/line.ts
@@ -44,9 +44,3 @@ export const LINE_COLORS = [
 ] as const;
 
 export const LineColorsSchema = z.nativeEnum(LineColor);
-
-export const DEFAULT_TEXT_COLOR = LineColor.Blue;
-
-export const DEFAULT_BRUSH_COLOR = LineColor.Blue;
-
-export const DEFAULT_CONNECTOR_COLOR = LineColor.Grey;

--- a/packages/affine/model/src/consts/text.ts
+++ b/packages/affine/model/src/consts/text.ts
@@ -1,4 +1,5 @@
 import { createEnumMap } from '../utils/enum.js';
+import { LineColor } from './line.js';
 
 export enum ColorScheme {
   Dark = 'dark',
@@ -65,3 +66,5 @@ export enum TextResizing {
   AUTO_WIDTH,
   AUTO_HEIGHT,
 }
+
+export const DEFAULT_TEXT_COLOR = LineColor.Blue;

--- a/packages/affine/shared/src/utils/zod-schema.ts
+++ b/packages/affine/shared/src/utils/zod-schema.ts
@@ -1,6 +1,7 @@
 import {
   ConnectorMode,
   DEFAULT_CONNECTOR_COLOR,
+  DEFAULT_CONNECTOR_TEXT_COLOR,
   DEFAULT_FRONT_END_POINT_STYLE,
   DEFAULT_NOTE_BACKGROUND_COLOR,
   DEFAULT_NOTE_BORDER_SIZE,
@@ -75,6 +76,14 @@ export const ConnectorSchema = z
     strokeWidth: LineWidthSchema,
     rough: z.boolean(),
     mode: ConnectorModeSchema,
+    labelStyle: z.object({
+      color: LineColorSchema,
+      fontSize: z.number(),
+      fontFamily: FontFamilySchema,
+      fontWeight: FontWeightSchema,
+      fontStyle: FontStyleSchema,
+      textAlign: TextAlignSchema,
+    }),
   })
   .default({
     frontEndpointStyle: DEFAULT_FRONT_END_POINT_STYLE,
@@ -84,6 +93,14 @@ export const ConnectorSchema = z
     strokeWidth: LineWidth.Two,
     rough: false,
     mode: ConnectorMode.Curve,
+    labelStyle: {
+      color: DEFAULT_CONNECTOR_TEXT_COLOR,
+      fontSize: 16,
+      fontFamily: FontFamily.Inter,
+      fontWeight: FontWeight.Regular,
+      fontStyle: FontStyle.Normal,
+      textAlign: TextAlign.Center,
+    },
   });
 
 export const BrushSchema = z
@@ -144,35 +161,35 @@ export const RoundedShapeSchema = z
 export const TextSchema = z
   .object({
     color: TextColorSchema,
+    fontSize: z.number(),
     fontFamily: FontFamilySchema,
-    textAlign: TextAlignSchema,
     fontWeight: FontWeightSchema,
     fontStyle: FontStyleSchema,
-    fontSize: z.number(),
+    textAlign: TextAlignSchema,
   })
   .default({
     color: DEFAULT_TEXT_COLOR,
+    fontSize: 24,
     fontFamily: FontFamily.Inter,
-    textAlign: TextAlign.Left,
     fontWeight: FontWeight.Regular,
     fontStyle: FontStyle.Normal,
-    fontSize: 24,
+    textAlign: TextAlign.Left,
   });
 
 export const EdgelessTextSchema = z
   .object({
     color: TextColorSchema,
     fontFamily: FontFamilySchema,
-    textAlign: TextAlignSchema,
     fontWeight: FontWeightSchema,
     fontStyle: FontStyleSchema,
+    textAlign: TextAlignSchema,
   })
   .default({
     color: DEFAULT_TEXT_COLOR,
     fontFamily: FontFamily.Inter,
-    textAlign: TextAlign.Left,
     fontWeight: FontWeight.Regular,
     fontStyle: FontStyle.Normal,
+    textAlign: TextAlign.Left,
   });
 
 export const NoteSchema = z

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
@@ -172,7 +172,6 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
               edgeless.service.updateElement(connector.id, {
                 text: undefined,
                 labelXYWH: undefined,
-                labelStyle: undefined,
                 labelOffset: undefined,
               });
             } else if (len < text.length) {

--- a/packages/blocks/src/root-block/edgeless/utils/text.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/text.ts
@@ -22,7 +22,6 @@ import { DocCollection } from '@blocksuite/store';
 
 import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
-import { GET_DEFAULT_LINE_COLOR } from '../components/panel/color-panel.js';
 import { EdgelessConnectorLabelEditor } from '../components/text/edgeless-connector-label-editor.js';
 import { EdgelessFrameTitleEditor } from '../components/text/edgeless-frame-title-editor.js';
 import { EdgelessGroupTitleEditor } from '../components/text/edgeless-group-title-editor.js';
@@ -190,11 +189,8 @@ export function mountConnectorLabelEditor(
 
   if (!connector.text) {
     const text = new DocCollection.Y.Text();
-    const labelStyle = connector.labelStyle;
     const labelOffset = connector.labelOffset;
     let labelXYWH = connector.labelXYWH ?? [0, 0, 16, 16];
-
-    labelStyle.color = GET_DEFAULT_LINE_COLOR();
 
     if (point) {
       const center = connector.getNearestPoint(point);
@@ -208,7 +204,6 @@ export function mountConnectorLabelEditor(
     edgeless.service.updateElement(connector.id, {
       text,
       labelXYWH,
-      labelStyle: { ...labelStyle },
       labelOffset: { ...labelOffset },
     });
   }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -105,13 +105,10 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
 
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      this.notes.forEach(ele =>
-        this.doc.updateBlock(ele, packColor('background', { ...event.detail }))
-      );
-      this.edgeless.service.editPropsStore.recordLastProps(
-        'affine:note',
-        packColor('background', event.detail)
-      );
+      this.notes.forEach(element => {
+        const props = packColor('background', { ...event.detail });
+        this.edgeless.service.updateElement(element.id, props);
+      });
       return;
     }
 
@@ -136,12 +133,9 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
   }
 
   private _setBackground(background: string) {
-    this.notes.forEach(note => {
-      this.doc.updateBlock(note, { background });
+    this.notes.forEach(element => {
+      this.edgeless.service.updateElement(element.id, { background });
     });
-    this.edgeless.service.editPropsStore.recordLastProps('affine:note', {
-      background,
-    } as Record<string, unknown>);
   }
 
   private _setCollapse() {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-text-menu.ts
@@ -307,23 +307,10 @@ export class EdgelessChangeTextMenu extends WithDisposable(LitElement) {
 
   pickColor = (event: PickColorEvent) => {
     if (event.type === 'pick') {
-      this.elements.forEach(ele => {
-        if (ele instanceof ConnectorElementModel) {
-          this.service.updateElement(ele.id, {
-            labelStyle: {
-              ...ele.labelStyle,
-              ...packColor('color', { ...event.detail }),
-            },
-          });
-          this._updateElementBound(ele);
-          return;
-        }
-
-        this.service.updateElement(
-          ele.id,
-          packColor('color', { ...event.detail })
-        );
-        this._updateElementBound(ele);
+      this.elements.forEach(element => {
+        const props = packColor('color', { ...event.detail });
+        this.service.updateElement(element.id, buildProps(element, props));
+        this._updateElementBound(element);
       });
       return;
     }


### PR DESCRIPTION
Close issue [BS-1223](https://linear.app/affine-design/issue/BS-1223) and [BS-1224](https://linear.app/affine-design/issue/BS-1224).

### What changed?
- Add the connector's `labelStyle` in `zod-schema` file.
- Use `edgeless.service.updateElement` instead of `doc.updateBlock`.
- Refactor `pickColor` function.