### PR TITLE
refactor(blocks): provide position controll config for keyboard toolbar

### DIFF
--- a/packages/blocks/src/root-block/root-config.ts
+++ b/packages/blocks/src/root-block/root-config.ts
@@ -1,6 +1,7 @@
 import type { DatabaseOptionsConfig } from '../database-block/config.js';
 import type { ToolbarMoreMenuConfig } from './configs/index.js';
 import type { DocRemoteSelectionConfig } from './widgets/doc-remote-selection/config.js';
+import type { KeyboardToolbarConfig } from './widgets/keyboard-toolbar/config.js';
 import type { LinkedWidgetConfig } from './widgets/linked-doc/index.js';
 
 export interface RootBlockConfig {
@@ -8,4 +9,5 @@ export interface RootBlockConfig {
   docRemoteSelectionWidget?: Partial<DocRemoteSelectionConfig>;
   toolbarMoreMenu?: Partial<ToolbarMoreMenuConfig>;
   databaseOptions?: Partial<DatabaseOptionsConfig>;
+  keyboardToolbar?: Partial<KeyboardToolbarConfig>;
 }

--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -32,10 +32,7 @@ export {
 } from './format-bar/format-bar.js';
 export { AffineImageToolbarWidget } from './image-toolbar/index.js';
 export { AffineInnerModalWidget } from './inner-modal/inner-modal.js';
-export {
-  AFFINE_KEYBOARD_TOOLBAR_WIDGET,
-  AffineKeyboardToolbarWidget,
-} from './keyboard-toolbar/index.js';
+export * from './keyboard-toolbar/index.js';
 export { LinkedWidgetUtils } from './linked-doc/config.js';
 export {
   // It's used in the AFFiNE!

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
@@ -77,6 +77,17 @@ import { TOOL_PANEL_ICON_STYLE, TOOLBAR_ICON_STYLE } from './styles.js';
 
 export type KeyboardToolbarConfig = {
   items: KeyboardToolbarItem[];
+  /**
+   * @description Whether to use the screen height as the keyboard height when the virtual keyboard API is not supported.
+   * It is useful when the app is running in a webview and the keyboard is not overlaid on the content.
+   * @default false
+   */
+  useScreenHeight?: boolean;
+  /**
+   * @description The safe bottom padding of the keyboard toolbar.
+   * It is useful when the device has a rounded corner screen.
+   */
+  safeBottomPadding?: string;
 };
 
 export type KeyboardToolbarItem =
@@ -1019,4 +1030,5 @@ export const defaultKeyboardToolbarConfig: KeyboardToolbarConfig = {
       },
     },
   ],
+  useScreenHeight: false,
 };

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
@@ -6,12 +6,19 @@ import { html, nothing } from 'lit';
 import { PageRootBlockComponent } from '../../page/page-root-block.js';
 import { defaultKeyboardToolbarConfig } from './config.js';
 
