### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/gorgeous-rules-live.md
+++ b/.changeset/gorgeous-rules-live.md
@@ -1,0 +1,38 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+fix(edgeless): failed to add link in edgeless text (#8589)
+
+## Feat
+
+- feat(blocks): add callback control to AI panel hide and toggle (#8639)
+
+## Fix
+
+- fix(edgeless): failed to add link in edgeless text (#8589)
+- fix: add data-theme on surface ref component (#8638)
+- fix(edgeless): stop pointer event propagation from latex editor menu (#8633)
+- fix: use html theme observer result as default app theme value (#8635)
+- fix(blocks): incorrect mobile keyboard toolbar when scroll (#8634)
+
+## Chore
+
+- chore: release patch version (#8636)


### PR DESCRIPTION
fix(edgeless): failed to add link in edgeless text (#8589)
feat(blocks): add callback control to AI panel hide and toggle (#8639)
fix: add data-theme on surface ref component (#8638)
chore: release patch version (#8636)
fix(edgeless): stop pointer event propagation from latex editor menu (#8633)
fix: use html theme observer result as default app theme value (#8635)
fix(blocks): incorrect mobile keyboard toolbar when scroll