### PR TITLE
fix: add data-theme on surface ref component

### DIFF
--- a/packages/affine/block-surface/src/surface-block.ts
+++ b/packages/affine/block-surface/src/surface-block.ts
@@ -188,12 +188,24 @@ export class SurfaceBlockComponent extends BlockComponent<
       enableStackingCanvas: true,
       provider: {
         generateColorProperty: (color: Color, fallback: string) =>
-          themeService.generateColorProperty(color, fallback),
+          themeService.generateColorProperty(
+            color,
+            fallback,
+            themeService.edgelessTheme
+          ),
         getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          themeService.getColorValue(color, fallback, real),
-        getColorScheme: () => themeService.theme,
+          themeService.getColorValue(
+            color,
+            fallback,
+            real,
+            themeService.edgelessTheme
+          ),
+        getColorScheme: () => themeService.edgelessTheme,
         getPropertyValue: (property: string) =>
-          themeService.getCssVariableColor(property),
+          themeService.getCssVariableColor(
+            property,
+            themeService.edgelessTheme
+          ),
         selectedElements: () => this._edgelessService.selection.selectedIds,
       },
       onStackingCanvasCreated(canvas) {

--- a/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/surface-block.ts
@@ -101,13 +101,25 @@ export class MindmapSurfaceBlock extends BlockComponent<SurfaceBlockModel> {
       enableStackingCanvas: true,
       provider: {
         selectedElements: () => [],
-        getColorScheme: () => themeService.theme,
+        getColorScheme: () => themeService.edgelessTheme,
         getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          themeService.getColorValue(color, fallback, real),
+          themeService.getColorValue(
+            color,
+            fallback,
+            real,
+            themeService.edgelessTheme
+          ),
         generateColorProperty: (color: Color, fallback: string) =>
-          themeService.generateColorProperty(color, fallback),
+          themeService.generateColorProperty(
+            color,
+            fallback,
+            themeService.edgelessTheme
+          ),
         getPropertyValue: (property: string) =>
-          themeService.getCssVariableColor(property),
+          themeService.getCssVariableColor(
+            property,
+            themeService.edgelessTheme
+          ),
       },
       elementRenderers,
     });

--- a/packages/blocks/src/surface-ref-block/surface-ref-block.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-block.ts
@@ -19,6 +19,7 @@ import {
 import {
   DocModeProvider,
   EditPropsStore,
+  ThemeProvider,
 } from '@blocksuite/affine-shared/services';
 import { requestConnectedFrame } from '@blocksuite/affine-shared/utils';
 import {
@@ -609,10 +610,12 @@ export class SurfaceRefBlockComponent extends BlockComponent<
     const content = isEmpty
       ? this._renderRefPlaceholder(model)
       : this._renderRefContent(_referencedModel);
+    const edgelessTheme = this.std.get(ThemeProvider).edgeless$.value;
 
     return html`
       <div
         class="affine-surface-ref"
+        data-theme=${edgelessTheme}
         @click=${this._focusBlock}
         style=${styleMap({
           outline: this._focused

--- a/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-renderer.ts
@@ -69,12 +69,24 @@ export class SurfaceRefRenderer {
       enableStackingCanvas: options.enableStackingCanvas,
       provider: {
         generateColorProperty: (color: Color, fallback: string) =>
-          themeService.generateColorProperty(color, fallback),
-        getColorScheme: () => themeService.theme,
+          themeService.generateColorProperty(
+            color,
+            fallback,
+            themeService.edgelessTheme
+          ),
+        getColorScheme: () => themeService.edgelessTheme,
         getColorValue: (color: Color, fallback?: string, real?: boolean) =>
-          themeService.getColorValue(color, fallback, real),
+          themeService.getColorValue(
+            color,
+            fallback,
+            real,
+            themeService.edgelessTheme
+          ),
         getPropertyValue: (property: string) =>
-          themeService.getCssVariableColor(property),
+          themeService.getCssVariableColor(
+            property,
+            themeService.edgelessTheme
+          ),
       },
       elementRenderers,
     });

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -9,6 +9,7 @@ import {
   CommunityCanvasTextFonts,
   FontConfigExtension,
   NotificationExtension,
+  OverrideThemeExtension,
   type PageRootService,
   ParseDocUrlExtension,
   RefNodeSlotsExtension,
@@ -34,6 +35,7 @@ import {
   mockDocModeService,
   mockNotificationService,
   mockParseDocUrlService,
+  themeExtension,
 } from '../../_common/mock-services';
 
 function setDocModeFromUrlParams(service: DocModeProvider, docId: string) {
@@ -87,6 +89,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
     FontConfigExtension(CommunityCanvasTextFonts),
     ParseDocUrlExtension(mockParseDocUrlService(collection)),
     NotificationExtension(mockNotificationService(editor)),
+    OverrideThemeExtension(themeExtension),
     {
       setup: di => {
         di.override(DocModeProvider, () =>


### PR DESCRIPTION
Close issue [BS-1474](https://linear.app/affine-design/issue/BS-1474).

### What changed?
- Add `data-theme` on surface ref component
- Always use edgeless theme in `CanvasRenderer`

If edgeless theme is light:
![截屏2024-10-31 10.04.50.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/10e92138-6406-4ad5-adf1-f616198e892f.png)

If edgeless theme is dark:
![截屏2024-10-31 10.05.01.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/adf1eb81-2259-4005-87b7-d538d4135849.png)

