### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/eleven-flowers-press.md
+++ b/.changeset/eleven-flowers-press.md
@@ -1,0 +1,29 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+fix: color of canvas element under embed dark theme whiteboard is wrong (#8677)
+
+## Fix
+
+- fix: color of canvas element under embed dark theme whiteboard is wrong (#8677)
+- fix(edgeless): tool controller potential problem (#8675)
+- fix: typeError: f.\_def.innerType.shape[e] is undefined (#8676)
+- fix: whiteboard is first loaded, size of the linked doc card is scaled to wrong size (#8674)


### PR DESCRIPTION
- fix: color of canvas element under embed dark theme whiteboard is wrong (#8677)
- fix(edgeless): tool controller potential problem (#8675)
- fix: typeError: f.\_def.innerType.shape[e] is undefined (#8676)
- fix: whiteboard is first loaded, size of the linked doc card is scaled to wrong size (#8674)