### PR TITLE
fix(blocks): set max width to embed-linked-doc-block

### DIFF
--- a/packages/affine/block-embed/src/common/embed-block-element.ts
+++ b/packages/affine/block-embed/src/common/embed-block-element.ts
@@ -8,6 +8,7 @@ import type { TemplateResult } from 'lit';
 import { CaptionedBlockComponent } from '@blocksuite/affine-components/caption';
 import {
   EMBED_CARD_HEIGHT,
+  EMBED_CARD_MIN_WIDTH,
   EMBED_CARD_WIDTH,
 } from '@blocksuite/affine-shared/consts';
 import {
@@ -27,8 +28,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 
 import { styles } from './styles.js';
-
-export const EMBED_MIN_WIDTH = 450;
 
 export const EmbedDragHandleOption = DragHandleConfigExtension({
   flavour: /affine:embed-*/,
@@ -109,7 +108,7 @@ export class EmbedBlockComponent<
 
       const mode = this.std.get(DocModeProvider).getEditorMode();
       if (mode === 'edgeless') {
-        this.style.minWidth = `${EMBED_MIN_WIDTH}px`;
+        this.style.minWidth = `${EMBED_CARD_MIN_WIDTH}px`;
       }
     }
 

--- a/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
@@ -1,5 +1,6 @@
 import {
   EMBED_CARD_HEIGHT,
+  EMBED_CARD_MIN_WIDTH,
   EMBED_CARD_WIDTH,
 } from '@blocksuite/affine-shared/consts';
 import { css, html } from 'lit';
@@ -10,6 +11,8 @@ export const styles = css`
   .affine-embed-linked-doc-block {
     box-sizing: border-box;
     display: flex;
+    max-width: 100%;
+    min-width: ${EMBED_CARD_MIN_WIDTH}px;
     width: ${EMBED_CARD_WIDTH.horizontal}px;
     border-radius: 8px;
     border: 1px solid var(--affine-background-tertiary-color);

--- a/packages/affine/shared/src/consts/index.ts
+++ b/packages/affine/shared/src/consts/index.ts
@@ -8,6 +8,8 @@ export const EDGELESS_BLOCK_CHILD_BORDER_WIDTH = 2;
 // In AFFiNE, to avoid the option element to be covered by the header, we need to reserve the space for the header
 export const PAGE_HEADER_HEIGHT = 53;
 
+export const EMBED_CARD_MIN_WIDTH = 450;
+
 export const EMBED_CARD_WIDTH: Record<EmbedCardStyle, number> = {
   horizontal: 752,
   horizontalThin: 752,

--- a/tests/edgeless/edgeless-text.spec.ts
+++ b/tests/edgeless/edgeless-text.spec.ts
@@ -360,37 +360,37 @@ test.describe('edgeless text block', () => {
     await page.mouse.click(0, 0);
     // select text element
     await page.mouse.click(130, 140);
-    const selectedRect = await getEdgelessSelectedRect(page);
+    const selectedRect0 = await getEdgelessSelectedRect(page);
 
     // from right to left
     await page.mouse.move(
-      selectedRect.x + selectedRect.width,
-      selectedRect.y + selectedRect.height / 2
+      selectedRect0.x + selectedRect0.width,
+      selectedRect0.y + selectedRect0.height / 2
     );
     await page.mouse.down();
     await page.mouse.move(
-      selectedRect.x + selectedRect.width - 45,
-      selectedRect.y + selectedRect.height / 2,
+      selectedRect0.x,
+      selectedRect0.y + selectedRect0.height / 2,
       {
         steps: 10,
       }
     );
     await page.mouse.up();
 
-    // not changed
     expect(await getPageSnapshot(page, true)).toMatchSnapshot(
-      `${testInfo.title}_link_to_card.json`
+      `${testInfo.title}_link_to_card_min_width.json`
     );
 
+    const selectedRect1 = await getEdgelessSelectedRect(page);
     // from left to right
     await page.mouse.move(
-      selectedRect.x + selectedRect.width,
-      selectedRect.y + selectedRect.height / 2
+      selectedRect1.x + selectedRect1.width,
+      selectedRect1.y + selectedRect1.height / 2
     );
     await page.mouse.down();
     await page.mouse.move(
-      selectedRect.x + selectedRect.width + 45,
-      selectedRect.y + selectedRect.height / 2,
+      selectedRect0.x + selectedRect0.width + 45,
+      selectedRect1.y + selectedRect1.height / 2,
       {
         steps: 10,
       }

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,819.0031127929688,164]",
+            "xywh": "[25,-287.5,541.7999877929688,164]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",


### PR DESCRIPTION
Close [BS-1439](https://linear.app/affine-design/issue/BS-1439/embed-card-没有最大宽度)

![CleanShot 2024-09-24 at 13.13.29@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/8de26069-e9ec-4f6a-b96e-5f264db605ad.png)

