### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/soft-badgers-allow.md
+++ b/.changeset/soft-badgers-allow.md
@@ -1,0 +1,26 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+## Fix
+
+- fix(edgeless): stop pointer event propagation from latex editor menu (#8633)
+- fix: use html theme observer result as default app theme value (#8635)
+- fix(blocks): incorrect mobile keyboard toolbar when scroll (#8634)


### PR DESCRIPTION
## Fix
- fix(edgeless): stop pointer event propagation from latex editor menu (#8633)
- fix: use html theme observer result as default app theme value (#8635)
- fix(blocks): incorrect mobile keyboard toolbar when scroll (#8634)