### PR TITLE
refactor: edgeless tool manager

### DIFF
--- a/packages/framework/block-std/src/gfx/identifiers.ts
+++ b/packages/framework/block-std/src/gfx/identifiers.ts
@@ -1,0 +1,10 @@
+import type { ServiceIdentifier } from '@blocksuite/global/di';
+
+import type { GfxController } from './controller.js';
+
+import { LifeCycleWatcherIdentifier } from '../identifier.js';
+
+export const gfxControllerKey = 'GfxController';
+export const GfxControllerIdentifier = LifeCycleWatcherIdentifier(
+  gfxControllerKey
+) as ServiceIdentifier<GfxController>;

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -9,9 +9,10 @@ export {
   getTopElements,
   hasDescendantElementImpl,
 } from '../utils/tree.js';
-export { GfxController, GfxControllerIdentifier } from './controller.js';
+export { GfxController } from './controller.js';
 export * from './gfx-block-model.js';
 export { GridManager } from './grid.js';
+export { GfxControllerIdentifier } from './identifiers.js';
 export { LayerManager, type ReorderingDirection } from './layer.js';
 export {
   type GfxContainerElement,
@@ -46,7 +47,9 @@ export {
   type SurfaceBlockProps,
   type SurfaceMiddleware,
 } from './surface/surface-model.js';
-export * from './viewport.js';
+export { BaseTool, GfxToolExtension, type GfxToolsMap } from './tool/tool.js';
 
+export { ToolController } from './tool/tool-controller.js';
+export * from './viewport.js';
 export { GfxViewportElement } from './viewport-element.js';
 export { generateKeyBetween, generateNKeysBetween } from 'fractional-indexing';

--- a/packages/framework/block-std/src/gfx/keyboard.ts
+++ b/packages/framework/block-std/src/gfx/keyboard.ts
@@ -1,0 +1,43 @@
+import { DisposableGroup } from '@blocksuite/global/utils';
+import { Signal } from '@preact/signals-core';
+
+import type { BlockStdScope } from '../scope/block-std-scope.js';
+
+export class KeyboardController {
+  private _disposable = new DisposableGroup();
+
+  shiftKey$ = new Signal<boolean>(false);
+
+  spaceKey$ = new Signal<boolean>(false);
+
+  constructor(readonly std: BlockStdScope) {
+    this._init();
+  }
+
+  private _init() {
+    this._disposable.add(
+      this.std.event.add('keyDown', evt => {
+        const state = evt.get('keyboardState');
+
+        this.shiftKey$.value = state.raw.shiftKey && state.raw.key === 'Shift';
+        this.spaceKey$.value = state.raw.code === 'Space';
+      })
+    );
+
+    this._disposable.add(
+      this.std.event.add('keyUp', evt => {
+        const state = evt.get('keyboardState');
+
+        this.shiftKey$.value = !state.raw.shiftKey && state.raw.key === 'Shift';
+
+        if (state.raw.code === 'Space') {
+          this.spaceKey$.value = false;
+        }
+      })
+    );
+  }
+
+  dispose() {
+    this._disposable.dispose();
+  }
+}

--- a/packages/framework/block-std/src/gfx/tool/tool-controller.ts
+++ b/packages/framework/block-std/src/gfx/tool/tool-controller.ts
@@ -1,0 +1,163 @@
+import { DisposableGroup, type IBound } from '@blocksuite/global/utils';
+import { Signal } from '@preact/signals-core';
+
+import type { UIEventStateContext } from '../../event/index.js';
+import type { BlockStdScope } from '../../scope/block-std-scope.js';
+import type { BaseTool } from './tool.js';
+
+const supportedEvents = [
+  'dragStart',
+  'dragEnd',
+  'dragMove',
+  'click',
+  'doubleClick',
+  'tripleClick',
+  'pointerMove',
+  'pointerDown',
+  'pointerUp',
+  'pointerOut',
+  'contextMenu',
+] as const;
+
+export interface ToolEventTarget {
+  addHook(
+    evtName: (typeof supportedEvents)[number],
+    handler: (evtState: UIEventStateContext) => undefined | boolean
+  ): () => void;
+}
+
+export type SupportedEvents = (typeof supportedEvents)[number];
+
+export const eventTarget = Symbol('eventTarget');
+
+export class ToolController {
+  private _disposableGroup = new DisposableGroup();
+
+  private _tools = new Map<string, BaseTool>();
+
+  readonly currentToolName$ = new Signal<string>('');
+
+  readonly dragging$ = new Signal<boolean>(false);
+
+  readonly draggingArea$ = new Signal<IBound>({
+    x: 0,
+    y: 0,
+    w: 0,
+    h: 0,
+  });
+
+  readonly [eventTarget]: ToolEventTarget;
+
+  get currentTool$() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    return {
+      get value() {
+        return self._tools.get(self.currentToolName$.value);
+      },
+      peek() {
+        return self._tools.get(self.currentToolName$.peek());
+      },
+    };
+  }
+
+  constructor(readonly std: BlockStdScope) {
+    const { addHook } = this._initializeEvents();
+
+    this[eventTarget] = {
+      addHook,
+    };
+  }
+
+  private _initializeEvents() {
+    const hooks: Record<
+      string,
+      ((evtState: UIEventStateContext) => undefined | boolean)[]
+    > = {};
+    const invokeToolHandler = (
+      evtName: SupportedEvents,
+      ctx: UIEventStateContext
+    ) => {
+      const evtHooks = hooks[evtName];
+      const stopHandler = evtHooks?.reduce((pre, hook) => {
+        return pre || hook(ctx) === false;
+      }, false);
+
+      if (stopHandler || !this.currentTool$.peek()) {
+        return;
+      }
+
+      this.currentTool$.peek()?.[evtName](ctx);
+    };
+
+    /**
+     * Hook into the event lifecycle.
+     * All hooks will be executed despite the current active tool.
+     * This is useful for tools that need to perform some action before an event is handled.
+     * @param evtName
+     * @param handler
+     */
+    const addHook = (
+      evtName: (typeof supportedEvents)[number],
+      handler: (evtState: UIEventStateContext) => undefined | boolean
+    ) => {
+      hooks[evtName] = hooks[evtName] ?? [];
+      hooks[evtName].push(handler);
+
+      return () => {
+        const idx = hooks[evtName].indexOf(handler);
+        if (idx !== -1) {
+          hooks[evtName].splice(idx, 1);
+        }
+      };
+    };
+
+    this._disposableGroup.add(
+      this.std.event.add('dragStart', ctx => {
+        this.dragging$.value = true;
+        invokeToolHandler('dragStart', ctx);
+      })
+    );
+
+    this._disposableGroup.add(
+      this.std.event.add('dragEnd', ctx => {
+        this.dragging$.value = false;
+        invokeToolHandler('dragEnd', ctx);
+      })
+    );
+
+    supportedEvents.slice(2).forEach(evtName => {
+      this._disposableGroup.add(
+        this.std.event.add(evtName, ctx => {
+          invokeToolHandler(evtName, ctx);
+        })
+      );
+    });
+
+    return {
+      addHook,
+    };
+  }
+
+  dispose() {
+    this._tools.forEach(tool => {
+      tool.unmounted();
+    });
+  }
+
+  register(tools: BaseTool) {
+    if (this._tools.has(tools.toolName)) {
+      this._tools.get(tools.toolName)?.unmounted();
+    }
+
+    this._tools.set(tools.toolName, tools);
+    tools.mounted();
+  }
+
+  use(toolName: string, options: Record<string, unknown> = {}) {
+    this.currentTool$.peek()?.deactivate();
+    this.currentToolName$.value = toolName;
+    this.currentTool$.peek()?.activate(options);
+  }
+}

