### PR TITLE
feat(blocks): parse url service

### DIFF
--- a/packages/affine/shared/src/services/index.ts
+++ b/packages/affine/shared/src/services/index.ts
@@ -4,5 +4,6 @@ export * from './editor-setting-service.js';
 export * from './embed-option-service.js';
 export * from './font-loader/index.js';
 export * from './notification-service.js';
+export * from './parse-url-service.js';
 export * from './quick-search-service.js';
 export * from './telemetry-service.js';

--- a/packages/affine/shared/src/services/parse-url-service.ts
+++ b/packages/affine/shared/src/services/parse-url-service.ts
@@ -1,0 +1,26 @@
+import type { ExtensionType } from '@blocksuite/block-std';
+
+import { createIdentifier } from '@blocksuite/global/di';
+
+export interface ParseDocUrlService {
+  parseDocUrl: (url: string) =>
+    | {
+        docId: string;
+        blockIds?: string[];
+        elementIds?: string[];
+      }
+    | undefined;
+}
+
+export const ParseDocUrlProvider =
+  createIdentifier<ParseDocUrlService>('ParseDocUrlService');
+
+export function ParseDocUrlExtension(
+  parseDocUrlService: ParseDocUrlService
+): ExtensionType {
+  return {
+    setup: di => {
+      di.addImpl(ParseDocUrlProvider, parseDocUrlService);
+    },
+  };
+}

--- a/packages/affine/shared/src/services/quick-search-service.ts
+++ b/packages/affine/shared/src/services/quick-search-service.ts
@@ -4,21 +4,17 @@ import type { ExtensionType } from '@blocksuite/block-std';
 import { createIdentifier } from '@blocksuite/global/di';
 
 export interface QuickSearchService {
-  searchDoc: (options: {
-    action?: 'insert';
-    userInput?: string;
-    skipSelection?: boolean;
-    trigger?: 'edgeless-toolbar' | 'slash-command' | 'shortcut';
-  }) => Promise<QuickSearchResult>;
+  openQuickSearch: () => Promise<QuickSearchResult>;
 }
 
 export type QuickSearchResult =
   | {
       docId: string;
-      isNewDoc?: boolean;
       params?: ReferenceParams;
     }
-  | { userInput: string }
+  | {
+      externalUrl: string;
+    }
   | null;
 
 export const QuickSearchProvider = createIdentifier<QuickSearchService>(

--- a/packages/blocks/src/database-block/columns/link/cell-renderer.ts
+++ b/packages/blocks/src/database-block/columns/link/cell-renderer.ts
@@ -1,5 +1,5 @@
 import { RefNodeSlotsProvider } from '@blocksuite/affine-components/rich-text';
-import { QuickSearchProvider } from '@blocksuite/affine-shared/services';
+import { ParseDocUrlProvider } from '@blocksuite/affine-shared/services';
 import {
   isValidUrl,
   normalizeUrl,
@@ -157,21 +157,14 @@ export class LinkCell extends BaseCellRenderer<string> {
         this.docId = undefined;
         return;
       }
-      const result = std?.getOptional(QuickSearchProvider)?.searchDoc({
-        userInput: this.value,
-        skipSelection: true,
-      });
-      result
-        ?.then(res => {
-          if (res && 'docId' in res) {
-            this.docId = res.docId;
-            return;
-          }
-          this.docId = undefined;
-        })
-        .catch(() => {
-          this.docId = undefined;
-        });
+      const result = std
+        ?.getOptional(ParseDocUrlProvider)
+        ?.parseDocUrl(this.value);
+      if (result) {
+        this.docId = result.docId;
+      } else {
+        this.docId = undefined;
+      }
     }
   }
 

--- a/packages/blocks/src/database-block/columns/title/text.ts
+++ b/packages/blocks/src/database-block/columns/title/text.ts
@@ -4,7 +4,7 @@ import {
   DefaultInlineManagerExtension,
   type RichText,
 } from '@blocksuite/affine-components/rich-text';
-import { QuickSearchProvider } from '@blocksuite/affine-shared/services';
+import { ParseDocUrlProvider } from '@blocksuite/affine-shared/services';
 import {
   getViewportElement,
   isValidUrl,
@@ -192,7 +192,7 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
     e.stopPropagation();
   };
 
