### PR TITLE
fix(blocks): fix slash menu is triggered in ignored blocks

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -4,7 +4,10 @@ import {
   type AffineInlineEditor,
   getInlineEditorByModel,
 } from '@blocksuite/affine-components/rich-text';
-import { getCurrentNativeRange } from '@blocksuite/affine-shared/utils';
+import {
+  getCurrentNativeRange,
+  matchFlavours,
+} from '@blocksuite/affine-shared/utils';
 import { WidgetComponent } from '@blocksuite/block-std';
 import {
   assertExists,
@@ -153,6 +156,8 @@ export class AffineSlashMenuWidget extends WidgetComponent {
 
       const model = this.host.doc.getBlock(textSelection.blockId)?.model;
       if (!model) return;
+
+      if (matchFlavours(model, this.config.ignoreBlockTypes)) return;
 
       const inlineRange = inlineEditor.getInlineRange();
       if (!inlineRange) return;

--- a/tests/slash-menu.spec.ts
+++ b/tests/slash-menu.spec.ts
@@ -497,6 +497,19 @@ test.describe('slash menu should show and hide correctly', () => {
   });
 });
 
+test.describe('slash menu should not be shown in ignored blocks', () => {
+  test('code block', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+
+    await type(page, '```');
+    await pressEnter(page);
+    await type(page, '/');
+    await expect(page.locator('.slash-menu')).toBeHidden();
+  });
+});
+
 test('should slash menu works with fast type', async ({ page }) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);


### PR DESCRIPTION
Close [BS-1501](https://linear.app/affine-design/issue/BS-1501/修正代碼區塊中-的響應問題)