### PR TITLE
fix: edgeless image block rotate

### DIFF
--- a/packages/blocks/src/image-block/image-edgeless-block.ts
+++ b/packages/blocks/src/image-block/image-edgeless-block.ts
@@ -82,9 +82,12 @@ export class ImageEdgelessBlockComponent extends GfxBlockComponent<
   }
 
   override renderGfxBlock() {
+    const rotate = this.model.rotate ?? 0;
     const containerStyleMap = styleMap({
       position: 'relative',
       width: '100%',
+      transform: `rotate(${rotate}deg)`,
+      transformOrigin: 'center',
     });
 
     return html`


### PR DESCRIPTION
[BS-1495](https://linear.app/affine-design/issue/BS-1495/edgeless-旋转图形不沃克)