### PR TITLE
fix: latex editor shake

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/nodes/latex-node/latex-editor-menu.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/latex-node/latex-editor-menu.ts
@@ -60,6 +60,7 @@ export class LatexEditorMenu extends SignalWatcher(
       box-shadow: 0px 0px 0px 2px rgba(30, 150, 235, 0.3);
 
       font-family: ${unsafeCSS(cssVar('fontCodeFamily'))};
+      border: 1px solid transparent;
     }
     .latex-editor:focus-within {
       border: 1px solid ${unsafeCSS(cssVar('blue700'))};


### PR DESCRIPTION
Close [BS-1364](https://linear.app/affine-design/issue/BS-1364/[可优化的]-input-popup-的-ui-抖动)