### PR TITLE
refactor(blocks): remove hover state after button pressed in mobile

### DIFF
--- a/packages/blocks/src/_common/components/button.ts
+++ b/packages/blocks/src/_common/components/button.ts
@@ -41,8 +41,11 @@ export class IconButton extends LitElement {
       padding: 4px;
     }
 
-    :host(:hover) {
-      background: var(--affine-hover-color);
+    // This media query can detect if the device has a hover capability
+    @media (hover: hover) {
+      :host(:hover) {
+        background: var(--affine-hover-color);
+      }
     }
 
     :host(:active) {


### PR DESCRIPTION
This PR prevents the hover state from being retained after a button is touched on mobile devices by using the `@media (hover: hover)` media query, which detects if the device has hover capability.

### Before 
The pressed button has hover background

https://github.com/user-attachments/assets/2768a73b-e89f-4227-837e-7a4ef3052322

### After
The pressed button dose not have hover background

https://github.com/user-attachments/assets/e2ec1ac7-5f06-4f9c-91bb-29d1d6ed04aa