### PR TITLE
fix: refactor frame panel to use EditorHost instead of AffineEditorContainer

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
+++ b/packages/blocks/src/root-block/edgeless/components/frame/frame-preview.ts
@@ -16,7 +16,6 @@ import { css, html, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import type { EdgelessRootPreviewBlockComponent } from '../../edgeless-root-preview-block.js';
 import type { EdgelessRootService } from '../../edgeless-root-service.js';
 
@@ -99,13 +98,20 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
 
   private _previewSpec = SpecProvider.getInstance().getSpec('edgeless:preview');
 
+  get _originalDoc() {
+    return this.frame.doc;
+  }
+
   private _initPreviewDoc() {
-    this._previewDoc = this.doc.collection.getDoc(this.doc.id, {
-      query: this._docFilter,
-      readonly: true,
-    });
+    this._previewDoc = this._originalDoc.collection.getDoc(
+      this._originalDoc.id,
+      {
+        query: this._docFilter,
+        readonly: true,
+      }
+    );
     this.disposables.add(() => {
-      this.doc.blockCollection.clearQuery(this._docFilter);
+      this._originalDoc.blockCollection.clearQuery(this._docFilter);
     });
   }
 
@@ -199,8 +205,8 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
   }
 
   override render() {
-    const { frame, host } = this;
-    const noContent = !frame || !frame.xywh || !host;
+    const { frame } = this;
+    const noContent = !frame || !frame.xywh;
 
     return html`<div class="frame-preview-container">
       ${noContent ? nothing : this._renderSurfaceContent()}
@@ -213,20 +219,11 @@ export class FramePreview extends WithDisposable(ShadowlessElement) {
     }
   }
 
-  @property({ attribute: false })
-  accessor doc!: Doc;
-
-  @property({ attribute: false })
-  accessor edgeless: EdgelessRootBlockComponent | null = null;
-
   @state()
   accessor fillScreen = false;
 
   @property({ attribute: false })
   accessor frame!: FrameBlockModel;
-
-  @property({ attribute: false })
-  accessor host!: EditorHost;
 
   @query('editor-host')
   accessor previewEditor: EditorHost | null = null;

--- a/packages/playground/apps/_common/components/custom-frame-panel.ts
+++ b/packages/playground/apps/_common/components/custom-frame-panel.ts
@@ -1,7 +1,7 @@
 import type { AffineEditorContainer } from '@blocksuite/presets';
 
-import { DocModeProvider } from '@blocksuite/affine-shared/services';
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import { effect } from '@preact/signals-core';
 import { css, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -24,7 +24,7 @@ export class CustomFramePanel extends WithDisposable(ShadowlessElement) {
 
   private _renderPanel() {
     return html`<affine-frame-panel
-      .editor=${this.editor}
+      .host=${this.editor.std.host}
     ></affine-frame-panel>`;
   }
 
@@ -32,11 +32,14 @@ export class CustomFramePanel extends WithDisposable(ShadowlessElement) {
     super.connectedCallback();
 
     this.disposables.add(
-      this.editor.std.get(DocModeProvider).onPrimaryModeChange(() => {
-        this.editor.updateComplete
-          .then(() => this.requestUpdate())
-          .catch(console.error);
-      }, this.editor.doc.id)
+      effect(() => {
+        const std = this.editor.std;
+        if (std) {
+          this.editor.updateComplete
+            .then(() => this.requestUpdate())
+            .catch(console.error);
+        }
+      })
     );
   }
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -21,6 +21,7 @@
     "@blocksuite/presets": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@blocksuite/sync": "workspace:*",
+    "@preact/signals-core": "^1.8.0",
     "@shoelace-style/shoelace": "2.16.0",
     "@toeverything/y-indexeddb": "0.10.0-canary.9",
     "@types/katex": "^0.16.7",

--- a/packages/presets/src/fragments/frame-panel/card/frame-card.ts
+++ b/packages/presets/src/fragments/frame-panel/card/frame-card.ts
@@ -1,15 +1,6 @@
-import type { EditorHost } from '@blocksuite/block-std';
-import type { Doc } from '@blocksuite/store';
-
 import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
-import {
-  type EdgelessRootBlockComponent,
-  type FrameBlockModel,
-  on,
-  once,
-} from '@blocksuite/blocks';
-import { DisposableGroup } from '@blocksuite/global/utils';
-import { css, html, nothing, type PropertyValues } from 'lit';
+import { type FrameBlockModel, on, once } from '@blocksuite/blocks';
+import { css, html, nothing } from 'lit';
 import { property, query } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -116,17 +107,6 @@ export const AFFINE_FRAME_CARD = 'affine-frame-card';
 export class FrameCard extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
-  private _clearFrameDisposables = () => {
-    this._frameDisposables?.dispose();
-    this._frameDisposables = null;
-  };
-
-  private _frameDisposables: DisposableGroup | null = null;
-
-  private _updateElement = () => {
-    this.requestUpdate();
-  };
-
   private _dispatchDragEvent(e: MouseEvent) {
     e.preventDefault();
     if (e.button !== 0) return;
@@ -195,21 +175,6 @@ export class FrameCard extends WithDisposable(ShadowlessElement) {
     </div>`;
   }
 
