### PR TITLE
chore: make playground run in secure context

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@tweakpane/core": "^2.0.4",
     "@types/micromatch": "^4.0.9",
+    "@vitejs/plugin-basic-ssl": "^1.1.0",
     "graphql": "^16.9.0",
     "magic-string": "^0.30.11",
     "vite-plugin-wasm": "^3.3.0"

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,6 +1,7 @@
 import type { GetManualChunk } from 'rollup';
 import type { Plugin } from 'vite';
 
+import basicSsl from '@vitejs/plugin-basic-ssl';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { cpus } from 'node:os';
@@ -163,6 +164,9 @@ export default ({ mode }) => {
 
   return defineConfig({
     envDir: __dirname,
+    server: {
+      https: {},
+    },
     define: {
       'import.meta.env.PLAYGROUND_SERVER': JSON.stringify(
         process.env.PLAYGROUND_SERVER ?? 'http://localhost:8787'
@@ -187,6 +191,7 @@ export default ({ mode }) => {
         }),
       wasm(),
       clearSiteDataPlugin(),
+      basicSsl(),
     ],
     esbuild: {
       target: 'es2018',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,6 +1853,7 @@ __metadata:
     "@tweakpane/core": "npm:^2.0.4"
     "@types/katex": "npm:^0.16.7"
     "@types/micromatch": "npm:^4.0.9"
+    "@vitejs/plugin-basic-ssl": "npm:^1.1.0"
     browser-fs-access: "npm:^0.35.0"
     graphql: "npm:^16.9.0"
     jszip: "npm:^3.10.1"
@@ -5200,6 +5201,15 @@ __metadata:
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
   checksum: 10/c6fe89a505e513a7592e1438280db1c075764793a2397877ff1351721fe8792a966a5359769e30242b3cd023f2efb9e63ca2ca88019d73b564488cc20e3eab12
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-basic-ssl@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@vitejs/plugin-basic-ssl@npm:1.1.0"
+  peerDependencies:
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+  checksum: 10/2c0631d1202a1b5f198a96c761cbcdde3730cc03a9be565ea12c37b47c22dd22976dc4bd614a400c431a55be0270359cf59fbb0530e77fafc0e591b1f58858ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
when accessing the playground via IP on the LAN, the following error is thrown
<img width="451" alt="image" src="https://github.com/user-attachments/assets/90b455f6-01c5-49cc-8c67-2089b0e07d02">
