### PR TITLE
fix: outline popup ref area

### DIFF
--- a/packages/presets/src/fragments/outline/card/outline-card.ts
+++ b/packages/presets/src/fragments/outline/card/outline-card.ts
@@ -87,13 +87,16 @@ const styles = css`
 
   .display-mode-button-group {
     display: none;
+    position: absolute;
+    right: 8px;
+    top: -6px;
+    padding-top: 8px;
+    padding-bottom: 8px;
     align-items: center;
     gap: 4px;
-    padding: 2px;
     font-size: 12px;
     font-weight: 500;
     line-height: 20px;
-    position: relative;
   }
 
   .card-preview:hover .display-mode-button-group {
@@ -293,7 +296,7 @@ export class OutlineNoteCard extends SignalWatcher(WithDisposable(LitElement)) {
         this._showPopper = display === 'show';
       },
       {
-        mainAxis: 8,
+        mainAxis: 0,
         crossAxis: -60,
       }
     );


### PR DESCRIPTION
Before (unable to click on the hover popup):

https://github.com/user-attachments/assets/350ab3b5-4611-4728-9fef-4350989be457

After:

https://github.com/user-attachments/assets/92b948b0-ae72-4851-9aff-bd6c4e510ec7

