### PR TITLE
fix: enhance button layout with icon alignment

### DIFF
--- a/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
+++ b/packages/blocks/src/root-block/widgets/code-language-list/components/lang-button.ts
@@ -38,6 +38,11 @@ export class LanguageListButton extends WithDisposable(
     .lang-button[hover] {
       background: var(--affine-hover-color-filled);
     }
+
+    .lang-button-icon {
+      display: flex;
+      align-items: center;
+    }
   `;
 
   private _abortController?: AbortController;
@@ -121,7 +126,7 @@ export class LanguageListButton extends WithDisposable(
       @click=${this._clickLangBtn}
       ?disabled=${this.blockComponent.doc.readonly}
     >
-      <span slot="suffix">
+      <span class="lang-button-icon" slot="suffix">
         ${!this.blockComponent.doc.readonly ? ArrowDownIcon : nothing}
       </span>
     </icon-button> `;


### PR DESCRIPTION
This PR improves the layout of the language list button by aligning the icon properly within the button.

The changes include the addition of a flex display for the icon, ensuring better visual consistency and user experience.

Before

<img width="376" alt="Screenshot 2024-10-11 at 19 24 29" src="https://github.com/user-attachments/assets/14305832-385c-4c48-b141-5ae05024545e">

After

<img width="465" alt="Screenshot 2024-10-11 at 19 24 13" src="https://github.com/user-attachments/assets/7dee123b-b9f4-4f39-98bb-394078845cec">


