### PR TITLE
refactor(edgeless): make new block element always be on the top

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-panel.ts
@@ -225,18 +225,14 @@ export class EdgelessTemplatePanel extends WithDisposable(LitElement) {
         middlewares.push(createInsertPlaceMiddleware(currentContentBound));
       }
 
-      const idxGenerator = service.layer.createIndexGenerator(true);
+      const idxGenerator = service.layer.createIndexGenerator();
 
-      middlewares.push(
-        createRegenerateIndexMiddleware((type: string) => idxGenerator(type))
-      );
+      middlewares.push(createRegenerateIndexMiddleware(() => idxGenerator()));
     }
 
     if (type === 'sticker') {
       middlewares.push(
-        createStickerMiddleware(center, () =>
-          service.layer.generateIndex('affine:image')
-        )
+        createStickerMiddleware(center, () => service.layer.generateIndex())
       );
     }
 

--- a/packages/blocks/src/root-block/edgeless/services/template-middlewares.ts
+++ b/packages/blocks/src/root-block/edgeless/services/template-middlewares.ts
@@ -227,7 +227,7 @@ export const createStickerMiddleware = (
 };
 
 export const createRegenerateIndexMiddleware = (
-  generateIndex: (type: string) => string
+  generateIndex: () => string
 ) => {
   return (job: TemplateJob) => {
     job.slots.beforeInsert.on(blockData => {
@@ -309,11 +309,11 @@ export const createRegenerateIndexMiddleware = (
       frameList.sort((a, b) => sortIndex(a, b, groupIndexMap));
 
       frameList.forEach(index => {
-        indexMap.set(index.id, generateIndex('affine:frame'));
+        indexMap.set(index.id, generateIndex());
       });
 
       indexList.forEach(index => {
-        indexMap.set(index.id, generateIndex(index.flavour));
+        indexMap.set(index.id, generateIndex());
       });
     };
     const resetIndex = (blockJson: BlockSnapshot) => {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/release-from-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/release-from-group-button.ts
@@ -18,9 +18,7 @@ export class EdgelessReleaseFromGroupButton extends WithDisposable(LitElement) {
     // eslint-disable-next-line unicorn/prefer-dom-node-remove
     group.removeChild(element);
 
-    element.index = service.layer.generateIndex(
-      'flavour' in element ? element.flavour : element.type
-    );
+    element.index = service.layer.generateIndex();
 
     const parent = group.group;
     if (parent instanceof GroupElementModel) {

--- a/packages/presets/src/__tests__/edgeless/frame.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/frame.spec.ts
@@ -71,11 +71,11 @@ describe('frame', () => {
   test('frame should always be placed under the bottom of other blocks', async () => {
     addNote(doc, {
       xywh: '[0,0,300,300]',
-      index: service.layer.generateIndex('affine:note'),
+      index: service.layer.generateIndex(),
     });
     addNote(doc, {
       xywh: '[100,100,300,300]',
-      index: service.layer.generateIndex('affine:note'),
+      index: service.layer.generateIndex(),
     });
     const frameId = service.doc.addBlock(
       'affine:frame',

--- a/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/packages/presets/src/__tests__/edgeless/surface-ref.spec.ts
@@ -28,24 +28,26 @@ describe('basic', () => {
     service = edgelessRoot.service;
 
     noteAId = addNote(doc, {
-      index: service.generateIndex('affine:note'),
+      index: service.generateIndex(),
     });
     shapeAId = service.addElement('shape', {
       type: 'rect',
       xywh: '[0, 0, 100, 100]',
+      index: service.generateIndex(),
     });
     noteBId = addNote(doc, {
-      // force to be the last note
-      index: service.generateIndex('shape'),
+      index: service.generateIndex(),
     });
     shapeBId = service.addElement('shape', {
       type: 'rect',
       xywh: '[100, 0, 100, 100]',
+      index: service.generateIndex(),
     });
     frameId = service.addBlock(
       'affine:frame',
       {
         xywh: '[0, 0, 800, 200]',
+        index: service.generateIndex(),
       },
       service.surface.id
     );
@@ -114,7 +116,7 @@ describe('basic', () => {
     ) as HTMLCanvasElement[];
 
     expect(refBlocks.length).toBe(2);
-    expect(stackingCanvas.length).toBe(1);
+    expect(stackingCanvas.length).toBe(2);
     expect(stackingCanvas[0].style.zIndex > refBlocks[0].style.zIndex).toBe(
       true
     );

--- a/tests/edgeless/connector/label.spec.ts
+++ b/tests/edgeless/connector/label.spec.ts
@@ -313,18 +313,21 @@ test.describe('connector label with straight shape', () => {
     await page.mouse.click(105, 200);
 
     await page.keyboard.press('Enter');
+    await waitNextFrame(page);
     await type(page, ' a ');
     await assertEdgelessCanvasText(page, ' a ');
 
     await page.keyboard.press(`${SHORT_KEY}+Enter`);
 
     await page.keyboard.press('Enter');
+    await waitNextFrame(page);
     await type(page, 'b');
     await assertEdgelessCanvasText(page, 'b');
 
     await page.keyboard.press('Escape');
 
     await page.keyboard.press('Enter');
+    await waitNextFrame(page);
     await type(page, 'c');
     await assertEdgelessCanvasText(page, 'c');
   });

--- a/tests/edgeless/group/group.spec.ts
+++ b/tests/edgeless/group/group.spec.ts
@@ -154,6 +154,7 @@ test.describe('group', () => {
       await assertSelectedBound(page, [100, 0, 100, 100]);
     });
   });
+
   test.describe('delete', () => {
     test.beforeEach(async ({ page }) => {
       await init(page);

--- a/tests/edgeless/note/note.spec.ts
+++ b/tests/edgeless/note/note.spec.ts
@@ -254,6 +254,7 @@ test('duplicate note should work correctly', async ({ page }) => {
   await selectNoteInEdgeless(page, noteId);
 
   await triggerComponentToolbarAction(page, 'duplicate');
+  await waitNextFrame(page, 200); // wait viewport fit animation
   const moreActionsContainer = page.locator('.more-actions-container');
   await expect(moreActionsContainer).toBeHidden();
 
@@ -262,9 +263,7 @@ test('duplicate note should work correctly', async ({ page }) => {
   const [firstNote, secondNote] = await noteLocator.all();
 
   // content should be same
-  expect(
-    (await firstNote.innerText()) === (await secondNote.innerText())
-  ).toBeTruthy();
+  expect(await firstNote.innerText()).toEqual(await secondNote.innerText());
 
   // size should be same
   const firstNoteBox = await firstNote.boundingBox();

--- a/tests/edgeless/text.spec.ts
+++ b/tests/edgeless/text.spec.ts
@@ -199,6 +199,8 @@ test.describe('edgeless canvas text', () => {
 
     // select text element
     await page.mouse.click(150, 140);
+    await waitNextFrame(page);
+
     // should exit selected rect and record last width and height, then compare them
     let selectedRect = await getEdgelessSelectedRect(page);
     let lastWidth = selectedRect.width;
@@ -227,6 +229,8 @@ test.describe('edgeless canvas text', () => {
 
     // select text element
     await page.mouse.click(150, 140);
+    await waitNextFrame(page);
+
     // check selected rect and record the last width and height
     selectedRect = await getEdgelessSelectedRect(page);
     lastWidth = selectedRect.width;
@@ -268,6 +272,8 @@ test.describe('edgeless canvas text', () => {
 
     // select text element
     await page.mouse.click(150, 140);
+    await waitNextFrame(page);
+
     let selectedRect = await getEdgelessSelectedRect(page);
     let lastWidth = selectedRect.width;
     let lastHeight = selectedRect.height;
@@ -300,6 +306,8 @@ test.describe('edgeless canvas text', () => {
 
     // select text element
     await page.mouse.click(150, 140);
+    await waitNextFrame(page);
+
     // after input, the width of the text element should be the same as before, but the height should be changed
     selectedRect = await getEdgelessSelectedRect(page);
     expect(selectedRect.width).toBeCloseTo(Math.round(lastWidth));


### PR DESCRIPTION
Close [BS-1399](https://linear.app/affine-design/issue/BS-1399/edgeless-layer-index相关问题)

### What changes
- Ensure the new edgeless element is always on top after refactoring the `LayerManager.generateIndex()` and `LayerManager.createIndexGenerator()` methods to be type-agnostic. Previously, the block or canvas type was used to determine whether to place a new block in the second-to-last layer.
- Fix incorrect index order of elements after ungrouping.
- Update layer related tests
- Fix some flaky edgeless e2e tests.

### Before

https://github.com/user-attachments/assets/6cb57241-9184-44fe-b6a6-49fd51d4cf4f

### After

https://github.com/user-attachments/assets/694552c0-ffc1-45b1-9a96-f0904d9f70d8

### Changes Needed in AFFiNE Side
remove `xxx` parameter from `generateIndex(xxx)` in the following files:
- `packages/frontend/core/src/blocksuite/presets/ai/ai-panel.ts:116`
- `packages/frontend/core/src/blocksuite/presets/ai/_common/chat-actions-handle.ts:316`