### PR TITLE
fix(blocks): can not toggle text style in empty paragraph

### DIFF
--- a/packages/affine/components/src/rich-text/format/format-text.ts
+++ b/packages/affine/components/src/rich-text/format/format-text.ts
@@ -52,7 +52,6 @@ export const formatTextCommand: Command<
 
         if (inlineRange.length === 0) {
           const delta = inlineEditor.getDeltaByRangeIndex(inlineRange.index);
-          if (!delta) return;
 
           inlineEditor.setMarks({
             ...inlineEditor.marks,
@@ -63,7 +62,8 @@ export const formatTextCommand: Command<
                     key,
                     (inlineEditor.marks &&
                       inlineEditor.marks[key as keyof AffineTextAttributes]) ||
-                    (delta.attributes &&
+                    (delta &&
+                      delta.attributes &&
                       delta.attributes[key as keyof AffineTextAttributes])
                       ? null
                       : value,

--- a/tests/hotkey/hotkey.spec.ts
+++ b/tests/hotkey/hotkey.spec.ts
@@ -162,6 +162,22 @@ test('use formatted cursor with hotkey', async ({ page }, testInfo) => {
   );
 });
 
+test('use formatted cursor with hotkey at empty line', async ({
+  page,
+}, testInfo) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  // format bold
+  await page.keyboard.press(`${SHORT_KEY}+b`, { delay: 50 });
+  await type(page, 'aaa');
+
+  expect(await getPageSnapshot(page, true)).toMatchSnapshot(
+    `${testInfo.title}_bold.json`
+  );
+});
+
 test('should single line format hotkey work', async ({ page }, testInfo) => {
   await enterPlaygroundRoom(page);
   await initEmptyParagraphState(page);

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-at-empty-line-bold.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-at-empty-line-bold.json
@@ -1,0 +1,58 @@
+{
+  "type": "block",
+  "id": "0",
+  "flavour": "affine:page",
+  "version": 2,
+  "props": {
+    "title": {
+      "$blocksuite:internal:text$": true,
+      "delta": []
+    }
+  },
+  "children": [
+    {
+      "type": "block",
+      "id": "1",
+      "flavour": "affine:note",
+      "version": 1,
+      "props": {
+        "xywh": "[0,0,498,92]",
+        "background": "--affine-note-background-white",
+        "index": "a0",
+        "hidden": false,
+        "displayMode": "both",
+        "edgeless": {
+          "style": {
+            "borderRadius": 8,
+            "borderSize": 4,
+            "borderStyle": "none",
+            "shadowType": "--affine-note-shadow-box"
+          }
+        }
+      },
+      "children": [
+        {
+          "type": "block",
+          "id": "2",
+          "flavour": "affine:paragraph",
+          "version": 1,
+          "props": {
+            "type": "text",
+            "text": {
+              "$blocksuite:internal:text$": true,
+              "delta": [
+                {
+                  "insert": "aaa",
+                  "attributes": {
+                    "bold": true
+                  }
+                }
+              ]
+            }
+          },
+          "children": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Close [BS-1697](https://linear.app/affine-design/issue/BS-1697/空段落无法切换bold，进行加粗输入)


### Before

https://github.com/user-attachments/assets/ced2d025-e9a1-4f33-89f2-5efa5a84fa26


### After

https://github.com/user-attachments/assets/5a13acf8-5e0f-454b-a5eb-6cef536bc58f

