### PR TITLE
chore: configrable visibility of reference node popup

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/affine-inline-specs.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/affine-inline-specs.ts
@@ -135,6 +135,9 @@ export const ReferenceInlineSpecExtension = InlineSpecExtension(
     if (config.interactable !== undefined) {
       configProvider.setInteractable(config.interactable);
     }
+    if (config.hidePopup !== undefined) {
+      configProvider.setHidePopup(config.hidePopup);
+    }
     return {
       name: 'reference',
       schema: z

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-config.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-config.ts
@@ -10,6 +10,7 @@ export interface ReferenceNodeConfig {
   customIcon?: ((reference: AffineReference) => TemplateResult) | null;
   customTitle?: ((reference: AffineReference) => string) | null;
   interactable?: boolean;
+  hidePopup?: boolean;
 }
 
 export const ReferenceNodeConfigIdentifier =
@@ -35,6 +36,8 @@ export class ReferenceNodeConfigProvider {
 
   private _customTitle: ((reference: AffineReference) => string) | null = null;
 
+  private _hidePopup = false;
+
   private _interactable = true;
 
   get customContent() {
@@ -53,6 +56,10 @@ export class ReferenceNodeConfigProvider {
     return this.std.doc;
   }
 
+  get hidePopup() {
+    return this._hidePopup;
+  }
+
   get interactable() {
     return this._interactable;
   }
@@ -69,6 +76,10 @@ export class ReferenceNodeConfigProvider {
 
   setCustomTitle(title: ReferenceNodeConfigProvider['_customTitle']) {
     this._customTitle = title;
+  }
+
+  setHidePopup(hidePopup: boolean) {
+    this._hidePopup = hidePopup;
   }
 
   setInteractable(interactable: boolean) {

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
@@ -95,6 +95,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     this,
     ({ abortController }) => {
       if (
+        this.config.hidePopup ||
         this.doc?.readonly ||
         this.closest('.prevent-reference-popup') ||
         !this.selfInlineRange ||


### PR DESCRIPTION
This PR make the visibility of reference node popup can be configure. Related to [BS-1730](https://linear.app/affine-design/issue/BS-1730/%E7%A6%81%E7%94%A8-block-yuan%E7%B4%A0%E7%9A%84-toolbar)