### PR TITLE
feat(blocks): add scroll anchoring widget

### DIFF
--- a/.github/snapshot-changeset.md
+++ b/.github/snapshot-changeset.md
@@ -1,15 +1,19 @@
 ---
-'@blocksuite/global': patch
-'@blocksuite/block-std': patch
-'@blocksuite/store': patch
-'@blocksuite/inline': patch
-'@blocksuite/sync': patch
-'@blocksuite/affine-shared': patch
-'@blocksuite/affine-model': patch
-'@blocksuite/affine-components': patch
-'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-embed': patch
 '@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/affine-data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
 '@blocksuite/blocks': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
 '@blocksuite/presets': patch
 ---
 

--- a/packages/affine/shared/src/selection/hightlight.ts
+++ b/packages/affine/shared/src/selection/hightlight.ts
@@ -1,0 +1,59 @@
+import {
+  type ReferenceParams,
+  ReferenceParamsSchema,
+} from '@blocksuite/affine-model';
+import { BaseSelection } from '@blocksuite/block-std';
+
+export class HighlightSelection extends BaseSelection {
+  static override group = 'scene';
+
+  static override type = 'highlight';
+
+  readonly blockIds: string[] = [];
+
+  readonly elementIds: string[] = [];
+
+  readonly mode: 'page' | 'edgeless' = 'page';
+
+  constructor({ mode, blockIds, elementIds }: ReferenceParams) {
+    super({ blockId: '[scene-highlight]' });
+
+    this.mode = mode ?? 'page';
+    this.blockIds = blockIds ?? [];
+    this.elementIds = elementIds ?? [];
+  }
+
+  static override fromJSON(json: Record<string, unknown>): HighlightSelection {
+    const result = ReferenceParamsSchema.parse(json);
+    return new HighlightSelection(result);
+  }
+
+  override equals(other: HighlightSelection): boolean {
+    return (
+      this.mode === other.mode &&
+      this.blockId === other.blockId &&
+      this.blockIds.length === other.blockIds.length &&
+      this.elementIds.length === other.elementIds.length &&
+      this.blockIds.every((id, n) => id === other.blockIds[n]) &&
+      this.elementIds.every((id, n) => id === other.elementIds[n])
+    );
+  }
+
+  override toJSON(): Record<string, unknown> {
+    return {
+      type: 'highlight',
+      mode: this.mode,
+      blockId: this.blockId,
+      blockIds: this.blockIds,
+      elementIds: this.elementIds,
+    };
+  }
+}
+
+declare global {
+  namespace BlockSuite {
+    interface Selection {
+      highlight: typeof HighlightSelection;
+    }
+  }
+}

--- a/packages/affine/shared/src/selection/image.ts
+++ b/packages/affine/shared/src/selection/image.ts
@@ -11,10 +11,8 @@ export class ImageSelection extends BaseSelection {
   static override type = 'image';
 
   static override fromJSON(json: Record<string, unknown>): ImageSelection {
-    ImageSelectionSchema.parse(json);
-    return new ImageSelection({
-      blockId: json.blockId as string,
-    });
+    const result = ImageSelectionSchema.parse(json);
+    return new ImageSelection(result);
   }
 
   override equals(other: BaseSelection): boolean {

--- a/packages/affine/shared/src/selection/index.ts
+++ b/packages/affine/shared/src/selection/index.ts
@@ -1,1 +1,2 @@
+export { HighlightSelection } from './hightlight.js';
 export { ImageSelection } from './image.js';

--- a/packages/affine/widget-scroll-anchoring/package.json
+++ b/packages/affine/widget-scroll-anchoring/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@blocksuite/affine-widget-scroll-anchoring",
+  "version": "0.17.10",
+  "description": "Affine scroll anchroing widget.",
+  "type": "module",
+  "repository": "toeverything/blocksuite",
+  "scripts": {
+    "build": "tsc",
+    "test:unit": "nx vite:test --run --passWithNoTests",
+    "test:unit:coverage": "nx vite:test --run --coverage",
+    "test:e2e": "playwright test"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "toeverything",
+  "license": "MPL-2.0",
+  "dependencies": {
+    "@blocksuite/affine-model": "workspace:*",
+    "@blocksuite/affine-shared": "workspace:*",
+    "@blocksuite/block-std": "workspace:*",
+    "@blocksuite/global": "workspace:*",
+    "@preact/signals-core": "^1.8.0",
+    "@toeverything/theme": "^1.0.8",
+    "lit": "^3.2.0"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./effects": "./src/effects.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "./effects": {
+        "import": "./dist/effects.js",
+        "types": "./dist/effects.d.ts"
+      }
+    }
+  },
+  "files": [
+    "src",
+    "dist",
+    "!src/__tests__",
+    "!dist/__tests__"
+  ]
+}

--- a/packages/affine/widget-scroll-anchoring/src/effects.ts
+++ b/packages/affine/widget-scroll-anchoring/src/effects.ts
@@ -1,0 +1,17 @@
+import {
+  AFFINE_SCROLL_ANCHORING_WIDGET,
+  AffineScrollAnchoringWidget,
+} from './scroll-anchoring.js';
+
+export function effects() {
+  customElements.define(
+    AFFINE_SCROLL_ANCHORING_WIDGET,
+    AffineScrollAnchoringWidget
+  );
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AFFINE_SCROLL_ANCHORING_WIDGET]: AffineScrollAnchoringWidget;
+  }
+}

