### PR TITLE
feat(blocks): parse doc url with mode

### DIFF
--- a/packages/affine/shared/src/services/parse-url-service.ts
+++ b/packages/affine/shared/src/services/parse-url-service.ts
@@ -1,3 +1,4 @@
+import type { DocMode } from '@blocksuite/affine-model';
 import type { ExtensionType } from '@blocksuite/block-std';
 
 import { createIdentifier } from '@blocksuite/global/di';
@@ -8,6 +9,7 @@ export interface ParseDocUrlService {
         docId: string;
         blockIds?: string[];
         elementIds?: string[];
+        mode?: DocMode;
       }
     | undefined;
 }

--- a/packages/blocks/src/database-block/columns/title/text.ts
+++ b/packages/blocks/src/database-block/columns/title/text.ts
@@ -206,12 +206,17 @@ export class HeaderAreaTextCellEditing extends BaseTextCell {
     if (isValidUrl(text)) {
       const std = this.std;
       const result = std?.getOptional(ParseDocUrlProvider)?.parseDocUrl(text);
-      if (result && 'docId' in result) {
+      if (result) {
         const text = ' ';
         inlineEditor.insertText(inlineRange, text, {
           reference: {
             type: 'LinkedPage',
             pageId: result.docId,
+            params: {
+              blockIds: result.blockIds,
+              elementIds: result.elementIds,
+              mode: result.mode,
+            },
           },
         });
         inlineEditor.setInlineRange({

--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -56,7 +56,6 @@ import {
 } from '../../../_common/consts.js';
 import { ExportManager } from '../../../_common/export-manager/export-manager.js';
 import { getRootByEditorHost } from '../../../_common/utils/query.js';
-import { extractSearchParams } from '../../../_common/utils/url.js';
 import { ClipboardAdapter } from '../../clipboard/adapter.js';
 import { PageClipboard } from '../../clipboard/index.js';
 import {
@@ -261,28 +260,27 @@ export class EdgelessClipboardController extends PageClipboard {
 
       // try to interpret url as affine doc url
       const parseDocUrlService = this.std.getOptional(ParseDocUrlProvider);
-      const doc = parseDocUrlService?.parseDocUrl(url);
-      const pageId = doc && 'docId' in doc ? doc.docId : undefined;
+      const docUrlInfo = parseDocUrlService?.parseDocUrl(url);
       const options: Record<string, unknown> = {};
 
       let flavour = 'affine:bookmark';
       let style = BookmarkStyles[0];
       let isLinkToNode = false;
 
-      if (pageId) {
-        options.pageId = pageId;
+      if (docUrlInfo) {
+        options.pageId = docUrlInfo.docId;
         flavour = 'affine:embed-linked-doc';
         style = 'vertical';
 
-        const extracted = extractSearchParams(url);
-
         isLinkToNode = Boolean(
-          extracted?.params?.mode &&
-            (extracted.params.blockIds?.length ||
-              extracted.params.elementIds?.length)
+          docUrlInfo.blockIds?.length || docUrlInfo.elementIds?.length
         );
 
-        Object.assign(options, extracted);
+        Object.assign(options, {
+          mode: docUrlInfo.mode,
+          blockIds: docUrlInfo.blockIds,
+          elementIds: docUrlInfo.elementIds,
+        });
       } else {
         options.url = url;
 


### PR DESCRIPTION
I forgot to return the `mode` field when parse doc url.
In addition, I also modified the implementation of parsing url in clipboard, and now it completely use parsedocurl for parsing.