### PR TITLE
fix(blocks): can not search in at menu with IME

### DIFF
--- a/packages/blocks/src/_common/components/utils.ts
+++ b/packages/blocks/src/_common/components/utils.ts
@@ -21,10 +21,6 @@ export function getQuery(
   if (nativeRange.startContainer !== nativeRange.endContainer) {
     return null;
   }
-  const textNode = nativeRange.startContainer;
-  if (textNode.nodeType !== Node.TEXT_NODE) {
-    return null;
-  }
   const curRange = inlineEditor.getInlineRange();
   if (!startRange || !curRange) {
     return null;


### PR DESCRIPTION
Close [BS-1531](https://linear.app/affine-design/issue/BS-1531/macos-chrome-无法在menu中使用中文搜索) 

https://github.com/toeverything/blocksuite/blob/3ecef3d1d57dd77314c0b13e02d2bda6efc41911/packages/blocks/src/_common/components/utils.ts#L24-L27

When `compositionend` event is emitted, the node in the current native range is a `ELEMENT_NODE` not a `TEXT_NODE` in MacOS. That will make the searching query of @ menu to be null, and then the menu will be auto-closed.
```
<div contenteditable="true" class=" inline-editor " data-v-root="true">
```