--- a/packages/affine/widget-scroll-anchoring/src/index.ts
+++ b/packages/affine/widget-scroll-anchoring/src/index.ts
@@ -1,0 +1,1 @@
+export * from './scroll-anchoring.js';

--- a/packages/affine/widget-scroll-anchoring/src/scroll-anchoring.ts
+++ b/packages/affine/widget-scroll-anchoring/src/scroll-anchoring.ts
@@ -1,0 +1,230 @@
+import type { DocMode } from '@blocksuite/affine-model';
+
+import { HighlightSelection } from '@blocksuite/affine-shared/selection';
+import { WidgetComponent } from '@blocksuite/block-std';
+import {
+  GfxControllerIdentifier,
+  type GfxModel,
+} from '@blocksuite/block-std/gfx';
+import { Bound, deserializeXYWH } from '@blocksuite/global/utils';
+import { computed, signal } from '@preact/signals-core';
+import { cssVarV2 } from '@toeverything/theme/v2';
+import { css, html, nothing, unsafeCSS } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+export const AFFINE_SCROLL_ANCHORING_WIDGET = 'affine-scroll-anchoring-widget';
+
+export class AffineScrollAnchoringWidget extends WidgetComponent {
+  static override styles = css`
+    :host {
+      pointer-events: none;
+      position: absolute;
+      left: 0px;
+      top: 0px;
+      transform-origin: left top;
+      contain: size layout;
+      z-index: 1;
+
+      & .highlight {
+        position: absolute;
+        box-sizing: border-box;
+
+        &.edgeless {
+          border-width: 1.39px;
+          border-style: solid;
+          border-color: ${unsafeCSS(
+            cssVarV2('layer/insideBorder/primaryBorder')
+          )};
+          box-shadow: var(--affine-active-shadow);
+        }
+
+        &.page {
+          border-radius: 5px;
+          background-color: var(--affine-hover-color);
+        }
+      }
+    }
+  `;
+
+  #requestUpdateFn = () => this.requestUpdate();
+
+  #resizeObserver: ResizeObserver = new ResizeObserver(this.#requestUpdateFn);
+
+  anchor = signal<{ mode: DocMode; id: string } | null>(null);
+
+  anchorBounds = signal<Bound | null>(null);
+
+  highlighted = computed(() => this.service.selectionManager.find('highlight'));
+
+  #getBoundsInEdgeless() {
+    const controller = this.std.getOptional(GfxControllerIdentifier);
+    if (!controller) return;
+
+    const bounds = this.anchorBounds.peek();
+    if (!bounds) return;
+
+    const { x, y, w, h } = bounds;
+    const zoom = controller.viewport.zoom;
+    const [vx, vy] = controller.viewport.toViewCoord(x, y);
+
+    return new Bound(vx, vy, w * zoom, h * zoom);
+  }
+
+  #getBoundsInPage(id: string) {
+    const blockComponent = this.std.view.getBlock(id);
+    if (!blockComponent) return;
+
+    const { left, top, width, height } = blockComponent.getBoundingClientRect();
+    const container = this.offsetParent;
+    const containerRect = container?.getBoundingClientRect();
+
+    const offsetX = (containerRect?.left ?? 0) + (container?.scrollLeft ?? 0);
+    const offsetY = (containerRect?.top ?? 0) + (container?.scrollTop ?? 0);
+
+    return new Bound(left - offsetX, top - offsetY, width, height);
+  }
+
+  #moveToAnchorInEdgeless(id: string) {
+    const controller = this.std.getOptional(GfxControllerIdentifier);
+    if (!controller) return;
+
+    const model = controller.getElementById<GfxModel>(id);
+    if (!model) return;
+
+    const xywh = model.xywh;
+    if (!xywh) return;
+
+    let bounds = Bound.fromXYWH(deserializeXYWH(xywh));
+
+    const viewport = controller.viewport;
+    const blockComponent = this.std.view.getBlock(id);
+    const parentComponent = blockComponent?.parentComponent;
+    if (parentComponent && parentComponent.flavour === 'affine:note') {
+      const { left: x, width: w } = parentComponent.getBoundingClientRect();
+      const { top: y, height: h } = blockComponent.getBoundingClientRect();
+      const coord = viewport.toModelCoordFromClientCoord([x, y]);
+      bounds = new Bound(
+        coord[0],
+        coord[1],
+        w / viewport.zoom,
+        h / viewport.zoom
+      );
+    }
+
+    const { zoom, centerX, centerY } = viewport.getFitToScreenData(
+      bounds,
+      [20, 20, 100, 20]
+    );
+
+    viewport.setCenter(centerX, centerY);
+    viewport.setZoom(zoom);
+
+    this.anchorBounds.value = bounds;
+  }
+
+  #moveToAnchorInPage(id: string) {
+    const blockComponent = this.std.view.getBlock(id);
+    if (!blockComponent) return;
+
+    blockComponent.scrollIntoView({
+      behavior: 'instant',
+      block: 'center',
+    });
+
+    this.anchorBounds.value = Bound.fromDOMRect(
+      blockComponent.getBoundingClientRect()
+    );
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    this.std.selection.register(HighlightSelection);
+
+    this.#resizeObserver.observe(this.offsetParent!);
+    this.handleEvent('wheel', this.#requestUpdateFn);
+    this.disposables.addFromEvent(window, 'resize', this.#requestUpdateFn);
+
+    // Clears highlight
+    this.disposables.addFromEvent(this.host, 'pointerdown', () => {
+      this.anchor.value = null;
+      this.anchorBounds.value = null;
+    });
+
+    // In edgeless
+    const controler = this.std.getOptional(GfxControllerIdentifier);
+    if (controler) {
+      this.disposables.add(
+        controler.viewport.viewportUpdated.on(this.#requestUpdateFn)
+      );
+    }
+
+    this.disposables.add(
+      this.anchor.subscribe(anchor => {
+        if (!anchor) return;
+
+        requestAnimationFrame(() => {
+          const { mode, id } = anchor;
+
+          if (mode === 'edgeless') {
+            this.#moveToAnchorInEdgeless(id);
+            return;
+          }
+
+          this.#moveToAnchorInPage(id);
+        });
+      })
+    );
+
+    this.disposables.add(
+      this.highlighted.subscribe(highlighted => {
+        if (!highlighted) return;
+
+        const {
+          mode,
+          blockIds: [bid],
+          elementIds: [eid],
+        } = highlighted;
+        const id = mode === 'page' ? bid : eid || bid;
+        if (!id) return;
+
+        // Consumes highlight selection
+        this.std.selection.clear(['highlight']);
+
+        this.anchor.value = { mode, id };
+      })
+    );
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#resizeObserver.disconnect();
+  }
+
+  override render() {
+    const anchor = this.anchor.value;
+    if (!anchor) return nothing;
+
+    const { mode, id } = anchor;
+
+    const bounds =
+      mode === 'edgeless'
+        ? this.#getBoundsInEdgeless()
+        : this.#getBoundsInPage(id);
+    if (!bounds) return;
+
+    const classes = { highlight: true, [mode]: true };
+    const style = {
+      left: `${bounds.x}px`,
+      top: `${bounds.y}px`,
+      width: `${bounds.w}px`,
+      height: `${bounds.h}px`,
+    };
+
+    return html`<div
+      class=${classMap(classes)}
+      style=${styleMap(style)}
+    ></div>`;
+  }
+}

--- a/packages/affine/widget-scroll-anchoring/tsconfig.json
+++ b/packages/affine/widget-scroll-anchoring/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/",
+    "outDir": "./dist/",
+    "noEmit": false
+  },
+  "include": ["./src"],
+  "references": [
+    {
+      "path": "../../framework/global"
+    },
+    {
+      "path": "../../framework/block-std"
+    },
+    {
+      "path": "../model"
+    },
+    {
+      "path": "../shared"
+    }
+  ]
+}

