### PR TITLE
fix: should update outline panel notes after slicing note

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
@@ -1,4 +1,5 @@
 import { SmallScissorsIcon } from '@blocksuite/affine-components/icons';
+import { EDGELESS_BLOCK_CHILD_PADDING } from '@blocksuite/affine-shared/consts';
 import { TelemetryProvider } from '@blocksuite/affine-shared/services';
 import { getRectByBlockComponent } from '@blocksuite/affine-shared/utils';
 import { WithDisposable } from '@blocksuite/block-std';
@@ -317,12 +318,11 @@ export class NoteSlicer extends WithDisposable(LitElement) {
             const event = ctx.get('pointerState');
             const { raw } = event;
             const target = raw.target as HTMLElement;
-            if (!target) return false;
+            if (!target) return;
+
             if (target.closest('note-slicer')) {
               this._sliceNote();
-              return true;
             }
-            return false;
           })
         );
       }
@@ -362,7 +362,7 @@ export class NoteSlicer extends WithDisposable(LitElement) {
     if (!noteBlock || !this._divingLinePositions.length) return nothing;
 
     const rect = getRectByBlockComponent(noteBlock);
-    const width = rect.width;
+    const width = rect.width - 2 * EDGELESS_BLOCK_CHILD_PADDING;
     const buttonPosition = this._divingLinePositions[this._activeSlicerIndex];
 
     return html`<div class="note-slicer-container">

--- a/packages/presets/src/fragments/outline/outline-panel.ts
+++ b/packages/presets/src/fragments/outline/outline-panel.ts
@@ -1,8 +1,6 @@
-import { DocModeProvider } from '@blocksuite/affine-shared/services';
 import { SignalWatcher, WithDisposable } from '@blocksuite/block-std';
-import { DisposableGroup } from '@blocksuite/global/utils';
 import { baseTheme } from '@toeverything/theme';
-import { css, html, LitElement, type PropertyValues, unsafeCSS } from 'lit';
+import { css, html, LitElement, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { AffineEditorContainer } from '../../editors/editor-container.js';
@@ -62,8 +60,6 @@ export const AFFINE_OUTLINE_PANEL = 'affine-outline-panel';
 export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
   static override styles = styles;
 
-  private _editorDisposables: DisposableGroup | null = null;
-
   private _setNoticeVisibility = (visibility: boolean) => {
     this._noticeVisible = visibility;
   };
@@ -99,11 +95,6 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
     return this.editor.mode;
   }
 
-  private _clearEditorDisposables() {
-    this._editorDisposables?.dispose();
-    this._editorDisposables = null;
-  }
-
   private _loadSettingsFromLocalStorage() {
     const settings = localStorage.getItem(outlineSettingsKey);
     if (settings) {
@@ -117,29 +108,6 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
     localStorage.setItem(outlineSettingsKey, JSON.stringify(this._settings));
   }
 
-  private _setEditorDisposables() {
-    this._clearEditorDisposables();
-    this._editorDisposables = new DisposableGroup();
-    this._editorDisposables.add(
-      this.editor.std.get(DocModeProvider).onPrimaryModeChange(() => {
-        this.editor.updateComplete
-          .then(() => {
-            this.requestUpdate();
-          })
-          .catch(console.error);
-      }, this.editor.doc.id)
-    );
-    this._editorDisposables.add(
-      this.editor.slots.docUpdated.on(() => {
-        this.editor.updateComplete
-          .then(() => {
-            this.requestUpdate();
-          })
-          .catch(console.error);
-      })
-    );
-  }
-
   private _updateAndSaveSettings(
     newSettings: Partial<OutlineSettingsDataType>
   ) {
@@ -150,11 +118,6 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
   override connectedCallback() {
     super.connectedCallback();
     this._loadSettingsFromLocalStorage();
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    this._clearEditorDisposables();
   }
 
   override render() {
@@ -189,12 +152,6 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
         ></affine-outline-notice>
       </div>
     `;
-  }
-
-  override updated(_changedProperties: PropertyValues) {
-    if (_changedProperties.has('editor')) {
-      this._setEditorDisposables();
-    }
   }
 
   @state()

