### PR TITLE
fix: add paragraph when last block in note is not empty paragraph

### DIFF
--- a/packages/blocks/src/root-block/page/page-root-block.ts
+++ b/packages/blocks/src/root-block/page/page-root-block.ts
@@ -349,17 +349,7 @@ export class PageRootBlockComponent extends BlockComponent<
         const last = lastNote.children.at(-1);
         if (
           !last ||
-          !last.text ||
-          matchFlavours(last, [
-            'affine:code',
-            'affine:divider',
-            'affine:image',
-            'affine:database',
-            'affine:bookmark',
-            'affine:attachment',
-            'affine:surface-ref',
-          ]) ||
-          /affine:embed-*/.test(last.flavour)
+          !(matchFlavours(last, ['affine:paragraph']) && last.text.length === 0)
         ) {
           if (readonly) return;
           const paragraphId = this.doc.addBlock(

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -1253,14 +1253,6 @@ export function inlineEditorInnerTextToString(innerText: string): string {
 }
 
 export async function focusTitle(page: Page) {
-  // click to ensure editor is active
-  await page.mouse.move(0, 0);
-  const editor = getEditorHostLocator(page);
-  const locator = editor.locator('affine-page-root').first();
-  // need to set `force` to true when clicking on `affine-selected-blocks`
-  await locator.click({ force: true });
-  // avoid trigger double click
-  await page.waitForTimeout(500);
   await page.evaluate(i => {
     const docTitle = document.querySelectorAll('doc-title')[i];
     if (!docTitle) {

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -1253,6 +1253,7 @@ export function inlineEditorInnerTextToString(innerText: string): string {
 }
 
 export async function focusTitle(page: Page) {
+  await page.locator('doc-title rich-text').click();
   await page.evaluate(i => {
     const docTitle = document.querySelectorAll('doc-title')[i];
     if (!docTitle) {
@@ -1267,7 +1268,7 @@ export async function focusTitle(page: Page) {
     }
     docTitleRichText.inlineEditor.focusEnd();
   }, currentEditorIndex);
-  await waitNextFrame(page);
+  await waitNextFrame(page, 200);
 }
 
 /**


### PR DESCRIPTION
Close [BS-1734](https://linear.app/affine-design/issue/BS-1734/page-editor-需要撑开整个页面，并且支持点击新建段落)