--- a/packages/affine/widget-scroll-anchoring/typedoc.json
+++ b/packages/affine/widget-scroll-anchoring/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/affine/widget-scroll-anchoring/vitest.config.ts
+++ b/packages/affine/widget-scroll-anchoring/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: {
+    target: 'es2018',
+  },
+  test: {
+    globalSetup: '../../../scripts/vitest-global.ts',
+    include: ['src/__tests__/**/*.unit.spec.ts'],
+    testTimeout: 1000,
+    coverage: {
+      provider: 'istanbul', // or 'c8'
+      reporter: ['lcov'],
+      reportsDirectory: '../../../.coverage/affine-widget-scroll-anchoring',
+    },
+    /**
+     * Custom handler for console.log in tests.
+     *
+     * Return `false` to ignore the log.
+     */
+    onConsoleLog(log, type) {
+      if (log.includes('https://lit.dev/msg/dev-mode')) {
+        return false;
+      }
+      console.warn(`Unexpected ${type} log`, log);
+      throw new Error(log);
+    },
+    environment: 'happy-dom',
+  },
+});

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -23,6 +23,7 @@
     "@blocksuite/affine-components": "workspace:*",
     "@blocksuite/affine-model": "workspace:*",
     "@blocksuite/affine-shared": "workspace:*",
