### PR TITLE
fix: brush element lineWidth bug

### DIFF
--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -138,15 +138,21 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
     instance['_local'].delete('commands');
   })
   @derive((lineWidth: number, instance: Instance) => {
-    if (lineWidth === instance.lineWidth) return {};
+    const oldBound = instance.elementBound;
 
-    const bound = instance.elementBound;
+    if (
+      lineWidth === instance.lineWidth ||
+      oldBound.w === 0 ||
+      oldBound.h === 0
+    )
+      return {};
+
     const points = instance.points;
     const transformed = transformPointsToNewBound(
       points.map(([x, y]) => ({ x, y })),
-      bound,
-      lineWidth / 2,
-      inflateBound(bound, lineWidth - instance.lineWidth),
+      oldBound,
+      instance.lineWidth / 2,
+      inflateBound(oldBound, lineWidth - instance.lineWidth),
       lineWidth / 2
     );
 
@@ -194,14 +200,14 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
 
   @derive((xywh: SerializedXYWH, instance: Instance) => {
     const bound = Bound.deserialize(xywh);
+
     if (bound.w === instance.w && bound.h === instance.h) return {};
 
     const { lineWidth } = instance;
-
     const transformed = transformPointsToNewBound(
       instance.points.map(([x, y]) => ({ x, y })),
       instance,
-      lineWidth / 2,
+      instance.lineWidth / 2,
       bound,
       lineWidth / 2
     );

--- a/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-model.spec.ts
@@ -499,3 +499,27 @@ describe('basic property', () => {
     expect(group.h).toBe(0);
   });
 });
+
+describe('brush', () => {
+  test('same lineWidth should have same xywh', () => {
+    const id = model.addElement({
+      type: 'brush',
+      lineWidth: 2,
+      points: [
+        [0, 0],
+        [100, 100],
+        [120, 150],
+      ],
+    });
+    const brush = model.getElementById(id) as BrushElementModel;
+    const oldBrushXYWH = brush.xywh;
+
+    brush.lineWidth = 4;
+
+    expect(brush.xywh).not.toBe(oldBrushXYWH);
+
+    brush.lineWidth = 2;
+
+    expect(brush.xywh).toBe(oldBrushXYWH);
+  });
+});


### PR DESCRIPTION
Fixes [BS-1392](https://linear.app/affine-design/issue/BS-1392/brush-设为最细时无法绘制)
Fixes [BS-1347](https://linear.app/affine-design/issue/BS-1347/pen-preview-的渲染快速拖动后，符号变化比较明显)