### PR TITLE
fix(blocks): init collpased state of list

### DIFF
--- a/packages/affine/block-list/src/list-block.ts
+++ b/packages/affine/block-list/src/list-block.ts
@@ -137,6 +137,7 @@ export class ListBlockComponent extends CaptionedBlockComponent<
     super.connectedCallback();
 
     this._inlineRangeProvider = getInlineRangeProvider(this);
+    this._isCollapsedWhenReadOnly = this.model.collapsed;
 
     this.disposables.add(
       effect(() => {

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -7,6 +7,7 @@ import {
   enterPlaygroundWithList,
   focusRichText,
   getPageSnapshot,
+  initEmptyEdgelessState,
   initEmptyParagraphState,
   initThreeLists,
   pressArrowLeft,
@@ -19,6 +20,7 @@ import {
   pressSpace,
   pressTab,
   redoByClick,
+  switchEditorMode,
   switchReadonly,
   type,
   undoByClick,
@@ -794,5 +796,27 @@ test.describe('readonly', () => {
       await checkBox.click();
       await expect(page.locator('.affine-list--checked')).toHaveCount(1);
     }
+  });
+
+  test('should render collapsed list correctly', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    // await switchEditorMode(page);
+    await initThreeLists(page);
+
+    const toggleIcon = getToggleIcon(page);
+    const collapsed = page.locator('.affine-list__collapsed');
+
+    await expect(collapsed).toHaveCount(0);
+
+    await toggleIcon.click();
+    await expect(collapsed).toHaveCount(1);
+
+    await switchReadonly(page);
+    // trick for render a readonly doc from scratch
+    await switchEditorMode(page);
+    await switchEditorMode(page);
+
+    await expect(collapsed).toHaveCount(1);
   });
 });


### PR DESCRIPTION
Close [BS-1558](https://linear.app/affine-design/issue/BS-1558/framepreview-渲染没有考虑list-toggled的情况)

This PR fix that a collpased list is not rendered correctly in readonly mode.