### PR TITLE
fix: color of button is actived on color picker

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
+++ b/packages/blocks/src/root-block/edgeless/components/color-picker/styles.ts
@@ -40,7 +40,7 @@ export const COLOR_PICKER_STYLE = css`
 
   nav button[active] {
     color: var(--affine-text-primary-color, #121212);
-    background: var(--affine-white);
+    background: var(--affine-background-primary-color);
     box-shadow: var(--affine-shadow-1);
     pointer-events: none;
   }
@@ -95,7 +95,7 @@ export const COLOR_PICKER_STYLE = css`
   }
   .modes .mode button[active] {
     pointer-events: none;
-    outline: 2px solid var(--affine-brand-color);
+    outline: 2px solid var(--affine-brand-color, #1e96eb);
   }
 
   .content {
@@ -255,7 +255,7 @@ export const COLOR_PICKER_STYLE = css`
     gap: 4px;
     border-radius: 8px;
     border: 1px solid var(--affine-border-color);
-    background: var(--affine-white-30);
+    background: var(--affine-background-tertiary-color);
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
Closes: [BS-1773](https://linear.app/affine-design/issue/BS-1773/[bug]-edgeless-单独被设定为-light-mode-时-color-picker-的选中状态颜色错误)

![Screenshot 2024-11-06 at 15.49.57.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/d41f9522-11a5-4124-a835-e72f1545655f.png)

![Screenshot 2024-11-06 at 15.49.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/b85f35d9-b0d7-4f26-a3f6-ffb747003c67.png)

