### PR TITLE
fix(database): avoid filter bar flickering

### DIFF
--- a/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
+++ b/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
@@ -32,11 +32,15 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
 
   protected _frameId: number | undefined = undefined;
 
-  adjustStyle() {
+  adjustStyle(ignoreCache = false) {
     const rectWidth = this.getBoundingClientRect().width;
     const cacheKey = `${rectWidth}-${this.items.length}`;
 
-    if (this._countCache[0] === cacheKey && this._countCache[1] !== -1) {
+    if (
+      !!ignoreCache &&
+      this._countCache[0] === cacheKey &&
+      this._countCache[1] !== -1
+    ) {
       this.renderCount = this._countCache[1];
       return;
     }
@@ -90,7 +94,9 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
     }
 
     this._frameId = requestAnimationFrame(() => {
-      this.adjustStyle();
+      // when `updated` is invoked, it usually means user has changed the data
+      // so any item may change its size, we need to re-calculate the size
+      this.adjustStyle(true);
     });
   }
 

--- a/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
+++ b/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
@@ -23,22 +23,16 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
     }
   `;
 
-  protected _frameId: number | undefined = undefined;
+  protected frameId: number | undefined = undefined;
 
-  /**
-   * if the width of `more` may change, the UI may flicker
-   * because the width of `more` is not stable, we need to calculate the max width of `more`
-   */
-  protected _maxMoreWidth = -1;
-
-  widthList: number[] = [];
+  protected widthList: number[] = [];
 
   adjustStyle() {
-    if (this._frameId) {
-      cancelAnimationFrame(this._frameId);
+    if (this.frameId) {
+      cancelAnimationFrame(this.frameId);
     }
 
-    this._frameId = requestAnimationFrame(() => {
+    this.frameId = requestAnimationFrame(() => {
       this.doAdjustStyle();
     });
   }
@@ -54,10 +48,12 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
     });
   }
 
-  doAdjustStyle() {
+  protected doAdjustStyle() {
     const moreWidth = this.more.getBoundingClientRect().width;
     this.widthList[this.renderCount] = moreWidth;
-    const maxWidth = this.getBoundingClientRect().width;
+
+    const containerWidth = this.getBoundingClientRect().width;
+
     let width = 0;
     for (let i = 0; i < this.items.length; i++) {
       const itemWidth = this.items[i].getBoundingClientRect().width;
@@ -65,29 +61,11 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
       // if it exceeds the limit, render n items(in i++ round).
       const totalWidth =
         width + itemWidth + (this.widthList[i + 1] ?? moreWidth);
-      if (totalWidth > maxWidth) {
+      if (totalWidth > containerWidth) {
         this.renderCount = i;
         return;
       }
       width += itemWidth;
-    }
-    this.renderCount = this.items.length;
-  }
-
-  protected doAdjustStyle1() {
-    this._maxMoreWidth = Math.max(
-      this._maxMoreWidth,
-      this.more.getBoundingClientRect().width
-    );
-
-    let maxWidth = this.getBoundingClientRect().width - this._maxMoreWidth;
-    for (let i = 0; i < this.items.length; i++) {
-      const width = this.items[i].getBoundingClientRect().width;
-      maxWidth -= width;
-      if (maxWidth < 0) {
-        this.renderCount = i;
-        return;
-      }
     }
     this.renderCount = this.items.length;
   }

--- a/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
+++ b/packages/affine/data-view/src/core/common/component/overflow/overflow.ts
@@ -31,6 +31,8 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
    */
   protected _maxMoreWidth = -1;
 
+  widthList: number[] = [];
+
   adjustStyle() {
     if (this._frameId) {
       cancelAnimationFrame(this._frameId);
@@ -52,7 +54,27 @@ export class Overflow extends SignalWatcher(WithDisposable(ShadowlessElement)) {
     });
   }
 
-  protected doAdjustStyle() {
+  doAdjustStyle() {
+    const moreWidth = this.more.getBoundingClientRect().width;
+    this.widthList[this.renderCount] = moreWidth;
+    const maxWidth = this.getBoundingClientRect().width;
+    let width = 0;
+    for (let i = 0; i < this.items.length; i++) {
+      const itemWidth = this.items[i].getBoundingClientRect().width;
+      // Try to calculate the width occupied by rendering n+1 items;
+      // if it exceeds the limit, render n items(in i++ round).
+      const totalWidth =
+        width + itemWidth + (this.widthList[i + 1] ?? moreWidth);
+      if (totalWidth > maxWidth) {
+        this.renderCount = i;
+        return;
+      }
+      width += itemWidth;
+    }
+    this.renderCount = this.items.length;
+  }
+
+  protected doAdjustStyle1() {
     this._maxMoreWidth = Math.max(
       this._maxMoreWidth,
       this.more.getBoundingClientRect().width


### PR DESCRIPTION
https://github.com/user-attachments/assets/49aedca7-4f50-4c4c-aa27-e84b902b794b

close: #8560 

the problem cause is that we render both `add filter` and `{n} more` on `more view`, so the `renderCount` changes every times when recalculate.

first time we calculate it can place 3 items, after render, we can only place 2 items, and we will re-render...