### PR TITLE
refactor(blocks): extract indent dedent check logics to commands

### DIFF
--- a/packages/affine/block-list/src/commands/index.ts
+++ b/packages/affine/block-list/src/commands/index.ts
@@ -1,8 +1,8 @@
 import type { BlockCommands } from '@blocksuite/block-std';
 
 import { convertToNumberedListCommand } from './convert-to-numbered-list.js';
-import { dedentListCommand } from './dedent-list.js';
-import { indentListCommand } from './indent-list.js';
+import { canDedentListCommand, dedentListCommand } from './dedent-list.js';
+import { canIndentListCommand, indentListCommand } from './indent-list.js';
 import { listToParagraphCommand } from './list-to-paragraph.js';
 import { splitListCommand } from './split-list.js';
 
@@ -10,6 +10,8 @@ export const commands: BlockCommands = {
   convertToNumberedList: convertToNumberedListCommand,
   listToParagraph: listToParagraphCommand,
   splitList: splitListCommand,
+  canIndentList: canIndentListCommand,
   indentList: indentListCommand,
+  canDedentList: canDedentListCommand,
   dedentList: dedentListCommand,
 };

--- a/packages/affine/block-list/src/commands/split-list.ts
+++ b/packages/affine/block-list/src/commands/split-list.ts
@@ -99,10 +99,14 @@ export const splitListCommand: Command<
      *   - ccc
      */
     if (parent.role === 'content') {
-      host.command.exec('dedentList', {
-        blockId,
-        inlineIndex: 0,
-      });
+      host.command
+        .chain()
+        .canDedentList({
+          blockId,
+          inlineIndex: 0,
+        })
+        .dedentList()
+        .run();
 
       next();
       return;

--- a/packages/affine/block-list/src/effects.ts
+++ b/packages/affine/block-list/src/effects.ts
@@ -1,6 +1,14 @@
+import type { IndentContext } from '@blocksuite/affine-shared/types';
+
 import type { convertToNumberedListCommand } from './commands/convert-to-numbered-list.js';
-import type { dedentListCommand } from './commands/dedent-list.js';
-import type { indentListCommand } from './commands/indent-list.js';
+import type {
+  canDedentListCommand,
+  dedentListCommand,
+} from './commands/dedent-list.js';
+import type {
+  canIndentListCommand,
+  indentListCommand,
+} from './commands/indent-list.js';
 import type { listToParagraphCommand } from './commands/list-to-paragraph.js';
 import type { splitListCommand } from './commands/split-list.js';
 import type { ListBlockService } from './list-service.js';
@@ -19,10 +27,13 @@ declare global {
 
     interface CommandContext {
       listConvertedId?: string;
+      indentContext?: IndentContext;
     }
 
     interface Commands {
       convertToNumberedList: typeof convertToNumberedListCommand;
+      canDedentList: typeof canDedentListCommand;
+      canIndentList: typeof canIndentListCommand;
       dedentList: typeof dedentListCommand;
       indentList: typeof indentListCommand;
       listToParagraph: typeof listToParagraphCommand;

--- a/packages/affine/block-list/src/list-keymap.ts
+++ b/packages/affine/block-list/src/list-keymap.ts
@@ -44,10 +44,14 @@ export const ListKeymapExtension = KeymapExtension(
         if (!text) return false;
 
         ctx.get('keyboardState').raw.preventDefault();
-        std.command.exec('indentList', {
-          blockId: text.from.blockId,
-          inlineIndex: text.from.index,
-        });
+        std.command
+          .chain()
+          .canIndentList({
+            blockId: text.from.blockId,
+            inlineIndex: text.from.index,
+          })
+          .indentList()
+          .run();
         return true;
       },
       'Shift-Tab': ctx => {
@@ -61,10 +65,14 @@ export const ListKeymapExtension = KeymapExtension(
         if (!text) return false;
 
         ctx.get('keyboardState').raw.preventDefault();
-        std.command.exec('dedentList', {
-          blockId: text.from.blockId,
-          inlineIndex: text.from.index,
-        });
+        std.command
+          .chain()
+          .canDedentList({
+            blockId: text.from.blockId,
+            inlineIndex: text.from.index,
+          })
+          .dedentList()
+          .run();
         return true;
       },
       Backspace: ctx => {

--- a/packages/affine/block-paragraph/src/commands/index.ts
+++ b/packages/affine/block-paragraph/src/commands/index.ts
@@ -2,14 +2,22 @@ import type { BlockCommands } from '@blocksuite/block-std';
 
 import { addParagraphCommand } from './add-paragraph.js';
 import { appendParagraphCommand } from './append-paragraph.js';
-import { dedentParagraphCommand } from './dedent-paragraph.js';
-import { indentParagraphCommand } from './indent-paragraph.js';
+import {
+  canDedentParagraphCommand,
+  dedentParagraphCommand,
+} from './dedent-paragraph.js';
+import {
+  canIndentParagraphCommand,
+  indentParagraphCommand,
+} from './indent-paragraph.js';
 import { splitParagraphCommand } from './split-paragraph.js';
 
 export const commands: BlockCommands = {
   appendParagraph: appendParagraphCommand,
   splitParagraph: splitParagraphCommand,
   addParagraph: addParagraphCommand,
+  canIndentParagraph: canIndentParagraphCommand,
+  canDedentParagraph: canDedentParagraphCommand,
   indentParagraph: indentParagraphCommand,
   dedentParagraph: dedentParagraphCommand,
 };

--- a/packages/affine/block-paragraph/src/effects.ts
+++ b/packages/affine/block-paragraph/src/effects.ts
@@ -1,7 +1,15 @@
+import type { IndentContext } from '@blocksuite/affine-shared/types';
+
 import type { addParagraphCommand } from './commands/add-paragraph.js';
 import type { appendParagraphCommand } from './commands/append-paragraph.js';
-import type { dedentParagraphCommand } from './commands/dedent-paragraph.js';
-import type { indentParagraphCommand } from './commands/indent-paragraph.js';
+import type {
+  canDedentParagraphCommand,
+  dedentParagraphCommand,
+} from './commands/dedent-paragraph.js';
+import type {
+  canIndentParagraphCommand,
+  indentParagraphCommand,
+} from './commands/indent-paragraph.js';
 import type { splitParagraphCommand } from './commands/split-paragraph.js';
 import type { ParagraphBlockService } from './paragraph-service.js';
 
@@ -19,12 +27,15 @@ declare global {
     interface Commands {
       addParagraph: typeof addParagraphCommand;
       appendParagraph: typeof appendParagraphCommand;
+      canIndentParagraph: typeof canIndentParagraphCommand;
+      canDedentParagraph: typeof canDedentParagraphCommand;
       dedentParagraph: typeof dedentParagraphCommand;
       indentParagraph: typeof indentParagraphCommand;
       splitParagraph: typeof splitParagraphCommand;
     }
     interface CommandContext {
       paragraphConvertedId?: string;
+      indentContext?: IndentContext;
     }
   }
   interface HTMLElementTagNameMap {

--- a/packages/affine/block-paragraph/src/paragraph-keymap.ts
+++ b/packages/affine/block-paragraph/src/paragraph-keymap.ts
@@ -43,7 +43,7 @@ export const ParagraphKeymapExtension = KeymapExtension(
           return true;
         }
 
-        std.command.exec('dedentParagraph');
+        std.command.chain().canDedentParagraph().dedentParagraph().run();
         return true;
       },
       'Mod-Enter': ctx => {
@@ -164,7 +164,11 @@ export const ParagraphKeymapExtension = KeymapExtension(
         return true;
       },
       Tab: ctx => {
-        const { success } = std.command.exec('indentParagraph');
+        const [success] = std.command
+          .chain()
+          .canIndentParagraph()
+          .indentParagraph()
+          .run();
         if (!success) {
           return;
         }
@@ -172,7 +176,11 @@ export const ParagraphKeymapExtension = KeymapExtension(
         return true;
       },
       'Shift-Tab': ctx => {
-        const { success } = std.command.exec('dedentParagraph');
+        const [success] = std.command
+          .chain()
+          .canDedentParagraph()
+          .dedentParagraph()
+          .run();
         if (!success) {
           return;
         }

--- a/packages/affine/shared/src/types/index.ts
+++ b/packages/affine/shared/src/types/index.ts
@@ -45,3 +45,13 @@ export type EmbedOptions = {
   styles: EmbedCardStyle[];
   viewType: 'card' | 'embed';
 };
+
+export type IndentContext = {
+  blockId: string;
+  inlineIndex: number;
+  flavour: Extract<
+    keyof BlockSuite.BlockModels,
+    'affine:paragraph' | 'affine:list'
+  >;
+  type: 'indent' | 'dedent';
+};


### PR DESCRIPTION
This PR extracts the checking logic from `indentXXX` methods to `canIndentXXX` methods, enabling the implementation of a stateful UI that indicates the ability to indent paragraphs or lists.

### What Changes
- Extract `indentXXX` and `dedentXXX` checking logics to `canIndentXXX` and `canDedentXXX` commands
  - `canIndentParagraph`
  - `canDedentParagraph`
  - `canIndentList`
  - `canDedentLIst`
- Before using `indentXXX`, you should run `canIndentXXX`. For example
  ```ts
  std.command
    .chain()
    .canIndentParagraph({blockId: 'block-id', inlineIndex: 0}) // the context is optional
    .indentParagraph()
    .run();
  ```