### PR TITLE
feat(blocks): support more markdown transformer api

### DIFF
--- a/packages/blocks/src/_common/transformers/middlewares.ts
+++ b/packages/blocks/src/_common/transformers/middlewares.ts
@@ -274,3 +274,25 @@ export const embedSyncedDocMiddleware =
   ({ adapterConfigs }) => {
     adapterConfigs.set('embedSyncedDocExportType', type);
   };
+
+export const fileNameMiddleware =
+  (fileName?: string): JobMiddleware =>
+  ({ slots }) => {
+    slots.beforeImport.on(payload => {
+      if (payload.type !== 'page') {
+        return;
+      }
+      if (!fileName) {
+        return;
+      }
+      payload.snapshot.meta.title = fileName;
+      payload.snapshot.blocks.props.title = {
+        '$blocksuite:internal:text$': true,
+        delta: [
+          {
+            insert: fileName,
+          },
+        ],
+      };
+    });
+  };

--- a/packages/playground/apps/starter/data/preset.ts
+++ b/packages/playground/apps/starter/data/preset.ts
@@ -22,9 +22,9 @@ export const preset: InitFn = async (collection: DocCollection, id: string) => {
   );
 
   // Import preset markdown content inside note block
-  await MarkdownTransformer.importMarkdown({
+  await MarkdownTransformer.importMarkdownToBlock({
     doc,
-    noteId,
+    blockId: noteId,
     markdown: presetMarkdown,
   });
 

--- a/packages/playground/apps/starter/data/synced.ts
+++ b/packages/playground/apps/starter/data/synced.ts
@@ -36,9 +36,9 @@ export const synced: InitFn = (collection: DocCollection, id: string) => {
     const noteId = docSyncedPage.addBlock('affine:note', {}, rootId);
 
     // Add markdown to note block
-    MarkdownTransformer.importMarkdown({
+    MarkdownTransformer.importMarkdownToBlock({
       doc: docSyncedPage,
-      noteId,
+      blockId: noteId,
       markdown: syncedDocMarkdown,
     }).catch(console.error);
   });
@@ -55,9 +55,9 @@ export const synced: InitFn = (collection: DocCollection, id: string) => {
     const noteId = docSyncedEdgeless.addBlock('affine:note', {}, rootId);
 
     // Add markdown to note block
-    MarkdownTransformer.importMarkdown({
+    MarkdownTransformer.importMarkdownToBlock({
       doc: docSyncedEdgeless,
-      noteId,
+      blockId: noteId,
       markdown: syncedDocMarkdown,
     }).catch(console.error);
   });
@@ -72,9 +72,9 @@ export const synced: InitFn = (collection: DocCollection, id: string) => {
     const noteId = docMain.addBlock('affine:note', {}, rootId);
 
     // Add markdown to note block
-    MarkdownTransformer.importMarkdown({
+    MarkdownTransformer.importMarkdownToBlock({
       doc: docMain,
-      noteId,
+      blockId: noteId,
       markdown: syncedDocMarkdown,
     })
       .then(() => {


### PR DESCRIPTION
[BS-1625](https://linear.app/affine-design/issue/BS-1625/markdown-transformer-支持多种导入方式)

Modified:
`importMarkdown` -> `importMarkdownToBlock`

New added:
```
type ImportMarkdownToDocOptions = {
  collection: DocCollection;
  markdown: string;
  fileName?: string;
};

type ImportMarkdownZipOptions = {
  collection: DocCollection;
  imported: Blob;
};

async function importMarkdownToDoc(options: ImportMarkdownToDocOptions): Promise<string>

async function importMarkdownZip(options: ImportMarkdownZipOptions): Promise<string[]>
```

Now the importMarkdownZip function supports importing markdown files with assets, which means it can properly import markdown images.
