### PR TITLE
fix: newly created note alignments cannot be stored persistently

### DIFF
--- a/packages/blocks/src/note-block/note-edgeless-block.ts
+++ b/packages/blocks/src/note-block/note-edgeless-block.ts
@@ -50,6 +50,7 @@ export class EdgelessNoteMask extends WithDisposable(ShadowlessElement) {
           bound.h = height;
           this.model.stash('xywh');
           this.model.xywh = bound.serialize();
+          this.model.pop('xywh');
         }
       }
     });
@@ -57,10 +58,6 @@ export class EdgelessNoteMask extends WithDisposable(ShadowlessElement) {
     observer.observe(maskDOM!);
 
     this._disposables.add(() => {
-      // check if model still exist
-      if (this.model.doc.getBlockById(this.model.id)) {
-        this.model.pop('xywh');
-      }
       observer.disconnect();
     });
   }

--- a/tests/edgeless/note/note.spec.ts
+++ b/tests/edgeless/note/note.spec.ts
@@ -82,7 +82,7 @@ test('can drag selected non-active note', async ({ page }) => {
 
   await undoByKeyboard(page);
   await waitNextFrame(page);
-  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 95]);
+  await assertNoteXYWH(page, [0, 0, NOTE_WIDTH, 92]);
 });
 
 test('add Note', async ({ page }) => {

--- a/tests/edgeless/selection/selection.spec.ts
+++ b/tests/edgeless/selection/selection.spec.ts
@@ -21,7 +21,9 @@ import {
 } from '../../utils/actions/index.js';
 import {
   assertBlockCount,
+  assertEdgelessRemoteSelectedModelRect,
   assertEdgelessRemoteSelectedRect,
+  assertEdgelessSelectedModelRect,
   assertEdgelessSelectedRect,
   assertSelectionInNote,
 } from '../../utils/asserts.js';
@@ -91,12 +93,18 @@ test('should update react of remote selection when resizing viewport', async ({
   await actions.switchEditorMode(pageB);
   await actions.zoomResetByKeyboard(pageB);
 
-  await addBasicRectShapeElement(pageA, { x: 100, y: 100 }, { x: 200, y: 200 });
-  await click(pageA, { x: 110, y: 110 });
-  await click(pageB, { x: 110, y: 110 });
+  await actions.createShapeElement(
+    pageA,
+    [0, 0],
+    [100, 100],
+    actions.Shape.Square
+  );
+  const point = await actions.toViewCoord(pageA, [50, 50]);
+  await click(pageA, { x: point[0], y: point[1] });
+  await click(pageB, { x: point[0], y: point[1] });
 
-  await assertEdgelessSelectedRect(pageB, [100, 100, 100, 100]);
-  await assertEdgelessRemoteSelectedRect(pageB, [100, 100, 100, 100]);
+  await assertEdgelessSelectedModelRect(pageB, [0, 0, 100, 100]);
+  await assertEdgelessRemoteSelectedModelRect(pageB, [0, 0, 100, 100]);
 
   // to 50%
   await actions.decreaseZoomLevel(pageB);

--- a/tests/utils/asserts.ts
+++ b/tests/utils/asserts.ts
@@ -32,6 +32,7 @@ import {
   getSortedIdsInViewport,
   getZoomLevel,
   toIdCountMap,
+  toModelCoord,
 } from './actions/edgeless.js';
 import {
   pressArrowLeft,
@@ -930,6 +931,19 @@ export async function assertEdgelessSelectedRect(page: Page, xywh: number[]) {
   expect(box.height).toBeCloseTo(h, 0);
 }
 
+export async function assertEdgelessSelectedModelRect(
+  page: Page,
+  xywh: number[]
+) {
+  const [x, y, w, h] = xywh;
+  const box = await getSelectedRect(page);
+  const [mX, mY] = await toModelCoord(page, [box.x, box.y]);
+  expect(mX).toBeCloseTo(x, 0);
+  expect(mY).toBeCloseTo(y, 0);
+  expect(box.width).toBeCloseTo(w, 0);
+  expect(box.height).toBeCloseTo(h, 0);
+}
+
 export async function assertEdgelessSelectedElementHandleCount(
   page: Page,
   count: number
@@ -956,6 +970,28 @@ export async function assertEdgelessRemoteSelectedRect(
 
   expect(box.x).toBeCloseTo(x, 0);
   expect(box.y).toBeCloseTo(y, 0);
+  expect(box.width).toBeCloseTo(w, 0);
+  expect(box.height).toBeCloseTo(h, 0);
+}
+
+export async function assertEdgelessRemoteSelectedModelRect(
+  page: Page,
+  xywh: number[],
+  index = 0
+) {
+  const [x, y, w, h] = xywh;
+  const editor = getEditorLocator(page);
+  const remoteSelectedRect = editor
+    .locator('affine-edgeless-remote-selection-widget')
+    .locator('.remote-rect')
+    .nth(index);
+
+  const box = await remoteSelectedRect.boundingBox();
+  if (!box) throw new Error('Missing edgeless remote selected rect');
+
+  const [mX, mY] = await toModelCoord(page, [box.x, box.y]);
+  expect(mX).toBeCloseTo(x, 0);
+  expect(mY).toBeCloseTo(y, 0);
   expect(box.width).toBeCloseTo(w, 0);
   expect(box.height).toBeCloseTo(h, 0);
 }


### PR DESCRIPTION
Fix issue [BS-1582](https://linear.app/affine-design/issue/BS-1582).

According to code in `sync-controller.ts`, if `xywh` has being stashed, the data in `yjs` can not be updated.

https://github.com/toeverything/blocksuite/blob/4493df8ab9f06e4bf52460505d446095a51b65eb/packages/framework/store/src/store/doc/block/sync-controller.ts#L173

