### PR TITLE
fix: adjust the function call order so that the printToPdf complete correctly

### DIFF
--- a/packages/affine/shared/src/utils/print-to-pdf.ts
+++ b/packages/affine/shared/src/utils/print-to-pdf.ts
@@ -123,7 +123,6 @@ export async function printToPdf(
         }, 1000);
       });
 
-      iframe.contentWindow.print();
       iframe.contentWindow.onafterprint = async () => {
         iframe.remove();
 
@@ -139,6 +138,8 @@ export async function printToPdf(
 
         resolve();
       };
+
+      iframe.contentWindow.print();
     };
   });
 }


### PR DESCRIPTION
close [AF-1408](https://linear.app/affine-design/issue/AF-1408/上线不久-打印能力的实现被报了个bug)

https://github.com/user-attachments/assets/58fae35d-f407-4b33-a4e7-905d023c209c