+export * from './config.js';
+
 export const AFFINE_KEYBOARD_TOOLBAR_WIDGET = 'affine-keyboard-toolbar-widget';
 
 export class AffineKeyboardToolbarWidget extends WidgetComponent {
   private readonly _showToolPanel$ = signal(false);
 
-  keyboardToolbarConfig = defaultKeyboardToolbarConfig;
+  get config() {
+    return {
+      ...defaultKeyboardToolbarConfig,
+      ...this.std.getConfig('affine:page')?.keyboardToolbar,
+    };
+  }
 
   override render() {
     if (
@@ -26,7 +33,7 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent {
 
     return html`<blocksuite-portal
       .template=${html`<affine-keyboard-toolbar
-        .config=${this.keyboardToolbarConfig}
+        .config=${this.config}
         .rootComponent=${this.block.rootComponent}
         .showToolPanel=${this._showToolPanel$}
       ></affine-keyboard-toolbar> `}

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
@@ -159,6 +159,18 @@ export class AffineKeyboardToolbar extends SignalWatcher(
     return this._path$.value.length > 0;
   }
 
+  private get _safeBottomPaddingStyle() {
+    const safeBottomPadding = this.config.safeBottomPadding;
+    return styleMap(
+      this._shrink$.value && safeBottomPadding
+        ? {
+            paddingBottom: safeBottomPadding,
+            height: `calc(${TOOLBAR_HEIGHT}px + ${safeBottomPadding})`,
+          }
+        : {}
+    );
+  }
+
   private _renderIcon(icon: KeyboardIconType) {
     return typeof icon === 'function' ? icon(this._context) : icon;
   }
@@ -257,10 +269,11 @@ export class AffineKeyboardToolbar extends SignalWatcher(
           document.body.style.paddingBottom = '0px';
         } else if (this._shrink$.value) {
           document.body.style.paddingBottom = `${TOOLBAR_HEIGHT}px`;
-        } else if (this._keyboardController.opened) {
+        } else if (
+          this._keyboardController.opened &&
+          !this.config.useScreenHeight
+        ) {
           document.body.style.paddingBottom = `${this._keyboardController.keyboardHeight + TOOLBAR_HEIGHT}px`;
-        } else if (this._isPanelOpened) {
-          document.body.style.paddingBottom = `${this._panelHeight$.value + TOOLBAR_HEIGHT}px`;
         } else {
           document.body.style.paddingBottom = '0px';
         }
@@ -271,10 +284,14 @@ export class AffineKeyboardToolbar extends SignalWatcher(
   override render() {
     if (!this._showToolbar$.value) return nothing;
 
-    this.style.bottom = `${this._shrink$.value ? -this._panelHeight$.value : 0}px`;
+    this.style.bottom =
+      (this.config.useScreenHeight && this._keyboardController.opened) ||
+      this._shrink$.value
+        ? `${-this._panelHeight$.value}px`
+        : '0px';
 
     return html`
-      <div class="keyboard-toolbar">
+      <div class="keyboard-toolbar" style=${this._safeBottomPaddingStyle}>
         ${this._renderItems()}
         <div class="divider"></div>
         ${this._renderKeyboardButton()}

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
@@ -8,6 +8,7 @@ import type { PageRootBlockComponent } from '../../page/page-root-block.js';
 import type {
   KeyboardSubToolbarConfig,
   KeyboardToolbarActionItem,
+  KeyboardToolbarConfig,
   KeyboardToolbarItem,
   KeyboardToolPanelConfig,
 } from './config.js';
@@ -29,6 +30,10 @@ export class VirtualKeyboardController implements ReactiveController {
       this._keyboardOpened$.value = virtualKeyboard.boundingRect.height > 0;
       this._keyboardHeight$.value = virtualKeyboard.boundingRect.height;
     } else if (visualViewport) {
+      const windowHeight = this.host.config.useScreenHeight
+        ? window.screen.height
+        : window.innerHeight;
+
       /**
        * ┌───────────────┐ - window top
        * │               │
@@ -42,10 +47,9 @@ export class VirtualKeyboardController implements ReactiveController {
        * │               │                       │ visualViewport.offsetTop
        * └───────────────┘ - window bottom       --
        */
-      this._keyboardOpened$.value =
-        window.innerHeight - visualViewport.height > 0;
+      this._keyboardOpened$.value = windowHeight - visualViewport.height > 0;
       this._keyboardHeight$.value =
-        window.innerHeight - visualViewport.height - visualViewport.offsetTop;
+        windowHeight - visualViewport.height - visualViewport.offsetTop;
     } else {
       notSupportedWarning();
     }
@@ -60,7 +64,10 @@ export class VirtualKeyboardController implements ReactiveController {
     }
   };
 
-  host: ReactiveControllerHost & { rootComponent: PageRootBlockComponent };
+  host: ReactiveControllerHost & {
+    rootComponent: PageRootBlockComponent;
+    config: KeyboardToolbarConfig;
+  };
 
   show = () => {
     if (navigator.virtualKeyboard) {
@@ -91,9 +98,7 @@ export class VirtualKeyboardController implements ReactiveController {
     return this._keyboardOpened$.value;
   }
 
-  constructor(
-    host: ReactiveControllerHost & { rootComponent: PageRootBlockComponent }
-  ) {
+  constructor(host: VirtualKeyboardController['host']) {
     (this.host = host).addController(this);
   }
 


### PR DESCRIPTION
This PR provide new two config field for mobile keyboard toolbar, `useScreenHeight` and `safeBottomPadding`.
### What Changes:
- `useScreenHeight`. It is useful when the editor is used in  a webview widget, where the entire size of visual viewport and window will effected by virutal keyboard and lead the calculation of the height of virtual keyboard not correct.
  ![CleanShot 2024-11-01 at 03.11.57@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/aa6555ee-f255-4d52-ae6c-538985b9a5ae.png)
- `safeBottomPadding`. It is useful when the device has rounded corner screen
 