### PR TITLE
fix(blocks): ime bugs of slash menu and at menu

### DIFF
--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -39,7 +39,7 @@ export function getQuery(
 interface ObserverParams {
   target: HTMLElement;
   signal: AbortSignal;
-  onInput?: () => void;
+  onInput?: (isComposition: boolean) => void;
   onDelete?: () => void;
   onMove?: (step: 1 | -1) => void;
   onConfirm?: () => void;
@@ -60,6 +60,8 @@ export const createKeydownObserver = ({
   interceptor = (_, next) => next(),
 }: ObserverParams) => {
   const keyDownListener = (e: KeyboardEvent) => {
+    if (e.key === 'Process' || e.isComposing) return;
+
     if (e.defaultPrevented) return;
 
     if (isControlledKeyboardEvent(e)) {
@@ -107,10 +109,10 @@ export const createKeydownObserver = ({
 
     if (
       // input abc, 123, etc.
-      (!isControlledKeyboardEvent(e) && e.key.length === 1) ||
-      e.isComposing
+      !isControlledKeyboardEvent(e) &&
+      e.key.length === 1
     ) {
-      onInput?.();
+      onInput?.(false);
       return;
     }
 
@@ -184,7 +186,7 @@ export const createKeydownObserver = ({
   target.addEventListener('paste', () => onDelete?.(), { signal });
 
   // Fix composition input
-  target.addEventListener('input', () => onInput?.(), { signal });
+  target.addEventListener('compositionend', () => onInput?.(true), { signal });
 };
 
 /**

--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -126,9 +126,15 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     createKeydownObserver({
       target: eventSource,
       signal: this.abortController.signal,
-      onInput: () => {
+      onInput: isComposition => {
         this._activatedItemIndex = 0;
-        this.inlineEditor.slots.renderComplete.once(this._updateLinkedDocGroup);
+        if (isComposition) {
+          this._updateLinkedDocGroup().catch(console.error);
+        } else {
+          this.inlineEditor.slots.renderComplete.once(
+            this._updateLinkedDocGroup
+          );
+        }
       },
       onPaste: () => {
         this._activatedItemIndex = 0;

--- a/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/slash-menu-popover.ts
@@ -221,8 +221,15 @@ export class SlashMenu extends WithDisposable(LitElement) {
 
         next();
       },
-      onInput: () =>
-        this.inlineEditor.slots.renderComplete.once(this._updateFilteredItems),
+      onInput: isComposition => {
+        if (isComposition) {
+          this._updateFilteredItems();
+        } else {
+          this.inlineEditor.slots.renderComplete.once(
+            this._updateFilteredItems
+          );
+        }
+      },
       onPaste: () => {
         setTimeout(() => {
           this._updateFilteredItems();

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -51,11 +51,14 @@ test.describe('slash menu should show and hide correctly', () => {
     await expect(slashMenu).toBeVisible();
   });
 
-  test("slash menu should show when user input '、'", async ({ page }) => {
+  // Playwright dose not support IME
+  // https://github.com/microsoft/playwright/issues/5777
+  test.skip("slash menu should show when user input '、'", async ({ page }) => {
     await initEmptyParagraphState(page);
     const slashMenu = page.locator(`.slash-menu`);
     await focusRichText(page);
     await type(page, '、');
+
     await expect(slashMenu).toBeVisible();
   });
 
@@ -778,23 +781,6 @@ test('should insert database', async ({ page }) => {
   expect(await tagColumn.innerText()).toBe('Status');
   const defaultRows = page.locator('.affine-database-block-row');
   expect(await defaultRows.count()).toBe(4);
-});
-
-test.skip('should compatible CJK IME', async ({ page }) => {
-  await enterPlaygroundRoom(page);
-  await initEmptyParagraphState(page);
-  await focusRichText(page);
-
-  await type(page, '、');
-  const slashMenu = page.locator(`.slash-menu`);
-
-  // Fix playwright can not trigger keyboard event with target: '、'
-  test.fail();
-  await expect(slashMenu).toBeVisible();
-  await type(page, 'h2');
-  const slashItems = slashMenu.locator('icon-button');
-  await expect(slashItems).toHaveCount(1);
-  await expect(slashItems).toHaveText(['Heading 2']);
 });
 
 test.describe('slash menu with customize menu', () => {


### PR DESCRIPTION
Close: [BS-1444](https://linear.app/affine-design/issue/BS-1444/在linked-doc面板，输入法输入后，面板消失), [BS-1443](https://linear.app/affine-design/issue/BS-1443/中文输入法下，段落开头输入-【【-无法唤起-linked-doc面板), [BS-1442](
https://linear.app/affine-design/issue/BS-1442/中文输入法下，输入-面板显示位置错误)

This PR fixes IME issues of the @ menu and slash menu, including:
- Incorrect positioning of the slash menu popover.
- Can not open the @ menu using `【【`.
- Can not search within the @ menu using IME.

The cause of these issues is that, in Windows Microsoft Pinyin, the inline range is updated when the `compositionend` event is triggered. Consequently, the slot `this.inlineEditor.slots.renderComplete.once` and `inlineEditor.slots.inlineRangeSync.once` are delayed until the next keyboard input. Related PR: #7914

### Before


https://github.com/user-attachments/assets/bf9aed3e-e673-437a-8375-7ce219d1d07c

### After


https://github.com/user-attachments/assets/4d3eebfd-0869-4051-87e6-c210216b4751

