### PR TITLE
feat(blocks): mobile at menu

### DIFF
--- a/packages/blocks/src/root-block/widgets/index.ts
+++ b/packages/blocks/src/root-block/widgets/index.ts
@@ -33,7 +33,10 @@ export {
 export { AffineImageToolbarWidget } from './image-toolbar/index.js';
 export { AffineInnerModalWidget } from './inner-modal/inner-modal.js';
 export * from './keyboard-toolbar/index.js';
-export { LinkedWidgetUtils } from './linked-doc/config.js';
+export {
+  type LinkedWidgetConfig,
+  LinkedWidgetUtils,
+} from './linked-doc/config.js';
 export {
   // It's used in the AFFiNE!
   showImportModal,

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
@@ -299,18 +299,7 @@ const pageToolGroup: KeyboardToolPanelGroup = {
         );
         if (!linkedDocWidget) return false;
 
-        const hasLinkedDocSchema = std.doc.schema.flavourSchemaMap.has(
-          'affine:embed-linked-doc'
-        );
-        if (!hasLinkedDocSchema) return false;
-
-        if (!('showLinkedDocPopover' in linkedDocWidget)) {
-          console.warn(
-            'You may not have correctly implemented the linkedDoc widget! "showLinkedDoc(model)" method not found on widget'
-          );
-          return false;
-        }
-        return true;
+        return std.doc.schema.flavourSchemaMap.has('affine:embed-linked-doc');
       },
       action: ({ rootComponent, closeToolbar }) => {
         const { std } = rootComponent;
@@ -337,7 +326,7 @@ const pageToolGroup: KeyboardToolPanelGroup = {
             const inlineEditor = getInlineEditorByModel(std.host, currentModel);
             // Wait for range to be updated
             inlineEditor?.slots.inlineRangeSync.once(() => {
-              linkedDocWidget.showLinkedDocPopover();
+              linkedDocWidget.show('mobile');
               closeToolbar();
             });
           })

--- a/packages/blocks/src/root-block/widgets/linked-doc/config.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/config.ts
@@ -1,4 +1,5 @@
 import type { BlockStdScope, EditorHost } from '@blocksuite/block-std';
+import type { InlineRange } from '@blocksuite/inline';
 import type { TemplateResult } from 'lit';
 
 import {
@@ -23,6 +24,43 @@ import {
 
 import { showImportModal } from './import-doc/index.js';
 
+export interface LinkedWidgetConfig {
+  /**
+   * The first item of the trigger keys will be the primary key
+   * e.g. @, [[
+   */
+  triggerKeys: [string, ...string[]];
+  /**
+   * Convert trigger key to primary key (the first item of the trigger keys)
+   * [[ -> @
+   */
+  convertTriggerKey: boolean;
+  ignoreBlockTypes: (keyof BlockSuite.BlockModels)[];
+  getMenus: (
+    query: string,
+    abort: () => void,
+    editorHost: EditorHost,
+    inlineEditor: AffineInlineEditor
+  ) => Promise<LinkedMenuGroup[]>;
+
+  mobile: {
+    useScreenHeight?: boolean;
+    /**
+     * The linked doc menu widget will scroll the container to make sure the input cursor is visible in viewport.
+     * It accepts a selector string, HTMLElement or Window
+     *
+     * @default getViewportElement(editorHost) this is the scrollable container in playground
+     */
+    scrollContainer?: string | HTMLElement | Window;
+    /**
+     * The offset between the top of viewport and the input cursor
+     *
+     * @default 46 The height of header in playground
+     */
+    scrollTopOffset?: number | (() => number);
+  };
+}
+
 export type LinkedMenuItem = {
   key: string;
   name: string;
@@ -45,8 +83,9 @@ export type LinkedMenuGroup = {
 export type LinkedDocContext = {
   std: BlockStdScope;
   inlineEditor: AffineInlineEditor;
+  startRange: InlineRange;
   triggerKey: string;
-  getMenus: typeof getMenus;
+  config: LinkedWidgetConfig;
   close: () => void;
 };
 

--- a/packages/blocks/src/root-block/widgets/linked-doc/effects.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/effects.ts
@@ -1,9 +1,15 @@
 import { ImportDoc } from './import-doc/import-doc.js';
 import { AFFINE_LINKED_DOC_WIDGET, AffineLinkedDocWidget } from './index.js';
 import { LinkedDocPopover } from './linked-doc-popover.js';
+import { AffineMobileLinkedDocMenu } from './mobile-linked-doc-menu.js';
 
 export function effects() {
   customElements.define('affine-linked-doc-popover', LinkedDocPopover);
   customElements.define(AFFINE_LINKED_DOC_WIDGET, AffineLinkedDocWidget);
   customElements.define('import-doc', ImportDoc);
+
+  customElements.define(
+    'affine-mobile-linked-doc-menu',
+    AffineMobileLinkedDocMenu
+  );
 }

--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -1,5 +1,3 @@
-import type { InlineRange } from '@blocksuite/inline';
-
 import { MoreHorizontalIcon } from '@blocksuite/affine-components/icons';
 import {
   getCurrentNativeRange,
@@ -20,13 +18,13 @@ import {
   getQuery,
 } from '../../../_common/components/utils.js';
 import { getPopperPosition } from '../../utils/position.js';
-import { styles } from './styles.js';
+import { linkedDocPopoverStyles } from './styles.js';
 
 @requiredProperties({
   context: PropTypes.object,
 })
 export class LinkedDocPopover extends WithDisposable(LitElement) {
-  static override styles = styles;
+  static override styles = linkedDocPopoverStyles;
 
   private _abort = () => {
     // remove popover dom
@@ -41,8 +39,6 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
 
   private _expanded = new Map<string, boolean>();
 
-  private _startRange: InlineRange | null = null;
-
   private _updateLinkedDocGroup = async () => {
     const query = this._query;
 
@@ -50,7 +46,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
       this.context.close();
       return;
     }
-    this._linkedDocGroup = await this.context.getMenus(
+    this._linkedDocGroup = await this.context.config.getMenus(
       query,
       this._abort,
       this.context.std.host,
@@ -76,7 +72,7 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
   }
 
   private get _query() {
-    return getQuery(this.context.inlineEditor, this._startRange);
+    return getQuery(this.context.inlineEditor, this.context.startRange);
   }
 
   private _getActionItems(group: LinkedMenuGroup) {
@@ -108,8 +104,6 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     super.connectedCallback();
 
     // init
-    this._startRange = this.context.inlineEditor.getInlineRange();
-
     void this._updateLinkedDocGroup();
     this._disposables.addFromEvent(this, 'mousedown', e => {
       // Prevent input from losing focus
@@ -147,10 +141,10 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
       },
       onDelete: () => {
         const curRange = this.context.inlineEditor.getInlineRange();
-        if (!this._startRange || !curRange) {
+        if (!this.context.startRange || !curRange) {
           return;
         }
-        if (curRange.index < this._startRange.index) {
+        if (curRange.index < this.context.startRange.index) {
           this.context.close();
         }
         this._activatedItemIndex = 0;

--- a/packages/blocks/src/root-block/widgets/linked-doc/mobile-linked-doc-menu.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/mobile-linked-doc-menu.ts
@@ -1,0 +1,234 @@
+import {
+  VirtualKeyboardController,
+  type VirtualKeyboardControllerConfig,
+} from '@blocksuite/affine-components/virtual-keyboard';
+import { getViewportElement } from '@blocksuite/affine-shared/utils';
+import { PropTypes, requiredProperties } from '@blocksuite/block-std';
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
+import { MoreHorizontalIcon } from '@blocksuite/icons/lit';
+import { signal } from '@preact/signals-core';
+import { html, LitElement, nothing } from 'lit';
+import { property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+import type {
+  LinkedDocContext,
+  LinkedMenuGroup,
+  LinkedMenuItem,
+} from './config.js';
+
+import {
+  cleanSpecifiedTail,
+  createKeydownObserver,
+  getQuery,
+} from '../../../_common/components/utils.js';
+import { mobileLinkedDocMenuStyles } from './styles.js';
+
+export const AFFINE_MOBILE_LINKED_DOC_MENU = 'affine-mobile-linked-doc-menu';
+
+@requiredProperties({
+  context: PropTypes.object,
+})
+export class AffineMobileLinkedDocMenu extends SignalWatcher(
+  WithDisposable(LitElement)
+) {
+  static override styles = mobileLinkedDocMenuStyles;
+
+  private readonly _expand$ = signal(false);
+
+  private _firstActionItem: LinkedMenuItem | null = null;
+
+  private readonly _keyboardController = new VirtualKeyboardController(this);
+
+  private readonly _linkedDocGroup$ = signal<LinkedMenuGroup[]>([]);
+
+  private readonly _renderItem = ({
+    key,
+    name,
+    icon,
+    action,
+  }: LinkedMenuItem) => {
+    return html`<button
+      class="mobile-linked-doc-menu-item"
+      data-id=${key}
+      @pointerup=${() => {
+        action()?.catch(console.error);
+      }}
+    >
+      ${icon}
+      <div class="text">${name}</div>
+    </button>`;
+  };
+
+  private readonly _updateLinkedDocGroup = async () => {
+    this._linkedDocGroup$.value = await this.context.config.getMenus(
+      this._query ?? '',
+      () => {
+        this.context.close();
+        cleanSpecifiedTail(
+          this.context.std.host,
+          this.context.inlineEditor,
+          this.context.triggerKey + (this._query ?? '')
+        );
+      },
+      this.context.std.host,
+      this.context.inlineEditor
+    );
+  };
+
+  private get _query() {
+    return getQuery(this.context.inlineEditor, this.context.startRange);
+  }
+
+  get virtualKeyboardControllerConfig(): VirtualKeyboardControllerConfig {
+    return {
+      useScreenHeight: this.context.config.mobile.useScreenHeight ?? false,
+      inputElement: this.context.std.host,
+    };
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    const { inlineEditor, close } = this.context;
+
+    this._updateLinkedDocGroup().catch(console.error);
+
+    // prevent editor blur when click menu
+    this._disposables.addFromEvent(this, 'pointerdown', e => {
+      e.preventDefault();
+    });
+
+    // close menu when click outside
+    this.disposables.addFromEvent(
+      window,
+      'pointerdown',
+      e => {
+        if (e.target === this) return;
+        close();
+      },
+      true
+    );
+
+    // bind some key events
+    {
+      const { eventSource } = inlineEditor;
+      if (!eventSource) return;
+
+      const keydownObserverAbortController = new AbortController();
+      this._disposables.add(() => keydownObserverAbortController.abort());
+
+      createKeydownObserver({
+        target: eventSource,
+        signal: keydownObserverAbortController.signal,
+        onInput: isComposition => {
+          if (isComposition) {
+            this._updateLinkedDocGroup().catch(console.error);
+          } else {
+            inlineEditor.slots.renderComplete.once(this._updateLinkedDocGroup);
+          }
+        },
+        onDelete: () => {
+          const curRange = inlineEditor.getInlineRange();
+          if (!this.context.startRange || !curRange) return;
+
+          if (curRange.index < this.context.startRange.index) {
+            this.context.close();
+          }
+          inlineEditor.slots.renderComplete.once(this._updateLinkedDocGroup);
+        },
+        onConfirm: () => {
+          this._firstActionItem?.action()?.catch(console.error);
+        },
+        onAbort: () => {
+          this.context.close();
+        },
+      });
+    }
+
+    // scroll block above the menu
+    {
+      // TODO(@L-Sun): header offset
+
+      const { scrollContainer, scrollTopOffset } = this.context.config.mobile;
+
+      let container = null;
+      let containerScrollTop = 0;
+      if (typeof scrollContainer === 'string') {
+        container = document.querySelector(scrollContainer);
+        containerScrollTop = container?.scrollTop ?? 0;
+      } else if (scrollContainer instanceof HTMLElement) {
+        container = scrollContainer;
+        containerScrollTop = scrollContainer.scrollTop;
+      } else if (scrollContainer === window) {
+        container = window;
+        containerScrollTop = scrollContainer.scrollY;
+      } else {
+        container = getViewportElement(this.context.std.host);
+        containerScrollTop = container?.scrollTop ?? 0;
+      }
+
+      let offset = 0;
+      if (typeof scrollTopOffset === 'function') {
+        offset = scrollTopOffset();
+      } else {
+        offset = scrollTopOffset ?? 0;
+      }
+
+      container?.scrollTo({
+        top:
+          inlineEditor.rootElement.getBoundingClientRect().top +
+          containerScrollTop -
+          offset,
+        behavior: 'smooth',
+      });
+    }
+  }
+
+  override render() {
+    if (this._linkedDocGroup$.value.length !== 2) {
+      return nothing;
+    }
+
+    let group = this._linkedDocGroup$.value[0];
+    let { items } = group;
+
+    if (group.items.length === 0) {
+      group = this._linkedDocGroup$.value[1];
+      items = group.items.filter(item => item.name !== 'Import');
+    }
+
+    const isOverflow =
+      !!group.maxDisplay && group.items.length > group.maxDisplay;
+
+    let moreItem = null;
+    if (!this._expand$.value && isOverflow) {
+      items = group.items.slice(0, group.maxDisplay);
+
+      moreItem = html`<div
+        class="mobile-linked-doc-menu-item"
+        @click=${() => {
+          this._expand$.value = true;
+        }}
+      >
+        ${MoreHorizontalIcon()}
+        <div class="text">${group.overflowText || 'more'}</div>
+      </div>`;
+    }
+
+    this._firstActionItem = items[0];
+
+    this.style.bottom =
+      this.context.config.mobile.useScreenHeight &&
+      this._keyboardController.opened
+        ? '0px'
+        : `max(0px, ${this._keyboardController.keyboardHeight}px)`;
+
+    return html`
+      ${repeat(items, item => item.key, this._renderItem)} ${moreItem}
+    `;
+  }
+
+  @property({ attribute: false })
+  accessor context!: LinkedDocContext;
+}

--- a/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
@@ -1,9 +1,10 @@
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import { baseTheme } from '@toeverything/theme';
 import { css, unsafeCSS } from 'lit';
 
 import { scrollbarStyle } from '../../../_common/components/utils.js';
 
-export const styles = css`
+export const linkedDocPopoverStyles = css`
   :host {
     position: absolute;
   }
@@ -49,4 +50,68 @@ export const styles = css`
   }
 
   ${scrollbarStyle('.linked-doc-popover .group')}
+`;
+
+export const mobileLinkedDocMenuStyles = css`
+  :host {
+    height: 220px;
+    width: 100%;
+    position: fixed;
+    overflow-y: auto;
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex-shrink: 0;
+
+    --border-style: 1px solid ${unsafeCSSVarV2('layer/insideBorder/border')};
+
+    border-radius: 12px 12px 0px 0px;
+    border-top: var(--border-style);
+    border-right: var(--border-style);
+    border-left: var(--border-style);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
+    box-shadow: 0px -3px 10px 0px rgba(0, 0, 0, 0.07);
+  }
+
+  ${scrollbarStyle(':host')}
+
+  .mobile-linked-doc-menu-item {
+    display: flex;
+    width: 100%;
+    height: 44px;
+    padding: 11px 20px;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+    box-sizing: border-box;
+
+    border: none;
+    background: inherit;
+
+    > svg {
+      width: 20px;
+      height: 20px;
+      color: ${unsafeCSSVarV2('icon/primary')};
+    }
+
+    .text {
+      overflow: hidden;
+      color: ${unsafeCSSVarV2('text/primary')};
+      text-align: justify;
+      text-overflow: ellipsis;
+
+      font-family: 'SF Pro';
+      font-size: 17px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 22px;
+      letter-spacing: -0.43px;
+    }
+  }
+
+  .mobile-linked-doc-menu-item:active {
+    background: ${unsafeCSSVarV2('layer/background/hoverOverlay')};
+  }
 `;

--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -218,18 +218,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         );
         if (!linkedDocWidget) return false;
 
-        const hasLinkedDocSchema = model.doc.schema.flavourSchemaMap.has(
-          'affine:embed-linked-doc'
-        );
-        if (!hasLinkedDocSchema) return false;
-
-        if (!('showLinkedDocPopover' in linkedDocWidget)) {
-          console.warn(
-            'You may not have correctly implemented the linkedDoc widget! "showLinkedDoc(model)" method not found on widget'
-          );
-          return false;
-        }
-        return true;
+        return model.doc.schema.flavourSchemaMap.has('affine:embed-linked-doc');
       },
       action: ({ model, rootComponent }) => {
         const { std } = rootComponent;
@@ -248,7 +237,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         const inlineEditor = getInlineEditorByModel(rootComponent.host, model);
         // Wait for range to be updated
         inlineEditor?.slots.inlineRangeSync.once(() => {
-          linkedDocWidget.showLinkedDocPopover();
+          linkedDocWidget.show();
         });
       },
     },

--- a/packages/framework/global/src/types/index.ts
+++ b/packages/framework/global/src/types/index.ts
@@ -16,6 +16,7 @@ export interface BlockSuiteFlags {
   enable_shape_shadow_blur: boolean;
   enable_new_dnd: boolean;
   enable_mobile_keyboard_toolbar: boolean;
+  enable_mobile_linked_doc_menu: boolean;
   readonly: Record<string, boolean>;
 }
 export * from './virtual-keyboard.js';

--- a/packages/framework/store/src/store/collection.ts
+++ b/packages/framework/store/src/store/collection.ts
@@ -67,6 +67,7 @@ const FLAGS_PRESET = {
   enable_shape_shadow_blur: false,
   enable_new_dnd: false,
   enable_mobile_keyboard_toolbar: false,
+  enable_mobile_linked_doc_menu: false,
   readonly: {},
 } satisfies BlockSuiteFlags;
 

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -95,7 +95,7 @@ test.describe('multiple page', () => {
 });
 
 test.describe('reference node', () => {
-  test('linked page popover can show and hide correctly', async ({ page }) => {
+  test('linked doc popover can show and hide correctly', async ({ page }) => {
     await enterPlaygroundRoom(page);
     const { paragraphId } = await initEmptyParagraphState(page);
     await focusRichText(page);
@@ -118,6 +118,23 @@ test.describe('reference node', () => {
     await type(page, '@');
     await expect(linkedDocPopover).toBeVisible();
     await assertRichTexts(page, ['@@']);
+    await pressBackspace(page);
+    await expect(linkedDocPopover).toBeHidden();
+  });
+
+  test('linked doc popover should not show when the current content is @xx and pressing backspace', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyParagraphState(page);
+    await focusRichText(page);
+    await type(page, '@');
+    await page.keyboard.press('Escape');
+    await type(page, 'a');
+
+    const { linkedDocPopover } = getLinkedDocPopover(page);
+    await expect(linkedDocPopover).toBeHidden();
+
     await pressBackspace(page);
     await expect(linkedDocPopover).toBeHidden();
   });


### PR DESCRIPTION
This PR introduce mobile @ menu(a.k.a linked doc widget). [(Close BS-1608)](https://linear.app/affine-design/issue/BS-1608/mobile-menu)

### Demo


https://github.com/user-attachments/assets/1631111d-4a6f-44ef-8c9b-97afd6bc921e


### What Changes:
- A new mobile at menu widget
- Fix at menu is triggered by <kbd>backspace</kbd> if previous character is `@`