### PR TITLE
refactor(edgeless): rewrite surface middleware builder

### DIFF
--- a/packages/blocks/src/_specs/preset/edgeless-specs.ts
+++ b/packages/blocks/src/_specs/preset/edgeless-specs.ts
@@ -5,7 +5,6 @@ import {
   EdgelessSurfaceBlockSpec,
 } from '@blocksuite/affine-block-surface';
 import { FontLoaderService } from '@blocksuite/affine-shared/services';
-import { SurfaceMiddlewareExtension } from '@blocksuite/block-std/gfx';
 
 import { EdgelessTextBlockSpec } from '../../edgeless-text-block/edgeless-text-spec.js';
 import { FrameBlockSpec } from '../../frame-block/frame-spec.js';
@@ -56,7 +55,7 @@ export const EdgelessBuiltInManager: ExtensionType[] = [
   FrameOverlay,
   EdgelessSnapManager,
   EdgelessFrameManager,
-  SurfaceMiddlewareExtension([EditPropsMiddlewareBuilder]),
+  EditPropsMiddlewareBuilder,
 ];
 
 export const EdgelessEditorBlockSpecs: ExtensionType[] = [

--- a/packages/blocks/src/root-block/edgeless/middlewares/base.ts
+++ b/packages/blocks/src/root-block/edgeless/middlewares/base.ts
@@ -1,29 +1,26 @@
-import type { BlockStdScope } from '@blocksuite/block-std';
-
 import { EditPropsStore } from '@blocksuite/affine-shared/services';
 import {
-  GfxControllerIdentifier,
-  type SurfaceMiddlewareBuilder,
+  type SurfaceMiddleware,
+  SurfaceMiddlewareBuilder,
 } from '@blocksuite/block-std/gfx';
 
 import { getLastPropsKey } from '../utils/get-last-props-key.js';
 
-export const EditPropsMiddlewareBuilder: SurfaceMiddlewareBuilder = (
-  std: BlockStdScope
-) => {
-  return ctx => {
+export class EditPropsMiddlewareBuilder extends SurfaceMiddlewareBuilder {
+  static override key = 'editProps';
+
+  middleware: SurfaceMiddleware = ctx => {
     if (ctx.type === 'beforeAdd') {
       const { type, props } = ctx.payload;
       const key = getLastPropsKey(type as BlockSuite.EdgelessModelKeys, props);
       const nProps = key
-        ? std.get(EditPropsStore).applyLastProps(key, ctx.payload.props)
+        ? this.std.get(EditPropsStore).applyLastProps(key, ctx.payload.props)
         : null;
 
       ctx.payload.props = {
         ...(nProps ?? props),
-        index:
-          props.index ?? std.get(GfxControllerIdentifier).layer.generateIndex(),
+        index: props.index ?? this.gfx.layer.generateIndex(),
       };
     }
   };
-};
+}

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -47,10 +47,11 @@ export {
 export {
   SurfaceBlockModel,
   type SurfaceBlockProps,
+  type SurfaceMiddleware,
 } from './surface/surface-model.js';
 
 export {
-  type SurfaceMiddlewareBuilder,
+  SurfaceMiddlewareBuilder,
   SurfaceMiddlewareExtension,
 } from './surface-middleware.js';
 

--- a/packages/framework/block-std/src/gfx/surface-middleware.ts
+++ b/packages/framework/block-std/src/gfx/surface-middleware.ts
@@ -1,27 +1,61 @@
+import { type Container, createIdentifier } from '@blocksuite/global/di';
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
+
 import type { BlockStdScope } from '../scope/block-std-scope.js';
 import type { SurfaceMiddleware } from './surface/surface-model.js';
 
+import { Extension } from '../extension/extension.js';
 import { LifeCycleWatcher } from '../extension/lifecycle-watcher.js';
+import { StdIdentifier } from '../identifier.js';
 import { onSurfaceAdded } from '../utils/gfx.js';
+import { GfxControllerIdentifier } from './identifiers.js';
 
-export type SurfaceMiddlewareBuilder = (
-  std: BlockStdScope
-) => SurfaceMiddleware;
+export abstract class SurfaceMiddlewareBuilder extends Extension {
+  static key: string = '';
 
-export function SurfaceMiddlewareExtension(
-  middlewares: SurfaceMiddlewareBuilder[]
-) {
-  return class SurfaceMiddlewareExtension extends LifeCycleWatcher {
-    static override key: string = 'surfaceMiddleware';
+  abstract middleware: SurfaceMiddleware;
 
-    override mounted(): void {
-      onSurfaceAdded(this.std.doc, surface => {
-        if (surface) {
-          surface.applyMiddlewares(
-            middlewares.map(builder => builder(this.std))
-          );
-        }
-      });
+  get gfx() {
+    return this.std.provider.get(GfxControllerIdentifier);
+  }
+
+  constructor(protected std: BlockStdScope) {
+    super();
+  }
+
+  static override setup(di: Container) {
+    if (!this.key) {
+      throw new BlockSuiteError(
+        ErrorCode.ValueNotExists,
+        'The surface middleware builder should have a static key property.'
+      );
     }
-  };
+
+    di.addImpl(SurfaceMiddlewareBuilderIdentifier(this.key), this, [
+      StdIdentifier,
+    ]);
+  }
+
+  mounted(): void {}
+
+  unmounted(): void {}
+}
+
+export const SurfaceMiddlewareBuilderIdentifier =
+  createIdentifier<SurfaceMiddlewareBuilder>('SurfaceMiddlewareBuilder');
+
+export class SurfaceMiddlewareExtension extends LifeCycleWatcher {
+  static override key: string = 'surfaceMiddleware';
+
+  override mounted(): void {
+    const builders = Array.from(
+      this.std.provider.getAll(SurfaceMiddlewareBuilderIdentifier).values()
+    );
+
+    onSurfaceAdded(this.std.doc, surface => {
+      if (surface) {
+        surface.applyMiddlewares(builders.map(builder => builder.middleware));
+      }
+    });
+  }
 }

--- a/packages/framework/block-std/src/scope/block-std-scope.ts
+++ b/packages/framework/block-std/src/scope/block-std-scope.ts
@@ -11,6 +11,7 @@ import { CommandManager } from '../command/index.js';
 import { UIEventDispatcher } from '../event/index.js';
 import { GfxController } from '../gfx/controller.js';
 import { GfxSelectionManager } from '../gfx/selection.js';
+import { SurfaceMiddlewareExtension } from '../gfx/surface-middleware.js';
 import { ToolController } from '../gfx/tool/tool-controller.js';
 import {
   BlockServiceIdentifier,
@@ -51,6 +52,7 @@ const internalExtensions = [
   CursorSelectionExtension,
   ToolController,
   GfxSelectionManager,
+  SurfaceMiddlewareExtension,
 ];
 
 export class BlockStdScope {


### PR DESCRIPTION
The previous middleware builder uses an internal class returned by a closure function, which may cause a problem where the DI container cannot parse the extension correctly.