### PR TITLE
fix: mind map issues

### DIFF
--- a/packages/affine/block-surface/src/element-model/utils/mindmap/layout.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/layout.ts
@@ -15,12 +15,6 @@ export type NodeDetail = {
    */
   index: string;
   parent?: string;
-
-  /**
-   * The preferred layout direction of the node, it only works when the layout type is BALANCE
-   * and the node is on the first level
-   */
-  preferredDir?: LayoutType;
 };
 
 export type MindmapNode = {

--- a/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
+++ b/packages/affine/block-surface/src/element-model/utils/mindmap/utils.ts
@@ -186,5 +186,5 @@ export function moveMindMapSubtree(
     return;
   }
 
-  return to.addTree(parent, subtree, index, layout);
+  return to.addTree(parent, subtree, index);
 }

--- a/packages/affine/block-surface/src/renderer/elements/shape/utils.ts
+++ b/packages/affine/block-surface/src/renderer/elements/shape/utils.ts
@@ -244,8 +244,8 @@ export function fitContent(shape: ShapeElementModel) {
       const str = delta.insert;
 
       maxWidth = Math.max(maxWidth, getLineWidth(str, font));
-      height += lineHeight + lineGap;
     }
+    height += lineHeight + lineGap;
   });
 
   height = Math.max(lineHeight + lineGap, height);

--- a/packages/affine/model/src/consts/text.ts
+++ b/packages/affine/model/src/consts/text.ts
@@ -63,7 +63,7 @@ export const FontFamilyList = Object.entries(FontFamilyMap) as {
 }[FontFamily][];
 
 export enum TextResizing {
-  AUTO_WIDTH,
+  AUTO_WIDTH_AND_HEIGHT,
   AUTO_HEIGHT,
 }
 

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -230,10 +230,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
     return edgeless.service.getElementById(id) as ConnectorElementModel;
   }
 
