### PR TITLE
feat(blocks): add input mask when @ menu inputting

### DIFF
--- a/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/linked-doc-popover.ts
@@ -111,7 +111,8 @@ export class LinkedDocPopover extends WithDisposable(LitElement) {
     });
     this._disposables.addFromEvent(window, 'mousedown', e => {
       if (e.target === this) return;
-      this._abort();
+      // We don't clear the query when clicking outside the popover
+      this.context.close();
     });
 
     const keydownObserverAbortController = new AbortController();

--- a/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
@@ -4,6 +4,15 @@ import { css, unsafeCSS } from 'lit';
 
 import { scrollbarStyle } from '../../../_common/components/utils.js';
 
+export const linkedDocWidgetStyles = css`
+  .input-mask {
+    position: absolute;
+    pointer-events: none;
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+  }
+`;
+
 export const linkedDocPopoverStyles = css`
   :host {
     position: absolute;


### PR DESCRIPTION
Close [BS-1788](https://linear.app/affine-design/issue/BS-1788/激活menu时，设置输入位置背景颜色)

This PR add a mask on the @ menu input arae.

![CleanShot 2024-11-08 at 04.11.04@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/a917f5d6-a671-497b-8743-39a4392b6755.png)