+    "@blocksuite/affine-widget-scroll-anchoring": "workspace:*",
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/data-view": "workspace:*",
     "@blocksuite/global": "workspace:*",

--- a/packages/blocks/src/effects.ts
+++ b/packages/blocks/src/effects.ts
@@ -12,6 +12,7 @@ import { effects as componentDragIndicatorEffects } from '@blocksuite/affine-com
 import { effects as componentPortalEffects } from '@blocksuite/affine-components/portal';
 import { effects as componentRichTextEffects } from '@blocksuite/affine-components/rich-text';
 import { effects as componentToolbarEffects } from '@blocksuite/affine-components/toolbar';
+import { effects as widgetScrollAnchoringEffects } from '@blocksuite/affine-widget-scroll-anchoring/effects';
 import { effects as stdEffects } from '@blocksuite/block-std/effects';
 import { effects as dataViewEffects } from '@blocksuite/data-view/effects';
 import { effects as inlineEffects } from '@blocksuite/inline/effects';
@@ -313,6 +314,8 @@ export function effects() {
   componentRichTextEffects();
   componentToolbarEffects();
   componentDragIndicatorEffects();
+
+  widgetScrollAnchoringEffects();
 
   customElements.define('affine-database-title', DatabaseTitle);
   customElements.define(

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -389,8 +389,7 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
 
   getFitToScreenData(
     padding: [number, number, number, number] = [0, 0, 0, 0],
-    inputBounds?: Bound[],
-    maxZoom = ZOOM_INITIAL
+    inputBounds?: Bound[]
   ) {
     let bounds = [];
     if (inputBounds && inputBounds.length) {
@@ -406,26 +405,14 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
       }
     }
 
-    const [pt, pr, pb, pl] = padding;
     const bound = getCommonBound(bounds);
-    let { centerX, centerY, zoom } = this.viewport;
 
-    if (!bound) {
-      return { zoom, centerX, centerY };
-    }
-
-    const { width, height } = this.viewport;
-
-    zoom = Math.min(
-      (width - FIT_TO_SCREEN_PADDING - (pr + pl)) / bound.w,
-      (height - FIT_TO_SCREEN_PADDING - (pt + pb)) / bound.h
+    return this.viewport.getFitToScreenData(
+      bound,
+      padding,
+      ZOOM_INITIAL,
+      FIT_TO_SCREEN_PADDING
     );
-    zoom = clamp(zoom, ZOOM_MIN, clamp(maxZoom, ZOOM_MIN, ZOOM_MAX));
-
-    centerX = bound.x + (bound.w + pr / zoom) / 2 - pl / zoom / 2;
-    centerY = bound.y + (bound.h + pb / zoom) / 2 - pt / zoom / 2;
-
-    return { zoom, centerX, centerY };
   }
 
   override mounted() {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-spec.ts
@@ -2,6 +2,7 @@ import {
   DocModeService,
   EmbedOptionService,
 } from '@blocksuite/affine-shared/services';
+import { AFFINE_SCROLL_ANCHORING_WIDGET } from '@blocksuite/affine-widget-scroll-anchoring';
 import {
   BlockViewExtension,
   CommandExtension,
@@ -64,6 +65,7 @@ export const edgelessRootWigetViewMap = {
   [AFFINE_EDGELESS_AUTO_CONNECT_WIDGET]: literal`${unsafeStatic(
     AFFINE_EDGELESS_AUTO_CONNECT_WIDGET
   )}`,
+  [AFFINE_SCROLL_ANCHORING_WIDGET]: literal`${unsafeStatic(AFFINE_SCROLL_ANCHORING_WIDGET)}`,
 };
 
 const EdgelessCommonExtension: ExtensionType[] = [

--- a/packages/blocks/src/root-block/page/page-root-spec.ts
+++ b/packages/blocks/src/root-block/page/page-root-spec.ts
@@ -2,6 +2,7 @@ import {
   DocModeService,
   EmbedOptionService,
 } from '@blocksuite/affine-shared/services';
+import { AFFINE_SCROLL_ANCHORING_WIDGET } from '@blocksuite/affine-widget-scroll-anchoring';
 import {
   BlockViewExtension,
   CommandExtension,
@@ -52,6 +53,7 @@ export const pageRootWidgetViewMap = {
   [AFFINE_VIEWPORT_OVERLAY_WIDGET]: literal`${unsafeStatic(
     AFFINE_VIEWPORT_OVERLAY_WIDGET
   )}`,
+  [AFFINE_SCROLL_ANCHORING_WIDGET]: literal`${unsafeStatic(AFFINE_SCROLL_ANCHORING_WIDGET)}`,
 };
 
 export const PageRootBlockSpec: ExtensionType[] = [

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -42,6 +42,9 @@
     },
     {
       "path": "../affine/block-surface"
+    },
+    {
+      "path": "../affine/widget-scroll-anchoring"
     }
   ]
 }

--- a/packages/framework/block-std/src/gfx/viewport.ts
+++ b/packages/framework/block-std/src/gfx/viewport.ts
@@ -158,6 +158,34 @@ export class Viewport {
     this.viewportUpdated.dispose();
   }
 
+  getFitToScreenData(
+    bounds?: Bound | null,
+    padding: [number, number, number, number] = [0, 0, 0, 0],
+    maxZoom = ZOOM_MAX,
+    fitToScreenPadding = 100
+  ) {
+    let { centerX, centerY, zoom } = this;
+
+    if (!bounds) {
+      return { zoom, centerX, centerY };
+    }
+
+    const { x, y, w, h } = bounds;
+    const [pt, pr, pb, pl] = padding;
+    const { width, height } = this;
+
+    zoom = Math.min(
+      (width - fitToScreenPadding - (pr + pl)) / w,
+      (height - fitToScreenPadding - (pt + pb)) / h
+    );
+    zoom = clamp(zoom, ZOOM_MIN, clamp(maxZoom, ZOOM_MIN, ZOOM_MAX));
+
+    centerX = x + (w + pr / zoom) / 2 - pl / zoom / 2;
+    centerY = y + (h + pb / zoom) / 2 - pt / zoom / 2;
+
+    return { zoom, centerX, centerY };
+  }
+
   isInViewport(bound: Bound) {
     const viewportBounds = Bound.from(this.viewportBounds);
     return (

--- a/packages/framework/block-std/src/selection/variants/block.ts
+++ b/packages/framework/block-std/src/selection/variants/block.ts
@@ -12,10 +12,8 @@ export class BlockSelection extends BaseSelection {
   static override type = 'block';
 
   static override fromJSON(json: Record<string, unknown>): BlockSelection {
-    BlockSelectionSchema.parse(json);
-    return new BlockSelection({
-      blockId: json.blockId as string,
-    });
+    const result = BlockSelectionSchema.parse(json);
+    return new BlockSelection(result);
   }
 
   override equals(other: BaseSelection): boolean {

--- a/packages/framework/block-std/src/selection/variants/cursor.ts
+++ b/packages/framework/block-std/src/selection/variants/cursor.ts
@@ -23,15 +23,14 @@ export class CursorSelection extends BaseSelection {
   }
 
   static override fromJSON(json: Record<string, unknown>): CursorSelection {
-    CursorSelectionSchema.parse(json);
-    return new CursorSelection(json.x as number, json.y as number);
+    const { x, y } = CursorSelectionSchema.parse(json);
+    return new CursorSelection(x, y);
   }
 
   override equals(other: BaseSelection): boolean {
     if (other instanceof CursorSelection) {
       return this.x === other.x && this.y === other.y;
     }
-
     return false;
   }
 

--- a/packages/framework/block-std/src/selection/variants/surface.ts
+++ b/packages/framework/block-std/src/selection/variants/surface.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import { BaseSelection } from '../base.js';
 
 const SurfaceSelectionSchema = z.object({
+  blockId: z.string(),
   elements: z.array(z.string()),
   editing: z.boolean(),
   inoperable: z.boolean().optional(),
@@ -32,33 +33,20 @@ export class SurfaceSelection extends BaseSelection {
     this.inoperable = inoperable;
   }
 
-  static override fromJSON(
-    json:
-      | Record<string, unknown>
-      | {
-          blockId: string[];
-          elements: string[];
-          editing: boolean;
-          inoperable?: boolean;
-        }
-  ): SurfaceSelection {
-    SurfaceSelectionSchema.parse(json);
-    return new SurfaceSelection(
-      json.blockId as string,
-      json.elements as string[],
-      json.editing as boolean,
-      (json.inoperable as boolean) || false
-    );
+  static override fromJSON(json: Record<string, unknown>): SurfaceSelection {
+    const { blockId, elements, editing, inoperable } =
+      SurfaceSelectionSchema.parse(json);
+    return new SurfaceSelection(blockId, elements, editing, inoperable);
   }
 
   override equals(other: BaseSelection): boolean {
     if (other instanceof SurfaceSelection) {
       return (
         this.blockId === other.blockId &&
-        this.elements.length === other.elements.length &&
-        this.elements.every((id, idx) => id === other.elements[idx]) &&
         this.editing === other.editing &&
-        this.inoperable === other.inoperable
+        this.inoperable === other.inoperable &&
+        this.elements.length === other.elements.length &&
+        this.elements.every((id, idx) => id === other.elements[idx])
       );
     }
 

--- a/packages/framework/block-std/src/selection/variants/text.ts
+++ b/packages/framework/block-std/src/selection/variants/text.ts
@@ -63,12 +63,8 @@ export class TextSelection extends BaseSelection {
   }
 
   static override fromJSON(json: Record<string, unknown>): TextSelection {
-    TextSelectionSchema.parse(json);
-    return new TextSelection({
-      from: json.from as TextRangePoint,
-      to: json.to as TextRangePoint | null,
-      reverse: !!json.reverse,
-    });
+    const result = TextSelectionSchema.parse(json);
+    return new TextSelection(result);
   }
 
   private _equalPoint(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@blocksuite/affine-widget-scroll-anchoring@workspace:*, @blocksuite/affine-widget-scroll-anchoring@workspace:packages/affine/widget-scroll-anchoring":
+  version: 0.0.0-use.local
+  resolution: "@blocksuite/affine-widget-scroll-anchoring@workspace:packages/affine/widget-scroll-anchoring"
+  dependencies:
+    "@blocksuite/affine-model": "workspace:*"
+    "@blocksuite/affine-shared": "workspace:*"
+    "@blocksuite/block-std": "workspace:*"
+    "@blocksuite/global": "workspace:*"
+    "@preact/signals-core": "npm:^1.8.0"
+    "@toeverything/theme": "npm:^1.0.8"
+    lit: "npm:^3.2.0"
+  languageName: unknown
+  linkType: soft
+
 "@blocksuite/block-std@workspace:*, @blocksuite/block-std@workspace:packages/framework/block-std":
   version: 0.0.0-use.local
   resolution: "@blocksuite/block-std@workspace:packages/framework/block-std"
@@ -1836,6 +1850,7 @@ __metadata:
     "@blocksuite/affine-components": "workspace:*"
     "@blocksuite/affine-model": "workspace:*"
     "@blocksuite/affine-shared": "workspace:*"
+    "@blocksuite/affine-widget-scroll-anchoring": "workspace:*"
     "@blocksuite/block-std": "workspace:*"
     "@blocksuite/data-view": "workspace:*"
     "@blocksuite/global": "workspace:*"


### PR DESCRIPTION
Closes [BS-1318](https://linear.app/affine-design/issue/BS-1318/在-selection-中添加-highlight-type)

* add highlight type selection
* impl scroll anchoring widget

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/8ypiIKZXudF5a0tIgIzf/ca7b10f9-a847-456a-9088-7151feeb0e35.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/8ypiIKZXudF5a0tIgIzf/ca7b10f9-a847-456a-9088-7151feeb0e35.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/ca7b10f9-a847-456a-9088-7151feeb0e35.mov">Screen Recording 2024-09-17 at 13.25.33.mov</video>

