### PR TITLE
fix(block-std): dispatcher pointerUp calls twice

### DIFF
--- a/packages/framework/block-std/src/event/control/pointer.ts
+++ b/packages/framework/block-std/src/event/control/pointer.ts
@@ -151,7 +151,6 @@ class ClickController extends PointerControllerBase {
     const context = createContext(event, state);
 
     const run = () => {
-      this._dispatcher.run('pointerUp', context);
       this._dispatcher.run('click', context);
       if (this._pointerDownCount === 2) {
         this._dispatcher.run('doubleClick', context);


### PR DESCRIPTION
When subscribing to pointerUp it is patched 2 times due to a duplicate in ClickController
