### PR TITLE
Introducing BlockSuite Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![NPM Canary Release](https://img.shields.io/npm/v/@blocksuite/presets/canary?color=6880ff)](https://github.com/toeverything/blocksuite/actions/workflows/canary-release.yml?query=branch%3Amaster)
 [![Open in StackBlitz](https://img.shields.io/badge/open%20in-StackBlitz-black)](https://stackblitz.com/github/toeverything/blocksuite)
 [![Join Discord](https://img.shields.io/discord/959027316334407691)](https://discord.gg/9vwSWmYYcZ)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20BlockSuite%20Guru-006BFF)](https://gurubase.io/g/blocksuite)
 
 ---
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [BlockSuite Guru](https://gurubase.io/g/blocksuite) to Gurubase. BlockSuite Guru uses the data from this repo and data from the [docs](https://blocksuite.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "BlockSuite Guru", which highlights that BlockSuite now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable BlockSuite Guru in Gurubase, just let me know that's totally fine.
