### PR TITLE
perf(edgeless): disable shape shadow blur

### DIFF
--- a/packages/affine/block-surface/src/renderer/elements/shape/utils.ts
+++ b/packages/affine/block-surface/src/renderer/elements/shape/utils.ts
@@ -69,9 +69,18 @@ export function drawGeneralShape(
     const { blur, offsetX, offsetY, color } = shapeModel.shadow;
     const scale = ctx.getTransform().a;
 
-    ctx.shadowBlur = blur * scale;
-    ctx.shadowOffsetX = offsetX * scale;
-    ctx.shadowOffsetY = offsetY * scale;
+    const enableShadowBlur = shapeModel.surface.doc.awarenessStore.getFlag(
+      'enable_shape_shadow_blur'
+    );
+
+    // hard shadow, or soft shadow if `enable_shape_shadow_blur` is true
+    // see comment of `shape.shadow` in `ShapeElementModel`
+    if (blur === 0 || enableShadowBlur) {
+      ctx.shadowBlur = blur * scale;
+      ctx.shadowOffsetX = offsetX * scale;
+      ctx.shadowOffsetY = offsetY * scale;
+    }
+
     ctx.shadowColor = renderer.getPropertyValue(color);
   }
 

--- a/packages/affine/model/src/elements/mindmap/style.ts
+++ b/packages/affine/model/src/elements/mindmap/style.ts
@@ -253,8 +253,8 @@ export class StyleThree extends MindmapStyleGetter {
       node: {
         radius: 10,
 
-        strokeWidth: 0,
-        strokeColor: 'transparent',
+        strokeWidth: 2,
+        strokeColor: strokeColor,
 
         fontFamily: FontFamily.Poppins,
         fontSize: 16,

--- a/packages/affine/model/src/elements/shape/shape.ts
+++ b/packages/affine/model/src/elements/shape/shape.ts
@@ -137,6 +137,12 @@ export class ShapeElementModel extends GfxPrimitiveElementModel<ShapeProps> {
 
   @field()
   accessor shadow: {
+    /**
+     * @deprecated Since the shadow blur will reduce the performance of canvas rendering,
+     * we already disable the shadow blur rendering by default, so set this field will not take effect.
+     * You can enable it by setting the flag `enable_shape_shadow_blur` in the awareness store.
+     * https://web.dev/articles/canvas-performance#avoid_shadowblur
+     */
     blur: number;
     offsetX: number;
     offsetY: number;

--- a/packages/framework/global/src/types/index.ts
+++ b/packages/framework/global/src/types/index.ts
@@ -13,5 +13,6 @@ export interface BlockSuiteFlags {
   enable_color_picker: boolean;
   enable_mind_map_import: boolean;
   enable_advanced_block_visibility: boolean;
+  enable_shape_shadow_blur: boolean;
   readonly: Record<string, boolean>;
 }

--- a/packages/framework/store/src/store/collection.ts
+++ b/packages/framework/store/src/store/collection.ts
@@ -64,6 +64,7 @@ const FLAGS_PRESET = {
   enable_color_picker: false,
   enable_mind_map_import: false,
   enable_advanced_block_visibility: false,
+  enable_shape_shadow_blur: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 

--- a/packages/playground/apps/starter/utils/collection.ts
+++ b/packages/playground/apps/starter/utils/collection.ts
@@ -72,6 +72,7 @@ export function createStarterDocCollection() {
       enable_color_picker: true,
       enable_mind_map_import: true,
       enable_advanced_block_visibility: true,
+      enable_shape_shadow_blur: false,
       ...flags,
     },
     awarenessSources: [new BroadcastChannelAwarenessSource(id)],


### PR DESCRIPTION
Close [BS-1557](https://linear.app/affine-design/issue/BS-1557/mindmap-改进)

### What changes:
- Disable shadow blur of shape since it reduce the performance of canvas rendering when there are many mindmap. Close [BS-1246](https://linear.app/affine-design/issue/BS-1246/mindmapframe，左右平移巨巨巨巨巨卡)
- Add border to Mindmap style two. Close [BS-1559](https://linear.app/affine-design/issue/BS-1559/mindmap-去掉shadow)

### Before

https://github.com/user-attachments/assets/affabb9c-2278-49ff-ae44-e880f550a8f2

### After

https://github.com/user-attachments/assets/757d55b3-8962-44bc-9712-4897235d6814