-  private _addMindmapNode(
-    direction: LayoutType.LEFT | LayoutType.RIGHT,
-    target: 'sibling' | 'child'
-  ) {
+  private _addMindmapNode(target: 'sibling' | 'child') {
     const mindmap = this.current.group;
 
     if (!(mindmap instanceof MindmapElementModel)) return;
@@ -247,8 +244,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
       parentNode.id,
       target === 'sibling' ? this.current.id : undefined,
       undefined,
-      undefined,
-      direction
+      undefined
     );
 
     requestAnimationFrame(() => {
@@ -583,7 +579,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
         <div
           class="edgeless-auto-complete-arrow"
           @pointerdown=${() => {
-            this._addMindmapNode(layout, target);
+            this._addMindmapNode(target);
           }}
         >
           ${icon}

--- a/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
+++ b/packages/blocks/src/root-block/edgeless/components/text/edgeless-shape-text-editor.ts
@@ -92,8 +92,6 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
     }
 
     this.element.textDisplay = true;
-    this.element.group instanceof MindmapElementModel &&
-      this.element.group.layout();
 
     this.remove();
     this.edgeless.service.selection.set({
@@ -115,8 +113,9 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
     if (
       (containerHeight !== this.element.h &&
         textResizing === TextResizing.AUTO_HEIGHT) ||
-      (textResizing === TextResizing.AUTO_WIDTH &&
-        containerWidth !== this.element.w)
+      (textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT &&
+        (containerWidth !== this.element.w ||
+          containerHeight !== this.element.h))
     ) {
       const [leftTopX, leftTopY] = Vec.rotWith(
         [this.richText.offsetLeft, this.richText.offsetTop],
@@ -131,7 +130,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
         xywh: new Bound(
           modelLeftTopX,
           modelLeftTopY,
-          textResizing === TextResizing.AUTO_WIDTH
+          textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT
             ? containerWidth
             : this.element.w,
           containerHeight
@@ -247,7 +246,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       leftTopX,
       leftTopY
     );
-    const autoWidth = textResizing === TextResizing.AUTO_WIDTH;
+    const autoWidth = textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT;
     const color = ThemeObserver.generateColorProperty(
       this.element.color,
       '#000000'
@@ -258,15 +257,17 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       left: x + 'px',
       top: y + 'px',
       width:
-        textResizing > TextResizing.AUTO_WIDTH
+        textResizing === TextResizing.AUTO_HEIGHT
           ? rect.width + 'px'
           : 'fit-content',
       // override rich-text style (height: 100%)
       height: 'initial',
       minHeight:
-        textResizing === TextResizing.AUTO_WIDTH ? '1em' : `${rect.height}px`,
+        textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT
+          ? '1em'
+          : `${rect.height}px`,
       maxWidth:
-        textResizing === TextResizing.AUTO_WIDTH
+        textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT
           ? this.element.maxWidth
             ? `${this.element.maxWidth}px`
             : undefined

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/basket-elements.ts
@@ -5,7 +5,6 @@ import {
   type MindmapElementModel,
 } from '@blocksuite/affine-block-surface';
 import {
-  LayoutType,
   type MindmapStyle,
   type ShapeElementModel,
   TextElementModel,
@@ -97,16 +96,10 @@ export const getMindmapRender =
     for (let i = 0; i < 3; i++) {
       const nodeX = x + rootW + 300;
       const nodeY = centerVertical - nodeH / 2 + (i - 1) * 50;
-      createNode(
-        root.id,
-        undefined,
-        undefined,
-        {
-          text: 'Text',
-          xywh: `[${nodeX},${nodeY},${nodeW},${nodeH}]`,
-        },
-        LayoutType.RIGHT
-      );
+      createNode(root.id, undefined, undefined, {
+        text: 'Text',
+        xywh: `[${nodeX},${nodeY},${nodeW},${nodeH}]`,
+      });
     }
 
     return mindmapId;

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/mindmap/mindmap-menu.ts
@@ -4,7 +4,10 @@ import type { Bound } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
 import { toast } from '@blocksuite/affine-components/toast';
-import { EditPropsStore } from '@blocksuite/affine-shared/services';
+import {
+  EditPropsStore,
+  TelemetryProvider,
+} from '@blocksuite/affine-shared/services';
 import { modelContext, stdContext } from '@blocksuite/block-std';
 import { ErrorCode } from '@blocksuite/global/exceptions';
 import { consume } from '@lit/context';
@@ -173,8 +176,22 @@ export class EdgelessMindmapMenu extends EdgelessToolbarToolMixin(
     edgelessBlock.gfxViewportElm.append(placeholder);
 
     this.onImportMindMap?.(bound)
+      .then(() => {
+        this.std.get(TelemetryProvider)?.track('CanvasElementAdded', {
+          page: 'whiteboard editor',
+          type: 'imported mind map',
+          other: 'success',
+          module: 'toolbar',
+        });
+      })
       .catch(e => {
         if (e.code === ErrorCode.UserAbortError) return;
+        this.std.get(TelemetryProvider)?.track('CanvasElementAdded', {
+          page: 'whiteboard editor',
+          type: 'imported mind map',
+          other: 'failed',
+          module: 'toolbar',
+        });
         toast(this.edgeless.host, 'Import failed, please try again');
         console.error(e);
       })

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -484,7 +484,14 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         const selection = service.selection;
         if (event.code === 'Space' && !event.repeat) {
           this._space(event);
-        } else if (!selection.editing && event.key.length === 1) {
+        } else if (
+          !selection.editing &&
+          event.key.length === 1 &&
+          !event.shiftKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.metaKey
+        ) {
           const elements = selection.selectedElements;
           const doc = this.rootComponent.doc;
 

--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -618,14 +618,19 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
     );
 
     if (
-      this._toBeMoved.every(
-        ele => !(ele.group instanceof MindmapElementModel)
-      ) ||
+      (this._toBeMoved.length &&
+        this._toBeMoved.every(
+          ele => !(ele.group instanceof MindmapElementModel)
+        )) ||
       (isSelectSingleMindMap(this._toBeMoved) &&
         this._toBeMoved[0].id ===
           (this._toBeMoved[0].group as MindmapElementModel).tree.id)
     ) {
-      this._alignBound = this._service.snap.setupAlignables(this._toBeMoved);
+      const mindmap = this._toBeMoved[0].group as MindmapElementModel;
+
+      this._alignBound = this._service.snap.setupAlignables(this._toBeMoved, [
+        ...(mindmap?.childElements || []),
+      ]);
     }
 
     this._clearDisposable();

--- a/packages/blocks/src/root-block/edgeless/utils/snap-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/snap-manager.ts
@@ -420,7 +420,10 @@ export class EdgelessSnapManager extends Overlay {
     });
   }
 
-  setupAlignables(alignables: BlockSuite.EdgelessModel[]): Bound {
+  setupAlignables(
+    alignables: BlockSuite.EdgelessModel[],
+    exclude: BlockSuite.EdgelessModel[] = []
+  ): Bound {
     if (alignables.length === 0) return new Bound();
 
     const connectors = alignables.filter(isConnectable).reduce((prev, el) => {
@@ -437,7 +440,7 @@ export class EdgelessSnapManager extends Overlay {
     const viewportBounds = Bound.from(viewport.viewportBounds);
     this._surface.renderer.addOverlay(this);
     const canvasElements = this._rootService.elements;
-    const excludes = [...alignables, ...connectors];
+    const excludes = new Set([...alignables, ...exclude, ...connectors]);
     this._alignableBounds = [];
     (
       [
@@ -448,7 +451,7 @@ export class EdgelessSnapManager extends Overlay {
       const bounds = this._getBoundsWithRotationByAlignable(alignable);
       if (
         viewportBounds.isOverlapWithBound(bounds) &&
-        !excludes.includes(alignable)
+        !excludes.has(alignable)
       ) {
         this._alignableBounds.push(bounds);
       }


### PR DESCRIPTION
Fixes [BS-1054](https://linear.app/affine-design/issue/BS-1054/mind-map-拖拽同级节点调整顺序的有效触发区域太小)
Fixes [BS-1317](https://linear.app/affine-design/issue/BS-1317/mind-map-编辑中，undo-需要两次才响应)
Fixes [BS-1284](https://linear.app/affine-design/issue/BS-1284/mind-map-软换行之后，节点没有立刻增加新的行空间)
Fixes [PD-1660](https://linear.app/affine-design/issue/PD-1660/radial-雷达视图在拖拽之后，左右节点不平衡分布了)
Fixes [BS-1334](https://linear.app/affine-design/issue/BS-1334/增加-mind-map-block-级别导入埋点)
Fixes [PD-1214](https://linear.app/affine-design/issue/PD-1214/拖拽非根节点，建议去掉对齐效果)
Fixes [BS-1316](https://linear.app/affine-design/issue/BS-1316/选中节点的时候，快捷键会误触发编辑)