### PR TITLE
refactor(blocks): render linked doc popover with blocksuite-portal

### DIFF
--- a/packages/affine/components/src/portal/portal.ts
+++ b/packages/affine/components/src/portal/portal.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit';
+import { html, LitElement, type TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 
 /**
@@ -50,7 +50,7 @@ export class Portal extends LitElement {
   accessor shadowDom: boolean | ShadowRootInit = true;
 
   @property({ attribute: false })
-  accessor template = html``;
+  accessor template: TemplateResult | undefined = html``;
 }
 
 declare global {

--- a/packages/blocks/src/effects.ts
+++ b/packages/blocks/src/effects.ts
@@ -209,7 +209,6 @@ import {
   AffineFormatBarWidget,
   AffineImageToolbarWidget,
   AffineInnerModalWidget,
-  AffineLinkedDocWidget,
   AffineModalWidget,
   AffinePageDraggingAreaWidget,
   AffinePieMenuWidget,
@@ -278,9 +277,7 @@ import { AffineImageToolbar } from './root-block/widgets/image-toolbar/component
 import { AFFINE_IMAGE_TOOLBAR_WIDGET } from './root-block/widgets/image-toolbar/index.js';
 import { AFFINE_INNER_MODAL_WIDGET } from './root-block/widgets/inner-modal/inner-modal.js';
 import { effects as widgetMobileToolbarEffects } from './root-block/widgets/keyboard-toolbar/effects.js';
-import { ImportDoc } from './root-block/widgets/linked-doc/import-doc/import-doc.js';
-import { AFFINE_LINKED_DOC_WIDGET } from './root-block/widgets/linked-doc/index.js';
-import { LinkedDocPopover } from './root-block/widgets/linked-doc/linked-doc-popover.js';
+import { effects as widgetLinkedDocEffects } from './root-block/widgets/linked-doc/effects.js';
 import { AffineCustomModal } from './root-block/widgets/modal/custom-modal.js';
 import { AFFINE_MODAL_WIDGET } from './root-block/widgets/modal/modal.js';
 import { AFFINE_PAGE_DRAGGING_AREA_WIDGET } from './root-block/widgets/page-dragging-area/page-dragging-area.js';
@@ -341,6 +338,7 @@ export function effects() {
 
   widgetScrollAnchoringEffects();
   widgetMobileToolbarEffects();
+  widgetLinkedDocEffects();
 
   customElements.define('affine-database-title', DatabaseTitle);
   customElements.define(
@@ -378,7 +376,6 @@ export function effects() {
   customElements.define('edgeless-note-mask', EdgelessNoteMask);
   customElements.define('affine-edgeless-note', EdgelessNoteBlockComponent);
   customElements.define('affine-preview-root', PreviewRootBlockComponent);
-  customElements.define('affine-linked-doc-popover', LinkedDocPopover);
   customElements.define('affine-page-image', ImageBlockPageComponent);
   customElements.define('affine-code', CodeBlockComponent);
   customElements.define('affine-image-fallback-card', ImageBlockFallbackCard);
@@ -616,7 +613,6 @@ export function effects() {
     'edgeless-change-attachment-button',
     EdgelessChangeAttachmentButton
   );
-  customElements.define('import-doc', ImportDoc);
   customElements.define('edgeless-more-button', EdgelessMoreButton);
   customElements.define('edgeless-shape-style-panel', EdgelessShapeStylePanel);
   customElements.define(
@@ -657,7 +653,6 @@ export function effects() {
   customElements.define(AFFINE_PIE_MENU_WIDGET, AffinePieMenuWidget);
   customElements.define(AFFINE_EDGELESS_COPILOT_WIDGET, EdgelessCopilotWidget);
 
-  customElements.define(AFFINE_LINKED_DOC_WIDGET, AffineLinkedDocWidget);
   customElements.define(
     EDGELESS_ELEMENT_TOOLBAR_WIDGET,
     EdgelessElementToolbarWidget

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
@@ -315,8 +315,14 @@ const pageToolGroup: KeyboardToolPanelGroup = {
       action: ({ rootComponent, closeToolbar }) => {
         const { std } = rootComponent;
 
-        const triggerKey =
-          std.getConfig('affine:page')?.linkedWidget?.triggerKeys?.[0] ?? '@';
+        const linkedDocWidget = std.view.getWidget(
+          'affine-linked-doc-widget',
+          rootComponent.model.id
+        );
+        if (!linkedDocWidget) return;
+        assertType<AffineLinkedDocWidget>(linkedDocWidget);
+
+        const triggerKey = linkedDocWidget.config.triggerKeys[0];
 
         std.command
           .chain()
@@ -328,17 +334,10 @@ const pageToolGroup: KeyboardToolPanelGroup = {
             const currentModel = selectedModels[0];
             insertContent(std.host, currentModel, triggerKey);
 
-            const linkedDocWidget = std.view.getWidget(
-              'affine-linked-doc-widget',
-              rootComponent.model.id
-            );
-            if (!linkedDocWidget) return;
-            assertType<AffineLinkedDocWidget>(linkedDocWidget);
-
             const inlineEditor = getInlineEditorByModel(std.host, currentModel);
             // Wait for range to be updated
             inlineEditor?.slots.inlineRangeSync.once(() => {
-              linkedDocWidget.showLinkedDocPopover(inlineEditor, triggerKey);
+              linkedDocWidget.showLinkedDocPopover();
               closeToolbar();
             });
           })

--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -1,4 +1,4 @@
-import type { EditorHost } from '@blocksuite/block-std';
+import type { BlockStdScope, EditorHost } from '@blocksuite/block-std';
 import type { TemplateResult } from 'lit';
 
 import {
@@ -40,6 +40,14 @@ export type LinkedMenuGroup = {
   maxDisplay?: number;
   // copywriting when display quantity exceeds
   overflowText?: string;
+};
+
+export type LinkedDocContext = {
+  std: BlockStdScope;
+  inlineEditor: AffineInlineEditor;
+  triggerKey: string;
+  getMenus: typeof getMenus;
+  close: () => void;
 };
 
 const DEFAULT_DOC_NAME = 'Untitled';

--- a/packages/blocks/src/root-block/widgets/linked-doc/effects.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/effects.ts
@@ -1,0 +1,9 @@
+import { ImportDoc } from './import-doc/import-doc.js';
+import { AFFINE_LINKED_DOC_WIDGET, AffineLinkedDocWidget } from './index.js';
+import { LinkedDocPopover } from './linked-doc-popover.js';
+
+export function effects() {
+  customElements.define('affine-linked-doc-popover', LinkedDocPopover);
+  customElements.define(AFFINE_LINKED_DOC_WIDGET, AffineLinkedDocWidget);
+  customElements.define('import-doc', ImportDoc);
+}

--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -1,52 +1,60 @@
-import type { AffineInlineEditor } from '@blocksuite/affine-components/rich-text';
-import type { EditorHost } from '@blocksuite/block-std';
+import type { InlineRange } from '@blocksuite/inline';
 
 import { MoreHorizontalIcon } from '@blocksuite/affine-components/icons';
-import { WithDisposable } from '@blocksuite/global/utils';
+import {
+  getCurrentNativeRange,
+  getViewportElement,
+} from '@blocksuite/affine-shared/utils';
+import { PropTypes, requiredProperties } from '@blocksuite/block-std';
+import { throttle, WithDisposable } from '@blocksuite/global/utils';
 import { html, LitElement, nothing } from 'lit';
-import { query, queryAll, state } from 'lit/decorators.js';
+import { property, query, queryAll, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import type { IconButton } from '../../../_common/components/button.js';
-import type { LinkedMenuGroup } from './config.js';
+import type { LinkedDocContext, LinkedMenuGroup } from './config.js';
 
 import {
   cleanSpecifiedTail,
   createKeydownObserver,
   getQuery,
 } from '../../../_common/components/utils.js';
+import { getPopperPosition } from '../../utils/position.js';
 import { styles } from './styles.js';
 
+@requiredProperties({
+  context: PropTypes.object,
+})
 export class LinkedDocPopover extends WithDisposable(LitElement) {
   static override styles = styles;
 
   private _abort = () => {
     // remove popover dom
-    this.abortController.abort();
+    this.context.close();
     // clear input query
     cleanSpecifiedTail(
-      this.editorHost,
-      this.inlineEditor,
-      this.triggerKey + (this._query || '')
+      this.context.std.host,
+      this.context.inlineEditor,
+      this.context.triggerKey + (this._query || '')
     );
   };
 
   private _expanded = new Map<string, boolean>();
 
-  private _startRange = this.inlineEditor.getInlineRange();
+  private _startRange: InlineRange | null = null;
 
   private _updateLinkedDocGroup = async () => {
     const query = this._query;
 
     if (query === null) {
-      this.abortController.abort();
+      this.context.close();
       return;
     }
-    this._linkedDocGroup = await this.getMenus(
+    this._linkedDocGroup = await this.context.getMenus(
       query,
       this._abort,
-      this.editorHost,
-      this.inlineEditor
+      this.context.std.host,
+      this.context.inlineEditor
     );
   };
 
@@ -68,22 +76,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
   }
 
   private get _query() {
-    return getQuery(this.inlineEditor, this._startRange);
-  }
-
-  constructor(
-    private triggerKey: string,
-    private getMenus: (
-      query: string,
-      abort: () => void,
-      editorHost: EditorHost,
-      inlineEditor: AffineInlineEditor
-    ) => Promise<LinkedMenuGroup[]>,
-    private editorHost: EditorHost,
-    private inlineEditor: AffineInlineEditor,
-    private abortController: AbortController
-  ) {
-    super();
+    return getQuery(this.context.inlineEditor, this._startRange);
   }
 
   private _getActionItems(group: LinkedMenuGroup) {
@@ -115,23 +108,33 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     super.connectedCallback();
 
     // init
+    this._startRange = this.context.inlineEditor.getInlineRange();
+
     void this._updateLinkedDocGroup();
     this._disposables.addFromEvent(this, 'mousedown', e => {
       // Prevent input from losing focus
       e.preventDefault();
     });
+    this._disposables.addFromEvent(window, 'mousedown', e => {
+      if (e.target === this) return;
+      this._abort();
+    });
 
-    const { eventSource } = this.inlineEditor;
+    const keydownObserverAbortController = new AbortController();
+    this._disposables.add(() => keydownObserverAbortController.abort());
+
+    const { eventSource } = this.context.inlineEditor;
     if (!eventSource) return;
+
     createKeydownObserver({
       target: eventSource,
-      signal: this.abortController.signal,
+      signal: keydownObserverAbortController.signal,
       onInput: isComposition => {
         this._activatedItemIndex = 0;
         if (isComposition) {
           this._updateLinkedDocGroup().catch(console.error);
         } else {
-          this.inlineEditor.slots.renderComplete.once(
+          this.context.inlineEditor.slots.renderComplete.once(
             this._updateLinkedDocGroup
           );
         }
@@ -143,15 +146,17 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
         }, 50);
       },
       onDelete: () => {
-        const curRange = this.inlineEditor.getInlineRange();
+        const curRange = this.context.inlineEditor.getInlineRange();
         if (!this._startRange || !curRange) {
           return;
         }
         if (curRange.index < this._startRange.index) {
-          this.abortController.abort();
+          this.context.close();
         }
         this._activatedItemIndex = 0;
-        this.inlineEditor.slots.renderComplete.once(this._updateLinkedDocGroup);
+        this.context.inlineEditor.slots.renderComplete.once(
+          this._updateLinkedDocGroup
+        );
       },
       onMove: step => {
         const itemLen = this._flattenActionList.length;
@@ -182,7 +187,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
           ?.catch(console.error);
       },
       onAbort: () => {
-        this.abortController.abort();
+        this.context.close();
       },
     });
   }
@@ -253,6 +258,33 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     this._position = position;
   }
 
+  override willUpdate() {
+    if (!this.hasUpdated) {
+      const curRange = getCurrentNativeRange();
+      if (!curRange) return;
+
+      const updatePosition = throttle(() => {
+        const position = getPopperPosition(this, curRange);
+        this.updatePosition(position);
+      }, 10);
+
+      this.disposables.addFromEvent(window, 'resize', updatePosition);
+      const scrollContainer = getViewportElement(this.context.std.host);
+      if (scrollContainer) {
+        // Note: in edgeless mode, the scroll container is not exist!
+        this.disposables.addFromEvent(
+          scrollContainer,
+          'scroll',
+          updatePosition,
+          {
+            passive: true,
+          }
+        );
+      }
+      updatePosition();
+    }
+  }
+
   @state()
   private accessor _activatedItemIndex = 0;
 
@@ -268,6 +300,9 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
 
   @state()
   private accessor _showTooltip = false;
+
+  @property({ attribute: false })
+  accessor context!: LinkedDocContext;
 
   @queryAll('icon-button')
   accessor iconButtons!: NodeListOf<IconButton>;

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -232,8 +232,6 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         return true;
       },
       action: ({ model, rootComponent }) => {
-        const triggerKey = '@';
-        insertContent(rootComponent.host, model, triggerKey);
         const { std } = rootComponent;
 
         const linkedDocWidget = std.view.getWidget(
@@ -243,10 +241,14 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         if (!linkedDocWidget) return;
         assertType<AffineLinkedDocWidget>(linkedDocWidget);
 
+        const triggerKey = linkedDocWidget.config.triggerKeys[0];
+
+        insertContent(rootComponent.host, model, triggerKey);
+
         const inlineEditor = getInlineEditorByModel(rootComponent.host, model);
         // Wait for range to be updated
         inlineEditor?.slots.inlineRangeSync.once(() => {
-          linkedDocWidget.showLinkedDocPopover(inlineEditor, triggerKey);
+          linkedDocWidget.showLinkedDocPopover();
         });
       },
     },


### PR DESCRIPTION
### What Changes:
- Using `<blocksuite-portal>` to render linked doc popover
- Move side effects of linked doc widget to single file `widgets/linked-doc/effects.ts`