### PR TITLE
fix(blocks): surface ref viewport element undefined

### DIFF
--- a/packages/affine/block-embed/src/common/render-linked-doc.ts
+++ b/packages/affine/block-embed/src/common/render-linked-doc.ts
@@ -55,6 +55,7 @@ function renderSurfaceRef(
   );
 
   card.surfaceRefRenderer = card.surfaceRefService.getRenderer(
+    card,
     card.model.id,
     linkedDoc
   );

--- a/packages/blocks/src/surface-ref-block/surface-ref-service.ts
+++ b/packages/blocks/src/surface-ref-block/surface-ref-service.ts
@@ -3,6 +3,8 @@ import type { Doc } from '@blocksuite/store';
 import { SurfaceRefBlockSchema } from '@blocksuite/affine-model';
 import { BlockService } from '@blocksuite/block-std';
 
+import type { SurfaceRefBlockComponent } from './surface-ref-block.js';
+
 import { SurfaceRefRenderer } from './surface-ref-renderer.js';
 
 export class SurfaceRefBlockService extends BlockService {
@@ -10,13 +12,19 @@ export class SurfaceRefBlockService extends BlockService {
 
   private _rendererMap = new Map<string, SurfaceRefRenderer>();
 
-  getRenderer(id: string, doc: Doc = this.doc, stackingCanvas = false) {
+  getRenderer(
+    surfaceRefBlockComponent: SurfaceRefBlockComponent,
+    id: string,
+    doc: Doc = this.doc,
+    stackingCanvas = false
+  ) {
     if (this._rendererMap.has(id)) {
       return this._rendererMap.get(id)!;
     }
     const renderer = new SurfaceRefRenderer(id, doc, this.std, {
       enableStackingCanvas: stackingCanvas,
     });
+    renderer.viewport.setViewportElm(surfaceRefBlockComponent);
     this._rendererMap.set(id, renderer);
     return renderer;
   }


### PR DESCRIPTION
In `packages/blocks/src/surface-ref-block/surface-ref-renderer.ts` the method `viewport.setViewportElm` is not called which make the following code throw undefined error.

https://github.com/toeverything/blocksuite/blob/65fbde6782f1d9a2468aaf4bf5a4cf508eb466d5/packages/framework/block-std/src/gfx/viewport.ts#L53-L55