### PR TITLE
fix(blocks): reset keyboard toolbar after blur

### DIFF
--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
@@ -246,6 +246,8 @@ export class AffineKeyboardToolbar extends SignalWatcher(
     this.disposables.addFromEvent(this.rootComponent, 'blur', () => {
       this._showToolbar$.value = false;
       this._shrink$.value = true;
+      this._currentPanelIndex$.value = -1;
+      this._path$.value = [];
     });
 
     // prevent editor blur when click item in toolbar

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
@@ -59,7 +59,6 @@ export class VirtualKeyboardController implements ReactiveController {
     if (navigator.virtualKeyboard) {
       navigator.virtualKeyboard.hide();
     } else {
-      if (document.activeElement !== this.host.rootComponent) return;
       this.host.rootComponent.inputMode = 'none';
     }
   };
@@ -73,7 +72,6 @@ export class VirtualKeyboardController implements ReactiveController {
     if (navigator.virtualKeyboard) {
       navigator.virtualKeyboard.show();
     } else {
-      if (document.activeElement !== this.host.rootComponent) return;
       this.host.rootComponent.inputMode = '';
     }
   };
@@ -115,17 +113,6 @@ export class VirtualKeyboardController implements ReactiveController {
         navigator.virtualKeyboard.overlaysContent = overlaysContent;
         this.host.rootComponent.virtualKeyboardPolicy = virtualKeyboardPolicy;
       });
-
-      this._disposables.addFromEvent(
-        this.host.rootComponent,
-        'focus',
-        this.show
-      );
-      this._disposables.addFromEvent(
-        this.host.rootComponent,
-        'blur',
-        this.hide
-      );
       this._disposables.addFromEvent(
         navigator.virtualKeyboard,
         'geometrychange',
@@ -145,6 +132,9 @@ export class VirtualKeyboardController implements ReactiveController {
     } else {
       notSupportedWarning();
     }
+
+    this._disposables.addFromEvent(this.host.rootComponent, 'focus', this.show);
+    this._disposables.addFromEvent(this.host.rootComponent, 'blur', this.hide);
 
     this._updateKeyboardHeight();
   }


### PR DESCRIPTION
### What Changes:
- Fix keyboard is not opened after blur then focus
- Fix the state of keybaord toolbar not reset after blur