-  private _setFrameDisposables(frame: FrameBlockModel) {
-    this._clearFrameDisposables();
-    this._frameDisposables = new DisposableGroup();
-    this._frameDisposables.add(frame.propsUpdated.on(this._updateElement));
-  }
-
-  override connectedCallback() {
-    super.connectedCallback();
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    this._clearFrameDisposables();
-  }
-
   override render() {
     const { pos, stackOrder, width } = this;
     const containerStyle =
@@ -242,21 +207,10 @@ export class FrameCard extends WithDisposable(ShadowlessElement) {
       >
         ${this.status === 'dragging' && stackOrder !== 0
           ? nothing
-          : html`<frame-preview
-              .edgeless=${this.edgeless}
-              .doc=${this.doc}
-              .host=${this.host}
-              .frame=${this.frame}
-            ></frame-preview>`}
+          : html`<frame-preview .frame=${this.frame}></frame-preview>`}
         ${this._DraggingCardNumber()}
       </div>
     </div>`;
-  }
-
-  override updated(_changedProperties: PropertyValues) {
-    if (_changedProperties.has('frame')) {
-      this._setFrameDisposables(this.frame);
-    }
   }
 
   @property({ attribute: false })
@@ -266,22 +220,13 @@ export class FrameCard extends WithDisposable(ShadowlessElement) {
   accessor containerElement!: HTMLElement;
 
   @property({ attribute: false })
-  accessor doc!: Doc;
-
-  @property({ attribute: false })
   accessor draggingCardNumber: number | undefined = undefined;
-
-  @property({ attribute: false })
-  accessor edgeless: EdgelessRootBlockComponent | null = null;
 
   @property({ attribute: false })
   accessor frame!: FrameBlockModel;
 
   @property({ attribute: false })
   accessor frameIndex!: string;
-
-  @property({ attribute: false })
-  accessor host!: EditorHost;
 
   @property({ attribute: false })
   accessor pos!: { x: number; y: number };

--- a/packages/presets/src/fragments/frame-panel/frame-panel.ts
+++ b/packages/presets/src/fragments/frame-panel/frame-panel.ts
@@ -1,11 +1,12 @@
-import { ShadowlessElement, WithDisposable } from '@blocksuite/block-std';
+import {
+  type EditorHost,
+  ShadowlessElement,
+  WithDisposable,
+} from '@blocksuite/block-std';
 import { FramePreview } from '@blocksuite/blocks';
-import { DisposableGroup } from '@blocksuite/global/utils';
 import { baseTheme } from '@toeverything/theme';
-import { css, html, type PropertyValues, unsafeCSS } from 'lit';
+import { css, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-
-import type { AffineEditorContainer } from '../../index.js';
 
 const styles = css`
   frame-panel {
@@ -64,39 +65,6 @@ export const AFFINE_FRAME_PANEL = 'affine-frame-panel';
 export class FramePanel extends WithDisposable(ShadowlessElement) {
   static override styles = styles;
 
-  private _editorDisposables: DisposableGroup | null = null;
-
-  get doc() {
-    return this.editor.doc;
-  }
-
-  get edgeless() {
-    return this.editor.querySelector('affine-edgeless-root');
-  }
-
-  get host() {
-    return this.editor.host;
-  }
-
-  private _clearEditorDisposables() {
-    this._editorDisposables?.dispose();
-    this._editorDisposables = null;
-  }
-
-  private _setEditorDisposables() {
-    this._clearEditorDisposables();
-    this._editorDisposables = new DisposableGroup();
-    this._editorDisposables.add(
-      this.editor.slots.docUpdated.on(() => {
-        this.editor.updateComplete
-          .then(() => {
-            this.requestUpdate();
-          })
-          .catch(console.error);
-      })
-    );
-  }
-
   override connectedCallback() {
     super.connectedCallback();
     if (!customElements.get('frame-preview')) {
@@ -104,38 +72,24 @@ export class FramePanel extends WithDisposable(ShadowlessElement) {
     }
   }
 
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    this._clearEditorDisposables();
-  }
-
   override render() {
     return html`<div class="frame-panel-container">
       <affine-frame-panel-header
-        .edgeless=${this.edgeless}
         .editorHost=${this.host}
       ></affine-frame-panel-header>
       <affine-frame-panel-body
         class="frame-panel-body"
-        .edgeless=${this.edgeless}
-        .doc=${this.doc}
         .editorHost=${this.host}
         .fitPadding=${this.fitPadding}
       ></affine-frame-panel-body>
     </div>`;
   }
 
-  override updated(_changedProperties: PropertyValues) {
-    if (_changedProperties.has('editor')) {
-      this._setEditorDisposables();
-    }
-  }
-
-  @property({ attribute: false })
-  accessor editor!: AffineEditorContainer;
-
   @property({ attribute: false })
   accessor fitPadding: number[] = [50, 380, 50, 50];
+
+  @property({ attribute: false })
+  accessor host!: EditorHost;
 }
 
 declare global {

--- a/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
+++ b/packages/presets/src/fragments/frame-panel/header/frames-setting-menu.ts
@@ -1,10 +1,7 @@
 import type { EditorHost } from '@blocksuite/block-std';
 
 import { WithDisposable } from '@blocksuite/block-std';
-import {
-  type EdgelessRootBlockComponent,
-  EditPropsStore,
-} from '@blocksuite/blocks';
+import { EdgelessRootService, EditPropsStore } from '@blocksuite/blocks';
 import { css, html, LitElement, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
@@ -78,14 +75,14 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
 
   private _onBlackBackgroundChange = (checked: boolean) => {
     this.blackBackground = checked;
-    this.edgeless?.slots.navigatorSettingUpdated.emit({
+    this._edgelessRootService?.slots.navigatorSettingUpdated.emit({
       blackBackground: this.blackBackground,
     });
   };
 
   private _onFillScreenChange = (checked: boolean) => {
     this.fillScreen = checked;
-    this.edgeless?.slots.navigatorSettingUpdated.emit({
+    this._edgelessRootService?.slots.navigatorSettingUpdated.emit({
       fillScreen: this.fillScreen,
     });
     this._editPropsStore.setStorage('presentFillScreen', this.fillScreen);
@@ -93,11 +90,15 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
 
   private _onHideToolBarChange = (checked: boolean) => {
     this.hideToolbar = checked;
-    this.edgeless?.slots.navigatorSettingUpdated.emit({
+    this._edgelessRootService?.slots.navigatorSettingUpdated.emit({
       hideToolbar: this.hideToolbar,
     });
     this._editPropsStore.setStorage('presentHideToolbar', this.hideToolbar);
   };
+
+  private get _edgelessRootService() {
+    return this.editorHost.std.getOptional(EdgelessRootService);
+  }
 
   private get _editPropsStore() {
     return this.editorHost.std.get(EditPropsStore);
@@ -167,10 +168,10 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
   }
 
   override updated(_changedProperties: PropertyValues) {
-    if (_changedProperties.has('edgeless')) {
-      if (this.edgeless) {
+    if (_changedProperties.has('editorHost')) {
+      if (this._edgelessRootService) {
         this.disposables.add(
-          this.edgeless.slots.navigatorSettingUpdated.on(
+          this._edgelessRootService.slots.navigatorSettingUpdated.on(
             ({ blackBackground, hideToolbar }) => {
               if (
                 blackBackground !== undefined &&
@@ -196,9 +197,6 @@ export class FramesSettingMenu extends WithDisposable(LitElement) {
 
   @state()
   accessor blackBackground = false;
-
-  @property({ attribute: false })
-  accessor edgeless!: EdgelessRootBlockComponent | null;
 
   @property({ attribute: false })
   accessor editorHost!: EditorHost;

--- a/packages/presets/src/fragments/frame-panel/utils/drag.ts
+++ b/packages/presets/src/fragments/frame-panel/utils/drag.ts
@@ -1,12 +1,4 @@
-import type { EditorHost } from '@blocksuite/block-std';
-import type { Doc } from '@blocksuite/store';
-
-import {
-  type EdgelessRootBlockComponent,
-  type FrameBlockModel,
-  on,
-  once,
-} from '@blocksuite/blocks';
+import { type FrameBlockModel, on, once } from '@blocksuite/blocks';
 
 import type { FramePanelBody } from '../body/frame-panel-body.js';
 
@@ -37,9 +29,6 @@ export function startDragging(
       x: number;
       y: number;
     };
-    edgeless: EdgelessRootBlockComponent | null;
-    doc: Doc;
-    editorHost: EditorHost;
   }
 ) {
   const {
@@ -52,18 +41,12 @@ export function startDragging(
     framePanelBody,
     frameListContainer,
     start,
-    edgeless,
-    doc,
-    editorHost,
   } = options;
   const cardElements = frames
     .slice(frames.length - 2, frames.length)
     .map((frame, idx, arr) => {
       const el = new FrameCard();
 
-      el.edgeless = edgeless;
-      el.doc = doc;
-      el.host = editorHost;
       el.frame = frame.frame;
 
       el.cardIndex = frame.cardIndex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,6 +1963,7 @@ __metadata:
     "@blocksuite/presets": "workspace:*"
     "@blocksuite/store": "workspace:*"
     "@blocksuite/sync": "workspace:*"
+    "@preact/signals-core": "npm:^1.8.0"
     "@shoelace-style/shoelace": "npm:2.16.0"
     "@toeverything/y-indexeddb": "npm:0.10.0-canary.9"
     "@tweakpane/core": "npm:^2.0.4"


### PR DESCRIPTION
[BS-1425](https://linear.app/affine-design/issue/BS-1425/refactor-frame-panel)
[BS-1414](https://linear.app/affine-design/issue/BS-1414/frame-preview-在切换模式后渲染内容异常)


1. To use editorHost instead of AffineEditorContainer
2. Remove useless slots.
3. Add more e2e tests. 