-  private _onPaste = async (e: ClipboardEvent) => {
+  private _onPaste = (e: ClipboardEvent) => {
     const inlineEditor = this.inlineEditor;
     assertExists(inlineEditor);
 
@@ -207,10 +207,7 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
     e.stopPropagation();
     if (isValidUrl(text)) {
       const std = this.std;
-      const result = await std?.getOptional(QuickSearchProvider)?.searchDoc({
-        userInput: text,
-        skipSelection: true,
-      });
+      const result = std?.getOptional(ParseDocUrlProvider)?.parseDocUrl(text);
       if (result && 'docId' in result) {
         const text = ' ';
         inlineEditor.insertText(inlineRange, text, {
@@ -266,7 +263,7 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
     this.disposables.addFromEvent(this.richText, 'copy', this._onCopy);
     this.disposables.addFromEvent(this.richText, 'cut', this._onCut);
     this.disposables.addFromEvent(this.richText, 'paste', e => {
-      this._onPaste(e).catch(console.error);
+      this._onPaste(e);
     });
     this.richText.updateComplete
       .then(() => {

--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -19,7 +19,7 @@ import {
 import { BookmarkStyles } from '@blocksuite/affine-model';
 import {
   EmbedOptionProvider,
-  QuickSearchProvider,
+  ParseDocUrlProvider,
   TelemetryProvider,
 } from '@blocksuite/affine-shared/services';
 import {
@@ -260,12 +260,8 @@ export class EdgelessClipboardController extends PageClipboard {
       );
 
       // try to interpret url as affine doc url
-      const quickSearchService = this.std.getOptional(QuickSearchProvider);
-      const doc = await quickSearchService?.searchDoc({
-        action: 'insert',
-        userInput: url,
-        skipSelection: true,
-      });
+      const parseDocUrlService = this.std.getOptional(ParseDocUrlProvider);
+      const doc = parseDocUrlService?.parseDocUrl(url);
       const pageId = doc && 'docId' in doc ? doc.docId : undefined;
       const options: Record<string, unknown> = {};
 

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-dense-menu.ts
@@ -24,14 +24,6 @@ export const buildLinkDenseMenu: DenseMenuBuilder = edgeless => ({
             module: 'toolbar',
             type: type.flavour?.split(':')[1],
           });
-        if (type.isNewDoc) {
-          edgeless.std.getOptional(TelemetryProvider)?.track('DocCreated', {
-            control: 'toolbar:general',
-            page: 'whiteboard editor',
-            module: 'edgeless toolbar',
-            type: type.flavour?.split(':')[1],
-          });
-        }
       })
       .catch(console.error);
   },

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/link/link-tool-button.ts
@@ -36,38 +36,16 @@ export class EdgelessLinkToolButton extends QuickToolMixin(LitElement) {
             type: type.flavour?.split(':')[1],
           });
 
-        if (type.isNewDoc) {
-          this.edgeless.std
-            .getOptional(TelemetryProvider)
-            ?.track('DocCreated', {
-              control: 'toolbar:general',
-              page: 'whiteboard editor',
-              module: 'edgeless toolbar',
-              segment: 'whiteboard',
-              type: type.flavour?.split(':')[1],
-            });
-          this.edgeless.std
-            .getOptional(TelemetryProvider)
-            ?.track('LinkedDocCreated', {
-              control: 'links',
-              page: 'whiteboard editor',
-              module: 'edgeless toolbar',
-              segment: 'whiteboard',
-              type: type.flavour?.split(':')[1],
-              other: 'new doc',
-            });
-        } else {
-          this.edgeless.std
-            .getOptional(TelemetryProvider)
-            ?.track('LinkedDocCreated', {
-              control: 'links',
-              page: 'whiteboard editor',
-              module: 'edgeless toolbar',
-              segment: 'whiteboard',
-              type: type.flavour?.split(':')[1],
-              other: 'existing doc',
-            });
-        }
+        this.edgeless.std
+          .getOptional(TelemetryProvider)
+          ?.track('LinkedDocCreated', {
+            control: 'links',
+            page: 'whiteboard editor',
+            module: 'edgeless toolbar',
+            segment: 'whiteboard',
+            type: type.flavour?.split(':')[1],
+            other: 'existing doc',
+          });
       })
       .catch(console.error);
   }

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/note/note-menu.ts
@@ -82,16 +82,6 @@ export class EdgelessNoteMenu extends EdgelessToolbarToolMixin(LitElement) {
             module: 'toolbar',
             type: type.flavour?.split(':')[1],
           });
-        if (type.isNewDoc) {
-          this.edgeless.std
-            .getOptional(TelemetryProvider)
-            ?.track('DocCreated', {
-              control: 'toolbar:general',
-              page: 'whiteboard editor',
-              module: 'edgeless toolbar',
-              type: type.flavour?.split(':')[1],
-            });
-        }
       })
       .catch(console.error);
   }

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -200,16 +200,6 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
                   segment: 'toolbar',
                   type: type.flavour?.split(':')[1],
                 });
