### PR TITLE
perf: optimize snapshot job handling

### DIFF
--- a/packages/affine/block-surface/src/surface-transformer.ts
+++ b/packages/affine/block-surface/src/surface-transformer.ts
@@ -1,7 +1,7 @@
 import type { SurfaceBlockProps } from '@blocksuite/block-std/gfx';
 import type {
   FromSnapshotPayload,
-  SnapshotReturn,
+  SnapshotNode,
   ToSnapshotPayload,
   Y,
 } from '@blocksuite/store';
@@ -66,7 +66,7 @@ export class SurfaceBlockTransformer extends BaseBlockTransformer<SurfaceBlockPr
 
   override async fromSnapshot(
     payload: FromSnapshotPayload
-  ): Promise<SnapshotReturn<SurfaceBlockProps>> {
+  ): Promise<SnapshotNode<SurfaceBlockProps>> {
     const snapshotRet = await super.fromSnapshot(payload);
     const elementsJSON = snapshotRet.props.elements as unknown as Record<
       string,

--- a/packages/affine/model/src/blocks/attachment/attachment-transformer.ts
+++ b/packages/affine/model/src/blocks/attachment/attachment-transformer.ts
@@ -1,6 +1,6 @@
 import type {
   FromSnapshotPayload,
-  SnapshotReturn,
+  SnapshotNode,
   ToSnapshotPayload,
 } from '@blocksuite/store';
 
@@ -11,7 +11,7 @@ import type { AttachmentBlockProps } from './attachment-model.js';
 export class AttachmentBlockTransformer extends BaseBlockTransformer<AttachmentBlockProps> {
   override async fromSnapshot(
     payload: FromSnapshotPayload
-  ): Promise<SnapshotReturn<AttachmentBlockProps>> {
+  ): Promise<SnapshotNode<AttachmentBlockProps>> {
     const snapshotRet = await super.fromSnapshot(payload);
     const sourceId = snapshotRet.props.sourceId;
     if (!payload.assets.isEmpty() && sourceId)

--- a/packages/affine/model/src/blocks/image/image-transformer.ts
+++ b/packages/affine/model/src/blocks/image/image-transformer.ts
@@ -1,6 +1,6 @@
 import type {
   FromSnapshotPayload,
-  SnapshotReturn,
+  SnapshotNode,
   ToSnapshotPayload,
 } from '@blocksuite/store';
 
@@ -11,7 +11,7 @@ import type { ImageBlockProps } from './image-model.js';
 export class ImageBlockTransformer extends BaseBlockTransformer<ImageBlockProps> {
   override async fromSnapshot(
     payload: FromSnapshotPayload
-  ): Promise<SnapshotReturn<ImageBlockProps>> {
+  ): Promise<SnapshotNode<ImageBlockProps>> {
     const snapshotRet = await super.fromSnapshot(payload);
     const sourceId = snapshotRet.props.sourceId;
     if (!payload.assets.isEmpty() && sourceId && !sourceId.startsWith('/'))

--- a/packages/blocks/src/root-block/edgeless/services/template-middlewares.ts
+++ b/packages/blocks/src/root-block/edgeless/services/template-middlewares.ts
@@ -1,5 +1,5 @@
 import type { ConnectorElementModel } from '@blocksuite/affine-model';
-import type { BlockSnapshot, SnapshotReturn } from '@blocksuite/store';
+import type { BlockSnapshot, SnapshotNode } from '@blocksuite/store';
 
 import { CommonUtils, sortIndex } from '@blocksuite/affine-block-surface';
 import { assertExists, assertType, Bound } from '@blocksuite/global/utils';
@@ -35,7 +35,7 @@ export const replaceIdMiddleware = (job: TemplateJob) => {
 
     if (blockJson.flavour === 'affine:surface-ref') {
       assertType<
-        SnapshotReturn<{
+        SnapshotNode<{
           reference: string;
         }>
       >(blockJson);

--- a/packages/blocks/src/root-block/edgeless/services/template.ts
+++ b/packages/blocks/src/root-block/edgeless/services/template.ts
@@ -17,7 +17,7 @@ import {
   type DocSnapshot,
   DocSnapshotSchema,
   Job,
-  type SnapshotReturn,
+  type SnapshotNode,
   type Y,
 } from '@blocksuite/store';
 
@@ -160,7 +160,7 @@ export class TemplateJob {
     modelDataList: {
       flavour: string;
       json: BlockSnapshot;
-      modelData: SnapshotReturn<object> | null;
+      modelData: SnapshotNode<object> | null;
       parent?: string;
       index?: number;
     }[]
@@ -225,7 +225,7 @@ export class TemplateJob {
     const modelDataList: {
       flavour: string;
       json: BlockSnapshot;
-      modelData: SnapshotReturn<object> | null;
+      modelData: SnapshotNode<object> | null;
       parent?: string;
       index?: number;
     }[] = [];

--- a/packages/framework/global/src/env/index.ts
+++ b/packages/framework/global/src/env/index.ts
@@ -25,6 +25,3 @@ export const IS_IPAD =
   (/Macintosh/i.test(agent) && globalThis.navigator?.maxTouchPoints > 2);
 
 export const IS_WINDOWS = /Win/.test(platform);
-
-export const REQUEST_IDLE_CALLBACK_ENABLED =
-  'requestIdleCallback' in globalThis;

--- a/packages/framework/store/src/adapter/base.ts
+++ b/packages/framework/store/src/adapter/base.ts
@@ -59,9 +59,9 @@ export abstract class BaseAdapter<AdapterTarget = unknown> {
     this.job = job;
   }
 
-  async fromBlock(mode: DraftModel) {
+  async fromBlock(model: DraftModel) {
     try {
-      const blockSnapshot = await this.job.blockToSnapshot(mode);
+      const blockSnapshot = await this.job.blockToSnapshot(model);
       if (!blockSnapshot) return;
       return await this.fromBlockSnapshot({
         snapshot: blockSnapshot,

--- a/packages/framework/store/src/transformer/base.ts
+++ b/packages/framework/store/src/transformer/base.ts
@@ -22,7 +22,7 @@ export type ToSnapshotPayload<Props extends object> = {
   assets: AssetsManager;
 };
 
-export type SnapshotReturn<Props extends object> = {
+export type SnapshotNode<Props extends object> = {
   id: string;
   flavour: string;
   version: number;
@@ -51,9 +51,7 @@ export class BaseBlockTransformer<Props extends object = object> {
 
   fromSnapshot({
     json,
-  }: FromSnapshotPayload):
-    | Promise<SnapshotReturn<Props>>
-    | SnapshotReturn<Props> {
+  }: FromSnapshotPayload): Promise<SnapshotNode<Props>> | SnapshotNode<Props> {
     const { flavour, id, version, props: _props } = json;
 
     const props = this._propsFromSnapshot(_props);


### PR DESCRIPTION
Close #8380


## Problem

The original process of converting snapshot JSON to blocks was significantly slowed to ensure UI responsiveness. It involved two types of async computations:

* Asynchronously converting snapshots to draft models.
* Asynchronously inserting draft models into the block tree using `doc.addBlock`.

Original import sequence:

```
Convert snapshot node A
Insert block A
Wait for tick

Convert snapshot node B
Insert block B
Wait for tick

Convert snapshot node C
Insert block C
Wait for tick
...
```

Despite `doc.addBlock` being synchronous, a `requestAnimationFrame` interval was added after each block insertion to prevent UI blocking. This resulted in long processing times when pasting thousands of blocks:

https://github.com/user-attachments/assets/3a6379c9-621e-490e-a79f-4377494d5915

## New Design

This PR reimplements the process:

1. Convert all snapshot nodes first, either using `Promise.all` or sequential awaits: Firstly we flatten the block tree, asynchronously convert all nodes, then rebuild the tree.
2. Insert the converted draft block tree in batches, **waiting for a tick after each _batch_ instead of after each _block_**.

This optimizes both block tree conversion and insertion while maintaining UI responsiveness.

## Performance Tests

### Comparing serial vs parallel (`Promise.all`) snapshot tree conversion:

- 1000 blocks: `Promise.all` 4.8ms, series 2.8ms
- 60 images: `Promise.all` 2.8ms, series 2.2ms

Serial conversion proved faster and was implemented in b90d736f65f51302750ea44efc91fc286b074f84. The flatten-rebuild logic was retained for scalability.

### Pasting 1000 blocks performance:

Original: ~10s (see screen recording above)

New: ~1s with maintained UI responsiveness

https://github.com/user-attachments/assets/0202330a-66ce-47f3-b220-44a4e9c7c37d

### Switching to imported documents:

Loading the block tree into DOM (by switching to an imported document) causes similar delays in both implementations.

---

Legacy first take:

<details>

This PR significantly improves the performance of block import operations by addressing several inefficiencies in the current implementation:

- Removed the need to wait for `requestAnimationFrame` after each block insertion (see #7796), which was causing significant slowdowns.
- <del>Fixed the batch mechanism (see #7790) that wasn't properly enabled, replacing serial execution with true parallel processing.</del>
- Instead of executing all remaining tasks at once after 100 items (still causing UI freezes), we now process tasks in consistent batches of 100 per tick.
- Replaced `setTimeout` with `requestIdleCallback` for batch ticks, better utilizing idle browser time.

These optimizations result in much faster block imports while maintaining UI responsiveness. The new implementation processes 100 tasks per tick, striking a balance between speed and smooth user experience.

Tested using [clipboard-test.md](https://github.com/user-attachments/files/17088183/clipboard-test.md) with 1000 line and 600 blocks:

## Before (took ~10s to paste)

https://github.com/user-attachments/assets/3a6379c9-621e-490e-a79f-4377494d5915

## After (instant response without blocking UI)

https://github.com/user-attachments/assets/dea7c1f9-a8c1-4926-92b7-f5cb40957fad

</details>


