### PR TITLE
refactor: update frame test with container test uitls

### DIFF
--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -2,7 +2,6 @@ import type { SurfaceBlockModel } from '@blocksuite/affine-block-surface';
 import type { Doc } from '@blocksuite/store';
 
 import { Overlay } from '@blocksuite/affine-block-surface';
-import { MindmapElementModel } from '@blocksuite/affine-model';
 import {
   getTopElements,
   type GfxModel,
@@ -180,17 +179,13 @@ export class EdgelessFrameManager {
   private _watchElementAdded() {
     this._disposable.add(
       this._rootService.surface.elementAdded.on(({ id, local }) => {
-        let element = this._rootService.surface.getElementById(id);
+        const element = this._rootService.surface.getElementById(id);
         if (element && local) {
           const frame = this.getFrameFromPoint(element.elementBound.center);
 
           // if the container created with a frame, skip it.
           if (isGfxContainerElm(element) && frame && element.hasChild(frame)) {
             return;
-          }
-
-          if (element.group instanceof MindmapElementModel) {
-            element = element.group;
           }
 
           frame && this.addElementsToFrame(frame, [element]);

--- a/tests/edgeless/frame/clipboard.spec.ts
+++ b/tests/edgeless/frame/clipboard.spec.ts
@@ -5,8 +5,12 @@ import {
   createFrame as _createFrame,
   autoFit,
   createShapeElement,
+  deleteAll,
   dragBetweenViewCoords,
   edgelessCommonSetup,
+  getAllSortedIds,
+  getFirstContainerId,
+  getIds,
   Shape,
   shiftClickView,
   triggerComponentToolbarAction,
@@ -17,9 +21,8 @@ import {
   pasteByKeyboard,
   pressBackspace,
   pressEscape,
-  selectAllByKeyboard,
 } from 'utils/actions/keyboard.js';
-import { assertSelectedBound } from 'utils/asserts.js';
+import { assertContainerOfElements } from 'utils/asserts.js';
 
 import { test } from '../../utils/playwright.js';
 
@@ -43,32 +46,17 @@ test.describe('frame copy and paste', () => {
   }) => {
     await createFrame(page, [50, 50], [450, 450]);
     await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
-    await pressEscape(page);
 
+    await pressEscape(page);
     await clickView(page, [60, 60]);
     await copyByKeyboard(page);
-
+    await deleteAll(page);
     await moveView(page, [500, 500]); // center copy
     await pasteByKeyboard(page);
 
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [200, 200, 100, 100], 0); // shape
-    await assertSelectedBound(page, [450, 450, 100, 100], 1); // shape
-    await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
-    await assertSelectedBound(page, [300, 300, 400, 400], 3); // frame
-    await pressEscape(page);
-
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [10, 10]);
-
-    await clickView(page, [360, 360]);
-    await dragBetweenViewCoords(page, [360, 360], [310, 310]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
-    await assertSelectedBound(page, [400, 400, 100, 100], 1); // shape
-    await assertSelectedBound(page, [0, 0, 400, 400], 2); // frame
-    await assertSelectedBound(page, [250, 250, 400, 400], 3); // frame
+    const frameId = await getFirstContainerId(page);
+    const shapeId = (await getAllSortedIds(page)).filter(id => id !== frameId);
+    await assertContainerOfElements(page, shapeId, frameId);
   });
 
   test('copy of frame by alt/option dragging should keep relationship of child elements', async ({
@@ -88,27 +76,24 @@ test.describe('frame copy and paste', () => {
     await clickView(page, [60, 60]);
     await page.keyboard.down('Alt');
     await dragBetweenViewCoords(page, [60, 60], [460, 460]);
-
     await page.keyboard.up('Alt');
     await pressEscape(page);
 
     await shiftClickView(page, [60, 60]);
     await shiftClickView(page, [250, 250]);
     await shiftClickView(page, [350, 350]);
-    await pressBackspace(page);
+    await pressBackspace(page); // remove original elements
 
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [600, 600, 100, 100], 0); // shape
-    await assertSelectedBound(page, [650, 650, 150, 150], 1); // group
-    await assertSelectedBound(page, [450, 450, 400, 400], 2); // frame
+    const frameId = await getFirstContainerId(page);
+    const groupId = await getFirstContainerId(page, [frameId]);
+    const shapeIds = (await getIds(page)).filter(
+      id => ![frameId, groupId].includes(id)
+    );
 
-    await clickView(page, [460, 460]);
-    await dragBetweenViewCoords(page, [460, 460], [510, 510]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [650, 650, 100, 100], 0); // shape
-    await assertSelectedBound(page, [700, 700, 150, 150], 1); // group
-    await assertSelectedBound(page, [500, 500, 400, 400], 2); // frame
+    await assertContainerOfElements(page, [groupId], frameId);
+    await assertContainerOfElements(page, [shapeIds[0]], frameId);
+    await assertContainerOfElements(page, [shapeIds[1]], groupId);
+    await assertContainerOfElements(page, [shapeIds[2]], groupId);
   });
 
   test('duplicate element in frame', async ({ page }) => {
@@ -123,11 +108,11 @@ test.describe('frame copy and paste', () => {
 
     await shiftClickView(page, [60, 60]);
     await shiftClickView(page, [150, 150]);
-    await pressBackspace(page);
+    await pressBackspace(page); // remove original elements
 
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [510, 100, 100, 100], 0); // shape
-    await assertSelectedBound(page, [460, 50, 400, 400], 1); // frame
+    const frameId = await getFirstContainerId(page);
+    const shapeIds = (await getIds(page)).filter(id => id !== frameId);
+    await assertContainerOfElements(page, shapeIds, frameId);
   });
 
   test('copy of element by alt/option dragging in frame should belong to frame', async ({
@@ -140,21 +125,11 @@ test.describe('frame copy and paste', () => {
     await clickView(page, [150, 150]);
     await page.keyboard.down('Alt');
     await dragBetweenViewCoords(page, [150, 150], [250, 250]);
-
     await page.keyboard.up('Alt');
 
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [100, 100, 100, 100], 0); // shape
-    await assertSelectedBound(page, [200, 200, 100, 100], 1); // shape
-    await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
-
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
-    await assertSelectedBound(page, [250, 250, 100, 100], 1); // shape
-    await assertSelectedBound(page, [100, 100, 400, 400], 2); // frame
+    const frameId = await getFirstContainerId(page);
+    const shapeIds = (await getIds(page)).filter(id => id !== frameId);
+    await assertContainerOfElements(page, shapeIds, frameId);
   });
 
   test('copy of element by alt/option dragging out of frame should not belong to frame', async ({
@@ -167,20 +142,11 @@ test.describe('frame copy and paste', () => {
     await clickView(page, [150, 150]);
     await page.keyboard.down('Alt');
     await dragBetweenViewCoords(page, [150, 150], [550, 550]);
-
     await page.keyboard.up('Alt');
 
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [100, 100, 100, 100], 0); // shape
-    await assertSelectedBound(page, [500, 500, 100, 100], 1); // shape
-    await assertSelectedBound(page, [50, 50, 400, 400], 2); // frame
-
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [150, 150, 100, 100], 0); // shape
-    await assertSelectedBound(page, [500, 500, 100, 100], 1); // shape
-    await assertSelectedBound(page, [100, 100, 400, 400], 2); // frame
+    const frameId = await getFirstContainerId(page);
+    const shapeIds = (await getIds(page)).filter(id => id !== frameId);
+    await assertContainerOfElements(page, [shapeIds[0]], frameId);
+    await assertContainerOfElements(page, [shapeIds[1]], null);
   });
 });

--- a/tests/edgeless/frame/frame-mindmap.spec.ts
+++ b/tests/edgeless/frame/frame-mindmap.spec.ts
@@ -5,14 +5,15 @@ import {
   dragBetweenViewCoords as _dragBetweenViewCoords,
   createFrame,
   edgelessCommonSetup,
+  getFirstContainerId,
   getSelectedBound,
   toViewCoord,
   triggerComponentToolbarAction,
   zoomResetByKeyboard,
 } from 'utils/actions/edgeless.js';
-import { pressEscape, selectAllByKeyboard } from 'utils/actions/keyboard.js';
+import { pressEscape } from 'utils/actions/keyboard.js';
 import { waitNextFrame } from 'utils/actions/misc.js';
-import { assertSelectedBound } from 'utils/asserts.js';
+import { assertContainerOfElements } from 'utils/asserts.js';
 
 import { test } from '../../utils/playwright.js';
 
@@ -31,17 +32,19 @@ test.beforeEach(async ({ page }) => {
   await zoomResetByKeyboard(page);
 });
 
-test('drag root node of mindmap into frame partially, move frame, then drag root node of mindmap out.', async ({
+test('drag root node of mindmap into frame partially, then drag root node of mindmap out.', async ({
   page,
 }) => {
   await createFrame(page, [50, 50], [550, 550]);
   await pressEscape(page);
-  await triggerComponentToolbarAction(page, 'addMindmap');
+  const frameId = await getFirstContainerId(page);
 
-  let mindmapBound = await getSelectedBound(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+  const mindmapId = await getFirstContainerId(page, [frameId]);
 
   // drag in
   {
+    const mindmapBound = await getSelectedBound(page);
     await clickView(page, [
       mindmapBound[0] + 10,
       mindmapBound[1] + 0.5 * mindmapBound[3],
@@ -51,35 +54,13 @@ test('drag root node of mindmap into frame partially, move frame, then drag root
       [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
       [100, 100]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // Drag frame
-  {
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(
-    page,
-    [
-      mindmapBound[0] + 50,
-      mindmapBound[1] + 50,
-      mindmapBound[2],
-      mindmapBound[3],
-    ],
-    0
-  ); // mindmap
-  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], frameId);
 
   // drag out
   {
-    mindmapBound = await getSelectedBound(page, 0);
-    pressEscape(page);
+    const mindmapBound = await getSelectedBound(page);
     await clickView(page, [
       mindmapBound[0] + 10,
       mindmapBound[1] + 0.5 * mindmapBound[3],
@@ -89,34 +70,25 @@ test('drag root node of mindmap into frame partially, move frame, then drag root
       [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
       [-100, -100]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // drag frame
-  {
-    await clickView(page, [110, 110]);
-    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(page, mindmapBound, 0); // mindmap
-  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], null);
 });
 
-test('drag root node of mindmap into frame fully, move frame, then drag root node of mindmap out.', async ({
+test('drag root node of mindmap into frame fully, then drag root node of mindmap out.', async ({
   page,
 }) => {
   await createFrame(page, [50, 50], [550, 550]);
+  const frameId = await getFirstContainerId(page);
   await pressEscape(page);
-  await triggerComponentToolbarAction(page, 'addMindmap');
 
-  let mindmapBound = await getSelectedBound(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+  const mindmapId = await getFirstContainerId(page, [frameId]);
 
   // drag in
   {
+    const mindmapBound = await getSelectedBound(page);
+
     await clickView(page, [
       mindmapBound[0] + 10,
       mindmapBound[1] + 0.5 * mindmapBound[3],
@@ -126,35 +98,13 @@ test('drag root node of mindmap into frame fully, move frame, then drag root nod
       [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
       [100, 200]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // Drag frame
-  {
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(
-    page,
-    [
-      mindmapBound[0] + 50,
-      mindmapBound[1] + 50,
-      mindmapBound[2],
-      mindmapBound[3],
-    ],
-    0
-  ); // mindmap
-  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], frameId);
 
   // drag out
   {
-    mindmapBound = await getSelectedBound(page, 0);
-    pressEscape(page);
+    const mindmapBound = await getSelectedBound(page);
     await clickView(page, [
       mindmapBound[0] + 10,
       mindmapBound[1] + 0.5 * mindmapBound[3],
@@ -164,34 +114,24 @@ test('drag root node of mindmap into frame fully, move frame, then drag root nod
       [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
       [-100, -100]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // drag frame
-  {
-    await clickView(page, [110, 110]);
-    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(page, mindmapBound, 0); // mindmap
-  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], null);
 });
 
-test('drag whole mindmap into frame, move frame, then drag root node of mindmap out.', async ({
+test('drag whole mindmap into frame, then drag root node of mindmap out.', async ({
   page,
 }) => {
   await createFrame(page, [50, 50], [550, 550]);
+  const frameId = await getFirstContainerId(page);
   await pressEscape(page);
-  await triggerComponentToolbarAction(page, 'addMindmap');
 
-  let mindmapBound = await getSelectedBound(page);
+  await triggerComponentToolbarAction(page, 'addMindmap');
+  const mindmapId = await getFirstContainerId(page, [frameId]);
 
   // drag in
   {
+    const mindmapBound = await getSelectedBound(page);
     await dragBetweenViewCoords(
       page,
       [mindmapBound[0] - 10, mindmapBound[1] - 10],
@@ -202,35 +142,13 @@ test('drag whole mindmap into frame, move frame, then drag root node of mindmap 
       [mindmapBound[0] + 10, mindmapBound[1] + 10],
       [100, 100]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // Drag frame
-  {
-    await clickView(page, [60, 60]);
-    await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(
-    page,
-    [
-      mindmapBound[0] + 50,
-      mindmapBound[1] + 50,
-      mindmapBound[2],
-      mindmapBound[3],
-    ],
-    0
-  ); // mindmap
-  await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], frameId);
 
   // drag out
   {
-    mindmapBound = await getSelectedBound(page, 0);
-    pressEscape(page);
+    const mindmapBound = await getSelectedBound(page);
     await clickView(page, [
       mindmapBound[0] + 10,
       mindmapBound[1] + 0.5 * mindmapBound[3],
@@ -240,87 +158,43 @@ test('drag whole mindmap into frame, move frame, then drag root node of mindmap 
       [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
       [0, 0]
     );
-    await pressEscape(page);
-    await selectAllByKeyboard(page);
-    mindmapBound = await getSelectedBound(page, 0);
-    await pressEscape(page);
   }
 
-  // drag frame
-  {
-    await clickView(page, [110, 110]);
-    await dragBetweenViewCoords(page, [110, 110], [160, 160]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(page, mindmapBound, 0); // mindmap
-  await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], null);
 });
 
-// FIXME(@L-Sun): This test is flaky
-test.fixme(
-  'add partial mindmap into frame, move frame, then drag root node of mindmap out.',
-  async ({ page }) => {
-    await createFrame(page, [50, 50], [550, 550]);
-    await pressEscape(page);
+test('add mindmap into frame, then drag root node of mindmap out.', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [550, 550]);
+  const frameId = await getFirstContainerId(page);
+  await pressEscape(page);
 
-    const button = page.locator('edgeless-mindmap-tool-button');
-    await button.click();
-    await toViewCoord(page, [100, 200]);
-    await clickView(page, [100, 200]);
+  const button = page.locator('edgeless-mindmap-tool-button');
+  await button.click();
+  await toViewCoord(page, [100, 200]);
+  await clickView(page, [100, 200]);
+  const mindmapId = await getFirstContainerId(page, [frameId]);
 
-    let mindmapBound = await getSelectedBound(page);
+  await assertContainerOfElements(page, [mindmapId], frameId);
 
-    // Drag frame
-    {
-      await clickView(page, [60, 60]);
-      await dragBetweenViewCoords(page, [60, 60], [110, 110]);
-    }
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(
+  // drag out
+  {
+    const mindmapBound = await getSelectedBound(page);
+    pressEscape(page);
+    await clickView(page, [
+      mindmapBound[0] + 10,
+      mindmapBound[1] + 0.5 * mindmapBound[3],
+    ]);
+    await dragBetweenViewCoords(
       page,
-      [
-        mindmapBound[0] + 50,
-        mindmapBound[1] + 50,
-        mindmapBound[2],
-        mindmapBound[3],
-      ],
-      0
-    ); // mindmap
-    await assertSelectedBound(page, [100, 100, 500, 500], 1); // frame
-
-    // drag out
-    {
-      mindmapBound = await getSelectedBound(page, 0);
-      pressEscape(page);
-      await clickView(page, [
-        mindmapBound[0] + 10,
-        mindmapBound[1] + 0.5 * mindmapBound[3],
-      ]);
-      await dragBetweenViewCoords(
-        page,
-        [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
-        [-20, -20]
-      );
-      await pressEscape(page);
-      await selectAllByKeyboard(page);
-      mindmapBound = await getSelectedBound(page, 0);
-      await pressEscape(page);
-    }
-
-    // drag frame
-    {
-      await clickView(page, [110, 110]);
-      await dragBetweenViewCoords(page, [110, 110], [160, 160]);
-      await pressEscape(page);
-    }
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, mindmapBound, 0); // mindmap
-    await assertSelectedBound(page, [150, 150, 500, 500], 1); // frame
+      [mindmapBound[0] + 10, mindmapBound[1] + 0.5 * mindmapBound[3]],
+      [-20, -20]
+    );
   }
-);
+
+  await assertContainerOfElements(page, [mindmapId], null);
+});
 
 test('add mindmap out of frame and add new node in frame then drag frame', async ({
   page,
@@ -333,10 +207,11 @@ test('add mindmap out of frame and add new node in frame then drag frame', async
   await toViewCoord(page, [20, 200]);
   await clickView(page, [20, 200]);
   await waitNextFrame(page, 100);
-  let mindmapBound = await getSelectedBound(page);
+  const mindmapId = await getFirstContainerId(page);
 
   // add new node
   {
+    const mindmapBound = await getSelectedBound(page);
     await pressEscape(page);
     await waitNextFrame(page, 500);
     await clickView(page, [
@@ -351,18 +226,5 @@ test('add mindmap out of frame and add new node in frame then drag frame', async
     await pressEscape(page, 2);
   }
 
-  await selectAllByKeyboard(page);
-  mindmapBound = await getSelectedBound(page, 0);
-  await pressEscape(page, 2);
-  await waitNextFrame(page, 100);
-
-  // Drag frame
-  {
-    await clickView(page, [510, 60]);
-    await dragBetweenViewCoords(page, [510, 60], [560, 110]);
-  }
-
-  await selectAllByKeyboard(page);
-  await assertSelectedBound(page, mindmapBound, 0); // mindmap
-  await assertSelectedBound(page, [550, 100, 500, 500], 1); // frame
+  await assertContainerOfElements(page, [mindmapId], null);
 });

--- a/tests/edgeless/frame/frame.spec.ts
+++ b/tests/edgeless/frame/frame.spec.ts
@@ -8,6 +8,7 @@ import {
   createShapeElement,
   dragBetweenViewCoords,
   edgelessCommonSetup,
+  getFirstContainerId,
   setEdgelessTool,
   Shape,
   shiftClickView,
@@ -21,7 +22,10 @@ import {
   selectAllByKeyboard,
   SHORT_KEY,
 } from '../../utils/actions/keyboard.js';
-import { assertSelectedBound } from '../../utils/asserts.js';
+import {
+  assertContainerChildCount,
+  assertSelectedBound,
+} from '../../utils/asserts.js';
 import { test } from '../../utils/playwright.js';
 
 const createFrame = async (
@@ -48,17 +52,6 @@ test.describe('add a frame then drag to move', () => {
     await shiftClickView(page, [150, 50]);
   };
 
-  const assertFrameHasTwoShapeChildren = async (page: Page) => {
-    await page.waitForTimeout(500);
-    await dragBetweenViewCoords(page, [50, 50], [100, 50]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [50, 0, 100, 100], 0);
-    await assertSelectedBound(page, [150, 0, 100, 100], 1);
-    // the third shape should not be moved
-    await assertSelectedBound(page, [200, 0, 100, 100], 2);
-  };
-
   test('multi select and add frame by shortcut F', async ({ page }) => {
     await createThreeShapesAndSelectTowShape(page);
     await page.keyboard.press('f');
@@ -66,7 +59,8 @@ test.describe('add a frame then drag to move', () => {
     await expect(page.locator('affine-frame')).toHaveCount(1);
     await assertSelectedBound(page, [-300, -270, 800, 640]);
 
-    await assertFrameHasTwoShapeChildren(page);
+    const frameId = await getFirstContainerId(page);
+    await assertContainerChildCount(page, frameId, 2);
   });
 
   test('multi select and add frame by component toolbar', async ({ page }) => {
@@ -76,7 +70,8 @@ test.describe('add a frame then drag to move', () => {
     await expect(page.locator('affine-frame')).toHaveCount(1);
     await assertSelectedBound(page, [-300, -270, 800, 640]);
 
-    await assertFrameHasTwoShapeChildren(page);
+    const frameId = await getFirstContainerId(page);
+    await assertContainerChildCount(page, frameId, 2);
   });
 
   test('multi select and add frame by more option create frame', async ({
@@ -88,7 +83,8 @@ test.describe('add a frame then drag to move', () => {
     await expect(page.locator('affine-frame')).toHaveCount(1);
     await assertSelectedBound(page, [-300, -270, 800, 640]);
 
-    await assertFrameHasTwoShapeChildren(page);
+    const frameId = await getFirstContainerId(page);
+    await assertContainerChildCount(page, frameId, 2);
   });
 
   test('multi select add frame by edgeless toolbar', async ({ page }) => {
@@ -101,13 +97,9 @@ test.describe('add a frame then drag to move', () => {
     await button.click();
     await assertSelectedBound(page, [-450, -550, 1200, 1200]);
 
-    await dragBetweenViewCoords(page, [50, 50], [100, 50]);
-
-    await selectAllByKeyboard(page);
-    await assertSelectedBound(page, [50, 0, 100, 100], 0);
-    await assertSelectedBound(page, [150, 0, 100, 100], 1);
-    // the third shape should be moved
-    await assertSelectedBound(page, [250, 0, 100, 100], 2);
+    // the third should be inner frame because
+    const frameId = await getFirstContainerId(page);
+    await assertContainerChildCount(page, frameId, 3);
   });
 
   test('add frame by dragging with shortcut F', async ({ page }) => {
@@ -120,7 +112,8 @@ test.describe('add a frame then drag to move', () => {
     await expect(page.locator('affine-frame')).toHaveCount(1);
     await assertSelectedBound(page, [-10, -10, 220, 120]);
 
-    await assertFrameHasTwoShapeChildren(page);
+    const frameId = await getFirstContainerId(page);
+    await assertContainerChildCount(page, frameId, 2);
   });
 });
 

--- a/tests/edgeless/group/clipboard.spec.ts
+++ b/tests/edgeless/group/clipboard.spec.ts
@@ -18,7 +18,7 @@ import {
   waitNextFrame,
 } from '../../utils/actions/index.js';
 import {
-  assertContainerChildren,
+  assertContainerChildCount,
   assertContainerIds,
 } from '../../utils/asserts.js';
 import { test } from '../../utils/playwright.js';
@@ -45,8 +45,8 @@ test.describe('clipboard', () => {
       [copyedGroupId]: 2,
       null: 2,
     });
-    await assertContainerChildren(page, originGroupId, 2);
-    await assertContainerChildren(page, copyedGroupId, 2);
+    await assertContainerChildCount(page, originGroupId, 2);
+    await assertContainerChildCount(page, copyedGroupId, 2);
   });
 
   test('copy and paste group with connector', async ({ page }) => {
@@ -71,8 +71,8 @@ test.describe('clipboard', () => {
       [copyedGroupId]: 3,
       null: 2,
     });
-    await assertContainerChildren(page, originGroupId, 3);
-    await assertContainerChildren(page, copyedGroupId, 3);
+    await assertContainerChildCount(page, originGroupId, 3);
+    await assertContainerChildCount(page, copyedGroupId, 3);
   });
 });
 

--- a/tests/edgeless/group/group-and-ungroup.spec.ts
+++ b/tests/edgeless/group/group-and-ungroup.spec.ts
@@ -16,8 +16,8 @@ import {
   undoByKeyboard,
 } from '../../utils/actions/index.js';
 import {
+  assertContainerChildCount,
   assertContainerChildIds,
-  assertContainerChildren,
   assertContainerIds,
   assertSelectedBound,
 } from '../../utils/asserts.js';
@@ -58,8 +58,8 @@ test.describe('group and ungroup in group', () => {
       [outterGroupId]: 2,
       null: 1,
     });
-    await assertContainerChildren(page, groupId, 2);
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
 
     // undo the creation
     await undoByKeyboard(page);
@@ -67,7 +67,7 @@ test.describe('group and ungroup in group', () => {
       [outterGroupId]: 3,
       null: 1,
     });
-    await assertContainerChildren(page, outterGroupId, 3);
+    await assertContainerChildCount(page, outterGroupId, 3);
 
     // redo the creation
     await redoByKeyboard(page);
@@ -76,8 +76,8 @@ test.describe('group and ungroup in group', () => {
       [outterGroupId]: 2,
       null: 1,
     });
-    await assertContainerChildren(page, groupId, 2);
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
   });
 
   test('ungroup in group', async ({ page }) => {

--- a/tests/edgeless/group/group.spec.ts
+++ b/tests/edgeless/group/group.spec.ts
@@ -20,7 +20,7 @@ import {
 import { captureHistory } from '../../utils/actions/misc.js';
 import {
   assertCanvasElementsCount,
-  assertContainerChildren,
+  assertContainerChildCount,
   assertContainerIds,
   assertEdgelessNonSelectedRect,
   assertSelectedBound,
@@ -175,7 +175,7 @@ test.describe('group', () => {
         [groupId]: 2,
         null: 1,
       });
-      await assertContainerChildren(page, groupId, 2);
+      await assertContainerChildCount(page, groupId, 2);
 
       // redo the delete
       await redoByKeyboard(page);
@@ -195,7 +195,7 @@ test.describe('group', () => {
         [groupId]: 1,
         null: 1,
       });
-      await assertContainerChildren(page, groupId, 1);
+      await assertContainerChildCount(page, groupId, 1);
 
       // undo the delete
       await undoByKeyboard(page);
@@ -204,7 +204,7 @@ test.describe('group', () => {
         [groupId]: 2,
         null: 1,
       });
-      await assertContainerChildren(page, groupId, 2);
+      await assertContainerChildCount(page, groupId, 2);
 
       // redo the delete
       await redoByKeyboard(page);
@@ -213,7 +213,7 @@ test.describe('group', () => {
         [groupId]: 1,
         null: 1,
       });
-      await assertContainerChildren(page, groupId, 1);
+      await assertContainerChildCount(page, groupId, 1);
     });
 
     test('delete group in group', async ({ page }) => {
@@ -234,7 +234,7 @@ test.describe('group', () => {
         [firstGroup]: 1,
         null: 1,
       });
-      await assertContainerChildren(page, firstGroup, 1);
+      await assertContainerChildCount(page, firstGroup, 1);
 
       // undo the delete
       await undoByKeyboard(page);
@@ -244,8 +244,8 @@ test.describe('group', () => {
         [secondGroup]: 2,
         null: 1,
       });
-      await assertContainerChildren(page, firstGroup, 2);
-      await assertContainerChildren(page, secondGroup, 2);
+      await assertContainerChildCount(page, firstGroup, 2);
+      await assertContainerChildCount(page, secondGroup, 2);
 
       // redo the delete
       await redoByKeyboard(page);
@@ -254,7 +254,7 @@ test.describe('group', () => {
         [firstGroup]: 1,
         null: 1,
       });
-      await assertContainerChildren(page, firstGroup, 1);
+      await assertContainerChildCount(page, firstGroup, 1);
     });
   });
 });

--- a/tests/edgeless/group/release.spec.ts
+++ b/tests/edgeless/group/release.spec.ts
@@ -14,7 +14,7 @@ import {
   undoByKeyboard,
 } from '../../utils/actions/index.js';
 import {
-  assertContainerChildren,
+  assertContainerChildCount,
   assertContainerIds,
   assertSelectedBound,
 } from '../../utils/asserts.js';
@@ -46,7 +46,7 @@ test.describe('release from group', () => {
       [outterGroupId]: 2,
       null: 2,
     });
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
     await assertSelectedBound(page, [0, 0, 100, 100]);
 
     // undo the release
@@ -55,7 +55,7 @@ test.describe('release from group', () => {
       [outterGroupId]: 3,
       null: 1,
     });
-    await assertContainerChildren(page, outterGroupId, 3);
+    await assertContainerChildCount(page, outterGroupId, 3);
     await assertSelectedBound(page, [0, 0, 100, 100]);
 
     // redo the release
@@ -64,7 +64,7 @@ test.describe('release from group', () => {
       [outterGroupId]: 2,
       null: 2,
     });
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
     await assertSelectedBound(page, [0, 0, 100, 100]);
   });
 
@@ -80,8 +80,8 @@ test.describe('release from group', () => {
       [outterGroupId]: 2,
       null: 1,
     });
-    await assertContainerChildren(page, groupId, 2);
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
 
     // release group from group
     await triggerComponentToolbarAction(page, 'releaseFromGroup');
@@ -90,8 +90,8 @@ test.describe('release from group', () => {
       [outterGroupId]: 1,
       null: 2,
     });
-    await assertContainerChildren(page, outterGroupId, 1);
-    await assertContainerChildren(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 1);
+    await assertContainerChildCount(page, groupId, 2);
 
     // undo the release
     await undoByKeyboard(page);
@@ -100,8 +100,8 @@ test.describe('release from group', () => {
       [outterGroupId]: 2,
       null: 1,
     });
-    await assertContainerChildren(page, groupId, 2);
-    await assertContainerChildren(page, outterGroupId, 2);
+    await assertContainerChildCount(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 2);
 
     // redo the release
     await redoByKeyboard(page);
@@ -110,7 +110,7 @@ test.describe('release from group', () => {
       [outterGroupId]: 1,
       null: 2,
     });
-    await assertContainerChildren(page, outterGroupId, 1);
-    await assertContainerChildren(page, groupId, 2);
+    await assertContainerChildCount(page, outterGroupId, 1);
+    await assertContainerChildCount(page, groupId, 2);
   });
 });

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -1617,6 +1617,7 @@ export async function getContainerChildIds(page: Page, id: string) {
       const container = document.querySelector('affine-edgeless-root');
       if (!container) throw new Error('container not found');
       const gfxModel = container.service.getElementById(id);
+
       return gfxModel && container.service.surface.isContainer(gfxModel)
         ? gfxModel.childIds
         : [];
@@ -1680,7 +1681,7 @@ export async function getFirstContainerId(page: Page, exclude: string[] = []) {
       const container = document.querySelector('affine-edgeless-root');
       if (!container) throw new Error('container not found');
       return (
-        container.service.elements.find(
+        container.service.edgelessElements.find(
           e =>
             container.service.surface.isContainer(e) && !exclude.includes(e.id)
         )?.id ?? ''

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -1152,12 +1152,12 @@ export async function assertContainerChildIds(
 export async function assertContainerOfElements(
   page: Page,
   elements: string[],
-  containerId: string
+  containerId: string | null
 ) {
-  const elementGroups = await getContainerOfElements(page, elements);
+  const elementContainers = await getContainerOfElements(page, elements);
 
-  elementGroups.forEach(elementGroup => {
-    expect(elementGroup).toEqual(containerId);
+  elementContainers.forEach(elementContainer => {
+    expect(elementContainer).toEqual(containerId);
   });
 }
 
@@ -1168,7 +1168,7 @@ export async function assertContainerOfElements(
  * @param containerId
  * @param childrenCount
  */
-export async function assertContainerChildren(
+export async function assertContainerChildCount(
   page: Page,
   containerId: string,
   childrenCount: number


### PR DESCRIPTION
This PR is a continuation of PR #8518 and refactors the frame test with container test utils.

### Bug fix
- Fix missing children when creating mindmap with toolbar, which lead to `xywh` is `[0, 0, 0, 0]` and fail to get the frame from the actual position of mindmap.