### PR TITLE
fix(inline): get text format from left delta by default when it is collapsed

### DIFF
--- a/packages/framework/inline/src/__tests__/editor.unit.spec.ts
+++ b/packages/framework/inline/src/__tests__/editor.unit.spec.ts
@@ -413,6 +413,60 @@ test('cursor with format', () => {
   ]);
 });
 
+test('getFormat', () => {
+  const yDoc = new Y.Doc();
+  const yText = yDoc.getText('text');
+  const inlineEditor = new InlineEditor(yText);
+
+  inlineEditor.insertText(
+    {
+      index: 0,
+      length: 0,
+    },
+    'aaa',
+    {
+      bold: true,
+    }
+  );
+
+  inlineEditor.insertText(
+    {
+      index: 3,
+      length: 0,
+    },
+    'bbb',
+    {
+      italic: true,
+    }
+  );
+
+  expect(inlineEditor.getFormat({ index: 0, length: 0 })).toEqual({});
+
+  expect(inlineEditor.getFormat({ index: 0, length: 1 })).toEqual({
+    bold: true,
+  });
+
+  expect(inlineEditor.getFormat({ index: 0, length: 3 })).toEqual({
+    bold: true,
+  });
+
+  expect(inlineEditor.getFormat({ index: 3, length: 0 })).toEqual({
+    bold: true,
+  });
+
+  expect(inlineEditor.getFormat({ index: 3, length: 1 })).toEqual({
+    italic: true,
+  });
+
+  expect(inlineEditor.getFormat({ index: 3, length: 3 })).toEqual({
+    italic: true,
+  });
+
+  expect(inlineEditor.getFormat({ index: 6, length: 0 })).toEqual({
+    italic: true,
+  });
+});
+
 test('incorrect format value `false`', () => {
   const yDoc = new Y.Doc();
   const yText = yDoc.getText('text');

--- a/packages/framework/inline/src/services/attribute.ts
+++ b/packages/framework/inline/src/services/attribute.ts
@@ -21,11 +21,18 @@ export class AttributeService<TextAttributes extends BaseTextAttributes> {
   getFormat = (inlineRange: InlineRange, loose = false): TextAttributes => {
     const deltas = this.editor.deltaService
       .getDeltasByInlineRange(inlineRange)
-      .filter(
-        ([_, position]) =>
-          position.index + position.length > inlineRange.index &&
-          position.index <= inlineRange.index + inlineRange.length
-      );
+      .filter(([_, position]) => {
+        const deltaStart = position.index;
+        const deltaEnd = position.index + position.length;
+        const inlineStart = inlineRange.index;
+        const inlineEnd = inlineRange.index + inlineRange.length;
+
+        if (inlineStart === inlineEnd) {
+          return deltaStart < inlineStart && inlineStart <= deltaEnd;
+        } else {
+          return deltaEnd > inlineStart && deltaStart <= inlineEnd;
+        }
+      });
     const maybeAttributesList = deltas.map(([delta]) => delta.attributes);
     if (loose) {
       return maybeAttributesList.reduce(

--- a/tests/hotkey/hotkey.spec.ts
+++ b/tests/hotkey/hotkey.spec.ts
@@ -61,19 +61,19 @@ test('single line rich-text inline code hotkey', async ({ page }) => {
   await type(page, 'hello');
   await dragBetweenIndices(page, [0, 0], [0, 5]);
   await inlineCode(page);
-  await assertTextFormat(page, 0, 0, { code: true });
+  await assertTextFormat(page, 0, 5, { code: true });
 
   // undo
   await undoByKeyboard(page);
-  await assertTextFormat(page, 0, 0, {});
+  await assertTextFormat(page, 0, 5, {});
   // redo
   await redoByKeyboard(page);
   await waitNextFrame(page);
-  await assertTextFormat(page, 0, 0, { code: true });
+  await assertTextFormat(page, 0, 5, { code: true });
 
   // the format should be removed after trigger the hotkey again
   await inlineCode(page);
-  await assertTextFormat(page, 0, 0, {});
+  await assertTextFormat(page, 0, 5, {});
 });
 
 test('type character jump out code node', async ({ page }, testInfo) => {
@@ -101,18 +101,18 @@ test('single line rich-text strikethrough hotkey', async ({ page }) => {
   await type(page, 'hello');
   await dragBetweenIndices(page, [0, 0], [0, 5]);
   await strikethrough(page);
-  await assertTextFormat(page, 0, 0, { strike: true });
+  await assertTextFormat(page, 0, 5, { strike: true });
 
   await undoByClick(page);
-  await assertTextFormat(page, 0, 0, {});
+  await assertTextFormat(page, 0, 5, {});
 
   await redoByClick(page);
-  await assertTextFormat(page, 0, 0, { strike: true });
+  await assertTextFormat(page, 0, 5, { strike: true });
 
   await waitNextFrame(page);
   // the format should be removed after trigger the hotkey again
   await strikethrough(page);
-  await assertTextFormat(page, 0, 0, {});
+  await assertTextFormat(page, 0, 5, {});
 });
 
 test('use formatted cursor with hotkey', async ({ page }, testInfo) => {


### PR DESCRIPTION
### What Changes
- change the behavior of `getFormat` from right delta to left delta when the inline range is collapsed.
- add unit test for `getFormat`

### After
This PR makes it possible to detect the current input text style using `const { textStyle } = std.command.exec('getTextStyle');`.
![CleanShot 2024-10-29 at 16.14.05@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/32a5a9d9-795c-4e6d-ad97-9b0965f0527a.png)

