### PR TITLE
chore: enable copy as png entry

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/more-menu/config.ts
@@ -201,6 +201,18 @@ export const clipboardGroup: MenuItemGroup<ElementToolbarMoreMenuContext> = {
       action: ({ edgeless }) => edgeless.clipboardController.copy(),
     },
     {
+      icon: CopyIcon({ width: '20', height: '20' }),
+      label: 'Copy as PNG',
+      type: 'copy-as-png',
+      action: async ({ edgeless, selectedElements }) => {
+        const blocks = selectedElements.filter(
+          el => 'xywh' in el
+        ) as BlockSuite.EdgelessBlockModelType[];
+        const shapes = selectedElements.filter(el => !('xywh' in el));
+        await edgeless.clipboardController.copyAsPng(blocks, shapes);
+      },
+    },
+    {
       icon: DuplicateIcon({ width: '20', height: '20' }),
       label: 'Duplicate',
       type: 'duplicate',


### PR DESCRIPTION
This is only used for debugging. New copy as PNG feature needs to be redesigned.