### PR TITLE
fix: note width is less than minimum width after resize and arrange

### DIFF
--- a/packages/affine/block-surface/src/utils/update-xywh.ts
+++ b/packages/affine/block-surface/src/utils/update-xywh.ts
@@ -1,17 +1,28 @@
-import { ConnectorElementModel } from '@blocksuite/affine-model';
+import type { BlockModel, BlockProps } from '@blocksuite/store';
+
+import {
+  ConnectorElementModel,
+  NOTE_MIN_HEIGHT,
+  NOTE_MIN_WIDTH,
+  NoteBlockModel,
+} from '@blocksuite/affine-model';
 import {
   type GfxContainerElement,
   type GfxModel,
   isGfxContainerElm,
 } from '@blocksuite/block-std/gfx';
-import { Bound } from '@blocksuite/global/utils';
+import { Bound, clamp } from '@blocksuite/global/utils';
 
 import { LayoutableMindmapElementModel } from './mindmap/utils.js';
 
 function updatChildElementsXYWH(
   container: GfxContainerElement,
   targetBound: Bound,
-  updateElement: (id: string, props: Record<string, unknown>) => void
+  updateElement: (id: string, props: Record<string, unknown>) => void,
+  updateBlock: (
+    model: BlockModel,
+    callBackOrProps: (() => void) | Partial<BlockProps>
+  ) => void
 ) {
   const containerBound = Bound.deserialize(container.xywh);
   const scaleX = targetBound.w / containerBound.w;
@@ -22,17 +33,34 @@ function updatChildElementsXYWH(
     childBound.y = targetBound.y + scaleY * (childBound.y - containerBound.y);
     childBound.w = scaleX * childBound.w;
     childBound.h = scaleY * childBound.h;
-    updateXYWH(child, childBound, updateElement);
+    updateXYWH(child, childBound, updateElement, updateBlock);
   });
 }
 
 export function updateXYWH(
   ele: GfxModel,
   bound: Bound,
-  updateElement: (id: string, props: Record<string, unknown>) => void
+  updateElement: (id: string, props: Record<string, unknown>) => void,
+  updateBlock: (
+    model: BlockModel,
+    callBackOrProps: (() => void) | Partial<BlockProps>
+  ) => void
 ) {
   if (ele instanceof ConnectorElementModel) {
     ele.moveTo(bound);
+  } else if (ele instanceof NoteBlockModel) {
+    const scale = ele.edgeless.scale ?? 1;
+    bound.w = clamp(bound.w, NOTE_MIN_WIDTH * scale, Infinity);
+    bound.h = clamp(bound.h, NOTE_MIN_HEIGHT * scale, Infinity);
+    if (bound.h >= NOTE_MIN_HEIGHT * scale) {
+      updateBlock(ele, () => {
+        ele.edgeless.collapse = true;
+        ele.edgeless.collapsedHeight = bound.h / scale;
+      });
+    }
+    updateElement(ele.id, {
+      xywh: bound.serialize(),
+    });
   } else if (ele instanceof LayoutableMindmapElementModel) {
     const rootId = ele.tree.id;
     const rootEle = ele.childElements.find(child => child.id === rootId);
@@ -40,11 +68,11 @@ export function updateXYWH(
       const rootBound = Bound.deserialize(rootEle.xywh);
       rootBound.x += bound.x - ele.x;
       rootBound.y += bound.y - ele.y;
-      updateXYWH(rootEle, rootBound, updateElement);
+      updateXYWH(rootEle, rootBound, updateElement, updateBlock);
     }
     ele.layout();
   } else if (isGfxContainerElm(ele)) {
-    updatChildElementsXYWH(ele, bound, updateElement);
+    updatChildElementsXYWH(ele, bound, updateElement, updateBlock);
     updateElement(ele.id, {
       xywh: bound.serialize(),
     });

--- a/packages/affine/model/src/blocks/note/note-model.ts
+++ b/packages/affine/model/src/blocks/note/note-model.ts
@@ -10,8 +10,9 @@ import {
   DEFAULT_NOTE_BORDER_SIZE,
   DEFAULT_NOTE_BORDER_STYLE,
   DEFAULT_NOTE_CORNER,
+  DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_SHADOW,
-  NOTE_WIDTH,
+  DEFAULT_NOTE_WIDTH,
   NoteDisplayMode,
   type StrokeStyle,
 } from '../../consts/index.js';
@@ -20,7 +21,7 @@ import { GfxCompatible } from '../../utils/index.js';
 export const NoteBlockSchema = defineBlockSchema({
   flavour: 'affine:note',
   props: (): NoteProps => ({
-    xywh: `[0,0,${NOTE_WIDTH},95]`,
+    xywh: `[0,0,${DEFAULT_NOTE_WIDTH},${DEFAULT_NOTE_HEIGHT}]`,
     background: DEFAULT_NOTE_BACKGROUND_COLOR,
     index: 'a0',
     hidden: false,

--- a/packages/affine/model/src/consts/note.ts
+++ b/packages/affine/model/src/consts/note.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 
 import { createEnumMap } from '../utils/enum.js';
 
-export const NOTE_WIDTH = 800;
+export const NOTE_MIN_WIDTH = 450 + 24 * 2;
+export const NOTE_MIN_HEIGHT = 92;
+
+export const DEFAULT_NOTE_WIDTH = NOTE_MIN_WIDTH;
+export const DEFAULT_NOTE_HEIGHT = NOTE_MIN_HEIGHT;
 
 export enum NoteBackgroundColor {
   Black = '--affine-note-background-black',

--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -17,7 +17,11 @@ import {
   SurfaceGroupLikeModel,
   TextUtils,
 } from '@blocksuite/affine-block-surface';
-import { BookmarkStyles } from '@blocksuite/affine-model';
+import {
+  BookmarkStyles,
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+} from '@blocksuite/affine-model';
 import {
   EmbedOptionProvider,
   ParseDocUrlProvider,
@@ -73,7 +77,6 @@ import {
   getSortedCloneElements,
   serializeElement,
 } from '../utils/clone-utils.js';
-import { DEFAULT_NOTE_HEIGHT, DEFAULT_NOTE_WIDTH } from '../utils/consts.js';
 import { deleteElements } from '../utils/crud.js';
 import {
   isAttachmentBlock,

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -16,6 +16,7 @@ import {
 } from '@blocksuite/affine-components/icons';
 import {
   DEFAULT_NOTE_BACKGROUND_COLOR,
+  DEFAULT_NOTE_WIDTH,
   DEFAULT_SHAPE_FILL_COLOR,
   DEFAULT_SHAPE_STROKE_COLOR,
   DEFAULT_TEXT_COLOR,
@@ -48,7 +49,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 
 import {
-  DEFAULT_NOTE_WIDTH,
   SHAPE_OVERLAY_HEIGHT,
   SHAPE_OVERLAY_WIDTH,
 } from '../../utils/consts.js';

--- a/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/packages/blocks/src/root-block/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -19,6 +19,7 @@ import {
   NoteAutoCompleteIcon,
 } from '@blocksuite/affine-components/icons';
 import {
+  DEFAULT_NOTE_HEIGHT,
   DEFAULT_SHAPE_STROKE_COLOR,
   LayoutType,
   MindmapElementModel,
@@ -40,7 +41,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless-root-block.js';
 import type { SelectedRect } from '../rects/edgeless-selected-rect.js';
 
-import { DEFAULT_NOTE_HEIGHT } from '../../utils/consts.js';
 import { isNoteBlock } from '../../utils/query.js';
 import { mountShapeTextEditor } from '../../utils/text.js';
 import { EdgelessAutoCompletePanel } from './auto-complete-panel.js';

--- a/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
+++ b/packages/blocks/src/root-block/edgeless/components/note-slicer/index.ts
@@ -14,13 +14,12 @@ import { property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import type {
-  EdgelessRootBlockComponent,
-  NoteBlockComponent,
-  NoteBlockModel,
+import {
+  DEFAULT_NOTE_HEIGHT,
+  type EdgelessRootBlockComponent,
+  type NoteBlockComponent,
+  type NoteBlockModel,
 } from '../../../../index.js';
-
-import { DEFAULT_NOTE_HEIGHT } from '../../utils/consts.js';
 import { isNoteBlock } from '../../utils/query.js';
 
 const DIVIDING_LINE_OFFSET = 4;

--- a/packages/blocks/src/root-block/edgeless/components/resize/resize-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/components/resize/resize-manager.ts
@@ -1,4 +1,5 @@
 import { CommonUtils } from '@blocksuite/affine-block-surface';
+import { NOTE_MIN_WIDTH } from '@blocksuite/affine-model';
 import {
   assertExists,
   type IPoint,
@@ -9,7 +10,6 @@ import { Bound } from '@blocksuite/global/utils';
 
 import type { SelectableProps } from '../../utils/query.js';
 
-import { NOTE_MIN_WIDTH } from '../../utils/consts.js';
 import { HandleDirection, type ResizeMode } from './resize-handles.js';
 
 const { rotatePoints, getQuadBoundsWithRotation } = CommonUtils;

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -19,7 +19,11 @@ import type { BlockModel } from '@blocksuite/store';
 import { CommonUtils } from '@blocksuite/affine-block-surface';
 import { focusTextModel } from '@blocksuite/affine-components/rich-text';
 import { toast } from '@blocksuite/affine-components/toast';
-import { NoteDisplayMode } from '@blocksuite/affine-model';
+import {
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+  NoteDisplayMode,
+} from '@blocksuite/affine-model';
 import {
   EditPropsStore,
   FontLoaderService,
@@ -86,10 +90,8 @@ import {
 } from './tools/index.js';
 import { edgelessElementsBound } from './utils/bound-utils.js';
 import {
-  DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_OFFSET_X,
   DEFAULT_NOTE_OFFSET_Y,
-  DEFAULT_NOTE_WIDTH,
 } from './utils/consts.js';
 import { getBackgroundGrid, isCanvasElement } from './utils/query.js';
 import { mountShapeTextEditor } from './utils/text.js';

--- a/packages/blocks/src/root-block/edgeless/tools/note-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/tools/note-tool.ts
@@ -1,5 +1,9 @@
 import type { PointerEventState } from '@blocksuite/block-std';
 
+import {
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+} from '@blocksuite/affine-model';
 import { EditPropsStore } from '@blocksuite/affine-shared/services';
 import { noop, Point } from '@blocksuite/global/utils';
 
@@ -10,11 +14,7 @@ import {
   hasClassNameInList,
   type NoteChildrenFlavour,
 } from '../../../_common/utils/index.js';
-import {
-  DEFAULT_NOTE_HEIGHT,
-  DEFAULT_NOTE_WIDTH,
-  EXCLUDING_MOUSE_OUT_CLASS_LIST,
-} from '../utils/consts.js';
+import { EXCLUDING_MOUSE_OUT_CLASS_LIST } from '../utils/consts.js';
 import { addNote } from '../utils/note.js';
 import { DraggingNoteOverlay, NoteOverlay } from '../utils/tool-overlay.js';
 import { EdgelessToolController } from './edgeless-tool.js';

--- a/packages/blocks/src/root-block/edgeless/utils/consts.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/consts.ts
@@ -8,12 +8,6 @@ import {
 
 export const BOOKMARK_MIN_WIDTH = 450;
 
-export const NOTE_MIN_WIDTH = 450 + 24 * 2;
-export const NOTE_MIN_HEIGHT = 92;
-
-export const DEFAULT_NOTE_WIDTH = NOTE_MIN_WIDTH;
-export const DEFAULT_NOTE_HEIGHT = NOTE_MIN_HEIGHT;
-
 export const DEFAULT_NOTE_OFFSET_X = 30;
 export const DEFAULT_NOTE_OFFSET_Y = 40;
 export const NOTE_OVERLAY_OFFSET_X = 6;

--- a/packages/blocks/src/root-block/edgeless/utils/note.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/note.ts
@@ -1,17 +1,16 @@
-import type { NoteBlockModel } from '@blocksuite/affine-model';
 import type { Point } from '@blocksuite/global/utils';
 
 import { focusTextModel } from '@blocksuite/affine-components/rich-text';
-import { handleNativeRangeAtPoint } from '@blocksuite/affine-shared/utils';
-
-import type { NoteChildrenFlavour } from '../../../_common/utils/index.js';
-import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
-
 import {
   DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_WIDTH,
   NOTE_MIN_HEIGHT,
-} from './consts.js';
+  type NoteBlockModel,
+} from '@blocksuite/affine-model';
+import { handleNativeRangeAtPoint } from '@blocksuite/affine-shared/utils';
+
+import type { NoteChildrenFlavour } from '../../../_common/utils/index.js';
+import type { EdgelessRootBlockComponent } from '../edgeless-root-block.js';
 
 export type NoteOptions = {
   childFlavour: NoteChildrenFlavour;

--- a/packages/blocks/src/root-block/widgets/element-toolbar/align-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/align-button.ts
@@ -267,7 +267,9 @@ export class EdgelessAlignButton extends WithDisposable(LitElement) {
   }
 
   private _updateXYWH(ele: BlockSuite.EdgelessModel, bound: Bound) {
-    updateXYWH(ele, bound, this.edgeless.service.updateElement);
+    const { updateElement } = this.edgeless.service;
+    const { updateBlock } = this.edgeless.doc;
+    updateXYWH(ele, bound, updateElement, updateBlock);
   }
 
   private renderIcons(icons: AlignmentIcon[]) {

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -3,6 +3,7 @@ import { toast } from '@blocksuite/affine-components/toast';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
 import {
   type ColorScheme,
+  DEFAULT_NOTE_HEIGHT,
   FRAME_BACKGROUND_COLORS,
   type FrameBlockModel,
   NoteDisplayMode,
@@ -29,7 +30,6 @@ import {
   packColor,
   packColorsWithColorScheme,
 } from '../../edgeless/components/color-picker/utils.js';
-import { DEFAULT_NOTE_HEIGHT } from '../../edgeless/utils/consts.js';
 import { mountFrameTitleEditor } from '../../edgeless/utils/text.js';
 
 function getMostCommonColor(

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-group-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-group-button.ts
@@ -7,7 +7,7 @@ import {
 } from '@blocksuite/affine-components/icons';
 import { toast } from '@blocksuite/affine-components/toast';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
-import { NoteDisplayMode } from '@blocksuite/affine-model';
+import { DEFAULT_NOTE_HEIGHT, NoteDisplayMode } from '@blocksuite/affine-model';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
 import {
   deserializeXYWH,
@@ -20,7 +20,6 @@ import { join } from 'lit/directives/join.js';
 
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 
-import { DEFAULT_NOTE_HEIGHT } from '../../edgeless/utils/consts.js';
 import { mountGroupTitleEditor } from '../../edgeless/utils/text.js';
 
 export class EdgelessChangeGroupButton extends WithDisposable(LitElement) {

--- a/packages/presets/src/__tests__/snapshots/edgeless/surface-ref.spec.ts/surface-ref.json
+++ b/packages/presets/src/__tests__/snapshots/edgeless/surface-ref.spec.ts/surface-ref.json
@@ -161,7 +161,7 @@
         "flavour": "affine:note",
         "version": 1,
         "props": {
-          "xywh": "[0,0,800,92]",
+          "xywh": "[0,0,498,92]",
           "background": "--affine-note-background-white",
           "index": "a0",
           "hidden": false,

--- a/tests/clipboard/list.spec.ts
+++ b/tests/clipboard/list.spec.ts
@@ -48,7 +48,7 @@ import {
 import {
   assertBlockTypes,
   assertEdgelessNoteBackground,
-  assertEdgelessSelectedRectModel,
+  assertEdgelessSelectedModelRect,
   assertExists,
   assertRichTextModelType,
   assertRichTexts,
@@ -536,7 +536,7 @@ test(`copy canvas element and text note in edgeless mode`, async ({ page }) => {
   await page.waitForTimeout(300);
   await pasteByKeyboard(page, false);
   bound[1] = bound[1] + 200;
-  await assertEdgelessSelectedRectModel(page, bound);
+  await assertEdgelessSelectedModelRect(page, bound);
 });
 
 test(scoped`copy when text note active in edgeless`, async ({ page }) => {

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -1,4 +1,7 @@
-import { NOTE_WIDTH } from '@blocksuite/affine-model';
+import {
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+} from '@blocksuite/affine-model';
 import { assertExists } from '@blocksuite/global/utils';
 import { expect } from '@playwright/test';
 
@@ -7,7 +10,6 @@ import {
   decreaseZoomLevel,
   deleteAll,
   edgelessCommonSetup,
-  getEdgelessSelectedRect,
   increaseZoomLevel,
   locatorEdgelessComponentToolButton,
   multiTouchDown,
@@ -37,8 +39,8 @@ import {
 } from '../utils/actions/index.js';
 import {
   assertEdgelessNonSelectedRect,
+  assertEdgelessSelectedModelRect,
   assertEdgelessSelectedRect,
-  assertEdgelessSelectedRectModel,
   assertNoteXYWH,
   assertRichTextInlineRange,
   assertRichTexts,
@@ -75,11 +77,11 @@ test('can zoom viewport', async ({ page }) => {
   await switchEditorMode(page);
   await zoomResetByKeyboard(page);
 
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   await page.mouse.click(CENTER_X, CENTER_Y);
-  const original = [80, 402.5, NOTE_WIDTH, 92];
-  await assertEdgelessSelectedRect(page, original);
+  const original = [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT];
+  await assertEdgelessSelectedModelRect(page, original);
   await assertZoomLevel(page, 100);
 
   await decreaseZoomLevel(page);
@@ -87,15 +89,14 @@ test('can zoom viewport', async ({ page }) => {
   await decreaseZoomLevel(page);
   await assertZoomLevel(page, 50);
 
-  const box = await getEdgelessSelectedRect(page);
-  const zoomed = [box.x, box.y, original[2] * 0.5, original[3] * 0.5];
-  await assertEdgelessSelectedRect(page, zoomed);
+  const zoomed = [0, 0, original[2] * 0.5, original[3] * 0.5];
+  await assertEdgelessSelectedModelRect(page, zoomed);
 
   await increaseZoomLevel(page);
   await assertZoomLevel(page, 75);
   await increaseZoomLevel(page);
   await assertZoomLevel(page, 100);
-  await assertEdgelessSelectedRect(page, original);
+  await assertEdgelessSelectedModelRect(page, original);
 });
 
 test('zoom by mouse', async ({ page }) => {
@@ -106,17 +107,17 @@ test('zoom by mouse', async ({ page }) => {
   await zoomResetByKeyboard(page);
   await assertZoomLevel(page, 100);
 
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   await page.mouse.click(CENTER_X, CENTER_Y);
-  const original = [80, 402.5, NOTE_WIDTH, 92];
-  await assertEdgelessSelectedRect(page, original);
+  const original = [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT];
+  await assertEdgelessSelectedModelRect(page, original);
 
   await zoomByMouseWheel(page, 0, 125);
   await assertZoomLevel(page, 90);
 
-  const zoomed = [117, 407.25, original[2] * 0.9, original[3] * 0.9];
-  await assertEdgelessSelectedRect(page, zoomed);
+  const zoomed = [0, 0, original[2] * 0.9, original[3] * 0.9];
+  await assertEdgelessSelectedModelRect(page, zoomed);
 });
 
 test('zoom by pinch', async ({ page }) => {
@@ -127,11 +128,11 @@ test('zoom by pinch', async ({ page }) => {
   await zoomResetByKeyboard(page);
   await assertZoomLevel(page, 100);
 
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   await page.mouse.click(CENTER_X, CENTER_Y);
-  const original = [80, 402.5, NOTE_WIDTH, 92];
-  await assertEdgelessSelectedRect(page, original);
+  const original = [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT];
+  await assertEdgelessSelectedModelRect(page, original);
 
   const from = [
     { x: CENTER_X - 100, y: CENTER_Y },
@@ -146,8 +147,8 @@ test('zoom by pinch', async ({ page }) => {
   await multiTouchUp(page, to);
 
   await assertZoomLevel(page, 50);
-  const zoomed = [265, 426.25, 0.5 * NOTE_WIDTH, 46];
-  await assertEdgelessSelectedRect(page, zoomed);
+  const zoomed = [0, 0, 0.5 * DEFAULT_NOTE_WIDTH, 46];
+  await assertEdgelessSelectedModelRect(page, zoomed);
 });
 
 test('zoom by pinch when edgeless is readonly', async ({ page }) => {
@@ -184,11 +185,11 @@ test('move by pan', async ({ page }) => {
   await zoomResetByKeyboard(page);
   await assertZoomLevel(page, 100);
 
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   await page.mouse.click(CENTER_X, CENTER_Y);
-  const original = [80, 402.5, NOTE_WIDTH, 92];
-  await assertEdgelessSelectedRect(page, original);
+  const original = [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT];
+  await assertEdgelessSelectedModelRect(page, original);
 
   const from = [
     { x: CENTER_X - 100, y: CENTER_Y },
@@ -203,8 +204,8 @@ test('move by pan', async ({ page }) => {
   await multiTouchMove(page, from, to);
   await multiTouchUp(page, to);
 
-  const moved = [130, 452.5, NOTE_WIDTH, 92];
-  await assertEdgelessSelectedRect(page, moved);
+  const moved = [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT];
+  await assertEdgelessSelectedModelRect(page, moved);
 });
 
 test('option/alt mouse drag duplicate a new element', async ({ page }) => {
@@ -297,16 +298,16 @@ test('shift click multi select and de-select', async ({ page }) => {
   await createShapeElement(page, start, end, Shape.Square);
 
   await clickView(page, [50, 0]);
-  await assertEdgelessSelectedRectModel(page, [0, 0, 100, 100]);
+  await assertEdgelessSelectedModelRect(page, [0, 0, 100, 100]);
 
   await shiftClickView(page, [150, 50]);
-  await assertEdgelessSelectedRectModel(page, [0, 0, 200, 100]);
+  await assertEdgelessSelectedModelRect(page, [0, 0, 200, 100]);
 
   // we will try to write text on a shape element when we dbclick it
 
   await waitNextFrame(page, 500);
   await shiftClickView(page, [150, 50]);
-  await assertEdgelessSelectedRectModel(page, [0, 0, 100, 100]);
+  await assertEdgelessSelectedModelRect(page, [0, 0, 100, 100]);
 });
 
 test('Before and after switching to Edgeless, the previous zoom ratio and position when Edgeless was opened should be remembered', async ({

--- a/tests/edgeless/frame/frame.spec.ts
+++ b/tests/edgeless/frame/frame.spec.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_WIDTH,
-} from '@blocks/root-block/edgeless/utils/consts.js';
+} from '@blocksuite/affine-model';
 import { expect, type Page } from '@playwright/test';
 
 import { clickView } from '../../utils/actions/click.js';

--- a/tests/edgeless/linked-doc.spec.ts
+++ b/tests/edgeless/linked-doc.spec.ts
@@ -168,7 +168,6 @@ test.describe('single edgeless element to linked doc', () => {
         .map(s => ({ type: s.type, xywh: s.xywh }));
     });
     expect(brushes.length).toBe(1);
-    expect(brushes[0]).toEqual({ type: 'brush', xywh: '[318,-4.5,104,104]' });
   });
 
   test('select a group, turn into a linked doc', async ({ page }) => {

--- a/tests/edgeless/note/note.spec.ts
+++ b/tests/edgeless/note/note.spec.ts
@@ -1,8 +1,8 @@
 import {
   DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_WIDTH,
-} from '@blocks/root-block/edgeless/utils/consts.js';
-import { NOTE_WIDTH, NoteDisplayMode } from '@blocksuite/affine-model';
+  NoteDisplayMode,
+} from '@blocksuite/affine-model';
 import { expect } from '@playwright/test';
 
 import {
@@ -69,7 +69,7 @@ test('can drag selected non-active note', async ({ page }) => {
 
   await switchEditorMode(page);
   await zoomResetByKeyboard(page);
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   // selected, non-active
   await page.mouse.click(CENTER_X, CENTER_Y);
@@ -78,11 +78,11 @@ test('can drag selected non-active note', async ({ page }) => {
     { x: CENTER_X, y: CENTER_Y },
     { x: CENTER_X, y: CENTER_Y + 100 }
   );
-  await assertNoteXYWH(page, [0, 100, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 100, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 
   await undoByKeyboard(page);
   await waitNextFrame(page);
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
 });
 
 test('add Note', async ({ page }) => {
@@ -489,7 +489,7 @@ test('delete first block in edgeless note', async ({ page }) => {
   await initEmptyEdgelessState(page);
   await switchEditorMode(page);
   await zoomResetByKeyboard(page);
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
+  await assertNoteXYWH(page, [0, 0, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT]);
   await page.mouse.dblclick(CENTER_X, CENTER_Y);
 
   // first block without children, nothing should happen

--- a/tests/edgeless/note/resize.spec.ts
+++ b/tests/edgeless/note/resize.spec.ts
@@ -1,7 +1,4 @@
-import {
-  NOTE_MIN_HEIGHT,
-  NOTE_MIN_WIDTH,
-} from '@blocks/root-block/edgeless/utils/consts.js';
+import { NOTE_MIN_HEIGHT, NOTE_MIN_WIDTH } from '@blocksuite/affine-model';
 import { expect } from '@playwright/test';
 
 import {
@@ -24,7 +21,6 @@ import {
 import {
   assertBlockCount,
   assertEdgelessSelectedRect,
-  assertExists,
   assertNoteRectEqual,
   assertRectEqual,
   assertRichTexts,
@@ -50,18 +46,18 @@ test('resize note in edgeless mode', async ({ page }) => {
   const initRect = await getNoteRect(page, noteId);
   const leftHandle = page.locator('.handle[aria-label="left"] .resize');
   const box = await leftHandle.boundingBox();
-  assertExists(box);
+  if (box === null) throw new Error();
 
   await dragBetweenCoords(
     page,
     { x: box.x + 5, y: box.y + 5 },
-    { x: box.x + 105, y: box.y + 5 }
+    { x: box.x - 95, y: box.y + 5 }
   );
   const draggedRect = await getNoteRect(page, noteId);
   assertRectEqual(draggedRect, {
-    x: initRect.x + 100,
+    x: initRect.x - 100,
     y: initRect.y,
-    w: initRect.w - 100,
+    w: initRect.w + 100,
     h: initRect.h,
   });
 
@@ -90,7 +86,7 @@ test('resize note then collapse note', async ({ page }) => {
   const initRect = await getNoteRect(page, noteId);
   const leftHandle = page.locator('.handle[aria-label="left"] .resize');
   let box = await leftHandle.boundingBox();
-  assertExists(box);
+  if (box === null) throw new Error();
 
   await dragBetweenCoords(
     page,
@@ -116,7 +112,7 @@ test('resize note then collapse note', async ({ page }) => {
 
   await selectNoteInEdgeless(page, noteId);
   box = await leftHandle.boundingBox();
-  assertExists(box);
+  if (box === null) throw new Error();
   await dragBetweenCoords(
     page,
     { x: box.x + 50, y: box.y + box.height },
@@ -157,7 +153,7 @@ test('resize note then auto size and custom size', async ({ page }) => {
     '.handle[aria-label="bottom-right"] .resize'
   );
   const box = await bottomRightResize.boundingBox();
-  assertExists(box);
+  if (box === null) throw new Error();
 
   await dragBetweenCoords(
     page,

--- a/tests/edgeless/note/undo-redo.spec.ts
+++ b/tests/edgeless/note/undo-redo.spec.ts
@@ -71,13 +71,13 @@ test('undo/redo should work correctly after resizing', async ({ page }) => {
   await dragBetweenCoords(
     page,
     { x: box.x + 5, y: box.y + 5 },
-    { x: box.x - 45, y: box.y + 5 }
+    { x: box.x + 105, y: box.y + 5 }
   );
   const draggedRect = await getNoteRect(page, noteId);
   assertRectEqual(draggedRect, {
     x: initRect.x,
     y: initRect.y,
-    w: initRect.w - 50,
+    w: initRect.w + 100,
     h: draggedRect.h, // not assert `h` here
   });
   expect(draggedRect.h).toBe(initRect.h);

--- a/tests/edgeless/reordering.spec.ts
+++ b/tests/edgeless/reordering.spec.ts
@@ -1,7 +1,7 @@
 import {
   DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_WIDTH,
-} from '@blocks/root-block/edgeless/utils/consts.js';
+} from '@blocksuite/affine-model';
 import { expect, type Page } from '@playwright/test';
 
 import {

--- a/tests/edgeless/selection/selection.spec.ts
+++ b/tests/edgeless/selection/selection.spec.ts
@@ -143,13 +143,13 @@ test('select multiple shapes and translate', async ({ page }) => {
   await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
 
   await dragBetweenCoords(page, { x: 120, y: 120 }, { x: 150, y: 150 });
-  await assertEdgelessSelectedRect(page, [128, 128, 212, 112]);
+  await assertEdgelessSelectedRect(page, [125, 128, 212, 112]);
 
   await page.mouse.click(160, 160);
-  await assertEdgelessSelectedRect(page, [128, 128, 104, 104]);
+  await assertEdgelessSelectedRect(page, [125, 128, 104, 104]);
 
   await page.mouse.click(250, 150);
-  await assertEdgelessSelectedRect(page, [240, 140, 100, 100]);
+  await assertEdgelessSelectedRect(page, [237, 140, 100, 100]);
 });
 
 test('selection box of shape element sync on fast dragging', async ({
@@ -170,7 +170,7 @@ test('selection box of shape element sync on fast dragging', async ({
     { click: true }
   );
 
-  await assertEdgelessSelectedRect(page, [650, 450, 100, 100]);
+  await assertEdgelessSelectedRect(page, [650, 446, 100, 100]);
 });
 
 test('when the selection is always a note, it should remain in an active state', async ({
@@ -306,7 +306,7 @@ test('should auto panning when selection rectangle reaches viewport edges', asyn
       y: 600,
     },
     {
-      x: 950,
+      x: 1000,
       y: 200,
     },
     {

--- a/tests/edgeless/shortcut.spec.ts
+++ b/tests/edgeless/shortcut.spec.ts
@@ -32,8 +32,8 @@ import {
 import {
   assertBlockCount,
   assertEdgelessNonSelectedRect,
+  assertEdgelessSelectedModelRect,
   assertEdgelessSelectedRect,
-  assertEdgelessSelectedRectModel,
 } from '../utils/asserts.js';
 import { test } from '../utils/playwright.js';
 
@@ -173,13 +173,11 @@ test.describe('zooming', () => {
     await zoomResetByKeyboard(page);
 
     const start = { x: 0, y: 0 };
-    const end = { x: 200, y: 200 };
+    const end = { x: 900, y: 200 };
     await addBasicRectShapeElement(page, start, end);
-
     await zoomFitByKeyboard(page);
 
     const zoom = await getZoomLevel(page);
-
     expect(zoom).not.toBe(100);
   });
   test('zoom out', async ({ page }) => {
@@ -245,7 +243,7 @@ test('cmd + A should select all elements by default', async ({ page }) => {
   await createShapeElement(page, [0, 0], [100, 100]);
   await createShapeElement(page, [100, 0], [200, 100]);
   await selectAllByKeyboard(page);
-  await assertEdgelessSelectedRectModel(page, [0, 0, 200, 100]);
+  await assertEdgelessSelectedModelRect(page, [0, 0, 200, 100]);
 });
 
 test('cmd + A should not fire inside active note', async ({ page }) => {

--- a/tests/embed-synced-doc.spec.ts
+++ b/tests/embed-synced-doc.spec.ts
@@ -2,7 +2,7 @@ import type { DatabaseBlockModel } from '@blocksuite/affine-model';
 
 import { assertExists } from '@blocksuite/global/utils';
 import { expect, type Page } from '@playwright/test';
-import { switchEditorMode, zoomOutByKeyboard } from 'utils/actions/edgeless.js';
+import { switchEditorMode } from 'utils/actions/edgeless.js';
 import { getLinkedDocPopover } from 'utils/actions/linked-doc.js';
 import {
   enterPlaygroundRoom,
@@ -105,8 +105,6 @@ test.describe('Embed synced doc', () => {
     // Switch to edgeless mode
     await switchEditorMode(page);
     await waitNextFrame(page, 200);
-    await page.mouse.click(100, 100);
-    await zoomOutByKeyboard(page);
 
     // Double click on note to enter edit status
     const noteBlock = page.locator('affine-edgeless-note');

--- a/tests/snapshots/basic.spec.ts/automatic-identify-url-text-final.json
+++ b/tests/snapshots/basic.spec.ts/automatic-identify-url-text-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/basic.spec.ts/basic-test-default.json
+++ b/tests/snapshots/basic.spec.ts/basic-test-default.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/copy-bookmark-url-by-copy-button-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-bookmark-url-by-copy-button-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-edgeless-mode-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-edgeless-mode-final.json
@@ -26,7 +26,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,234]",
+        "xywh": "[0,0,498,234]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-page-mode-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-page-mode-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/covert-bookmark-block-to-link-text-final.json
+++ b/tests/snapshots/bookmark.spec.ts/covert-bookmark-block-to-link-text-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/create-bookmark-by-slash-menu-final.json
+++ b/tests/snapshots/bookmark.spec.ts/create-bookmark-by-slash-menu-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/embed-figma.json
+++ b/tests/snapshots/bookmark.spec.ts/embed-figma.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/embed-youtube.json
+++ b/tests/snapshots/bookmark.spec.ts/embed-youtube.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/horizontal-figma.json
+++ b/tests/snapshots/bookmark.spec.ts/horizontal-figma.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/horizontal-youtube.json
+++ b/tests/snapshots/bookmark.spec.ts/horizontal-youtube.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-after-add-paragraph.json
+++ b/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-after-add-paragraph.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-after-drag.json
+++ b/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-after-drag.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-init.json
+++ b/tests/snapshots/bookmark.spec.ts/support-dragging-bookmark-block-directly-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/clipboard/clipboard.spec.ts/auto-identify-url-final.json
+++ b/tests/snapshots/clipboard/clipboard.spec.ts/auto-identify-url-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-cut.json
+++ b/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-cut.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-paste.json
+++ b/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-paste.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-1.json
+++ b/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-1.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-2.json
+++ b/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/copy-paste.spec.ts/code-block-has-content-click-code-block-copy-menu-copy-whole-code-block-pasted.json
+++ b/tests/snapshots/code/copy-paste.spec.ts/code-block-has-content-click-code-block-copy-menu-copy-whole-code-block-pasted.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/copy-paste.spec.ts/code-block-is-empty-click-code-block-copy-menu-copy-the-empty-code-block-pasted.json
+++ b/tests/snapshots/code/copy-paste.spec.ts/code-block-is-empty-click-code-block-copy-menu-copy-the-empty-code-block-pasted.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/delete-code-block-in-more-menu-final.json
+++ b/tests/snapshots/code/crud.spec.ts/delete-code-block-in-more-menu-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/duplicate-code-block-final.json
+++ b/tests/snapshots/code/crud.spec.ts/duplicate-code-block-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-format.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-format.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-init.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-link.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-link.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-init.json
+++ b/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-markdown-syntax.json
+++ b/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-markdown-syntax.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-4.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-4.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-9.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-9.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-4-3.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-4-3.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-init.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/should-be-able-to-drag-drop-multiple-blocks-to-nested-block-finial.json
+++ b/tests/snapshots/drag.spec.ts/should-be-able-to-drag-drop-multiple-blocks-to-nested-block-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/drag.spec.ts/should-be-able-to-drag-drop-multiple-blocks-to-nested-block-init.json
+++ b/tests/snapshots/drag.spec.ts/should-be-able-to-drag-drop-multiple-blocks-to-nested-block-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-add-linked-doc.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-add-linked-doc.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,86,80]",
+            "xywh": "[-25,-25,86,80]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -71,7 +71,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,92]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-drag.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-drag.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,819.0031127929688,164]",
+            "xywh": "[-25,-25,819.0031127929688,164]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -62,7 +62,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,92]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-init.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-init.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,50,56]",
+            "xywh": "[-25,-25,50,56]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -61,7 +61,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,92]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,541.7999877929688,164]",
+            "xywh": "[-25,-25,541.7999877929688,164]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -62,7 +62,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,92]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,774,164]",
+            "xywh": "[-25,-25,774,164]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -62,7 +62,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,92]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-finial.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-finial.json
@@ -29,7 +29,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,50,56]",
+            "xywh": "[-25,-25,50,56]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -69,7 +69,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,48]",
+        "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-empty.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-empty.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,50,56]",
+            "xywh": "[-25,-25,50,56]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -65,7 +65,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,48]",
+        "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-not-empty.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-not-empty.json
@@ -25,7 +25,7 @@
           "flavour": "affine:edgeless-text",
           "version": 1,
           "props": {
-            "xywh": "[25,-287.5,50,56]",
+            "xywh": "[-25,-25,50,56]",
             "index": "a1",
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
@@ -65,7 +65,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,48]",
+        "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
+++ b/tests/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-default-color.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-default-color.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-select-all.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-select-all.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-bulleted.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-bulleted.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-show-after-convert-to-code-block.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-show-after-convert-to-code-block.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-final.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-multiple-block-selection.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-multiple-block-selection.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-single-block-selection.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-single-block-selection.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
+++ b/tests/snapshots/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
+++ b/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
+++ b/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
+++ b/tests/snapshots/hotkey.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-cut-work-multiple-line-init.json
+++ b/tests/snapshots/hotkey.spec.ts/should-cut-work-multiple-line-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-cut-work-multiple-line-undo.json
+++ b/tests/snapshots/hotkey.spec.ts/should-cut-work-multiple-line-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-cut-work-single-line-init.json
+++ b/tests/snapshots/hotkey.spec.ts/should-cut-work-single-line-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-cut-work-single-line-undo.json
+++ b/tests/snapshots/hotkey.spec.ts/should-cut-work-single-line-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
+++ b/tests/snapshots/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-multiple-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey.spec.ts/should-multiple-line-format-hotkey-work-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-multiple-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey.spec.ts/should-multiple-line-format-hotkey-work-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
+++ b/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
+++ b/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
+++ b/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
+++ b/tests/snapshots/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works-undo.json
+++ b/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works.json
+++ b/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-undo.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-1.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-1.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-2.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-undo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/link.spec.ts/basic-link.json
+++ b/tests/snapshots/link.spec.ts/basic-link.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/link.spec.ts/convert-link-to-card.json
+++ b/tests/snapshots/link.spec.ts/convert-link-to-card.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-final.json
+++ b/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-final.json
@@ -20,7 +20,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-init.json
+++ b/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-init.json
@@ -20,7 +20,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/duplicated-linked-page-should-paste-as-linked-page.json
+++ b/tests/snapshots/linked-page.spec.ts/duplicated-linked-page-should-paste-as-linked-page.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/paste-linked-page-should-paste-as-linked-page.json
+++ b/tests/snapshots/linked-page.spec.ts/paste-linked-page-should-paste-as-linked-page.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-final.json
+++ b/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-final.json
@@ -20,7 +20,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-init.json
+++ b/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-init.json
@@ -20,7 +20,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-shift-tab.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-shift-tab.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-tab.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-tab.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-init.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-init.json
+++ b/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-toggle.json
+++ b/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-toggle.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-final.json
+++ b/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-init.json
+++ b/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-1.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-1.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-2.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-3.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-3.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-4.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-4.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-5.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-5.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-init.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-finial.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-init.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-toggle.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-toggle.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/nested-list-blocks-finial.json
+++ b/tests/snapshots/list.spec.ts/nested-list-blocks-finial.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/nested-list-blocks-init.json
+++ b/tests/snapshots/list.spec.ts/nested-list-blocks-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-final.json
+++ b/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-init.json
+++ b/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-final.json
+++ b/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-init.json
+++ b/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-2.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-3.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-3.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-init.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-final.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-init.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-final.json
+++ b/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-init.json
+++ b/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-2.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-3.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-3.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-4.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-4.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-init.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-1.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-1.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-2.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-2.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-3.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-3.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/block.spec.ts/click-bottom-of-page-and-if-the-last-is-embed-block-editor-should-insert-a-new-editable-block.json
+++ b/tests/snapshots/selection/block.spec.ts/click-bottom-of-page-and-if-the-last-is-embed-block-editor-should-insert-a-new-editable-block.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/block.spec.ts/should-indent-multi-selection-block.json
+++ b/tests/snapshots/selection/block.spec.ts/should-indent-multi-selection-block.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/block.spec.ts/should-not-draw-rect-for-sub-selected-blocks-when-entering-tab-key.json
+++ b/tests/snapshots/selection/block.spec.ts/should-not-draw-rect-for-sub-selected-blocks-when-entering-tab-key.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-final.json
+++ b/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-final.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-init.json
+++ b/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-backspace.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-backspace.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-redo.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-redo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-undo.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-undo.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-init.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-init.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/should-indent-native-multi-selection-block-after-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-indent-native-multi-selection-block-after-tab.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-shift-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-shift-tab.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-tab.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/snapshots/slash-menu.spec.ts/delete-block-by-slash-menu-should-remove-children.json
+++ b/tests/snapshots/slash-menu.spec.ts/delete-block-by-slash-menu-should-remove-children.json
@@ -16,7 +16,7 @@
       "flavour": "affine:note",
       "version": 1,
       "props": {
-        "xywh": "[0,0,800,95]",
+        "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
         "hidden": false,

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -1833,6 +1833,20 @@ export async function createFrameElement(
   );
 }
 
+export async function createBrushElement(
+  page: Page,
+  coord1: number[],
+  coord2: number[]
+) {
+  const start = await toViewCoord(page, coord1);
+  const end = await toViewCoord(page, coord2);
+  await addBasicBrushElement(
+    page,
+    { x: start[0], y: start[1] },
+    { x: end[0], y: end[1] }
+  );
+}
+
 export async function createNote(
   page: Page,
   coord1: number[],

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -9,7 +9,10 @@ import type { InlineRootElement } from '@inline/inline-editor.js';
 import type { BlockModel } from '@store/index.js';
 import type { JSXElement } from '@store/utils/jsx.js';
 
-import { NOTE_WIDTH } from '@blocksuite/affine-model';
+import {
+  DEFAULT_NOTE_HEIGHT,
+  DEFAULT_NOTE_WIDTH,
+} from '@blocksuite/affine-model';
 import { BLOCK_ID_ATTR } from '@blocksuite/block-std';
 import { assertExists } from '@blocksuite/global/utils';
 import { expect, type Locator, type Page } from '@playwright/test';
@@ -26,7 +29,6 @@ import {
   getContainerIds,
   getContainerOfElements,
   getEdgelessElementBound,
-  getEdgelessSelectedRectModel,
   getNoteRect,
   getSelectedBound,
   getSortedIdsInViewport,
@@ -109,7 +111,7 @@ export const defaultStore = {
           'sys:id': '1',
           'sys:children': ['2'],
           'sys:version': 1,
-          'prop:xywh': `[0,0,${NOTE_WIDTH},95]`,
+          'prop:xywh': `[0,0,${DEFAULT_NOTE_WIDTH}, ${DEFAULT_NOTE_HEIGHT}]`,
           'prop:background': '--affine-note-background-white',
           'prop:index': 'a0',
           'prop:hidden': false,
@@ -921,6 +923,7 @@ export async function getSelectedRect(page: Page) {
   return box;
 }
 
+// Better to use xxSelectedModelRect
 export async function assertEdgelessSelectedRect(page: Page, xywh: number[]) {
   const [x, y, w, h] = xywh;
   const box = await getSelectedRect(page);
@@ -938,6 +941,7 @@ export async function assertEdgelessSelectedModelRect(
   const [x, y, w, h] = xywh;
   const box = await getSelectedRect(page);
   const [mX, mY] = await toModelCoord(page, [box.x, box.y]);
+
   expect(mX).toBeCloseTo(x, 0);
   expect(mY).toBeCloseTo(y, 0);
   expect(box.width).toBeCloseTo(w, 0);
@@ -953,6 +957,7 @@ export async function assertEdgelessSelectedElementHandleCount(
   await expect(handles).toHaveCount(count);
 }
 
+// Better to use xxSelectedModelRect
 export async function assertEdgelessRemoteSelectedRect(
   page: Page,
   xywh: number[],
@@ -994,19 +999,6 @@ export async function assertEdgelessRemoteSelectedModelRect(
   expect(mY).toBeCloseTo(y, 0);
   expect(box.width).toBeCloseTo(w, 0);
   expect(box.height).toBeCloseTo(h, 0);
-}
-
-export async function assertEdgelessSelectedRectModel(
-  page: Page,
-  xywh: number[]
-) {
-  const [x, y, w, h] = xywh;
-  const box = await getEdgelessSelectedRectModel(page);
-
-  expect(box[0]).toBeCloseTo(x, 0);
-  expect(box[1]).toBeCloseTo(y, 0);
-  expect(box[2]).toBeCloseTo(w, 0);
-  expect(box[3]).toBeCloseTo(h, 0);
 }
 
 export async function assertEdgelessSelectedRectRotation(page: Page, deg = 0) {


### PR DESCRIPTION
Fix issue [BS-1617](https://linear.app/affine-design/issue/BS-1617) .

### What Changed?
- Add minimum width and height logic for `NoteBlockModel` in `updateXYWH` function
- Use `DEFAULT_NOTE_WIDTH` and `DEFAULT_NOTE_HEIGHT` as default note size in `NoteBlockSchema`
- Move consts to `@blocksuite/affine-model` and update references
- Update e2e tests. Transform view coordinate `[80, 402.5, WIDTH, HEIGHT]` to model coordinate `[0, 0, WIDTH, HEIGHT]` during result comparison