### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/perfect-nails-guess.md
+++ b/.changeset/perfect-nails-guess.md
@@ -1,0 +1,30 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+Bug Fixes:
+
+- fix(blocks): can not search in at menu with IME. [#8481](https://github.com/toeverything/blocksuite/pull/8481)
+- fix(std): dispatcher pointerUp calls twice. [#8485](https://github.com/toeverything/blocksuite/pull/8485)
+- fix(blocks): pasting elements with css inline style. [#8491](https://github.com/toeverything/blocksuite/pull/8491)
+- fix(blocks): hide outline panel toggle button when callback is null. [#8493](https://github.com/toeverything/blocksuite/pull/8493)
+- fix(blocks): pasting twice when span inside h tag. [#8496](https://github.com/toeverything/blocksuite/pull/8496)
+- fix(blocks): image should be displayed when in vertical mode. [#8497](https://github.com/toeverything/blocksuite/pull/8497)
+- fix: press backspace at the start of first line when edgeless text exist. [#8498](https://github.com/toeverything/blocksuite/pull/8498)


### PR DESCRIPTION
### Bug Fixes:

- fix(blocks): can not search in at menu with IME. #8481
- fix(std): dispatcher pointerUp calls twice. #8485
- fix(blocks): pasting elements with css inline style. #8491
- fix(blocks): hide outline panel toggle button when callback is null. #8493
- fix(blocks): pasting twice when span inside h tag. #8496
- fix(blocks): image should be displayed when in vertical mode. #8497
- fix: press backspace at the start of first line when edgeless text exist. #8498