### PR TITLE
fix: whiteboard is first loaded, size of the linked doc card is scaled to wrong size

### DIFF
--- a/packages/affine/block-embed/src/embed-figma-block/embed-figma-block.ts
+++ b/packages/affine/block-embed/src/embed-figma-block/embed-figma-block.ts
@@ -56,6 +56,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockComponent<
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     if (!this.model.description && !this.model.title) {
       this.doc.withoutTransact(() => {
@@ -99,10 +100,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockComponent<
   }
 
   override renderBlock() {
-    const { title, description, style, url } = this.model;
-
-    this._cardStyle = style;
-
+    const { title, description, url } = this.model;
     const titleText = title ?? 'Figma';
     const descriptionText = description ?? url;
 

--- a/packages/affine/block-embed/src/embed-github-block/embed-github-block.ts
+++ b/packages/affine/block-embed/src/embed-github-block/embed-github-block.ts
@@ -76,6 +76,7 @@ export class EmbedGithubBlockComponent extends EmbedBlockComponent<
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     if (!this.model.owner || !this.model.repo || !this.model.githubId) {
       this.doc.withoutTransact(() => {
@@ -131,8 +132,6 @@ export class EmbedGithubBlockComponent extends EmbedBlockComponent<
       image,
       style,
     } = this.model;
-
-    this._cardStyle = style;
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;

--- a/packages/affine/block-embed/src/embed-html-block/embed-html-block.ts
+++ b/packages/affine/block-embed/src/embed-html-block/embed-html-block.ts
@@ -49,6 +49,7 @@ export class EmbedHtmlBlockComponent extends EmbedBlockComponent<EmbedHtmlModel>
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     // this is required to prevent iframe from capturing pointer events
     this.disposables.add(
@@ -75,10 +76,6 @@ export class EmbedHtmlBlockComponent extends EmbedBlockComponent<EmbedHtmlModel>
   }
 
   override renderBlock(): unknown {
-    const { style } = this.model;
-
-    this._cardStyle = style;
-
     const titleText = 'Basic HTML Page Structure';
 
     const htmlSrc = `

--- a/packages/affine/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -260,6 +260,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
   override connectedCallback() {
     super.connectedCallback();
 
+    this._cardStyle = this.model.style;
     this._isLinkToNode = isLinkToNode(this.model);
 
     this._load().catch(e => {
@@ -342,8 +343,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
   }
 
   override renderBlock() {
-    this._cardStyle = this.model.style;
-
     const linkedDoc = this.linkedDoc;
     const isDeleted = !linkedDoc;
     const isLoading = this._loading;

--- a/packages/affine/block-embed/src/embed-loom-block/embed-loom-block.ts
+++ b/packages/affine/block-embed/src/embed-loom-block/embed-loom-block.ts
@@ -61,6 +61,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     if (!this.model.videoId) {
       this.doc.withoutTransact(() => {
@@ -115,9 +116,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
   }
 
   override renderBlock() {
-    const { image, title = 'Loom', description, videoId, style } = this.model;
-
-    this._cardStyle = style;
+    const { image, title = 'Loom', description, videoId } = this.model;
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;

--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -427,6 +427,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     this.style.display = 'block';
     this._load().catch(e => {
@@ -500,10 +501,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
 
   override renderBlock() {
     delete this.dataset.nestedEditor;
-
-    const { style } = this.model;
-
-    this._cardStyle = style;
 
     const syncedDoc = this.syncedDoc;
     const { isLoading, isError, isDeleted, isCycle } = this.blockState;

--- a/packages/affine/block-embed/src/embed-youtube-block/embed-youtube-block.ts
+++ b/packages/affine/block-embed/src/embed-youtube-block/embed-youtube-block.ts
@@ -64,6 +64,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
 
   override connectedCallback() {
     super.connectedCallback();
+    this._cardStyle = this.model.style;
 
     if (!this.model.videoId) {
       this.doc.withoutTransact(() => {
@@ -129,10 +130,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
       creator,
       creatorImage,
       videoId,
-      style,
     } = this.model;
-
-    this._cardStyle = style;
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;


### PR DESCRIPTION
Fix issue [BS-1572](https://linear.app/affine-design/issue/BS-1572).

Set the value of `_cardStyle` at an earlier opportunity, in case the scale calculation uses the old `_cardStyle` value.