### PR TITLE
fix: can not remember frame settings

### DIFF
--- a/packages/affine/model/src/consts/frame.ts
+++ b/packages/affine/model/src/consts/frame.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export enum FrameBackgroundColor {
+  Blue = '--affine-tag-blue',
+  Gray = '--affine-tag-gray',
+  Green = '--affine-tag-green',
+  Orange = '--affine-tag-orange',
+  Pink = '--affine-tag-pink',
+  Purple = '--affine-tag-purple',
+  Red = '--affine-tag-red',
+  Teal = '--affine-tag-teal',
+  Yellow = '--affine-tag-yellow',
+}
+
+export const FRAME_BACKGROUND_COLORS = [
+  FrameBackgroundColor.Gray,
+  FrameBackgroundColor.Red,
+  FrameBackgroundColor.Orange,
+  FrameBackgroundColor.Yellow,
+  FrameBackgroundColor.Green,
+  FrameBackgroundColor.Teal,
+  FrameBackgroundColor.Blue,
+  FrameBackgroundColor.Purple,
+  FrameBackgroundColor.Pink,
+];
+
+export const FrameBackgroundColorsSchema = z.nativeEnum(FrameBackgroundColor);

--- a/packages/affine/model/src/consts/index.ts
+++ b/packages/affine/model/src/consts/index.ts
@@ -1,6 +1,7 @@
 export * from './brush.js';
 export * from './connector.js';
 export * from './doc.js';
+export * from './frame.js';
 export * from './line.js';
 export * from './mindmap.js';
 export * from './note.js';

--- a/packages/affine/shared/src/utils/zod-schema.ts
+++ b/packages/affine/shared/src/utils/zod-schema.ts
@@ -18,6 +18,7 @@ import {
   FontFamily,
   FontStyle,
   FontWeight,
+  FrameBackgroundColorsSchema,
   LayoutType,
   LineColor,
   LineColorsSchema,
@@ -64,6 +65,10 @@ const ShapeStrokeColorSchema = z.union([StrokeColorsSchema, ColorSchema]);
 const TextColorSchema = z.union([LineColorsSchema, ColorSchema]);
 const NoteBackgroundColorSchema = z.union([
   NoteBackgroundColorsSchema,
+  ColorSchema,
+]);
+const FrameBackgroundColorSchema = z.union([
+  FrameBackgroundColorsSchema,
   ColorSchema,
 ]);
 
@@ -228,6 +233,12 @@ export const MindmapSchema = z
     style: MindmapStyle.ONE,
   });
 
+export const FrameSchema = z
+  .object({
+    background: FrameBackgroundColorSchema.optional(),
+  })
+  .default({});
+
 export const NodePropsSchema = z.object({
   connector: ConnectorSchema,
   brush: BrushSchema,
@@ -235,6 +246,7 @@ export const NodePropsSchema = z.object({
   mindmap: MindmapSchema,
   'affine:edgeless-text': EdgelessTextSchema,
   'affine:note': NoteSchema,
+  'affine:frame': FrameSchema,
   // shapes
   'shape:diamond': ShapeSchema,
   'shape:ellipse': ShapeSchema,

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -3,6 +3,7 @@ import { toast } from '@blocksuite/affine-components/toast';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
 import {
   type ColorScheme,
+  FRAME_BACKGROUND_COLORS,
   type FrameBlockModel,
   NoteDisplayMode,
 } from '@blocksuite/affine-model';
@@ -30,18 +31,6 @@ import {
 } from '../../edgeless/components/color-picker/utils.js';
 import { DEFAULT_NOTE_HEIGHT } from '../../edgeless/utils/consts.js';
 import { mountFrameTitleEditor } from '../../edgeless/utils/text.js';
-
-const FRAME_BACKGROUND = [
-  '--affine-tag-gray',
-  '--affine-tag-red',
-  '--affine-tag-orange',
-  '--affine-tag-yellow',
-  '--affine-tag-green',
-  '--affine-tag-teal',
-  '--affine-tag-blue',
-  '--affine-tag-purple',
-  '--affine-tag-pink',
-] as const;
 
 function getMostCommonColor(
   elements: FrameBlockModel[],
@@ -183,7 +172,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
                 .color=${background}
                 .colors=${colors}
                 .colorType=${type}
-                .palettes=${FRAME_BACKGROUND}
+                .palettes=${FRAME_BACKGROUND_COLORS}
               >
               </edgeless-color-picker-button>
             `;
@@ -204,7 +193,7 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
             >
               <edgeless-color-panel
                 .value=${background}
-                .options=${FRAME_BACKGROUND}
+                .options=${FRAME_BACKGROUND_COLORS}
                 @select=${(e: ColorEvent) => this._setFrameBackground(e.detail)}
               >
               </edgeless-color-panel>


### PR DESCRIPTION
Close issue [BS-1220](https://linear.app/affine-design/issue/BS-1220).

### What changed?
- Add `affine:frame` in `zod-schema`
- Move `FRAME_BACKGROUND_COLORS` to `consts/frame.ts`.


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/f0eff1b4-9add-4670-bd7b-2374fad5d296.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/f0eff1b4-9add-4670-bd7b-2374fad5d296.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/f0eff1b4-9add-4670-bd7b-2374fad5d296.mov">录屏2024-09-10 16.56.49.mov</video>

