### PR TITLE
feat(edgeless): tweak block visibility ui

### DIFF
--- a/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
+++ b/packages/blocks/src/root-block/widgets/edgeless-auto-connect/edgeless-auto-connect.ts
@@ -552,7 +552,13 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<
   }
 
   override render() {
-    if (!this._show || this._dragging) return nothing;
+    const advancedVisibilityEnabled = this.doc.awarenessStore.getFlag(
+      'enable_advanced_block_visibility'
+    );
+
+    if (!this._show || this._dragging || !advancedVisibilityEnabled) {
+      return nothing;
+    }
 
     this._updateLabels();
 

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-note-button.ts
@@ -121,6 +121,10 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     );
   };
 
+  private get _advancedVisibilityEnabled() {
+    return this.doc.awarenessStore.getFlag('enable_advanced_block_visibility');
+  }
+
   private get doc() {
     return this.edgeless.doc;
   }
@@ -264,7 +268,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
     const isDocOnly = displayMode === NoteDisplayMode.DocOnly;
 
     const buttons = [
-      onlyOne
+      onlyOne && this._advancedVisibilityEnabled
         ? html`
             <span class="display-mode-button-label">Show in</span>
             <editor-menu-button
@@ -400,7 +404,7 @@ export class EdgelessChangeNoteButton extends WithDisposable(LitElement) {
             </editor-menu-button>
           `,
 
-      onlyOne
+      onlyOne && this._advancedVisibilityEnabled
         ? html`
             <editor-icon-button
               aria-label="Slicer"

--- a/packages/framework/global/src/types/index.ts
+++ b/packages/framework/global/src/types/index.ts
@@ -12,5 +12,6 @@ export interface BlockSuiteFlags {
   enable_ai_chat_block: boolean;
   enable_color_picker: boolean;
   enable_mind_map_import: boolean;
+  enable_advanced_block_visibility: boolean;
   readonly: Record<string, boolean>;
 }

--- a/packages/framework/store/src/store/collection.ts
+++ b/packages/framework/store/src/store/collection.ts
@@ -63,6 +63,7 @@ const FLAGS_PRESET = {
   enable_ai_chat_block: false,
   enable_color_picker: false,
   enable_mind_map_import: false,
+  enable_advanced_block_visibility: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 

--- a/packages/playground/apps/starter/utils/collection.ts
+++ b/packages/playground/apps/starter/utils/collection.ts
@@ -71,6 +71,7 @@ export function createStarterDocCollection() {
       enable_edgeless_text: true,
       enable_color_picker: true,
       enable_mind_map_import: true,
+      enable_advanced_block_visibility: true,
       ...flags,
     },
     awarenessSources: [new BroadcastChannelAwarenessSource(id)],

--- a/packages/presets/src/fragments/outline/card/outline-card.ts
+++ b/packages/presets/src/fragments/outline/card/outline-card.ts
@@ -311,6 +311,9 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
       'card-header-container': true,
       'enable-sorting': this.enableNotesSorting,
     });
+    const advancedVisibilityEnabled = this.doc.awarenessStore.getFlag(
+      'enable_advanced_block_visibility'
+    );
 
     return html`
       <div
@@ -325,27 +328,36 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
           @dblclick=${this._dispatchFitViewEvent}
         >
         ${html`<div class=${cardHeaderClasses}>
-          ${this.invisible
-            ? html`<span class="card-header-icon">${HiddenIcon}</span>`
-            : html`<span class="card-number">${this.number}</span>`}
+          ${
+            this.invisible
+              ? html`<span class="card-header-icon">${HiddenIcon}</span>`
+              : html`<span class="card-number">${this.number}</span>`
+          }
           <span class="card-divider"></span>
-          <div class="display-mode-button-group">
-            <span class="display-mode-button-label">Show in</span>
-            <edgeless-tool-icon-button
-              .tooltip=${this._showPopper ? '' : 'Display Mode'}
-              .tipPosition=${'left-start'}
-              .iconContainerPadding=${0}
-              @click=${(e: MouseEvent) => {
-                e.stopPropagation();
-                this._displayModePopper?.toggle();
-              }}
-              @dblclick=${(e: MouseEvent) => e.stopPropagation()}
-            >
-              <div class="display-mode-button">
-                <span class="current-mode-label">${currentMode}</span>
-                ${SmallArrowDownIcon}
-              </div>
-            </edgeless-tool-icon-button>
+          ${
+            advancedVisibilityEnabled
+              ? html`
+                  <div class="display-mode-button-group">
+                    <span class="display-mode-button-label">Show in</span>
+                    <edgeless-tool-icon-button
+                      .tooltip=${this._showPopper ? '' : 'Display Mode'}
+                      .tipPosition=${'left-start'}
+                      .iconContainerPadding=${0}
+                      @click=${(e: MouseEvent) => {
+                        e.stopPropagation();
+                        this._displayModePopper?.toggle();
+                      }}
+                      @dblclick=${(e: MouseEvent) => e.stopPropagation()}
+                    >
+                      <div class="display-mode-button">
+                        <span class="current-mode-label">${currentMode}</span>
+                        ${SmallArrowDownIcon}
+                      </div>
+                    </edgeless-tool-icon-button>
+                  </div>
+                `
+              : nothing
+          }
           </div>
           <note-display-mode-panel
             .displayMode=${displayMode}


### PR DESCRIPTION
The `enable_advanced_block_visibility` flag is used to config the visibility related UI and it's false by default.


https://github.com/user-attachments/assets/5890abd3-872d-422c-b144-dcd0631a1735

