### PR TITLE
fix(inline): filter embed gap in `getTextPoint`

### DIFF
--- a/packages/framework/inline/src/services/range.ts
+++ b/packages/framework/inline/src/services/range.ts
@@ -404,7 +404,9 @@ export class RangeService<TextAttributes extends BaseTextAttributes> {
 
     let index = 0;
     for (const vLine of vLines) {
-      const texts = getTextNodesFromElement(vLine);
+      const texts = getTextNodesFromElement(vLine).filter(
+        text => !text.parentElement?.closest('[data-v-embed-gap="true"]')
+      );
       if (texts.length === 0) {
         return null;
       }


### PR DESCRIPTION
Close [BS-1365](https://linear.app/affine-design/issue/BS-1365/创建-inline-latex-的预期行为错误)
Close [BS-1368](https://linear.app/affine-design/issue/BS-1366/[行内-latex]输入完成-latex-后不能继续输入文字)