### PR TITLE
fix(blocks): text may be undefined when editing connector label

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-connector-label-editor.ts
@@ -256,7 +256,7 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
       `scale(${zoom})`,
     ];
 
-    const isEmpty = !connector.text!.length && !this._isComposition;
+    const isEmpty = !connector.text?.length && !this._isComposition;
     const color = ThemeObserver.generateColorProperty(labelColor, '#000000');
 
     return html`


### PR DESCRIPTION
Closes [BS-1338](https://linear.app/affine-design/issue/BS-1338/[bug]-mindmap-用-connector-连接会-crash)
Should check if text exists after text is reset to undefined