### PR TITLE
fix(blocks): fix some bugs of surface-ref

### DIFF
--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -1,8 +1,9 @@
-import type {
-  EdgelessRootBlockComponent,
-  SurfaceRefBlockComponent,
+import {
+  type EdgelessRootBlockComponent,
+  EdgelessRootService,
+  type FrameBlockComponent,
+  type SurfaceRefBlockComponent,
 } from '@blocksuite/blocks';
-
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { wait } from '../utils/common.js';
@@ -12,33 +13,33 @@ import { setupEditor } from '../utils/setup.js';
 describe('basic', () => {
   let service: EdgelessRootBlockComponent['service'];
   let edgelessRoot: EdgelessRootBlockComponent;
-  let noteA = '';
-  let noteB = '';
-  let shapeA = '';
-  let shapeB = '';
-  let frame = '';
+  let noteAId = '';
+  let noteBId = '';
+  let shapeAId = '';
+  let shapeBId = '';
+  let frameId = '';
 
   beforeEach(async () => {
     const cleanup = await setupEditor('edgeless');
     edgelessRoot = getDocRootBlock(doc, editor, 'edgeless');
     service = edgelessRoot.service;
 
-    noteA = addNote(doc, {
+    noteAId = addNote(doc, {
       index: service.generateIndex('affine:note'),
     });
-    shapeA = service.addElement('shape', {
+    shapeAId = service.addElement('shape', {
       type: 'rect',
       xywh: '[0, 0, 100, 100]',
     });
-    noteB = addNote(doc, {
+    noteBId = addNote(doc, {
       // force to be the last note
       index: service.generateIndex('shape'),
     });
-    shapeB = service.addElement('shape', {
+    shapeBId = service.addElement('shape', {
       type: 'rect',
       xywh: '[100, 0, 100, 100]',
     });
-    frame = service.addBlock(
+    frameId = service.addBlock(
       'affine:frame',
       {
         xywh: '[0, 0, 800, 200]',
@@ -53,9 +54,9 @@ describe('basic', () => {
     const surfaceRefId = doc.addBlock(
       'affine:surface-ref',
       {
-        reference: frame,
+        reference: frameId,
       },
-      noteA
+      noteAId
     );
 
     editor.mode = 'page';
@@ -72,9 +73,9 @@ describe('basic', () => {
     const surfaceRefId = doc.addBlock(
       'affine:surface-ref',
       {
-        reference: frame,
+        reference: frameId,
       },
-      noteA
+      noteAId
     );
 
     await wait();
@@ -91,9 +92,9 @@ describe('basic', () => {
     const surfaceRefId = doc.addBlock(
       'affine:surface-ref',
       {
-        reference: frame,
+        reference: frameId,
       },
-      noteA
+      noteAId
     );
 
     editor.mode = 'page';
@@ -119,10 +120,10 @@ describe('basic', () => {
   test('content in group should be rendered in the correct order', async () => {
     const groupId = service.addElement('group', {
       children: {
-        [shapeA]: true,
-        [shapeB]: true,
-        [noteA]: true,
-        [noteB]: true,
+        [shapeAId]: true,
+        [shapeBId]: true,
+        [noteAId]: true,
+        [noteBId]: true,
       },
     });
     const surfaceRefId = doc.addBlock(
@@ -130,7 +131,7 @@ describe('basic', () => {
       {
         reference: groupId,
       },
-      noteA
+      noteAId
     );
 
     editor.mode = 'page';
@@ -153,13 +154,40 @@ describe('basic', () => {
     );
   });
 
-  test('view in edgeless mode button', async () => {
+  test('frame should be rendered in surface-ref viewport', async () => {
+    const surfaceRefId = doc.addBlock(
+      'affine:surface-ref',
+      {
+        reference: frameId,
+      },
+      noteAId
+    );
+
+    editor.mode = 'page';
+    await wait();
+
+    const surfaceRef = document.querySelector(
+      `affine-surface-ref[data-block-id="${surfaceRefId}"]`
+    ) as SurfaceRefBlockComponent;
+
+    const edgeless = surfaceRef.previewEditor!.std.get(EdgelessRootService);
+
+    const frame = surfaceRef.querySelector(
+      'affine-frame'
+    ) as FrameBlockComponent;
+
+    expect(
+      edgeless.viewport.isInViewport(frame.model.elementBound)
+    ).toBeTruthy();
+  });
+
+  test('group should be rendered in surface-ref viewport', async () => {
     const groupId = service.addElement('group', {
       children: {
-        [shapeA]: true,
-        [shapeB]: true,
-        [noteA]: true,
-        [noteB]: true,
+        [shapeAId]: true,
+        [shapeBId]: true,
+        [noteAId]: true,
+        [noteBId]: true,
       },
     });
     const surfaceRefId = doc.addBlock(
@@ -167,7 +195,68 @@ describe('basic', () => {
       {
         reference: groupId,
       },
-      noteA
+      noteAId
+    );
+
+    editor.mode = 'page';
+    await wait();
+
+    const surfaceRef = document.querySelector(
+      `affine-surface-ref[data-block-id="${surfaceRefId}"]`
+    ) as SurfaceRefBlockComponent;
+
+    const edgeless = surfaceRef.previewEditor!.std.get(EdgelessRootService);
+
+    const group = edgeless.getElementById(groupId)!;
+
+    expect(edgeless.viewport.isInViewport(group.elementBound)).toBeTruthy();
+  });
+
+  test('viewport of surface-ref should be updated when the reference xywh updated', async () => {
+    const surfaceRefId = doc.addBlock(
+      'affine:surface-ref',
+      {
+        reference: frameId,
+      },
+      noteAId
+    );
+
+    editor.mode = 'page';
+    await wait();
+
+    const surfaceRef = document.querySelector(
+      `affine-surface-ref[data-block-id="${surfaceRefId}"]`
+    ) as SurfaceRefBlockComponent;
+
+    const edgeless = surfaceRef.previewEditor!.std.get(EdgelessRootService);
+
+    const frame = surfaceRef.querySelector(
+      'affine-frame'
+    ) as FrameBlockComponent;
+
+    const oldViewport = edgeless.viewport.viewportBounds;
+
+    frame.model.xywh = '[100, 100, 800, 200]';
+    await wait();
+
+    expect(edgeless.viewport.viewportBounds).not.toEqual(oldViewport);
+  });
+
+  test('view in edgeless mode button', async () => {
+    const groupId = service.addElement('group', {
+      children: {
+        [shapeAId]: true,
+        [shapeBId]: true,
+        [noteAId]: true,
+        [noteBId]: true,
+      },
+    });
+    const surfaceRefId = doc.addBlock(
+      'affine:surface-ref',
+      {
+        reference: groupId,
+      },
+      noteAId
     );
 
     editor.mode = 'page';


### PR DESCRIPTION
### What changes:
- Migrated viewport of `edgeless-root-preview` to `gfx-viewport`. This change will improve the performance of `surface-ref` in doc mode.
- Fixed incorrect viewport of `surface-ref` of group
- Fixed that `EditorHost` of `surface-ref` will re-render repeatedly.
- Fixed viewport of `surface-ref` no update when the position of reference updated.
- Add related tests
