### PR TITLE
fix(edgeless): inline style only work on list and paragraph

### DIFF
--- a/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
@@ -21,6 +21,15 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       word-break: keep-all !important;
       text-wrap: nowrap !important;
     }
+
+    .edgeless-text-block-container affine-paragraph,
+    affine-list {
+      color: var(--edgeless-text-color);
+      font-family: var(--edgeless-text-font-family);
+      font-style: var(--edgeless-text-font-style);
+      font-weight: var(--edgeless-text-font-weight);
+      text-align: var(--edgeless-text-text-align);
+    }
   `;
 
   private _resizeObserver = new ResizeObserver(() => {
@@ -277,11 +286,11 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
     );
 
     const style = styleMap({
-      color,
-      fontFamily: TextUtils.wrapFontFamily(fontFamily),
-      fontStyle,
-      fontWeight,
-      textAlign,
+      '--edgeless-text-color': color,
+      '--edgeless-text-font-family': TextUtils.wrapFontFamily(fontFamily),
+      '--edgeless-text-font-style': fontStyle,
+      '--edgeless-text-font-weight': fontWeight,
+      '--edgeless-text-text-align': textAlign,
     });
 
     return html`


### PR DESCRIPTION
Close [BS-753](https://linear.app/affine-design/issue/BS-753/edgeless-text-中的-cardembed-等-block-不应跟着整个-text-变字体颜色字体家族和字重)
Close [BS-1635](https://linear.app/affine-design/issue/BS-1635/bug-edgeless-text-选择对齐的时候会影响-card)