--- a/packages/framework/block-std/src/gfx/tool/tool.ts
+++ b/packages/framework/block-std/src/gfx/tool/tool.ts
@@ -1,0 +1,98 @@
+import { type Container, createIdentifier } from '@blocksuite/global/di';
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
+
+import type { UIEventStateContext } from '../../event/base.js';
+import type { ExtensionType } from '../../extension/extension.js';
+import type { GfxController } from '../controller.js';
+
+import { GfxControllerIdentifier } from '../identifiers.js';
+import { eventTarget, type SupportedEvents } from './tool-controller.js';
+
+export abstract class BaseTool {
+  static toolName: string = '';
+
+  get active() {
+    return this.gfx.tool.currentTool$.peek() === this;
+  }
+
+  get toolName() {
+    return (this.constructor as typeof BaseTool).toolName;
+  }
+
+  constructor(readonly gfx: GfxController) {}
+
+  /**
+   * Called when the tool is activated.
+   * @param option - The data passed as second argument when calling `ToolController.use`.
+   */
+  activate(_: Record<string, unknown>): void {}
+
+  addHook(
+    evtName: SupportedEvents,
+    handler: (evtState: UIEventStateContext) => undefined | boolean
+  ): void {
+    this.gfx.tool[eventTarget].addHook(evtName, handler);
+  }
+
+  click(_: UIEventStateContext): void {}
+
+  contextMenu(_: UIEventStateContext): void {}
+
+  /**
+   * Called when the tool is deactivated.
+   */
+  deactivate(): void {}
+
+  doubleClick(_: UIEventStateContext): void {}
+
+  dragEnd(_: UIEventStateContext): void {}
+
+  dragMove(_: UIEventStateContext): void {}
+
+  dragStart(_: UIEventStateContext): void {}
+
+  /**
+   * Called when the tool is registered.
+   */
+  mounted(): void {}
+
+  pointerDown(_: UIEventStateContext): void {}
+
+  pointerMove(_: UIEventStateContext): void {}
+
+  pointerOut(_: UIEventStateContext): void {}
+
+  pointerUp(_: UIEventStateContext): void {}
+
+  tripleClick(_: UIEventStateContext): void {}
+
+  /**
+   * Called when the tool is unloaded, usually when the whole `ToolController` is destroyed.
+   */
+  unmounted(): void {}
+}
+
+export const ToolIdentifier = createIdentifier<BaseTool>('GfxTool');
+
+export function GfxToolExtension(
+  toolCtors: (typeof BaseTool)[]
+): ExtensionType {
+  return {
+    setup: (di: Container) => {
+      toolCtors.forEach(Ctor => {
+        if (!Ctor.toolName) {
+          throw new BlockSuiteError(
+            ErrorCode.ValueNotExists,
+            'The tool must have a static property `toolName`'
+          );
+        }
+
+        di.addImpl(ToolIdentifier(Ctor.toolName), Ctor, [
+          GfxControllerIdentifier,
+        ]);
+      });
+    },
+  };
+}
+
+export interface GfxToolsMap {}


