### PR TITLE
fix: improve open link on link popup

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/affine-link.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/affine-link.ts
@@ -32,23 +32,6 @@ export class AffineLink extends ShadowlessElement {
   // The link has been identified.
   private _identified: boolean = false;
 
-  private _onClick = (e: MouseEvent) => {
-    if (!this._identified) {
-      this._identified = true;
-      this._identify();
-    }
-
-    const referenceInfo = this._referenceInfo;
-    if (!referenceInfo) return;
-
-    const refNodeSlotsProvider = this.std?.getOptional(RefNodeSlotsProvider);
-    if (!refNodeSlotsProvider) return;
-
-    e.preventDefault();
-
-    refNodeSlotsProvider.docLinkClicked.emit(referenceInfo);
-  };
-
   // see https://github.com/toeverything/AFFiNE/issues/1540
   private _onMouseUp = () => {
     const anchorElement = this.querySelector('a');
@@ -87,12 +70,33 @@ export class AffineLink extends ShadowlessElement {
           this.inlineEditor,
           'view',
           this.selfInlineRange,
-          abortController
+          abortController,
+          (e?: MouseEvent) => {
+            this.openLink(e);
+            abortController.abort();
+          }
         ),
       };
     },
     { enterDelay: 500 }
   );
+
+  openLink = (e?: MouseEvent) => {
+    if (!this._identified) {
+      this._identified = true;
+      this._identify();
+    }
+
+    const referenceInfo = this._referenceInfo;
+    if (!referenceInfo) return;
+
+    const refNodeSlotsProvider = this.std?.getOptional(RefNodeSlotsProvider);
+    if (!refNodeSlotsProvider) return;
+
+    e?.preventDefault();
+
+    refNodeSlotsProvider.docLinkClicked.emit(referenceInfo);
+  };
 
   // Workaround for links not working in contenteditable div
   // see also https://stackoverflow.com/questions/12059211/how-to-make-clickable-anchor-in-contenteditable-div
@@ -156,7 +160,7 @@ export class AffineLink extends ShadowlessElement {
       rel="noopener noreferrer"
       target="_blank"
       style=${styleMap(style)}
-      @click=${this._onClick}
+      @click=${this.openLink}
       @mouseup=${this._onMouseUp}
       ><v-text .str=${this.delta.insert}></v-text
     ></a>`;

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -128,6 +128,11 @@ export class LinkPopup extends WithDisposable(LitElement) {
   private _embedOptions: EmbedOptions | null = null;
 
   private _openLink = () => {
+    if (this.openLink) {
+      this.openLink();
+      return;
+    }
+
     let link = this.currentLink;
     if (!link) return;
     if (!link.match(/^[a-zA-Z]+:\/\//)) {
@@ -161,6 +166,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
           href=${this.currentLink}
           rel="noopener noreferrer"
           target="_blank"
+          @click=${(e: MouseEvent) => this.openLink?.(e)}
         >
           <span>${getHostName(this.currentLink)}</span>
         </a>
@@ -618,6 +624,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
 
   @query('.mock-selection-container')
   accessor mockSelectionContainer!: HTMLDivElement;
+
+  @property({ attribute: false })
+  accessor openLink: ((e?: MouseEvent) => void) | null = null;
 
   @query('.affine-link-popover-container')
   accessor popupContainer!: HTMLDivElement;

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/toggle-link-popup.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/toggle-link-popup.ts
@@ -8,12 +8,14 @@ export function toggleLinkPopup(
   inlineEditor: AffineInlineEditor,
   type: LinkPopup['type'],
   targetInlineRange: InlineRange,
-  abortController: AbortController
+  abortController: AbortController,
+  openLink: ((e?: MouseEvent) => void) | null = null
 ): LinkPopup {
   const popup = new LinkPopup();
   popup.inlineEditor = inlineEditor;
   popup.type = type;
   popup.targetInlineRange = targetInlineRange;
+  popup.openLink = openLink;
   popup.abortController = abortController;
 
   document.body.append(popup);


### PR DESCRIPTION
Closes [BS-1496](https://linear.app/affine-design/issue/BS-1496/当-hover-affine-link-时，-单击-link-popup-上的-open-link-也应该需要判断下站内链接的情况)

When a user opens a link on a link-popup, it is also necessary to identify whether it is an in-app link.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/8ypiIKZXudF5a0tIgIzf/8bc7efee-f158-4fac-815d-39f15139d55e.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/8ypiIKZXudF5a0tIgIzf/8bc7efee-f158-4fac-815d-39f15139d55e.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/8bc7efee-f158-4fac-815d-39f15139d55e.mov">Screen Recording 2024-09-25 at 16.24.35.mov</video>

