### PR TITLE
fix: should update outline panel notes when changing note display mode

### DIFF
--- a/packages/presets/src/fragments/outline/body/outline-panel-body.ts
+++ b/packages/presets/src/fragments/outline/body/outline-panel-body.ts
@@ -483,6 +483,17 @@ export class OutlinePanelBody extends SignalWatcher(
         this._updateNoticeVisibility();
       })
     );
+    this._docDisposables.add(
+      this.doc.slots.blockUpdated.on(payload => {
+        if (
+          payload.type === 'update' &&
+          payload.flavour === 'affine:note' &&
+          payload.props.key === 'displayMode'
+        ) {
+          this._updateNotes();
+        }
+      })
+    );
   }
 
   /**
@@ -531,7 +542,7 @@ export class OutlinePanelBody extends SignalWatcher(
     const newSelected: string[] = [];
 
     rootModel.children.forEach(block => {
-      if (!['affine:note'].includes(block.flavour)) return;
+      if (!BlocksUtils.matchFlavours(block, ['affine:note'])) return;
 
       const blockModel = block as NoteBlockModel;
 


### PR DESCRIPTION
Fix: [BS-1406](https://linear.app/affine-design/issue/BS-1406/更改-note-displaymode-需要同步更新-outline-panel)