### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/two-rice-hope.md
+++ b/.changeset/two-rice-hope.md
@@ -1,0 +1,33 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+fix(blocks): reset keyboard toolbar after blur (#8646)
+
+## Fix
+
+- fix(blocks): reset keyboard toolbar after blur (#8646)
+- fix: scale note and edgeless-text when resize and align elements (#8642)
+- fix(edgeless): can not insert link when no selection (#8644)
+- fix(database): prevent 0 in number cells from getting rendered as an empty string (#8629)
+
+## Refactor
+
+- refactor(blocks): provide position controll config for keyboard toolbar (#8645)


### PR DESCRIPTION
## Fix

- fix(blocks): reset keyboard toolbar after blur (#8646)
- fix: scale note and edgeless-text when resize and align elements (#8642)
- fix(edgeless): can not insert link when no selection (#8644)
- fix(database): prevent 0 in number cells from getting rendered as an empty string (#8629)

## Refactor

- refactor(blocks): provide position controll config for keyboard toolbar (#8645)