### PR TITLE
refactor(blocks): simplify frame manager implementation

### DIFF
--- a/packages/affine/model/src/blocks/frame/frame-model.ts
+++ b/packages/affine/model/src/blocks/frame/frame-model.ts
@@ -82,7 +82,7 @@ export class FrameBlockModel
     });
   }
 
-  addChildren(elements: (BlockSuite.EdgelessModel | string)[]): void {
+  addChildren(elements: (GfxModel | string)[]): void {
     elements = [...new Set(elements)];
 
     const newChildren: Record<string, boolean> = {};

--- a/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/default-tool.ts
@@ -944,7 +944,7 @@ export class DefaultToolController extends EdgelessToolController<DefaultTool> {
       } else {
         // only apply to root nodes of trees
         toBeMovedTopElements.map(element =>
-          frameManager.removeParentFrame(element)
+          frameManager.removeFromParentFrame(element)
         );
       }
     }


### PR DESCRIPTION
This PR removes redundant code related to the container-child element relationship, which is now maintained by the new `TreeManager` after #8239 .