### PR TITLE
fix: color with transparency does not remember

### DIFF
--- a/packages/affine/block-surface/package.json
+++ b/packages/affine/block-surface/package.json
@@ -26,15 +26,11 @@
     "@toeverything/theme": "^1.0.8",
     "fractional-indexing": "^3.2.0",
     "lit": "^3.2.0",
-    "lodash.isplainobject": "^4.0.6",
-    "lodash.merge": "^4.6.2",
     "nanoid": "^5.0.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/dompurify": "^3.0.5",
-    "@types/lodash.isplainobject": "^4.0.9",
-    "@types/lodash.merge": "^4.6.9"
+    "@types/dompurify": "^3.0.5"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/affine/model/src/blocks/note/note-model.ts
+++ b/packages/affine/model/src/blocks/note/note-model.ts
@@ -58,7 +58,7 @@ export const NoteBlockSchema = defineBlockSchema({
   },
 });
 
-type NoteProps = {
+export type NoteProps = {
   xywh: SerializedXYWH;
   background: Color;
   index: string;
@@ -75,7 +75,7 @@ type NoteProps = {
   hidden: boolean;
 };
 
-type NoteEdgelessProps = {
+export type NoteEdgelessProps = {
   style: {
     borderRadius: number;
     borderSize: number;

--- a/packages/affine/model/src/blocks/paragraph/paragraph-model.ts
+++ b/packages/affine/model/src/blocks/paragraph/paragraph-model.ts
@@ -1,4 +1,8 @@
-import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
+import {
+  defineBlockSchema,
+  type SchemaToModel,
+  type Text,
+} from '@blocksuite/store';
 
 export type ParagraphType =
   | 'text'
@@ -10,10 +14,15 @@ export type ParagraphType =
   | 'h5'
   | 'h6';
 
+export type ParagraphProps = {
+  type: ParagraphType;
+  text: Text;
+};
+
 export const ParagraphBlockSchema = defineBlockSchema({
   flavour: 'affine:paragraph',
-  props: internal => ({
-    type: 'text' as ParagraphType,
+  props: (internal): ParagraphProps => ({
+    type: 'text',
     text: internal.Text(),
   }),
   metadata: {

--- a/packages/affine/model/src/blocks/root/root-block-model.ts
+++ b/packages/affine/model/src/blocks/root/root-block-model.ts
@@ -2,7 +2,7 @@ import type { Text } from '@blocksuite/store';
 
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
-type RootBlockProps = {
+export type RootBlockProps = {
   title: Text;
 };
 

--- a/packages/affine/shared/package.json
+++ b/packages/affine/shared/package.json
@@ -25,6 +25,8 @@
     "@lit/context": "^1.1.2",
     "@toeverything/theme": "^1.0.8",
     "lit": "^3.2.0",
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.mergewith": "^4.6.2",
     "minimatch": "^10.0.1",
     "zod": "^3.23.8"
   },
@@ -92,5 +94,9 @@
     "dist",
     "!src/__tests__",
     "!dist/__tests__"
-  ]
+  ],
+  "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.9",
+    "@types/lodash.mergewith": "^4"
+  }
 }

--- a/packages/affine/shared/src/services/edit-props-store.ts
+++ b/packages/affine/shared/src/services/edit-props-store.ts
@@ -1,4 +1,3 @@
-import { ColorSchema, NodePropsSchema } from '@blocksuite/affine-shared/utils';
 import { type BlockStdScope, LifeCycleWatcher } from '@blocksuite/block-std';
 import {
   type DeepPartial,
@@ -7,17 +6,20 @@ import {
 } from '@blocksuite/global/utils';
 import { computed, type Signal, signal } from '@lit-labs/preact-signals';
 import clonedeep from 'lodash.clonedeep';
-import isPlainObject from 'lodash.isplainobject';
-import merge from 'lodash.merge';
+import mergeWith from 'lodash.mergewith';
 import { z } from 'zod';
 
+import {
+  ColorSchema,
+  makeDeepOptional,
+  NodePropsSchema,
+} from '../utils/index.js';
 import { EditorSettingProvider } from './editor-setting-service.js';
 
 const LastPropsSchema = NodePropsSchema;
+const OptionalPropsSchema = makeDeepOptional(NodePropsSchema);
 export type LastProps = z.infer<typeof NodePropsSchema>;
 export type LastPropsKey = keyof LastProps;
-
-const SESSION_PROP_KEY = 'blocksuite:prop:record';
 
 const SessionPropsSchema = z.object({
   viewport: z.union([
@@ -59,6 +61,13 @@ function isSessionProp(key: string): key is keyof SessionProps {
   return key in SessionPropsSchema.shape;
 }
 
+function customizer(_target: unknown, source: unknown) {
+  if (ColorSchema.safeParse(source).success) {
+    return source;
+  }
+  return;
+}
+
 export class EditPropsStore extends LifeCycleWatcher {
   static override key = 'EditPropsStore';
 
@@ -86,21 +95,15 @@ export class EditPropsStore extends LifeCycleWatcher {
       }, {})
     );
 
-    const props = sessionStorage.getItem(SESSION_PROP_KEY);
-    if (props) {
-      const result = LastPropsSchema.safeParse(JSON.parse(props));
-      if (result.success) {
-        merge(clonedeep(initProps), result.data);
-      }
-    }
-
     this.lastProps$ = computed(() => {
       const editorSetting$ = this.std.getOptional(EditorSettingProvider);
-      return merge(
+      const nextProps = mergeWith(
         clonedeep(initProps),
         editorSetting$?.value,
-        this.innerProps$.value
+        this.innerProps$.value,
+        customizer
       );
+      return LastPropsSchema.parse(nextProps);
     });
   }
 
@@ -134,7 +137,7 @@ export class EditPropsStore extends LifeCycleWatcher {
 
   applyLastProps(key: LastPropsKey, props: Record<string, unknown>) {
     const lastProps = this.lastProps$.value[key];
-    return merge(clonedeep(lastProps), props);
+    return mergeWith(clonedeep(lastProps), props, customizer);
   }
 
   dispose() {
@@ -163,16 +166,17 @@ export class EditPropsStore extends LifeCycleWatcher {
   }
 
   recordLastProps(key: LastPropsKey, props: Partial<LastProps[LastPropsKey]>) {
-    const overrideProps = extractProps(
-      props,
-      LastPropsSchema.shape[key]._def.innerType
-    );
+    const schema = OptionalPropsSchema._def.innerType.shape[key];
+    const overrideProps = schema.parse(props);
     if (Object.keys(overrideProps).length === 0) return;
 
     const innerProps = this.innerProps$.value;
-    this.innerProps$.value = merge(clonedeep(innerProps), {
-      [key]: overrideProps,
-    });
+    const nextProps = mergeWith(
+      clonedeep(innerProps),
+      { [key]: overrideProps },
+      customizer
+    );
+    this.innerProps$.value = OptionalPropsSchema.parse(nextProps);
   }
 
   setStorage<T extends StoragePropsKey>(key: T, value: StorageProps[T]) {
@@ -189,49 +193,4 @@ export class EditPropsStore extends LifeCycleWatcher {
     super.unmounted();
     this.dispose();
   }
-}
-
-function extractProps(
-  props: Record<string, unknown>,
-  ref: z.ZodObject<z.ZodRawShape>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  Object.entries(props).forEach(([key, value]) => {
-    if (!(key in ref.shape)) return;
-    if (isPlainObject(value)) {
-      if (isColorType(key, value)) {
-        const color = processColorValue(value as z.infer<typeof ColorSchema>);
-        if (Object.keys(color).length === 0) return;
-        result[key] = color;
-        return;
-      }
-
-      result[key] = extractProps(
-        props[key] as Record<string, unknown>,
-        ref.shape[key] as z.ZodObject<z.ZodRawShape>
-      );
-    } else {
-      result[key] = value;
-    }
-  });
-
-  return result;
-}
-
-function isColorType(key: string, value: unknown) {
-  return (
-    ['background', 'color', 'stroke', 'fill', 'Color'].some(
-      stuff => key.startsWith(stuff) || key.endsWith(stuff)
-    ) && ColorSchema.safeParse(value).success
-  );
-}
-
-// Don't want the user to create a transparent element, so the alpha value is removed.
-function processColorValue(value: z.infer<typeof ColorSchema>) {
-  const obj: Record<string, string> = {};
-  for (const [k, v] of Object.entries(value)) {
-    obj[k] = v.startsWith('#') ? v.substring(0, 7) : v;
-  }
-  return obj;
 }

--- a/packages/affine/shared/src/theme/theme-observer.ts
+++ b/packages/affine/shared/src/theme/theme-observer.ts
@@ -64,27 +64,24 @@ export class ThemeObserver {
         : `var(${fallback})`
       : fallback;
 
+    let result: string | undefined;
     if (typeof color === 'string') {
-      return (
-        (color.startsWith('--')
-          ? color.endsWith(TRANSPARENT)
-            ? TRANSPARENT
-            : `var(${color})`
-          : color) ?? fallback
-      );
+      result = color;
+    } else if (color.light && color.dark) {
+      result = this.mode === ColorScheme.Dark ? color.dark : color.light;
+    } else if (color.normal) {
+      result = color.normal;
     }
 
-    if (!color) {
+    if (!result) {
       return fallback;
     }
 
-    if (color.light && color.dark) {
-      return this.mode === ColorScheme.Dark
-        ? `var(${color.dark})`
-        : `var(${color.light})`;
+    if (result.startsWith('--')) {
+      return result.endsWith(TRANSPARENT) ? TRANSPARENT : `var(${result})`;
     }
 
-    return color.normal ?? fallback;
+    return result;
   }
 
   /**

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -44,9 +44,6 @@
     "html2canvas": "^1.4.1",
     "katex": "^0.16.11",
     "lit": "^3.2.0",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isplainobject": "^4.0.6",
-    "lodash.merge": "^4.6.2",
     "mdast-util-gfm-autolink-literal": "^2.0.1",
     "mdast-util-gfm-strikethrough": "^2.0.0",
     "mdast-util-gfm-table": "^2.0.0",
@@ -106,9 +103,6 @@
   ],
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
-    "@types/katex": "^0.16.7",
-    "@types/lodash.clonedeep": "^4.5.9",
-    "@types/lodash.isplainobject": "^4.0.9",
-    "@types/lodash.merge": "^4.6.9"
+    "@types/katex": "^0.16.7"
   }
 }

--- a/packages/blocks/src/surface-ref-block/index.ts
+++ b/packages/blocks/src/surface-ref-block/index.ts
@@ -8,6 +8,8 @@ export {
   PageSurfaceRefBlockSpec,
 } from './surface-ref-spec.js';
 
+export * from './utils.js';
+
 declare global {
   namespace BlockSuite {
     interface BlockServices {

--- a/packages/presets/src/__tests__/edgeless/last-props.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/last-props.spec.ts
@@ -3,9 +3,25 @@ import type { BlockStdScope } from '@blocksuite/block-std';
 import {
   type BrushElementModel,
   type ConnectorElementModel,
+  DEFAULT_NOTE_BACKGROUND_COLOR,
+  DEFAULT_NOTE_SHADOW,
+  DEFAULT_TEXT_COLOR,
   type EdgelessRootBlockComponent,
+  type EdgelessTextBlockModel,
   EditPropsStore,
+  FontFamily,
+  FrameBackgroundColor,
+  type FrameBlockModel,
+  getSurfaceBlock,
+  LayoutType,
+  LineColor,
+  type MindmapElementModel,
+  MindmapStyle,
+  NoteBackgroundColor,
+  type NoteBlockModel,
+  NoteShadow,
   type ShapeElementModel,
+  ShapeFillColor,
   ShapeType,
   type TextElementModel,
 } from '@blocksuite/blocks';
@@ -32,28 +48,28 @@ describe('apply last props', () => {
     // rect shape
     const rectId = service.addElement('shape', { shapeType: ShapeType.Rect });
     const rectShape = service.getElementById(rectId) as ShapeElementModel;
-    expect(rectShape.fillColor).toBe('--affine-palette-shape-yellow');
+    expect(rectShape.fillColor).toBe(ShapeFillColor.Yellow);
     service.updateElement(rectId, {
-      fillColor: '--affine-palette-shape-orange',
+      fillColor: ShapeFillColor.Orange,
     });
     expect(
       std.get(EditPropsStore).lastProps$.value[`shape:${ShapeType.Rect}`]
         .fillColor
-    ).toBe('--affine-palette-shape-orange');
+    ).toBe(ShapeFillColor.Orange);
 
     // diamond shape
     const diamondId = service.addElement('shape', {
       shapeType: ShapeType.Diamond,
     });
     const diamondShape = service.getElementById(diamondId) as ShapeElementModel;
-    expect(diamondShape.fillColor).toBe('--affine-palette-shape-yellow');
+    expect(diamondShape.fillColor).toBe(ShapeFillColor.Yellow);
     service.updateElement(diamondId, {
-      fillColor: '--affine-palette-shape-blue',
+      fillColor: ShapeFillColor.Blue,
     });
     expect(
       std.get(EditPropsStore).lastProps$.value[`shape:${ShapeType.Diamond}`]
         .fillColor
-    ).toBe('--affine-palette-shape-blue');
+    ).toBe(ShapeFillColor.Blue);
 
     // rounded rect shape
     const roundedRectId = service.addElement('shape', {
@@ -63,18 +79,18 @@ describe('apply last props', () => {
     const roundedRectShape = service.getElementById(
       roundedRectId
     ) as ShapeElementModel;
-    expect(roundedRectShape.fillColor).toBe('--affine-palette-shape-yellow');
+    expect(roundedRectShape.fillColor).toBe(ShapeFillColor.Yellow);
     service.updateElement(roundedRectId, {
-      fillColor: '--affine-palette-shape-green',
+      fillColor: ShapeFillColor.Green,
     });
     expect(
       std.get(EditPropsStore).lastProps$.value['shape:roundedRect'].fillColor
-    ).toBe('--affine-palette-shape-green');
+    ).toBe(ShapeFillColor.Green);
 
     // apply last props
     const rectId2 = service.addElement('shape', { shapeType: ShapeType.Rect });
     const rectShape2 = service.getElementById(rectId2) as ShapeElementModel;
-    expect(rectShape2.fillColor).toBe('--affine-palette-shape-orange');
+    expect(rectShape2.fillColor).toBe(ShapeFillColor.Orange);
 
     const diamondId2 = service.addElement('shape', {
       shapeType: ShapeType.Diamond,
@@ -82,39 +98,51 @@ describe('apply last props', () => {
     const diamondShape2 = service.getElementById(
       diamondId2
     ) as ShapeElementModel;
-    expect(diamondShape2.fillColor).toBe('--affine-palette-shape-blue');
+    expect(diamondShape2.fillColor).toBe(ShapeFillColor.Blue);
 
     const roundedRectId2 = service.addElement('shape', {
       shapeType: ShapeType.Rect,
       radius: 0.1,
     });
-    const droundedRectShape2 = service.getElementById(
+    const roundedRectShape2 = service.getElementById(
       roundedRectId2
     ) as ShapeElementModel;
-    expect(droundedRectShape2.fillColor).toBe('--affine-palette-shape-green');
+    expect(roundedRectShape2.fillColor).toBe(ShapeFillColor.Green);
   });
 
   test('connector', () => {
     const id = service.addElement('connector', { mode: 0 });
     const connector = service.getElementById(id) as ConnectorElementModel;
-    expect(connector.stroke).toBe('--affine-palette-line-grey');
+    expect(connector.stroke).toBe(LineColor.Grey);
     expect(connector.strokeWidth).toBe(2);
     expect(connector.strokeStyle).toBe('solid');
     expect(connector.frontEndpointStyle).toBe('None');
     expect(connector.rearEndpointStyle).toBe('Arrow');
     service.updateElement(id, { strokeWidth: 10 });
-    const secondConnector = service.getElementById(
-      service.addElement('connector', { mode: 1 })
-    ) as ShapeElementModel;
-    expect(secondConnector.strokeWidth).toBe(10);
+
+    const id2 = service.addElement('connector', { mode: 1 });
+    const connector2 = service.getElementById(id2) as ConnectorElementModel;
+    expect(connector2.strokeWidth).toBe(10);
+    service.updateElement(id2, {
+      labelStyle: {
+        color: LineColor.Magenta,
+        fontFamily: FontFamily.Kalam,
+      },
+    });
+
+    const id3 = service.addElement('connector', { mode: 1 });
+    const connector3 = service.getElementById(id3) as ConnectorElementModel;
+    expect(connector3.strokeWidth).toBe(10);
+    expect(connector3.labelStyle.color).toBe(LineColor.Magenta);
+    expect(connector3.labelStyle.fontFamily).toBe(FontFamily.Kalam);
   });
 
   test('brush', () => {
     const id = service.addElement('brush', {});
     const brush = service.getElementById(id) as BrushElementModel;
     expect(brush.color).toEqual({
-      dark: '--affine-palette-line-white',
-      light: '--affine-palette-line-black',
+      dark: LineColor.White,
+      light: LineColor.Black,
     });
     expect(brush.lineWidth).toBe(4);
     service.updateElement(id, { lineWidth: 10 });
@@ -133,5 +161,89 @@ describe('apply last props', () => {
       service.addElement('text', {})
     ) as TextElementModel;
     expect(secondText.fontSize).toBe(36);
+  });
+
+  test('mindmap', () => {
+    const id = service.addElement('mindmap', {});
+    const mindmap = service.getElementById(id) as MindmapElementModel;
+    expect(mindmap.layoutType).toBe(LayoutType.RIGHT);
+    expect(mindmap.style).toBe(MindmapStyle.ONE);
+    service.updateElement(id, {
+      layoutType: LayoutType.BALANCE,
+      style: MindmapStyle.THREE,
+    });
+
+    const id2 = service.addElement('mindmap', {});
+    const mindmap2 = service.getElementById(id2) as MindmapElementModel;
+    expect(mindmap2.layoutType).toBe(LayoutType.BALANCE);
+    expect(mindmap2.style).toBe(MindmapStyle.THREE);
+  });
+
+  test('edgeless-text', () => {
+    const surface = getSurfaceBlock(doc);
+    const id = service.addBlock('affine:edgeless-text', {}, surface!.id);
+    const text = service.getElementById(id) as EdgelessTextBlockModel;
+    expect(text.color).toBe(DEFAULT_TEXT_COLOR);
+    expect(text.fontFamily).toBe(FontFamily.Inter);
+    service.updateElement(id, {
+      color: LineColor.Green,
+      fontFamily: FontFamily.OrelegaOne,
+    });
+
+    const id2 = service.addBlock('affine:edgeless-text', {}, surface!.id);
+    const text2 = service.getElementById(id2) as EdgelessTextBlockModel;
+    expect(text2.color).toBe(LineColor.Green);
+    expect(text2.fontFamily).toBe(FontFamily.OrelegaOne);
+  });
+
+  test('note', () => {
+    const id = service.addBlock('affine:note', {}, doc.root!.id);
+    const note = service.getElementById(id) as NoteBlockModel;
+    expect(note.background).toBe(DEFAULT_NOTE_BACKGROUND_COLOR);
+    expect(note.edgeless.style.shadowType).toBe(DEFAULT_NOTE_SHADOW);
+    service.updateElement(id, {
+      background: NoteBackgroundColor.Purple,
+      edgeless: {
+        style: {
+          shadowType: NoteShadow.Film,
+        },
+      },
+    });
+
+    const id2 = service.addBlock('affine:note', {}, doc.root!.id);
+    const note2 = service.getElementById(id2) as NoteBlockModel;
+    expect(note2.background).toBe(NoteBackgroundColor.Purple);
+    expect(note2.edgeless.style.shadowType).toBe(NoteShadow.Film);
+  });
+
+  test('frame', () => {
+    const surface = getSurfaceBlock(doc);
+    const id = service.addBlock('affine:frame', {}, surface!.id);
+    const note = service.getElementById(id) as FrameBlockModel;
+    expect(note.background).toBe('--affine-palette-transparent');
+    service.updateElement(id, {
+      background: FrameBackgroundColor.Purple,
+    });
+
+    const id2 = service.addBlock('affine:frame', {}, surface!.id);
+    const frame2 = service.getElementById(id2) as FrameBlockModel;
+    expect(frame2.background).toBe(FrameBackgroundColor.Purple);
+    service.updateElement(id, {
+      background: { normal: '#def4e740' },
+    });
+
+    const id3 = service.addBlock('affine:frame', {}, surface!.id);
+    const frame3 = service.getElementById(id3) as FrameBlockModel;
+    expect(frame3.background).toEqual({ normal: '#def4e740' });
+    service.updateElement(id, {
+      background: { light: '#a381aa23', dark: '#6e907452' },
+    });
+
+    const id4 = service.addBlock('affine:frame', {}, surface!.id);
+    const frame4 = service.getElementById(id4) as FrameBlockModel;
+    expect(frame4.background).toEqual({
+      light: '#a381aa23',
+      dark: '#6e907452',
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1713,12 +1713,8 @@ __metadata:
     "@lit/context": "npm:^1.1.2"
     "@toeverything/theme": "npm:^1.0.8"
     "@types/dompurify": "npm:^3.0.5"
-    "@types/lodash.isplainobject": "npm:^4.0.9"
-    "@types/lodash.merge": "npm:^4.6.9"
     fractional-indexing: "npm:^3.2.0"
     lit: "npm:^3.2.0"
-    lodash.isplainobject: "npm:^4.0.6"
-    lodash.merge: "npm:^4.6.2"
     nanoid: "npm:^5.0.7"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -1774,7 +1770,11 @@ __metadata:
     "@lit-labs/preact-signals": "npm:^1.0.2"
     "@lit/context": "npm:^1.1.2"
     "@toeverything/theme": "npm:^1.0.8"
+    "@types/lodash.clonedeep": "npm:^4.5.9"
+    "@types/lodash.mergewith": "npm:^4"
     lit: "npm:^3.2.0"
+    lodash.clonedeep: "npm:^4.5.0"
+    lodash.mergewith: "npm:^4.6.2"
     minimatch: "npm:^10.0.1"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -1824,9 +1824,6 @@ __metadata:
     "@types/dompurify": "npm:^3.0.5"
     "@types/hast": "npm:^3.0.4"
     "@types/katex": "npm:^0.16.7"
-    "@types/lodash.clonedeep": "npm:^4.5.9"
-    "@types/lodash.isplainobject": "npm:^4.0.9"
-    "@types/lodash.merge": "npm:^4.6.9"
     "@types/mdast": "npm:^4.0.4"
     "@types/sortablejs": "npm:^1.15.8"
     collapse-white-space: "npm:^2.1.0"
@@ -1838,9 +1835,6 @@ __metadata:
     html2canvas: "npm:^1.4.1"
     katex: "npm:^0.16.11"
     lit: "npm:^3.2.0"
-    lodash.clonedeep: "npm:^4.5.0"
-    lodash.isplainobject: "npm:^4.0.6"
-    lodash.merge: "npm:^4.6.2"
     mdast-util-gfm-autolink-literal: "npm:^2.0.1"
     mdast-util-gfm-strikethrough: "npm:^2.0.0"
     mdast-util-gfm-table: "npm:^2.0.0"
@@ -4910,21 +4904,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash.isplainobject@npm:^4.0.9":
-  version: 4.0.9
-  resolution: "@types/lodash.isplainobject@npm:4.0.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10/2ccfff10ff81a78caa9ed4d660efecdebaa145e428c0e3b175650d6de27a5fa06627e2fab0636ab25178f57ec58325fc31b46398aef05df0a912e65b211a20b2
-  languageName: node
-  linkType: hard
-
 "@types/lodash.merge@npm:^4.6.9":
   version: 4.6.9
   resolution: "@types/lodash.merge@npm:4.6.9"
   dependencies:
     "@types/lodash": "npm:*"
   checksum: 10/d0dd6654547c9d8d905184d14aa5c2a37a1ed1c3204f5ab20b7d591a05f34859ef09d3b72c065e94ca1989abf9109eb8230f67c4d64a5768b1d65b9ed8baf8e7
+  languageName: node
+  linkType: hard
+
+"@types/lodash.mergewith@npm:^4":
+  version: 4.6.9
+  resolution: "@types/lodash.mergewith@npm:4.6.9"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10/c5a67e83040103decfd37090127118f5758773d0ce2a1756d442b371721737c7752f48f62544cc970f44abec8471f260cc4c844e1a4fdef8b76cb96bdec8a595
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Close issue [BS-1411](https://linear.app/affine-design/issue/BS-1411). Remember the color and transparency settings.

What changed?
- Add a `makeDeepOptional` function to make a zod schema deep optional.
- Use `OptionalPropsSchema.parse` instead of `extractProps`, which can ensure the schema of override props.
- Refactor logic of `generateColorProperty`.
- Add `customizer` to process `ZodUnion` color schema merge.
- Add unit tests.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/baa458c6-ed47-47e1-971d-310184dd891d.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/baa458c6-ed47-47e1-971d-310184dd891d.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/baa458c6-ed47-47e1-971d-310184dd891d.mov">录屏2024-09-13 15.46.51.mov</video>