--- a/tests/fragments/outline/toc-viewer.spec.ts
+++ b/tests/fragments/outline/toc-viewer.spec.ts
@@ -1,0 +1,183 @@
+import { expect, type Page } from '@playwright/test';
+import { addNote, switchEditorMode } from 'utils/actions/edgeless.js';
+import { pressEnter, type } from 'utils/actions/keyboard.js';
+import {
+  enterPlaygroundRoom,
+  focusRichTextEnd,
+  focusTitle,
+  getEditorLocator,
+  initEmptyEdgelessState,
+  initEmptyParagraphState,
+  waitNextFrame,
+} from 'utils/actions/misc.js';
+
+import { test } from '../../utils/playwright.js';
+import {
+  createHeadingsWithGap,
+  getVerticalCenterFromLocator,
+} from './utils.js';
+
+test.describe('toc-viewer', () => {
+  async function toggleTocViewer(page: Page) {
+    await page.click('sl-button:text("Test Operations")');
+    await page.click('sl-menu-item:text("Enable Outline Viewer")');
+    await waitNextFrame(page);
+    const viewer = page.locator('affine-outline-viewer');
+    return viewer;
+  }
+
+  function getIndicators(page: Page) {
+    return page.locator('affine-outline-viewer .outline-viewer-indicator');
+  }
+
+  test('should display highlight indicators when non-empty headings exists', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await toggleTocViewer(page);
+
+    await focusRichTextEnd(page);
+
+    const indicators = getIndicators(page);
+
+    // heading 1 to 6
+    for (let i = 1; i <= 6; i++) {
+      await type(page, `${'#'.repeat(i)} `);
+      await type(page, `Heading ${i}`);
+      await pressEnter(page);
+
+      await expect(indicators.nth(i - 1)).toBeVisible();
+    }
+  });
+
+  test('should be hidden when only empty headings exists', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await toggleTocViewer(page);
+
+    await focusTitle(page);
+    await type(page, 'Title');
+    await focusRichTextEnd(page);
+
+    const indicators = getIndicators(page);
+
+    // heading 1 to 6
+    for (let i = 1; i <= 6; i++) {
+      await type(page, `${'#'.repeat(i)} `);
+      await pressEnter(page);
+      await expect(indicators).toHaveCount(0);
+    }
+  });
+
+  test('should display outline content when hovering over indicators', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await toggleTocViewer(page);
+
+    await focusRichTextEnd(page);
+
+    await type(page, '# Heading 1');
+    await pressEnter(page);
+
+    const indicator = getIndicators(page).first();
+    await indicator.hover({ force: true });
+
+    const items = page.locator('.outline-viewer-item');
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toContainText(['Table of Contents']);
+    await expect(items.nth(1)).toContainText(['Heading 1']);
+  });
+
+  test('should highlight indicator when scrolling', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await toggleTocViewer(page);
+    await focusRichTextEnd(page);
+
+    const editor = getEditorLocator(page);
+    const indicators = getIndicators(page);
+    const headings = await createHeadingsWithGap(page);
+    await editor.locator('.inline-editor').first().scrollIntoViewIfNeeded();
+
+    const viewportCenter = await getVerticalCenterFromLocator(
+      page.locator('body')
+    );
+    for (let i = 0; i < headings.length; i++) {
+      const lastHeadingCenter = await getVerticalCenterFromLocator(headings[i]);
+      await page.mouse.wheel(0, lastHeadingCenter - viewportCenter + 50);
+      await expect(indicators.nth(i)).toHaveClass(/active/);
+    }
+  });
+
+  test('should highlight indicator when click item in outline panel', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    const viewer = await toggleTocViewer(page);
+
+    await focusRichTextEnd(page);
+    const headings = await createHeadingsWithGap(page);
+
+    const indicators = getIndicators(page);
+    await indicators.first().hover({ force: true });
+
+    const headingsInPanel = Array.from({ length: 6 }, (_, i) =>
+      viewer.locator(`.h${i + 1} > span`)
+    );
+
+    await headingsInPanel[2].click();
+    await expect(headings[2]).toBeVisible();
+    await expect(indicators.nth(2)).toHaveClass(/active/);
+  });
+
+  test('should hide in edgeless mode', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await toggleTocViewer(page);
+
+    const indicators = getIndicators(page);
+
+    await focusRichTextEnd(page);
+    await type(page, '# Heading 1');
+    await pressEnter(page);
+
+    await expect(indicators).toHaveCount(1);
+
+    await switchEditorMode(page);
+
+    await expect(indicators).toHaveCount(0);
+  });
+
+  test('should hide edgeless-only note headings', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    const viewer = await toggleTocViewer(page);
+
+    await focusRichTextEnd(page);
+
+    await type(page, '# Heading 1');
+    await pressEnter(page);
+
+    await type(page, '## Heading 2');
+    await pressEnter(page);
+
+    await switchEditorMode(page);
+
+    await addNote(page, '# Edgeless', 300, 300);
+
+    await switchEditorMode(page);
+
+    const indicators = getIndicators(page);
+    await expect(indicators).toHaveCount(2);
+
+    await indicators.first().hover({ force: true });
+
+    await expect(viewer).toBeVisible();
+    const hiddenTitle = viewer.locator('.hidden-title');
+    await expect(hiddenTitle).toBeHidden();
+  });
+});

--- a/tests/fragments/outline/utils.ts
+++ b/tests/fragments/outline/utils.ts
@@ -1,0 +1,27 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { pressEnter, type } from 'utils/actions/keyboard.js';
+import { getEditorHostLocator } from 'utils/actions/misc.js';
+
+export async function getVerticalCenterFromLocator(locator: Locator) {
+  const rect = await locator.boundingBox();
+  return rect!.y + rect!.height / 2;
+}
+
+export async function createHeadingsWithGap(page: Page) {
+  // heading 1 to 6
+  const editor = getEditorHostLocator(page);
+
+  const headings: Locator[] = [];
+  await pressEnter(page, 10);
+  for (let i = 1; i <= 6; i++) {
+    await type(page, `${'#'.repeat(i)} `);
+    await type(page, `Heading ${i}`);
+    const heading = editor.locator(`.h${i}`);
+    await expect(heading).toBeVisible();
+    headings.push(heading);
+    await pressEnter(page, 10);
+  }
+  await pressEnter(page, 10);
+
+  return headings;
+}


### PR DESCRIPTION
Fix: [BS-1358](https://linear.app/affine-design/issue/BS-1358/[bug]-使用剪刀切开之后-note-block-不会显示在-frame-toc-里) [BS-1002](https://linear.app/affine-design/issue/BS-1002/使用剪刀后，会触发选区)

Split outline.spec.ts tests into two files.