### PR TITLE
fix(blocks): incorrect width of embed-linked-doc-block in edgeless

### DIFF
--- a/packages/affine/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -16,6 +16,7 @@ import {
   EMBED_CARD_WIDTH,
 } from '@blocksuite/affine-shared/consts';
 import { DocModeProvider } from '@blocksuite/affine-shared/services';
+import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import { Bound } from '@blocksuite/global/utils';
 import { DocCollection } from '@blocksuite/store';
 import { html, nothing } from 'lit';
@@ -337,6 +338,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
     const isLoading = this._loading;
     const isError = this.isError;
     const isEmpty = this._isDocEmpty() && this.isBannerEmpty;
+    const inCanvas = matchFlavours(this.model.parent, ['affine:surface']);
 
     const cardClassMap = classMap({
       loading: isLoading,
@@ -345,6 +347,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
       empty: isEmpty,
       'banner-empty': this.isBannerEmpty,
       'note-empty': this.isNoteContentEmpty,
+      'in-canvas': inCanvas,
       [this._cardStyle]: true,
     });
 

--- a/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
@@ -11,8 +11,6 @@ export const styles = css`
   .affine-embed-linked-doc-block {
     box-sizing: border-box;
     display: flex;
-    max-width: 100%;
-    min-width: ${EMBED_CARD_MIN_WIDTH}px;
     width: ${EMBED_CARD_WIDTH.horizontal}px;
     border-radius: 8px;
     border: 1px solid var(--affine-background-tertiary-color);
@@ -181,11 +179,17 @@ export const styles = css`
     border-radius: 4px 4px var(--1, 0px) var(--1, 0px);
   }
 
+  .affine-embed-linked-doc-block:not(.in-canvas) {
+    max-width: 100%;
+    min-width: ${EMBED_CARD_MIN_WIDTH}px;
+  }
+
   .affine-embed-linked-doc-block.loading {
     .affine-embed-linked-doc-content-date {
       display: none;
     }
   }
+
   .affine-embed-linked-doc-block:not(.loading):not(.note-empty) {
     .affine-embed-linked-doc-content-note.render {
       display: block;


### PR DESCRIPTION
Close [BS-1497](https://linear.app/affine-design/issue/BS-1497/白板文档出错)

### Before

![CleanShot 2024-09-25 at 18.13.10@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/a3e465c8-4113-455e-a257-eefb50dc43e9.png)

### After

![CleanShot 2024-09-25 at 18.13.45@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/7e341b53-0501-438d-9270-28565602b35b.png)

