### PR TITLE
fix(edgeless): multi parent container of node of mindmap

### DIFF
--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -928,7 +928,11 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
 
     {
       const frameManager = this._service.frame;
-      const toBeMovedTopElements = getTopElements(this._toBeMoved);
+      const toBeMovedTopElements = getTopElements(
+        this._toBeMoved.map(el =>
+          el.group instanceof MindmapElementModel ? el.group : el
+        )
+      );
       if (this._hoveredFrame) {
         frameManager.addElementsToFrame(
           this._hoveredFrame,

--- a/tests/edgeless/frame/frame-mindmap.spec.ts
+++ b/tests/edgeless/frame/frame-mindmap.spec.ts
@@ -1,0 +1,348 @@
+import { clickView } from 'utils/actions/click.js';
+import {
+  createFrame,
+  dragBetweenViewCoords,
+  edgelessCommonSetup,
+  getSelectedBound,
+  toViewCoord,
+  triggerComponentToolbarAction,
+  zoomResetByKeyboard,
+} from 'utils/actions/edgeless.js';
+import { pressEscape, selectAllByKeyboard } from 'utils/actions/keyboard.js';
+import { waitNextFrame } from 'utils/actions/misc.js';
+import { assertSelectedBound } from 'utils/asserts.js';
+
+import { test } from '../../utils/playwright.js';
+
+test.beforeEach(async ({ page }) => {
+  await edgelessCommonSetup(page);
+  await zoomResetByKeyboard(page);
+});
+
+test('drag root node of mindmap into frame partially, move frame, then drag root node of mindmap out.', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [550, 550]);
+  await pressEscape(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+
+  let mindmapBound = await getSelectedBound(page);
+
+  // drag in
+  {
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [100, 100]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // Drag frame
+  {
+    await clickView(page, [60, 60]);
+    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(
+    page,
+    [
+      mindmapBound[0] + 50,
+      mindmapBound[1] + 50,
+      mindmapBound[2],
+      mindmapBound[3],
+    ],
+    0
+  ); // mindmap
+  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+
+  // drag out
+  {
+    mindmapBound = await getSelectedBound(page, 0);
+    pressEscape(page);
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [0, 0]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // drag frame
+  {
+    await clickView(page, [110, 110]);
+    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(page, mindmapBound, 0); // mindmap
+  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+});
+
+test('drag root node of mindmap into frame fully, move frame, then drag root node of mindmap out.', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [550, 550]);
+  await pressEscape(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+
+  let mindmapBound = await getSelectedBound(page);
+
+  // drag in
+  {
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [100, 200]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // Drag frame
+  {
+    await clickView(page, [60, 60]);
+    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(
+    page,
+    [
+      mindmapBound[0] + 50,
+      mindmapBound[1] + 50,
+      mindmapBound[2],
+      mindmapBound[3],
+    ],
+    0
+  ); // mindmap
+  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+
+  // drag out
+  {
+    mindmapBound = await getSelectedBound(page, 0);
+    pressEscape(page);
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [0, 0]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // drag frame
+  {
+    await clickView(page, [110, 110]);
+    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(page, mindmapBound, 0); // mindmap
+  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+});
+
+test('drag whole mindmap into frame, move frame, then drag root node of mindmap out.', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [550, 550]);
+  await pressEscape(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+
+  let mindmapBound = await getSelectedBound(page);
+
+  // drag in
+  {
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] - 10, mindmapBound[1] - 10],
+      [mindmapBound[0] + 10, mindmapBound[1] + 10]
+    );
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 10],
+      [100, 100]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // Drag frame
+  {
+    await clickView(page, [60, 60]);
+    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(
+    page,
+    [
+      mindmapBound[0] + 50,
+      mindmapBound[1] + 50,
+      mindmapBound[2],
+      mindmapBound[3],
+    ],
+    0
+  ); // mindmap
+  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+
+  // drag out
+  {
+    mindmapBound = await getSelectedBound(page, 0);
+    pressEscape(page);
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [0, 0]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // drag frame
+  {
+    await clickView(page, [110, 110]);
+    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
+  }
+});
+
+test('add partial mindmap into frame, move frame, then drag root node of mindmap out.', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [550, 550]);
+  await pressEscape(page);
+
+  const button = page.locator('edgeless-mindmap-tool-button');
+  await button.click();
+  await toViewCoord(page, [100, 200]);
+  await clickView(page, [100, 200]);
+
+  let mindmapBound = await getSelectedBound(page);
+
+  // Drag frame
+  {
+    await clickView(page, [60, 60]);
+    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(
+    page,
+    [
+      mindmapBound[0] + 50,
+      mindmapBound[1] + 50,
+      mindmapBound[2],
+      mindmapBound[3],
+    ],
+    0
+  ); // mindmap
+  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+
+  // drag out
+  {
+    mindmapBound = await getSelectedBound(page, 0);
+    pressEscape(page);
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
+      page,
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [-20, -20]
+    );
+    await pressEscape(page);
+    await selectAllByKeyboard(page);
+    mindmapBound = await getSelectedBound(page, 0);
+    await pressEscape(page);
+  }
+
+  // drag frame
+  {
+    await clickView(page, [110, 110]);
+    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
+    await pressEscape(page);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(page, mindmapBound, 0); // mindmap
+  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+});
+
+test('add mindmap out of frame and add new node in frame then drag frame', async ({
+  page,
+}) => {
+  await createFrame(page, [500, 50], [1000, 550]);
+  await pressEscape(page);
+
+  const button = page.locator('edgeless-mindmap-tool-button');
+  await button.click();
+  await toViewCoord(page, [0, 200]);
+  await clickView(page, [0, 200]);
+
+  let mindmapBound = await getSelectedBound(page);
+
+  // add new node
+  {
+    await clickView(page, [
+      mindmapBound[2] - 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await waitNextFrame(page, 100);
+    await clickView(page, [
+      mindmapBound[2] + 50,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await pressEscape(page, 2);
+  }
+
+  await selectAllByKeyboard(page);
+  mindmapBound = await getSelectedBound(page, 0);
+  await pressEscape(page, 2);
+  await waitNextFrame(page, 100);
+
+  // Drag frame
+  {
+    await clickView(page, [510, 60]);
+    await dragBetweenViewCoords(page, [510, 60], [560, 110]);
+  }
+
+  await selectAllByKeyboard(page);
+  await assertSelectedBound(page, mindmapBound, 0); // mindmap
+  await assertSelectedBound(page, [550, 100, 500, 500], 1); // frame
+});

--- a/tests/edgeless/frame/frame.spec.ts
+++ b/tests/edgeless/frame/frame.spec.ts
@@ -8,7 +8,6 @@ import {
   createShapeElement,
   dragBetweenViewCoords,
   edgelessCommonSetup,
-  getSelectedBound,
   setEdgelessTool,
   Shape,
   shiftClickView,
@@ -290,42 +289,6 @@ test.describe('add element to frame and then move frame', () => {
       await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
       await assertSelectedBound(page, [550, 550, 100, 100], 2); // inner frame
     });
-  });
-
-  test('add mindmap root node and move frame', async ({ page }) => {
-    await createFrame(page, [50, 50], [550, 550]);
-    await pressEscape(page);
-    await triggerComponentToolbarAction(page, 'addMindmap');
-    let mindmapBound = await getSelectedBound(page);
-    await clickView(page, [
-      mindmapBound[0] + 10,
-      mindmapBound[1] + 0.5 * mindmapBound[3],
-    ]);
-    await dragBetweenViewCoords(
-      page,
-      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
-      [mindmapBound[0] + 10 + 50, mindmapBound[1] + 0.5 * mindmapBound[3]]
-    );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page);
-    await pressEscape(page);
-
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(
-      page,
-      [
-        mindmapBound[0] + 50,
-        mindmapBound[1] + 50,
-        mindmapBound[2],
-        mindmapBound[3],
-      ],
-      0
-    ); // mindmap
-    await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
   });
 });
 

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -1183,7 +1183,6 @@ export async function assertCanvasElementsCount(page: Page, expected: number) {
   const number = await getCanvasElementsCount(page);
   expect(number).toEqual(expected);
 }
-
 export function assertBound(received: Bound, expected: Bound) {
   expect(received[0]).toBeCloseTo(expected[0], 0);
   expect(received[1]).toBeCloseTo(expected[1], 0);


### PR DESCRIPTION
Closes: [BS-1398](https://linear.app/affine-design/issue/BS-1398/[bug]-拖出-frame-后-mindmap-依然跟随-frame),  [BS-1400](https://linear.app/affine-design/issue/BS-1400/mindmap无法移出frame)

This PR fix mindmap is moved with frame moving when the mindmap has been drag out of frame.

### What changes
- add workround to avoid multiple container in `FrameManager` for nodes of mindmap.
  - The fix can be refactored after #8239
- add frame and mindmap e2e tests