### PR TITLE
fix: better scroll to target

### DIFF
--- a/packages/affine/widget-scroll-anchoring/src/scroll-anchoring.ts
+++ b/packages/affine/widget-scroll-anchoring/src/scroll-anchoring.ts
@@ -163,9 +163,13 @@ export class AffineScrollAnchoringWidget extends WidgetComponent {
       return;
     }
 
-    blockComponent.scrollIntoView({
-      behavior: 'instant',
-      block: 'center',
+    // use `requestAnimationFrame` to better scroll to the target
+    // because sometimes it is impossible to scroll to the target
+    requestAnimationFrame(() => {
+      blockComponent.scrollIntoView({
+        behavior: 'instant',
+        block: 'center',
+      });
     });
 
     this.#listened = false;


### PR DESCRIPTION
I think this will prevent the scroll event from being interrupted.

When you click affine-reference, the `refereshKey` parameter on the link will be updated.

`href="/workspace/gQux6wXgQWP-KkIC6uUDE/cvygdlykaIR5my9Hp_9nB?mode=page&blockIds=dx2sB9LE_eudTUbWAZ_N6&refreshKey=1-wP1OTe9AajEv6Rdm9X3"`

### Before

https://github.com/user-attachments/assets/8c91118a-1704-419b-ac2a-008ed7e624d7

### After


https://github.com/user-attachments/assets/b7a37e1e-db03-4207-90c4-1e743fee2c7a

