### PR TITLE
refactor(blocks): extract some common logics to commands

### DIFF
--- a/packages/affine/components/src/rich-text/effects.ts
+++ b/packages/affine/components/src/rich-text/effects.ts
@@ -12,6 +12,7 @@ import type {
   toggleItalic,
   toggleLink,
   toggleStrike,
+  toggleTextStyleCommand,
   toggleUnderline,
 } from './format/text-style.js';
 
@@ -63,6 +64,7 @@ declare global {
       toggleStrike: typeof toggleStrike;
       toggleCode: typeof toggleCode;
       toggleLink: typeof toggleLink;
+      toggleTextStyle: typeof toggleTextStyleCommand;
       getTextStyle: typeof getTextStyle;
       isTextStyleActive: typeof isTextStyleActive;
       insertInlineLatex: typeof insertInlineLatex;

--- a/packages/affine/components/src/rich-text/format/index.ts
+++ b/packages/affine/components/src/rich-text/format/index.ts
@@ -4,6 +4,7 @@ import { getTextSelectionCommand } from '@blocksuite/affine-shared/commands';
 
 import { deleteTextCommand } from './delete-text.js';
 export { textFormatConfigs } from './config.js';
+export type { TextFormatConfig } from './config.js';
 import { formatBlockCommand } from './format-block.js';
 export {
   FORMAT_BLOCK_SUPPORT_FLAVOURS,
@@ -21,9 +22,14 @@ import {
   toggleItalic,
   toggleLink,
   toggleStrike,
+  toggleTextStyleCommand,
   toggleUnderline,
 } from './text-style.js';
-export { clearMarksOnDiscontinuousInput, isFormatSupported } from './utils.js';
+export {
+  clearMarksOnDiscontinuousInput,
+  insertContent,
+  isFormatSupported,
+} from './utils.js';
 
 export const textCommands: BlockCommands = {
   deleteText: deleteTextCommand,
@@ -36,6 +42,7 @@ export const textCommands: BlockCommands = {
   toggleStrike: toggleStrike,
   toggleCode: toggleCode,
   toggleLink: toggleLink,
+  toggleTextStyle: toggleTextStyleCommand,
   isTextStyleActive: isTextStyleActive,
   getTextStyle: getTextStyle,
   getTextSelection: getTextSelectionCommand,

--- a/packages/affine/components/src/rich-text/index.ts
+++ b/packages/affine/components/src/rich-text/index.ts
@@ -15,8 +15,10 @@ export {
   FORMAT_BLOCK_SUPPORT_FLAVOURS,
   FORMAT_NATIVE_SUPPORT_FLAVOURS,
   FORMAT_TEXT_SUPPORT_FLAVOURS,
+  insertContent,
   isFormatSupported,
   textCommands,
+  type TextFormatConfig,
   textFormatConfigs,
 } from './format/index.js';
 export * from './inline/index.js';

--- a/packages/affine/model/src/blocks/latex/latex-model.ts
+++ b/packages/affine/model/src/blocks/latex/latex-model.ts
@@ -6,7 +6,7 @@ import {
 } from '@blocksuite/block-std/gfx';
 import { BlockModel, defineBlockSchema } from '@blocksuite/store';
 
-type LatexProps = {
+export type LatexProps = {
   xywh: SerializedXYWH;
   index: string;
   scale: number;

--- a/packages/affine/model/src/blocks/surface-ref/surface-ref-model.ts
+++ b/packages/affine/model/src/blocks/surface-ref/surface-ref-model.ts
@@ -1,6 +1,6 @@
 import { defineBlockSchema, type SchemaToModel } from '@blocksuite/store';
 
-type SurfaceRefProps = {
+export type SurfaceRefProps = {
   reference: string;
   caption: string;
   refFlavour: string;

--- a/packages/blocks/src/database-block/commands.ts
+++ b/packages/blocks/src/database-block/commands.ts
@@ -1,0 +1,41 @@
+import type { BlockCommands, Command } from '@blocksuite/block-std';
+
+export const insertDatabaseBlockCommand: Command<
+  'selectedModels',
+  'insertedDatabaseBlockId',
+  {
+    viewType: string;
+    place?: 'after' | 'before';
+    removeEmptyLine?: boolean;
+  }
+> = (ctx, next) => {
+  const { selectedModels, viewType, place, removeEmptyLine, std } = ctx;
+  if (!selectedModels?.length) return;
+
+  const targetModel =
+    place === 'before'
+      ? selectedModels[0]
+      : selectedModels[selectedModels.length - 1];
+
+  const service = std.getService('affine:database');
+  if (!service) return;
+
+  const result = std.doc.addSiblingBlocks(
+    targetModel,
+    [{ flavour: 'affine:database' }],
+    place
+  );
+  if (result.length === 0) return;
+
+  service.initDatabaseBlock(std.doc, targetModel, result[0], viewType, false);
+
+  if (removeEmptyLine && targetModel.text?.length === 0) {
+    std.doc.deleteBlock(targetModel);
+  }
+
+  next({ insertedDatabaseBlockId: result[0] });
+};
+
+export const commands: BlockCommands = {
+  insertDatabaseBlock: insertDatabaseBlockCommand,
+};

--- a/packages/blocks/src/database-block/database-spec.ts
+++ b/packages/blocks/src/database-block/database-spec.ts
@@ -1,17 +1,20 @@
 import {
   BlockViewExtension,
+  CommandExtension,
   type ExtensionType,
   FlavourExtension,
 } from '@blocksuite/block-std';
 import { DatabaseSelectionExtension } from '@blocksuite/data-view';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands.js';
 import { DatabaseDragHandleOption } from './config.js';
 import { DatabaseBlockService } from './database-service.js';
 
 export const DatabaseBlockSpec: ExtensionType[] = [
   FlavourExtension('affine:database'),
   DatabaseBlockService,
+  CommandExtension(commands),
   BlockViewExtension('affine:database', literal`affine-database`),
   DatabaseDragHandleOption,
   DatabaseSelectionExtension,

--- a/packages/blocks/src/database-block/effects.ts
+++ b/packages/blocks/src/database-block/effects.ts
@@ -1,0 +1,30 @@
+import type { DatabaseBlockModel } from '@blocksuite/affine-model';
+
+import type { insertDatabaseBlockCommand } from './commands.js';
+
+export function effects() {
+  // TODO(@L-Sun): move other effects to this file
+}
+
+declare global {
+  namespace BlockSuite {
+    interface BlockModels {
+      'affine:database': DatabaseBlockModel;
+    }
+
+    interface CommandContext {
+      insertedDatabaseBlockId?: string;
+    }
+
+    interface Commands {
+      /**
+       * insert a database block after or before the current block selection
+       * @param latex the LaTeX content. A input dialog will be shown if not provided
+       * @param removeEmptyLine remove the current block if it is empty
+       * @param place where to insert the LaTeX block
+       * @returns the id of the inserted LaTeX block
+       */
+      insertDatabaseBlock: typeof insertDatabaseBlockCommand;
+    }
+  }
+}

--- a/packages/blocks/src/effects.ts
+++ b/packages/blocks/src/effects.ts
@@ -71,6 +71,7 @@ import { CenterPeek } from './database-block/components/layout.js';
 import { DatabaseTitle } from './database-block/components/title/index.js';
 import { BlockRenderer } from './database-block/detail-panel/block-renderer.js';
 import { NoteRenderer } from './database-block/detail-panel/note-renderer.js';
+import { effects as blockDatabaseEffects } from './database-block/effects.js';
 import {
   DatabaseBlockComponent,
   type DatabaseBlockService,
@@ -97,11 +98,13 @@ import {
 } from './frame-block/index.js';
 import { ImageBlockFallbackCard } from './image-block/components/image-block-fallback.js';
 import { ImageBlockPageComponent } from './image-block/components/page-image-block.js';
+import { effects as blockImageEffects } from './image-block/effects.js';
 import {
   ImageBlockComponent,
   type ImageBlockService,
   ImageEdgelessBlockComponent,
 } from './image-block/index.js';
+import { effects as blockLatexEffects } from './latex-block/effects.js';
 import { LatexBlockComponent } from './latex-block/index.js';
 import {
   EdgelessNoteBlockComponent,
@@ -303,6 +306,7 @@ import {
   MindmapSurfaceBlock,
   MiniMindmapPreview,
 } from './surface-block/mini-mindmap/index.js';
+import { effects as blockSurfaceRefEffects } from './surface-ref-block/effects.js';
 import {
   EdgelessSurfaceRefBlockComponent,
   SurfaceRefBlockComponent,
@@ -322,6 +326,10 @@ export function effects() {
   blockEmbedEffects();
   blockSurfaceEffects();
   dataViewEffects();
+  blockImageEffects();
+  blockDatabaseEffects();
+  blockSurfaceRefEffects();
+  blockLatexEffects();
 
   componentCaptionEffects();
   componentContextMenuEffects();

--- a/packages/blocks/src/image-block/commands/index.ts
+++ b/packages/blocks/src/image-block/commands/index.ts
@@ -2,6 +2,9 @@ import type { BlockCommands } from '@blocksuite/block-std';
 
 import { getImageSelectionsCommand } from '@blocksuite/affine-shared/commands';
 
+import { insertImagesCommand } from './insert-images.js';
+
 export const commands: BlockCommands = {
   getImageSelections: getImageSelectionsCommand,
+  insertImages: insertImagesCommand,
 };

--- a/packages/blocks/src/image-block/commands/insert-images.ts
+++ b/packages/blocks/src/image-block/commands/insert-images.ts
@@ -1,0 +1,45 @@
+import type { Command } from '@blocksuite/block-std';
+
+import { getImageFilesFromLocal } from '@blocksuite/affine-shared/utils';
+
+import { addSiblingImageBlock } from '../utils.js';
+
+export const insertImagesCommand: Command<
+  'selectedModels',
+  'insertedImageIds',
+  { removeEmptyLine?: boolean; place?: 'after' | 'before' }
+> = (ctx, next) => {
+  const { selectedModels, place, removeEmptyLine, std } = ctx;
+  if (!selectedModels) return;
+
+  return next({
+    insertedImageIds: getImageFilesFromLocal().then(imageFiles => {
+      if (imageFiles.length === 0) return [];
+
+      if (selectedModels.length === 0) return [];
+
+      const targetModel =
+        place === 'before'
+          ? selectedModels[0]
+          : selectedModels[selectedModels.length - 1];
+
+      const imageService = std.getService('affine:image');
+      if (!imageService) return [];
+
+      const maxFileSize = imageService.maxFileSize;
+
+      const result = addSiblingImageBlock(
+        std.host,
+        imageFiles,
+        maxFileSize,
+        targetModel,
+        place
+      );
+      if (removeEmptyLine && targetModel.text?.length === 0) {
+        std.doc.deleteBlock(targetModel);
+      }
+
+      return result ?? [];
+    }),
+  });
+};

--- a/packages/blocks/src/image-block/effects.ts
+++ b/packages/blocks/src/image-block/effects.ts
@@ -1,0 +1,26 @@
+import type { getImageSelectionsCommand } from '@blocksuite/affine-shared/commands';
+
+import type { insertImagesCommand } from './commands/insert-images.js';
+
+export function effects() {
+  // TODO(@L-Sun): move other effects to this file
+}
+
+declare global {
+  namespace BlockSuite {
+    interface CommandContext {
+      insertedImageIds?: Promise<string[]>;
+    }
+
+    interface Commands {
+      getImageSelections: typeof getImageSelectionsCommand;
+      /**
+       * open file dialog to insert images before or after the current block selection
+       * @param removeEmptyLine remove the current block if it is empty
+       * @param place where to insert the images
+       * @returns a promise that resolves to the inserted image ids
+       */
+      insertImages: typeof insertImagesCommand;
+    }
+  }
+}

--- a/packages/blocks/src/latex-block/commands.ts
+++ b/packages/blocks/src/latex-block/commands.ts
@@ -1,0 +1,58 @@
+import type { LatexProps } from '@blocksuite/affine-model';
+import type { BlockCommands, Command } from '@blocksuite/block-std';
+
+import { assertInstanceOf } from '@blocksuite/global/utils';
+
+import { LatexBlockComponent } from './latex-block.js';
+
+export const insertLatexBlockCommand: Command<
+  'selectedModels',
+  'insertedLatexBlockId',
+  {
+    latex?: string;
+    place?: 'after' | 'before';
+    removeEmptyLine?: boolean;
+  }
+> = (ctx, next) => {
+  const { selectedModels, latex, place, removeEmptyLine, std } = ctx;
+  if (!selectedModels?.length) return;
+
+  const targetModel =
+    place === 'before'
+      ? selectedModels[0]
+      : selectedModels[selectedModels.length - 1];
+
+  const latexBlockProps: Partial<LatexProps> & {
+    flavour: 'affine:latex';
+  } = {
+    flavour: 'affine:latex',
+    latex: latex ?? '',
+  };
+
+  const result = std.doc.addSiblingBlocks(
+    targetModel,
+    [latexBlockProps],
+    place
+  );
+  if (result.length === 0) return;
+
+  if (removeEmptyLine && targetModel.text?.length === 0) {
+    std.doc.deleteBlock(targetModel);
+  }
+
+  next({
+    insertedLatexBlockId: std.host.updateComplete.then(async () => {
+      if (!latex) {
+        const blockComponent = std.view.getBlock(result[0]);
+        assertInstanceOf(blockComponent, LatexBlockComponent);
+        await blockComponent.updateComplete;
+        blockComponent.toggleEditor();
+      }
+      return result[0];
+    }),
+  });
+};
+
+export const commands: BlockCommands = {
+  insertLatexBlock: insertLatexBlockCommand,
+};

--- a/packages/blocks/src/latex-block/effects.ts
+++ b/packages/blocks/src/latex-block/effects.ts
@@ -1,0 +1,24 @@
+import type { insertLatexBlockCommand } from './commands.js';
+
+export function effects() {
+  // TODO(@L-Sun): move other effects to this file
+}
+
+declare global {
+  namespace BlockSuite {
+    interface CommandContext {
+      insertedLatexBlockId?: Promise<string>;
+    }
+
+    interface Commands {
+      /**
+       * insert a LaTeX block after or before the current block selection
+       * @param latex the LaTeX content. A input dialog will be shown if not provided
+       * @param place where to insert the LaTeX block
+       * @param removeEmptyLine remove the current block if it is empty
+       * @returns the id of the inserted LaTeX block
+       */
+      insertLatexBlock: typeof insertLatexBlockCommand;
+    }
+  }
+}

--- a/packages/blocks/src/latex-block/latex-spec.ts
+++ b/packages/blocks/src/latex-block/latex-spec.ts
@@ -1,6 +1,13 @@
-import { BlockViewExtension, type ExtensionType } from '@blocksuite/block-std';
+import {
+  BlockViewExtension,
+  CommandExtension,
+  type ExtensionType,
+} from '@blocksuite/block-std';
 import { literal } from 'lit/static-html.js';
+
+import { commands } from './commands.js';
 
 export const LatexBlockSpec: ExtensionType[] = [
   BlockViewExtension('affine:latex', literal`affine-latex`),
+  CommandExtension(commands),
 ];

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -53,6 +53,5 @@ export {
   type AffineSlashMenuItemGenerator,
   AffineSlashMenuWidget,
   type AffineSlashSubMenu,
-  insertContent,
 } from './slash-menu/index.js';
 export { AffineSurfaceRefToolbar } from './surface-ref-toolbar/surface-ref-toolbar.js';

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -12,7 +12,6 @@ import {
   LoomIcon,
   YoutubeIcon,
 } from '@blocksuite/affine-block-embed';
-import { CanvasElementType } from '@blocksuite/affine-block-surface';
 import {
   ArrowDownBigIcon,
   ArrowUpBigIcon,
@@ -34,19 +33,18 @@ import {
   YesterdayIcon,
 } from '@blocksuite/affine-components/icons';
 import {
-  clearMarksOnDiscontinuousInput,
   getInlineEditorByModel,
+  insertContent,
   REFERENCE_NODE,
   textFormatConfigs,
 } from '@blocksuite/affine-components/rich-text';
 import { toast } from '@blocksuite/affine-components/toast';
 import {
   createDefaultDoc,
-  getImageFilesFromLocal,
-  matchFlavours,
   openFileOrFiles,
 } from '@blocksuite/affine-shared/utils';
 import { viewPresets } from '@blocksuite/data-view/view-presets';
+import { assertType } from '@blocksuite/global/utils';
 import { GroupingIcon, TeXIcon } from '@blocksuite/icons/lit';
 import { Slice, Text } from '@blocksuite/store';
 
@@ -57,18 +55,13 @@ import type { AffineLinkedDocWidget } from '../linked-doc/index.js';
 import { toggleEmbedCardCreateModal } from '../../../_common/components/embed-card/modal/embed-card-create-modal.js';
 import { textConversionConfigs } from '../../../_common/configs/text-conversion.js';
 import { addSiblingAttachmentBlocks } from '../../../attachment-block/utils.js';
-import { addSiblingImageBlock } from '../../../image-block/utils.js';
-import { LatexBlockComponent } from '../../../latex-block/latex-block.js';
-import { onModelTextUpdated } from '../../../root-block/utils/index.js';
 import { getSurfaceBlock } from '../../../surface-ref-block/utils.js';
 import { type SlashMenuTooltip, slashMenuToolTips } from './tooltips/index.js';
 import {
   createConversionItem,
-  createDatabaseBlockInNextLine,
+  createTextFormatItem,
   formatDate,
   formatTime,
-  insertContent,
-  insideDatabase,
   insideEdgelessText,
   tryRemoveEmptyLine,
 } from './utils.js';
@@ -150,44 +143,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
     },
     ...textConversionConfigs
       .filter(i => i.flavour === 'affine:code')
-      .map<SlashMenuActionItem>(config => ({
-        ...createConversionItem(config),
-        showWhen: ({ model }) =>
-          model.doc.schema.flavourSchemaMap.has(config.flavour) &&
-          !insideDatabase(model),
-        action: ({ rootComponent }) => {
-          const { flavour, type } = config;
-          rootComponent.host.std.command
-            .chain()
-            .updateBlockType({
-              flavour,
-              props: { type },
-            })
-            .inline((ctx, next) => {
-              const newModels = ctx.updatedBlocks;
-              if (!newModels) return false;
-
-              // Reset selection if the target is code block
-              if (flavour === 'affine:code') {
-                if (newModels.length !== 1) {
-                  console.error(
-                    "Failed to reset selection! New model length isn't 1"
-                  );
-                  return false;
-                }
-                const codeModel = newModels[0];
-                onModelTextUpdated(rootComponent.host, codeModel, richText => {
-                  const inlineEditor = richText.inlineEditor;
-                  if (!inlineEditor) return;
-                  inlineEditor.focusEnd();
-                }).catch(console.error);
-              }
-
-              return next();
-            })
-            .run();
-        },
-      })),
+      .map<SlashMenuActionItem>(createConversionItem),
 
     ...textConversionConfigs
       .filter(i => i.type && ['divider', 'quote'].includes(i.type))
@@ -195,7 +151,6 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         ...createConversionItem(config),
         showWhen: ({ model }) =>
           model.doc.schema.flavourSchemaMap.has(config.flavour) &&
-          !insideDatabase(model) &&
           !insideEdgelessText(model),
       })),
 
@@ -226,32 +181,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
     { groupName: 'Style' },
     ...textFormatConfigs
       .filter(i => !['Code', 'Link'].includes(i.name))
-      .map<SlashMenuActionItem>(({ name, icon, id }) => ({
-        name,
-        icon,
-        tooltip: slashMenuToolTips[name],
-        action: ({ rootComponent, model }) => {
-          if (!model.text) {
-            return;
-          }
-          const len = model.text.length;
-          if (!len) {
-            const inlineEditor = getInlineEditorByModel(
-              rootComponent.host,
-              model
-            );
-            if (!inlineEditor) return;
-            inlineEditor.setMarks({
-              [id]: true,
-            });
-            clearMarksOnDiscontinuousInput(inlineEditor);
-            return;
-          }
-          model.text.format(0, len, {
-            [id]: true,
-          });
-        },
-      })),
+      .map<SlashMenuActionItem>(createTextFormatItem),
 
     // ---------------------------------------------------------
     {
@@ -283,16 +213,19 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       tooltip: slashMenuToolTips['Linked Doc'],
       alias: ['dual link'],
       showWhen: ({ rootComponent, model }) => {
-        const linkedDocWidgetEle =
-          rootComponent.widgetComponents['affine-linked-doc-widget'];
-        if (!linkedDocWidgetEle) return false;
+        const { std } = rootComponent;
+        const linkedDocWidget = std.view.getWidget(
+          'affine-linked-doc-widget',
+          rootComponent.model.id
+        );
+        if (!linkedDocWidget) return false;
 
         const hasLinkedDocSchema = model.doc.schema.flavourSchemaMap.has(
           'affine:embed-linked-doc'
         );
         if (!hasLinkedDocSchema) return false;
 
-        if (!('showLinkedDocPopover' in linkedDocWidgetEle)) {
+        if (!('showLinkedDocPopover' in linkedDocWidget)) {
           console.warn(
             'You may not have correctly implemented the linkedDoc widget! "showLinkedDoc(model)" method not found on widget'
           );
@@ -303,19 +236,18 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       action: ({ model, rootComponent }) => {
         const triggerKey = '@';
         insertContent(rootComponent.host, model, triggerKey);
-        if (!model.doc.root) return;
-        const widgetEle =
-          rootComponent.widgetComponents['affine-linked-doc-widget'];
-        if (!widgetEle) return;
-        // We have checked the existence of showLinkedDoc method in the showWhen
-        const linkedDocWidget = widgetEle as AffineLinkedDocWidget;
+        const { std } = rootComponent;
+
+        const linkedDocWidget = std.view.getWidget(
+          'affine-linked-doc-widget',
+          rootComponent.model.id
+        );
+        if (!linkedDocWidget) return;
+        assertType<AffineLinkedDocWidget>(linkedDocWidget);
+
+        const inlineEditor = getInlineEditorByModel(rootComponent.host, model);
         // Wait for range to be updated
-        setTimeout(() => {
-          const inlineEditor = getInlineEditorByModel(
-            rootComponent.host,
-            model
-          );
-          if (!inlineEditor) return;
+        inlineEditor?.slots.inlineRangeSync.once(() => {
           linkedDocWidget.showLinkedDocPopover(inlineEditor, triggerKey);
         });
       },
@@ -329,28 +261,15 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: ImageIcon20,
       tooltip: slashMenuToolTips['Image'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:image') &&
-        !insideDatabase(model),
-      action: async ({ rootComponent, model }) => {
-        const parent = rootComponent.doc.getParent(model);
-        if (!parent) {
-          return;
-        }
+        model.doc.schema.flavourSchemaMap.has('affine:image'),
+      action: async ({ rootComponent }) => {
+        const [success, ctx] = rootComponent.std.command
+          .chain()
+          .getSelectedModels()
+          .insertImages({ removeEmptyLine: true })
+          .run();
 
-        const imageFiles = await getImageFilesFromLocal();
-        if (!imageFiles.length) return;
-
-        const imageService = rootComponent.std.getService('affine:image');
-        if (!imageService) return;
-        const maxFileSize = imageService.maxFileSize;
-
-        addSiblingImageBlock(
-          rootComponent.host,
-          imageFiles,
-          maxFileSize,
-          model
-        );
-        tryRemoveEmptyLine(model);
+        if (success) await ctx.insertedImageIds;
       },
     },
     {
@@ -359,8 +278,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: LinkIcon,
       tooltip: slashMenuToolTips['Link'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:bookmark') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:bookmark'),
       action: async ({ rootComponent, model }) => {
         const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
@@ -383,8 +301,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       tooltip: slashMenuToolTips['Attachment'],
       alias: ['file'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:attachment') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:attachment'),
       action: async ({ rootComponent, model }) => {
         const file = await openFileOrFiles();
         if (!file) return;
@@ -409,8 +326,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: YoutubeIcon,
       tooltip: slashMenuToolTips['YouTube'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:embed-youtube') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:embed-youtube'),
       action: async ({ rootComponent, model }) => {
         const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
@@ -432,8 +348,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: GithubIcon,
       tooltip: slashMenuToolTips['Github'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:embed-github') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:embed-github'),
       action: async ({ rootComponent, model }) => {
         const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
@@ -457,8 +372,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       icon: FigmaIcon,
       tooltip: slashMenuToolTips['Figma'],
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:embed-figma') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:embed-figma'),
       action: async ({ rootComponent, model }) => {
         const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
@@ -479,8 +393,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       name: 'Loom',
       icon: LoomIcon,
       showWhen: ({ model }) =>
-        model.doc.schema.flavourSchemaMap.has('affine:embed-loom') &&
-        !insideDatabase(model),
+        model.doc.schema.flavourSchemaMap.has('affine:embed-loom'),
       action: async ({ rootComponent, model }) => {
         const parentModel = rootComponent.doc.getParent(model);
         if (!parentModel) {
@@ -505,38 +418,19 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         height: '20',
       }),
       alias: ['mathBlock, equationBlock', 'latexBlock'],
-      action: ({ rootComponent, model }) => {
-        const doc = rootComponent.doc;
-        const parent = doc.getParent(model);
-        if (!parent) return;
-
-        const index = parent.children.indexOf(model);
-        if (index === -1) return;
-
-        const id = doc.addBlock(
-          'affine:latex',
-          {
-            latex: '',
-          },
-          parent,
-          index + 1
-        );
-        rootComponent.host.updateComplete
-          .then(async () => {
-            const blockComponent = rootComponent.std.view.getBlock(id);
-            if (!(blockComponent instanceof LatexBlockComponent)) return;
-
-            await blockComponent.updateComplete;
-
-            blockComponent.toggleEditor();
+      action: ({ rootComponent }) => {
+        rootComponent.std.command
+          .chain()
+          .getSelectedModels()
+          .insertLatexBlock({
+            place: 'after',
+            removeEmptyLine: true,
           })
-          .catch(console.error);
+          .run();
       },
     },
 
-    // TODO-slash: Linear
-
-    // TODO-slash: Group & Frame explorer
+    // TODO(@L-Sun): Linear
 
     // ---------------------------------------------------------
     ({ model, rootComponent }) => {
@@ -550,62 +444,38 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
 
       const frameModels = doc
         .getBlocksByFlavour('affine:frame')
-        .map(block => block.model) as FrameBlockModel[];
+        .map(block => block.model as FrameBlockModel);
+
       const frameItems = frameModels.map<SlashMenuActionItem>(frameModel => ({
         name: 'Frame: ' + frameModel.title,
         icon: FrameIcon,
-        showWhen: () => !insideDatabase(model),
-        action: () => {
-          const insertIdx = parent.children.indexOf(model);
-          const surfaceRefProps = {
-            flavour: 'affine:surface-ref',
-            reference: frameModel.id,
-            refFlavour: 'affine:frame',
-          };
-
-          doc.addSiblingBlocks(
-            model,
-            [surfaceRefProps],
-            insertIdx === 0 ? 'before' : 'after'
-          );
-
-          if (
-            matchFlavours(model, ['affine:paragraph', 'affine:list']) &&
-            model.text.length === 0
-          ) {
-            doc.deleteBlock(model);
-          }
+        action: ({ rootComponent }) => {
+          rootComponent.std.command
+            .chain()
+            .getSelectedModels()
+            .insertSurfaceRefBlock({
+              reference: frameModel.id,
+              place: 'after',
+              removeEmptyLine: true,
+            })
+            .run();
         },
       }));
 
-      const groupElements = Array.from(
-        surfaceModel.elements.getValue()?.values() ?? []
-      ).filter(element => element.get('type') === CanvasElementType.GROUP);
-
-      const groupItems = groupElements.map(element => ({
-        name: 'Group: ' + element.get('title'),
+      const groupElements = surfaceModel.getElementsByType('group');
+      const groupItems = groupElements.map(group => ({
+        name: 'Group: ' + group.title.toString(),
         icon: GroupingIcon(),
         action: () => {
-          const { doc } = rootComponent;
-          const insertIdx = parent.children.indexOf(model);
-          const surfaceRefProps = {
-            flavour: 'affine:surface-ref',
-            reference: element.get('id'),
-            refFlavour: 'group',
-          };
-
-          doc.addSiblingBlocks(
-            model,
-            [surfaceRefProps],
-            insertIdx === 0 ? 'before' : 'after'
-          );
-
-          if (
-            matchFlavours(model, ['affine:paragraph', 'affine:list']) &&
-            model.text.length === 0
-          ) {
-            doc.deleteBlock(model);
-          }
+          rootComponent.std.command
+            .chain()
+            .getSelectedModels()
+            .insertSurfaceRefBlock({
+              reference: group.id,
+              place: 'after',
+              removeEmptyLine: true,
+            })
+            .run();
         },
       }));
 
@@ -686,23 +556,17 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       tooltip: slashMenuToolTips['Table View'],
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:database') &&
-        !insideDatabase(model) &&
         !insideEdgelessText(model),
-      action: ({ rootComponent, model }) => {
-        const id = createDatabaseBlockInNextLine(model);
-        if (!id) {
-          return;
-        }
-        const service = rootComponent.std.getService('affine:database');
-        if (!service) return;
-        service.initDatabaseBlock(
-          rootComponent.doc,
-          model,
-          id,
-          viewPresets.tableViewMeta.type,
-          false
-        );
-        tryRemoveEmptyLine(model);
+      action: ({ rootComponent }) => {
+        rootComponent.std.command
+          .chain()
+          .getSelectedModels()
+          .insertDatabaseBlock({
+            viewType: viewPresets.tableViewMeta.type,
+            place: 'after',
+            removeEmptyLine: true,
+          })
+          .run();
       },
     },
     {
@@ -712,7 +576,6 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       tooltip: slashMenuToolTips['Todo'],
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:database') &&
-        !insideDatabase(model) &&
         !insideEdgelessText(model) &&
         !!model.doc.awarenessStore.getFlag('enable_block_query'),
 
@@ -745,23 +608,17 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
       tooltip: slashMenuToolTips['Kanban View'],
       showWhen: ({ model }) =>
         model.doc.schema.flavourSchemaMap.has('affine:database') &&
-        !insideDatabase(model) &&
         !insideEdgelessText(model),
-      action: ({ model, rootComponent }) => {
-        const id = createDatabaseBlockInNextLine(model);
-        if (!id) {
-          return;
-        }
-        const service = rootComponent.std.getService('affine:database');
-        if (!service) return;
-        service.initDatabaseBlock(
-          rootComponent.doc,
-          model,
-          id,
-          viewPresets.kanbanViewMeta.type,
-          false
-        );
-        tryRemoveEmptyLine(model);
+      action: ({ rootComponent }) => {
+        rootComponent.std.command
+          .chain()
+          .getSelectedModels()
+          .insertDatabaseBlock({
+            viewType: viewPresets.kanbanViewMeta.type,
+            place: 'after',
+            removeEmptyLine: true,
+          })
+          .run();
       },
     },
 

--- a/packages/blocks/src/root-block/widgets/slash-menu/index.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/index.ts
@@ -34,8 +34,6 @@ import {
 import { SlashMenu } from './slash-menu-popover.js';
 import { filterEnabledSlashMenuItems } from './utils.js';
 
-export { insertContent } from './utils.js';
-
 export type AffineSlashMenuContext = SlashMenuContext;
 export type AffineSlashMenuItem = SlashMenuItem;
 export type AffineSlashMenuActionItem = SlashMenuActionItem;

--- a/packages/blocks/src/root-block/widgets/slash-menu/utils.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/utils.ts
@@ -1,8 +1,6 @@
-import type { AffineTextAttributes } from '@blocksuite/affine-components/rich-text';
-import type { EditorHost } from '@blocksuite/block-std';
+import type { TextFormatConfig } from '@blocksuite/affine-components/rich-text';
 import type { BlockModel } from '@blocksuite/store';
 
-import { getInlineEditorByModel } from '@blocksuite/affine-components/rich-text';
 import { isInsideBlockByFlavour } from '@blocksuite/affine-shared/utils';
 import { assertType } from '@blocksuite/global/utils';
 
@@ -82,31 +80,6 @@ export function getFirstNotDividerItem(
   return firstItem ?? null;
 }
 
-export function insertContent(
-  editorHost: EditorHost,
-  model: BlockModel,
-  text: string,
-  attributes?: AffineTextAttributes
-) {
-  if (!model.text) {
-    console.error("Can't insert text! Text not found");
-    return;
-  }
-  const inlineEditor = getInlineEditorByModel(editorHost, model);
-  if (!inlineEditor) {
-    console.error("Can't insert text! Inline editor not found");
-    return;
-  }
-  const inlineRange = inlineEditor.getInlineRange();
-  const index = inlineRange ? inlineRange.index : model.text.length;
-  model.text.insert(text, index, attributes as Record<string, unknown>);
-  // Update the caret to the end of the inserted text
-  inlineEditor.setInlineRange({
-    index: index + text.length,
-    length: 0,
-  });
-}
-
 export function formatDate(date: Date) {
   // yyyy-mm-dd
   const year = date.getFullYear();
@@ -126,30 +99,12 @@ export function formatTime(date: Date) {
   return strTime;
 }
 
-export function insideDatabase(model: BlockModel) {
-  return isInsideBlockByFlavour(model.doc, model, 'affine:database');
-}
-
 export function insideEdgelessText(model: BlockModel) {
   return isInsideBlockByFlavour(model.doc, model, 'affine:edgeless-text');
 }
 
-export function createDatabaseBlockInNextLine(model: BlockModel) {
-  let parent = model.doc.getParent(model);
-  while (parent && parent.flavour !== 'affine:note') {
-    model = parent;
-    parent = model.doc.getParent(parent);
-  }
-  if (!parent) {
-    return;
-  }
-  const index = parent.children.indexOf(model);
-
-  return model.doc.addBlock('affine:database', {}, parent, index + 1);
-}
-
 export function tryRemoveEmptyLine(model: BlockModel) {
-  if (!model.text?.length) {
+  if (model.text?.length === 0) {
     model.doc.deleteBlock(model);
   }
 }
@@ -165,14 +120,44 @@ export function createConversionItem(
     tooltip: slashMenuToolTips[name],
     showWhen: ({ model }) => model.doc.schema.flavourSchemaMap.has(flavour),
     action: ({ rootComponent }) => {
-      rootComponent.host.std.command
+      rootComponent.std.command
         .chain()
         .updateBlockType({
           flavour,
           props: { type },
         })
-        .inline((ctx, next) => (ctx.updatedBlocks ? next() : false))
         .run();
+    },
+  };
+}
+
+export function createTextFormatItem(
+  config: TextFormatConfig
+): SlashMenuActionItem {
+  const { name, icon, id, action } = config;
+  return {
+    name,
+    icon,
+    tooltip: slashMenuToolTips[name],
+    action: ({ rootComponent, model }) => {
+      const { std, host } = rootComponent;
+
+      if (model.text?.length !== 0) {
+        std.command
+          .chain()
+          .formatBlock({
+            blockSelections: [
+              std.selection.create('block', {
+                blockId: model.id,
+              }),
+            ],
+            styles: { [id]: true },
+          })
+          .run();
+      } else {
+        // like format bar when the line is empty
+        action(host);
+      }
     },
   };
 }

--- a/packages/blocks/src/surface-ref-block/commands.ts
+++ b/packages/blocks/src/surface-ref-block/commands.ts
@@ -1,0 +1,65 @@
+import type { SurfaceRefProps } from '@blocksuite/affine-model';
+import type { BlockCommands, Command } from '@blocksuite/block-std';
+
+import { matchFlavours } from '@blocksuite/affine-shared/utils';
+
+import { getSurfaceBlock } from './utils.js';
+
+export const insertSurfaceRefBlockCommand: Command<
+  'selectedModels',
+  'insertedSurfaceRefBlockId',
+  {
+    reference: string;
+    place: 'after' | 'before';
+    removeEmptyLine?: boolean;
+  }
+> = (ctx, next) => {
+  const { selectedModels, reference, place, removeEmptyLine, std } = ctx;
+  if (!selectedModels?.length) return;
+
+  const targetModel =
+    place === 'before'
+      ? selectedModels[0]
+      : selectedModels[selectedModels.length - 1];
+
+  const surfaceRefProps: Partial<SurfaceRefProps> & {
+    flavour: 'affine:surface-ref';
+  } = {
+    flavour: 'affine:surface-ref',
+    reference,
+  };
+
+  const surface = getSurfaceBlock(std.doc);
+  if (!surface) return;
+
+  const element = surface.getElementById(reference);
+  const blockModel = std.doc.getBlock(reference)?.model ?? null;
+
+  if (element?.type === 'group') {
+    surfaceRefProps.refFlavour = 'group';
+  } else if (matchFlavours(blockModel, ['affine:frame'])) {
+    surfaceRefProps.refFlavour = 'frame';
+  } else {
+    console.error(`reference not found ${reference}`);
+    return;
+  }
+
+  const result = std.doc.addSiblingBlocks(
+    targetModel,
+    [surfaceRefProps],
+    place
+  );
+  if (result.length === 0) return;
+
+  if (removeEmptyLine && targetModel.text?.length === 0) {
+    std.doc.deleteBlock(targetModel);
+  }
+
+  next({
+    insertedSurfaceRefBlockId: result[0],
+  });
+};
+
+export const commands: BlockCommands = {
+  insertSurfaceRefBlock: insertSurfaceRefBlockCommand,
+};

--- a/packages/blocks/src/surface-ref-block/effects.ts
+++ b/packages/blocks/src/surface-ref-block/effects.ts
@@ -1,0 +1,24 @@
+import type { insertSurfaceRefBlockCommand } from './commands.js';
+
+export function effects() {
+  // TODO(@L-Sun): move other effects to this file
+}
+
+declare global {
+  namespace BlockSuite {
+    interface CommandContext {
+      insertedSurfaceRefBlockId?: string;
+    }
+
+    interface Commands {
+      /**
+       * insert a SurfaceRef block after or before the current block selection
+       * @param reference the reference block id. The block should be group or frame
+       * @param place where to insert the LaTeX block
+       * @param removeEmptyLine remove the current block if it is empty
+       * @returns the id of the inserted SurfaceRef block
+       */
+      insertSurfaceRefBlock: typeof insertSurfaceRefBlockCommand;
+    }
+  }
+}

--- a/packages/blocks/src/surface-ref-block/surface-ref-spec.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-spec.ts
@@ -1,16 +1,19 @@
 import {
   BlockViewExtension,
+  CommandExtension,
   type ExtensionType,
   FlavourExtension,
   WidgetViewMapExtension,
 } from '@blocksuite/block-std';
 import { literal } from 'lit/static-html.js';
 
+import { commands } from './commands.js';
 import { SurfaceRefBlockService } from './surface-ref-service.js';
 
 export const PageSurfaceRefBlockSpec: ExtensionType[] = [
   FlavourExtension('affine:surface-ref'),
   SurfaceRefBlockService,
+  CommandExtension(commands),
   BlockViewExtension('affine:surface-ref', literal`affine-surface-ref`),
   WidgetViewMapExtension('affine:surface-ref', {
     surfaceToolbar: literal`affine-surface-ref-toolbar`,

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
@@ -33,20 +33,6 @@
       "children": [
         {
           "type": "block",
-          "id": "2",
-          "flavour": "affine:paragraph",
-          "version": 1,
-          "props": {
-            "type": "text",
-            "text": {
-              "$blocksuite:internal:text$": true,
-              "delta": []
-            }
-          },
-          "children": []
-        },
-        {
-          "type": "block",
           "id": "3",
           "flavour": "affine:latex",
           "version": 1,


### PR DESCRIPTION
Close [BS-1688](https://linear.app/affine-design/issue/BS-1688/将-slash-menu-中的-action-实现提取并重构为通用的-command，以便在不同组件中复用)

### What Changes
- refactor toggle text style commands to `toggleTextStyleCommand`
- some new intert block commands, which can put the new block before or after current block
  - `insertImages`, open a file dialog and insert the selected images
  - `insertLatexBlock`, insert a display LaTeX block, may be open input dialog if `latex` parameter not provided
  - `insertDatabaseBlock`
  - `insertSurfaceRefBlock`
- Simplify slash-menu config implementation