### PR TITLE
fix(blocks): not keep block selection when trigger latex editor

### DIFF
--- a/packages/blocks/src/latex-block/latex-block.ts
+++ b/packages/blocks/src/latex-block/latex-block.ts
@@ -114,11 +114,7 @@ export class LatexBlockComponent extends CaptionedBlockComponent<
     this._editorAbortController?.abort();
     this._editorAbortController = new AbortController();
 
-    this.selection.setGroup('note', [
-      this.selection.create('block', {
-        blockId: this.model.id,
-      }),
-    ]);
+    this.selection.setGroup('note', []);
 
     const portal = createLitPortal({
       template: html`<latex-editor-menu


### PR DESCRIPTION
Close [BS-1408](https://linear.app/affine-design/issue/BS-1408/[行间-latex]-input-内的删除行为会删掉整个-block)