### PR TITLE
fix: scale note and edgeless-text when resize and align elements

### DIFF
--- a/tests/edgeless/align.spec.ts
+++ b/tests/edgeless/align.spec.ts
@@ -322,7 +322,7 @@ test.describe('auto resize align', () => {
     // arrange
     await triggerComponentToolbarAction(page, 'autoResize');
     await waitNextFrame(page, 200);
-    await assertEdgelessSelectedModelRect(page, [0, 0, 270, 200]);
+    await assertEdgelessSelectedModelRect(page, [0, 0, 437.4, 200]);
   });
 
   test('resize and arrange note', async ({ page }) => {


### PR DESCRIPTION
Close issue [BS-1621](https://linear.app/affine-design/issue/BS-1621).

Before:

![截屏2024-10-31 17.46.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/1f55e745-9bf7-46d6-aa7b-7afac4206813.png)

After:

![截屏2024-10-31 17.44.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/3765e773-6fca-49f3-bd02-6c21f3ebe8b6.png)

