### PR TITLE
refactor(blocks): extract insert inline latex to command

### DIFF
--- a/packages/affine/components/src/rich-text/effects.ts
+++ b/packages/affine/components/src/rich-text/effects.ts
@@ -3,6 +3,7 @@ import type { deleteTextCommand } from './format/delete-text.js';
 import type { formatBlockCommand } from './format/format-block.js';
 import type { formatNativeCommand } from './format/format-native.js';
 import type { formatTextCommand } from './format/format-text.js';
+import type { insertInlineLatex } from './format/insert-inline-latex.js';
 import type {
   getTextStyle,
   isTextStyleActive,
@@ -64,6 +65,7 @@ declare global {
       toggleLink: typeof toggleLink;
       getTextStyle: typeof getTextStyle;
       isTextStyleActive: typeof isTextStyleActive;
+      insertInlineLatex: typeof insertInlineLatex;
     }
   }
 }

--- a/packages/affine/components/src/rich-text/format/index.ts
+++ b/packages/affine/components/src/rich-text/format/index.ts
@@ -12,6 +12,7 @@ export {
 } from './consts.js';
 import { formatNativeCommand } from './format-native.js';
 import { formatTextCommand } from './format-text.js';
+import { insertInlineLatex } from './insert-inline-latex.js';
 import {
   getTextStyle,
   isTextStyleActive,
@@ -38,4 +39,5 @@ export const textCommands: BlockCommands = {
   isTextStyleActive: isTextStyleActive,
   getTextStyle: getTextStyle,
   getTextSelection: getTextSelectionCommand,
+  insertInlineLatex: insertInlineLatex,
 };

--- a/packages/affine/components/src/rich-text/format/insert-inline-latex.ts
+++ b/packages/affine/components/src/rich-text/format/insert-inline-latex.ts
@@ -1,0 +1,58 @@
+import type { Command, TextSelection } from '@blocksuite/block-std';
+
+export const insertInlineLatex: Command<
+  'currentTextSelection',
+  never,
+  {
+    textSelection?: TextSelection;
+  }
+> = (ctx, next) => {
+  const textSelection = ctx.textSelection ?? ctx.currentTextSelection;
+  if (!textSelection || !textSelection.isCollapsed()) return;
+
+  const blockComponent = ctx.std.view.getBlock(textSelection.from.blockId);
+  if (!blockComponent) return;
+
+  const richText = blockComponent.querySelector('rich-text');
+  if (!richText) return;
+
+  const inlineEditor = richText.inlineEditor;
+  if (!inlineEditor) return;
+
+  inlineEditor.insertText(
+    {
+      index: textSelection.from.index,
+      length: 0,
+    },
+    ' '
+  );
+  inlineEditor.formatText(
+    {
+      index: textSelection.from.index,
+      length: 1,
+    },
+    {
+      latex: '',
+    }
+  );
+  inlineEditor.setInlineRange({
+    index: textSelection.from.index,
+    length: 1,
+  });
+
+  inlineEditor
+    .waitForUpdate()
+    .then(async () => {
+      await inlineEditor.waitForUpdate();
+
+      const textPoint = inlineEditor.getTextPoint(textSelection.from.index + 1);
+      if (!textPoint) return;
+      const [text] = textPoint;
+      const latexNode = text.parentElement?.closest('affine-latex-node');
+      if (!latexNode) return;
+      latexNode.toggleEditor();
+    })
+    .catch(console.error);
+
+  next();
+};

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -208,56 +208,11 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       }),
       alias: ['inlineMath, inlineEquation', 'inlineLatex'],
       action: ({ rootComponent }) => {
-        const selectionManager = rootComponent.host.selection;
-        const textSelection = selectionManager.filter('text')[0];
-        if (!textSelection || !textSelection.isCollapsed()) return;
-
-        const blockComponent = rootComponent.std.view.getBlock(
-          textSelection.from.blockId
-        );
-        if (!blockComponent) return;
-
-        const richText = blockComponent.querySelector('rich-text');
-        if (!richText) return;
-        const inlineEditor = richText.inlineEditor;
-        if (!inlineEditor) return;
-
-        inlineEditor.insertText(
-          {
-            index: textSelection.from.index,
-            length: 0,
-          },
-          ' '
-        );
-        inlineEditor.formatText(
-          {
-            index: textSelection.from.index,
-            length: 1,
-          },
-          {
-            latex: '',
-          }
-        );
-        inlineEditor.setInlineRange({
-          index: textSelection.from.index,
-          length: 1,
-        });
-
-        inlineEditor
-          .waitForUpdate()
-          .then(async () => {
-            await inlineEditor.waitForUpdate();
-
-            const textPoint = inlineEditor.getTextPoint(
-              textSelection.from.index + 1
-            );
-            if (!textPoint) return;
-            const [text] = textPoint;
-            const latexNode = text.parentElement?.closest('affine-latex-node');
-            if (!latexNode) return;
-            latexNode.toggleEditor();
-          })
-          .catch(console.error);
+        rootComponent.std.command
+          .chain()
+          .getTextSelection()
+          .insertInlineLatex()
+          .run();
       },
     },
 


### PR DESCRIPTION
This PR extract the implementation of insert inline equation from slash menu to a new rich-text command named `insertInlineLatex`