### PR TITLE
fix(blocks): height should not be updated when not in editing state

### DIFF
--- a/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
@@ -39,6 +39,10 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       return;
     }
 
+    if (!this.checkVisibility()) {
+      return;
+    }
+
     if (this._editing && !this.model.hasMaxWidth) {
       this._updateW();
     }


### PR DESCRIPTION
Closes [BS-1384](https://linear.app/affine-design/issue/BS-1384/[bug]-edgeless-连接-connector-后缩放会改变位置)