### PR TITLE
fix(blocks): hide outline panel toggle button when callback is null

### DIFF
--- a/packages/presets/src/fragments/outline/outline-viewer.ts
+++ b/packages/presets/src/fragments/outline/outline-viewer.ts
@@ -207,6 +207,19 @@ export class OutlineViewer extends SignalWatcher(WithDisposable(LitElement)) {
       ...headingBlocks,
     ];
 
+    const toggleOutlinePanelButton =
+      this.toggleOutlinePanel !== null
+        ? html`<edgeless-tool-icon-button
+            .tooltip=${'Open in sidebar'}
+            .tipPosition=${'top-end'}
+            .activeMode=${'background'}
+            @click=${this._toggleOutlinePanel}
+            data-testid="toggle-outline-panel-button"
+          >
+            ${TocIcon}
+          </edgeless-tool-icon-button>`
+        : nothing;
+
     return html`
       <div class="outline-viewer-root" @mouseenter=${this._scrollPanel}>
         <div class="outline-viewer-indicators-container">
@@ -227,14 +240,7 @@ export class OutlineViewer extends SignalWatcher(WithDisposable(LitElement)) {
         <div class="outline-viewer-panel">
           <div class="outline-viewer-item outline-viewer-header">
             <span>Table of Contents</span>
-            <edgeless-tool-icon-button
-              .tooltip=${'Open in sidebar'}
-              .tipPosition=${'top-end'}
-              .activeMode=${'background'}
-              @click=${this._toggleOutlinePanel}
-            >
-              ${TocIcon}
-            </edgeless-tool-icon-button>
+            ${toggleOutlinePanelButton}
           </div>
           ${repeat(
             items,

--- a/tests/fragments/outline/toc-viewer.spec.ts
+++ b/tests/fragments/outline/toc-viewer.spec.ts
@@ -1,3 +1,6 @@
+import type { OutlineViewer } from '@blocksuite/presets';
+
+import { noop } from '@blocksuite/global/utils';
 import { expect, type Page } from '@playwright/test';
 import { addNote, switchEditorMode } from 'utils/actions/edgeless.js';
 import { pressEnter, type } from 'utils/actions/keyboard.js';
@@ -179,5 +182,28 @@ test.describe('toc-viewer', () => {
     await expect(viewer).toBeVisible();
     const hiddenTitle = viewer.locator('.hidden-title');
     await expect(hiddenTitle).toBeHidden();
+  });
+
+  test('outline panel toggle button', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    const viewer = await toggleTocViewer(page);
+
+    await focusRichTextEnd(page);
+    await createHeadingsWithGap(page);
+
+    const toggleButton = viewer.locator(
+      '[data-testid="toggle-outline-panel-button"]'
+    );
+    await expect(toggleButton).toHaveCount(0);
+    await viewer.evaluate((el: OutlineViewer) => {
+      el.toggleOutlinePanel = () => {
+        noop();
+      };
+    });
+
+    await waitNextFrame(page);
+    await expect(toggleButton).toHaveCount(1);
+    await expect(toggleButton).toBeVisible();
   });
 });


### PR DESCRIPTION
Close [BS-1537](https://linear.app/affine-design/issue/BS-1537/share-page-中-toc-不应该有-[open-in-sidebar]-选项)