### PR TITLE
feat: add file type detection when exporting

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -45,7 +45,7 @@
     "date-fns": "^4.0.0",
     "dompurify": "^3.1.6",
     "fflate": "^0.8.2",
-    "file-type": "^19.4.1",
+    "file-type": "^19.5.0",
     "fractional-indexing": "^3.2.0",
     "html2canvas": "^1.4.1",
     "katex": "^0.16.11",

--- a/packages/framework/store/package.json
+++ b/packages/framework/store/package.json
@@ -26,6 +26,7 @@
     "@preact/signals-core": "^1.8.0",
     "@types/flexsearch": "^0.7.6",
     "@types/lodash.ismatch": "^4.4.9",
+    "file-type": "^19.5.0",
     "flexsearch": "0.7.43",
     "lib0": "^0.2.97",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/framework/store/src/__tests__/assets.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/assets.unit.spec.ts
@@ -1,0 +1,77 @@
+import { BlockSuiteError } from '@blocksuite/global/exceptions';
+import { describe, expect, test } from 'vitest';
+
+import { getAssetName } from '../adapter/assets.js';
+
+describe('getAssetName', () => {
+  test('should return the name if it exists', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new File([], 'image.png', { type: 'image/png' })],
+      ['blobId2', new File([], 'image', { type: 'image/png' })],
+      // inconsistent name with type
+      ['blobId3', new File([], 'image.jpg', { type: 'image/png' })],
+      // empty name
+      ['blobId4', new File([], '', { type: 'image/png' })],
+    ]);
+    expect(getAssetName(assets, 'blobId')).toBe('image.png');
+    expect(getAssetName(assets, 'blobId2')).toBe('image.png');
+    // respect the original name
+    expect(getAssetName(assets, 'blobId3')).toBe('image.jpg');
+    expect(getAssetName(assets, 'blobId4')).toBe('blobId4.png');
+  });
+
+  test('should return blobId with extension if name does not exist', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new Blob([], { type: 'image/jpeg' })],
+    ]);
+    const result = getAssetName(assets, 'blobId');
+    expect(result).toBe('blobId.jpeg');
+  });
+
+  test('should return the name if it exists but type is empty', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new File([], 'document.test', { type: '' })],
+    ]);
+    const result = getAssetName(assets, 'blobId');
+    expect(result).toBe('document.test');
+  });
+
+  test('should return the original name even not ext found', () => {
+    const assets = new Map<string, Blob>([['blobId', new File([], 'blob.')]]);
+    const result = getAssetName(assets, 'blobId');
+    expect(result).toBe('blob.');
+  });
+
+  test('should return blobId with "blob" extension if type is empty', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new Blob([])],
+      ['blobId2', new Blob([], { type: '' })],
+    ]);
+    expect(getAssetName(assets, 'blobId')).toBe('blobId.blob');
+    expect(getAssetName(assets, 'blobId2')).toBe('blobId2.blob');
+  });
+
+  test('should return blobId with last part of mime type if extension is not found', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new Blob([], { type: 'application/unknown' })],
+    ]);
+    const result = getAssetName(assets, 'blobId');
+    expect(result).toBe('blobId.unknown');
+  });
+
+  test('should return blobId with bin if type is octet-stream', () => {
+    const assets = new Map<string, Blob>([
+      ['blobId', new Blob([], { type: 'application/octet-stream' })],
+    ]);
+    const result = getAssetName(assets, 'blobId');
+    expect(result).toBe('blobId.bin');
+  });
+
+  test('should throw BlockSuiteError if blob is not found', () => {
+    const assets = new Map<string, Blob>();
+    expect(() => getAssetName(assets, 'blobId')).toThrow(BlockSuiteError);
+    expect(() => getAssetName(assets, 'blobId')).toThrowError(
+      'blob not found for blobId: blobId'
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,7 +1884,7 @@ __metadata:
     date-fns: "npm:^4.0.0"
     dompurify: "npm:^3.1.6"
     fflate: "npm:^0.8.2"
-    file-type: "npm:^19.4.1"
+    file-type: "npm:^19.5.0"
     fractional-indexing: "npm:^3.2.0"
     html2canvas: "npm:^1.4.1"
     katex: "npm:^0.16.11"
@@ -2074,6 +2074,7 @@ __metadata:
     "@types/lodash.clonedeep": "npm:^4.5.9"
     "@types/lodash.ismatch": "npm:^4.4.9"
     "@types/lodash.merge": "npm:^4.6.9"
+    file-type: "npm:^19.5.0"
     flexsearch: "npm:0.7.43"
     lib0: "npm:^0.2.97"
     lit: "npm:^3.2.0"
@@ -8263,7 +8264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^19.4.1":
+"file-type@npm:^19.5.0":
   version: 19.5.0
   resolution: "file-type@npm:19.5.0"
   dependencies:


### PR DESCRIPTION
This pull request enhances the `AssetsManager` to support file type detection. 

Currently, images are named as xxxxx.blob when exporting markdown, which is not user-friendly. This PR improves the export experience by introducing `file-type` to guess the file type.

Before

<img width="329" alt="Screenshot 2024-09-21 at 21 15 18" src="https://github.com/user-attachments/assets/987eb720-7abe-42ed-b1e2-709e81aa003f">

After

<img width="632" alt="Screenshot 2024-09-23 at 18 49 02" src="https://github.com/user-attachments/assets/bf8c55ab-762a-4344-aec8-f9588608dfaf">

<img width="359" alt="Screenshot 2024-09-23 at 18 48 48" src="https://github.com/user-attachments/assets/6681670f-23ed-4d53-b25b-58de57b08498">

---

Note that the `MemoryBlobSource` used by the playground will preserve the MIME type of the blob, which is different from the BlobSource of AFFiNE. Tweak the `MemoryBlobSource` to test these changes.

```diff
// packages/framework/sync/src/blob/impl/memory.ts

  set(key: string, value: Blob) {
+    // this.map.set(key, value);
+    this.map.set(key, new Blob([value]));
    return Promise.resolve(key);
  }
```