### PR TITLE
fix(blocks): show keyboard when at menu is triggered by keyboard toolbar

### DIFF
--- a/packages/affine/components/src/virtual-keyboard/controller.ts
+++ b/packages/affine/components/src/virtual-keyboard/controller.ts
@@ -20,6 +20,25 @@ export class VirtualKeyboardController implements ReactiveController {
 
   private readonly _keyboardOpened$ = signal(false);
 
+  private _storeInitialInputElementAttributes = () => {
+    const { inputElement } = this.config;
+    if (navigator.virtualKeyboard) {
+      const { overlaysContent } = navigator.virtualKeyboard;
+      const { virtualKeyboardPolicy } = inputElement;
+
+      this._disposables.add(() => {
+        if (!navigator.virtualKeyboard) return;
+        navigator.virtualKeyboard.overlaysContent = overlaysContent;
+        inputElement.virtualKeyboardPolicy = virtualKeyboardPolicy;
+      });
+    } else if (visualViewport) {
+      const { inputMode } = inputElement;
+      this._disposables.add(() => {
+        inputElement.inputMode = inputMode;
+      });
+    }
+  };
+
   private readonly _updateKeyboardHeight = () => {
     const { virtualKeyboard } = navigator;
     if (virtualKeyboard) {
@@ -103,20 +122,14 @@ export class VirtualKeyboardController implements ReactiveController {
   }
 
   hostConnected() {
+    this._storeInitialInputElementAttributes();
+
     const { inputElement } = this.config;
 
     if (navigator.virtualKeyboard) {
-      const { overlaysContent } = navigator.virtualKeyboard;
-      const { virtualKeyboardPolicy } = inputElement;
-
       navigator.virtualKeyboard.overlaysContent = true;
-      inputElement.virtualKeyboardPolicy = 'manual';
+      this.config.inputElement.virtualKeyboardPolicy = 'manual';
 
-      this._disposables.add(() => {
-        if (!navigator.virtualKeyboard) return;
-        navigator.virtualKeyboard.overlaysContent = overlaysContent;
-        inputElement.virtualKeyboardPolicy = virtualKeyboardPolicy;
-      });
       this._disposables.addFromEvent(
         navigator.virtualKeyboard,
         'geometrychange',

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
@@ -1,23 +1,42 @@
+import type { RootBlockModel } from '@blocksuite/affine-model';
+
 import { WidgetComponent } from '@blocksuite/block-std';
 import { IS_MOBILE } from '@blocksuite/global/env';
 import { signal } from '@preact/signals-core';
 import { html, nothing } from 'lit';
 
-import { PageRootBlockComponent } from '../../page/page-root-block.js';
+import type { PageRootBlockComponent } from '../../page/page-root-block.js';
+
 import { defaultKeyboardToolbarConfig } from './config.js';
 
 export * from './config.js';
 
 export const AFFINE_KEYBOARD_TOOLBAR_WIDGET = 'affine-keyboard-toolbar-widget';
 
-export class AffineKeyboardToolbarWidget extends WidgetComponent {
-  private readonly _showToolPanel$ = signal(false);
+export class AffineKeyboardToolbarWidget extends WidgetComponent<
+  RootBlockModel,
+  PageRootBlockComponent
+> {
+  private readonly _show$ = signal(false);
 
   get config() {
     return {
       ...defaultKeyboardToolbarConfig,
       ...this.std.getConfig('affine:page')?.keyboardToolbar,
     };
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    const { rootComponent } = this.block;
+    if (!rootComponent) return;
+    this.disposables.addFromEvent(rootComponent, 'focus', () => {
+      this._show$.value = true;
+    });
+    this.disposables.addFromEvent(rootComponent, 'blur', () => {
+      this._show$.value = false;
+    });
   }
 
   override render() {
@@ -28,14 +47,17 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent {
     )
       return nothing;
 
-    if (!(this.block.rootComponent instanceof PageRootBlockComponent))
-      return nothing;
+    if (!this._show$.value) return nothing;
+
+    if (!this.block.rootComponent) return nothing;
 
     return html`<blocksuite-portal
       .template=${html`<affine-keyboard-toolbar
         .config=${this.config}
         .rootComponent=${this.block.rootComponent}
-        .showToolPanel=${this._showToolPanel$}
+        .close=${() => {
+          this._show$.value = false;
+        }}
       ></affine-keyboard-toolbar> `}
     ></blocksuite-portal>`;
   }

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-toolbar.ts
@@ -6,7 +6,7 @@ import { PropTypes, requiredProperties } from '@blocksuite/block-std';
 import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
 import { ArrowLeftBigIcon, KeyboardIcon } from '@blocksuite/icons/lit';
 import { batch, effect, signal } from '@preact/signals-core';
-import { html, LitElement, nothing } from 'lit';
+import { html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -107,8 +107,6 @@ export class AffineKeyboardToolbar extends SignalWatcher(
 
   private readonly _path$ = signal<number[]>([]);
 
-  private readonly _showToolbar$ = signal(false);
-
   private readonly _shrink$ = signal(false);
 
   private get _context(): KeyboardToolbarContext {
@@ -116,7 +114,7 @@ export class AffineKeyboardToolbar extends SignalWatcher(
       std: this.rootComponent.std,
       rootComponent: this.rootComponent,
       closeToolbar: () => {
-        this._showToolbar$.value = false;
+        this.close();
       },
       closeToolPanel: () => {
         this._closeToolPanel();
@@ -245,17 +243,6 @@ export class AffineKeyboardToolbar extends SignalWatcher(
   override connectedCallback() {
     super.connectedCallback();
 
-    this.disposables.addFromEvent(this.rootComponent, 'focus', () => {
-      this._showToolbar$.value = true;
-      this._shrink$.value = false;
-    });
-    this.disposables.addFromEvent(this.rootComponent, 'blur', () => {
-      this._showToolbar$.value = false;
-      this._shrink$.value = true;
-      this._currentPanelIndex$.value = -1;
-      this._path$.value = [];
-    });
-
     // prevent editor blur when click item in toolbar
     this.disposables.addFromEvent(this, 'pointerdown', e => {
       e.preventDefault();
@@ -273,9 +260,7 @@ export class AffineKeyboardToolbar extends SignalWatcher(
 
     this.disposables.add(
       effect(() => {
-        if (!this._showToolbar$.value) {
-          document.body.style.paddingBottom = '0px';
-        } else if (this._shrink$.value) {
+        if (this._shrink$.value) {
           document.body.style.paddingBottom = `${TOOLBAR_HEIGHT}px`;
         } else if (
           this._keyboardController.opened &&
@@ -290,8 +275,6 @@ export class AffineKeyboardToolbar extends SignalWatcher(
   }
 
   override render() {
-    if (!this._showToolbar$.value) return nothing;
-
     this.style.bottom =
       (this.config.useScreenHeight && this._keyboardController.opened) ||
       this._shrink$.value
@@ -311,6 +294,9 @@ export class AffineKeyboardToolbar extends SignalWatcher(
       ></affine-keyboard-tool-panel>
     `;
   }
+
+  @property({ attribute: false })
+  accessor close = () => {};
 
   @property({ attribute: false })
   accessor config!: KeyboardToolbarConfig;

--- a/packages/blocks/src/root-block/widgets/linked-doc/index.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/index.ts
@@ -1,4 +1,5 @@
 import type { AffineInlineEditor } from '@blocksuite/affine-components/rich-text';
+import type { RootBlockModel } from '@blocksuite/affine-model';
 import type { SelectionRect } from '@blocksuite/affine-shared/commands';
 import type { UIEventStateContext } from '@blocksuite/block-std';
 import type { Disposable } from '@blocksuite/global/utils';
@@ -18,6 +19,8 @@ import { choose } from 'lit/directives/choose.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import type { PageRootBlockComponent } from '../../index.js';
+
 import {
   getMenus,
   type LinkedDocContext,
@@ -28,7 +31,10 @@ export { type LinkedWidgetConfig } from './config.js';
 
 export const AFFINE_LINKED_DOC_WIDGET = 'affine-linked-doc-widget';
 
-export class AffineLinkedDocWidget extends WidgetComponent {
+export class AffineLinkedDocWidget extends WidgetComponent<
+  RootBlockModel,
+  PageRootBlockComponent
+> {
   static override styles = linkedDocWidgetStyles;
 
   private _disposeObserveInputRects: Disposable | null = null;
@@ -148,8 +154,11 @@ export class AffineLinkedDocWidget extends WidgetComponent {
   };
 
   private readonly _renderLinkedDocMenu = () => {
+    if (!this.block.rootComponent) return nothing;
+
     return html`<affine-mobile-linked-doc-menu
       .context=${this._context}
+      .rootComponent=${this.block.rootComponent}
     ></affine-mobile-linked-doc-menu>`;
   };
 


### PR DESCRIPTION
### Fix
- keyboard is not opened when mobile `@` menu is triggered by keyboard toolbar
- mobile `@` menu is not closed after deleting `@`
- page is not scrolled to top when mobile `@` menu trigger by keyboard toolbar



https://github.com/user-attachments/assets/e4e08ec5-00df-4f9b-9179-18ac2b5f890e