-              if (type.isNewDoc) {
-                rootComponent.std
-                  .getOptional(TelemetryProvider)
-                  ?.track('DocCreated', {
-                    control: 'shortcut',
-                    page: 'whiteboard editor',
-                    segment: 'whiteboard',
-                    type: type.flavour?.split(':')[1],
-                  });
-              }
             })
             .catch(console.error);
         },

--- a/packages/playground/apps/_common/mock-services.ts
+++ b/packages/playground/apps/_common/mock-services.ts
@@ -4,7 +4,7 @@ import {
   type DocMode,
   type DocModeProvider,
   type NotificationService,
-  type QuickSearchService,
+  type ParseDocUrlService,
   toast,
 } from '@blocksuite/blocks';
 import { type DocCollection, Slot } from '@blocksuite/store';
@@ -92,15 +92,11 @@ export function mockNotificationService(editor: AffineEditorContainer) {
   return notificationService;
 }
 
-export function mockQuickSearchService(collection: DocCollection) {
-  const quickSearchService: QuickSearchService = {
-    async searchDoc({ userInput }) {
-      if (!userInput) {
-        return null;
-      }
-      if (URL.canParse(userInput)) {
-        await new Promise(resolve => setTimeout(resolve, 500));
-        const path = new URL(userInput).pathname;
+export function mockParseDocUrlService(collection: DocCollection) {
+  const parseDocUrlService: ParseDocUrlService = {
+    parseDocUrl: (url: string) => {
+      if (url && URL.canParse(url)) {
+        const path = new URL(url).pathname;
         const item =
           path.length > 1
             ? [...collection.docs.values()].find(doc => {
@@ -112,21 +108,9 @@ export function mockQuickSearchService(collection: DocCollection) {
             docId: item.id,
           };
         }
-        return {
-          userInput: userInput,
-        };
       }
-      const doc = [...collection.docs.values()].find(
-        v => v.meta?.title === userInput
-      );
-      if (doc) {
-        await new Promise(resolve => setTimeout(resolve, 500));
-        return {
-          docId: doc.id,
-        };
-      }
-      return null;
+      return;
     },
   };
-  return quickSearchService;
+  return parseDocUrlService;
 }

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -8,7 +8,7 @@ import {
   DocModeProvider,
   FontConfigExtension,
   NotificationExtension,
-  QuickSearchExtension,
+  ParseDocUrlExtension,
   RefNodeSlotsExtension,
   RefNodeSlotsProvider,
 } from '@blocksuite/blocks';
@@ -21,7 +21,7 @@ import { QuickEdgelessMenu } from '../../_common/components/quick-edgeless-menu.
 import {
   mockDocModeService,
   mockNotificationService,
-  mockQuickSearchService,
+  mockParseDocUrlService,
 } from '../../_common/mock-services.js';
 import { getExampleSpecs } from '../specs-examples/index.js';
 
@@ -118,7 +118,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
       DocModeExtension(
         mockDocModeService(getEditorModeCallback, setEditorModeCallBack)
       ),
-      QuickSearchExtension(mockQuickSearchService(collection)),
+      ParseDocUrlExtension(mockParseDocUrlService(collection)),
       NotificationExtension(mockNotificationService(editor)),
       FontConfigExtension(CommunityCanvasTextFonts),
       PeekViewExtension({

--- a/packages/playground/apps/starter/main.ts
+++ b/packages/playground/apps/starter/main.ts
@@ -8,6 +8,7 @@ import {
   CommunityCanvasTextFonts,
   DocModeProvider,
   FontConfigExtension,
+  ParseDocUrlProvider,
   QuickSearchProvider,
   RefNodeSlotsExtension,
   RefNodeSlotsProvider,
@@ -48,6 +49,7 @@ async function main() {
           QuickSearchProvider,
           DocModeProvider,
           RefNodeSlotsProvider,
+          ParseDocUrlService: ParseDocUrlProvider,
         },
         defaultExtensions: (): ExtensionType[] => [
           FontConfigExtension(CommunityCanvasTextFonts),

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -10,7 +10,7 @@ import {
   FontConfigExtension,
   NotificationExtension,
   type PageRootService,
-  QuickSearchExtension,
+  ParseDocUrlExtension,
   RefNodeSlotsExtension,
   RefNodeSlotsProvider,
   SpecProvider,
@@ -33,7 +33,7 @@ import { SidePanel } from '../../_common/components/side-panel.js';
 import {
   mockDocModeService,
   mockNotificationService,
-  mockQuickSearchService,
+  mockParseDocUrlService,
 } from '../../_common/mock-services';
 
 function setDocModeFromUrlParams(service: DocModeProvider, docId: string) {
@@ -85,7 +85,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
     refNodeSlotsExtension,
     PatchPageServiceWatcher,
     FontConfigExtension(CommunityCanvasTextFonts),
-    QuickSearchExtension(mockQuickSearchService(collection)),
+    ParseDocUrlExtension(mockParseDocUrlService(collection)),
     NotificationExtension(mockNotificationService(editor)),
     {
       setup: di => {

--- a/tests/clipboard/clipboard.spec.ts
+++ b/tests/clipboard/clipboard.spec.ts
@@ -15,7 +15,7 @@ import {
   getEditorLocator,
   getPageSnapshot,
   initEmptyParagraphState,
-  mockQuickSearch,
+  mockParseDocUrlService,
   pasteByKeyboard,
   pasteContent,
   pressEnter,
@@ -249,7 +249,7 @@ test(scoped`pasting internal url`, async ({ page }) => {
 
   await focusRichText(page);
   const docId = await getCurrentEditorDocId(page);
-  await mockQuickSearch(page, {
+  await mockParseDocUrlService(page, {
     'http://workspace/doc-id': docId,
   });
   await pasteContent(page, {
@@ -266,7 +266,7 @@ test(scoped`pasting internal url with params`, async ({ page }) => {
 
   await focusRichText(page);
   const docId = await getCurrentEditorDocId(page);
-  await mockQuickSearch(page, {
+  await mockParseDocUrlService(page, {
     'http://workspace/doc-id?mode=page&blockIds=rL2_GXbtLU2SsJVfCSmh_': docId,
   });
   await pasteContent(page, {

--- a/tests/edgeless/clipboard.spec.ts
+++ b/tests/edgeless/clipboard.spec.ts
@@ -20,7 +20,7 @@ import {
   focusTitle,
   getCurrentEditorDocId,
   initEmptyEdgelessState,
-  mockQuickSearch,
+  mockParseDocUrlService,
   pasteByKeyboard,
   pasteContent,
   selectAllByKeyboard,
@@ -197,7 +197,7 @@ test.describe('pasting URLs', () => {
     await switchEditorMode(page);
     await deleteAll(page);
 
-    await mockQuickSearch(page, {
+    await mockParseDocUrlService(page, {
       'http://workspace/doc-id': docId,
     });
 

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -98,8 +98,10 @@ async function initEmptyEditor({
             ...window.$blocksuite.defaultExtensions(),
             {
               setup: di => {
-                di.addImpl(window.$blocksuite.identifiers.QuickSearchProvider, {
-                  searchDoc: () => Promise.resolve(null),
+                di.addImpl(window.$blocksuite.identifiers.ParseDocUrlService, {
+                  parseDocUrl() {
+                    return undefined;
+                  },
                 });
               },
             },
@@ -1451,32 +1453,20 @@ export async function scrollToBottom(page: Page) {
   });
 }
 
-export async function mockQuickSearch(
+export async function mockParseDocUrlService(
   page: Page,
-  mapping: Record<string, string> // query -> docId
+  mapping: Record<string, string>
 ) {
-  // mock quick search service
   await page.evaluate(mapping => {
-    const quickSearchService = window.host.std.get(
-      window.$blocksuite.identifiers.QuickSearchProvider
+    const parseDocUrlService = window.host.std.get(
+      window.$blocksuite.identifiers.ParseDocUrlService
     );
-    quickSearchService.searchDoc = options => {
-      return new Promise(resolve => {
-        if (!options.userInput) {
-          return resolve(null);
-        }
-
-        const docId = mapping[options.userInput];
-        if (!docId) {
-          return resolve({
-            userInput: options.userInput,
-          });
-        } else {
-          return resolve({
-            docId,
-          });
-        }
-      });
+    parseDocUrlService.parseDocUrl = (url: string) => {
+      const docId = mapping[url];
+      if (docId) {
+        return { docId };
+      }
+      return;
     };
   }, mapping);
 }

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -25,6 +25,7 @@ declare global {
         QuickSearchProvider: typeof import('../../packages/affine/shared/src/services/quick-search-service.js').QuickSearchProvider;
         DocModeProvider: typeof import('../../packages/affine/shared/src/services/doc-mode-service.js').DocModeProvider;
         RefNodeSlotsProvider: typeof RefNodeSlotsProvider;
+        ParseDocUrlService: typeof import('../../packages/affine/shared/src/services/parse-url-service.js').ParseDocUrlProvider;
       };
       defaultExtensions: () => ExtensionType[];
       extensions: {


### PR DESCRIPTION
Before this, blocksuite used QuickSearchService to extract docId and other information from the url. This pr provides a ParseDocUrlService to handle such requirements.