### PR DESCRIPTION
The `EdgelessToolManager` has been renamed to `GfxToolController`. All the legacy tools will be rewrited using the new infra.

#### How to add a new tool
Let's take an example of pan tool.

```typescript
import { BaseTool } from '@blocksuite/block-std/gfx';

// extend the BaseTool
export class PanTool extends BaseTool {
  // every tool class should have static toolName
  static override toolName = 'pan';
    
  dragStart(e) {
    this._lastPoint = [e.x, e.y];
  }

  dragEnd(e) {
    this._lastPoint = null;
  }

  dragMove(e) {
    if (!this._lastPoint) return;

    const { viewport } = this._service;
    const { zoom } = viewport;

    const [lastX, lastY] = this._lastPoint;
    const deltaX = lastX - e.x;
    const deltaY = lastY - e.y;

    this._lastPoint = [e.x, e.y];

    this.gfx.viewport.applyDeltaCenter(deltaX / zoom, deltaY / zoom);
  }
}
```

Once you finish defining the tool, just append it to the spec array.

```typescript
// edgeless-spec.ts file
import { PanTool } from '../tools/pan-tool.ts';

export const EdgelessSpec = [
   // .... omit the other part of spec

   // append it to the array
   PanTool
]
```

Continue in https://github.com/toeverything/blocksuite/pull/8471