### PR TITLE
fix(blocks): outline header sorting button tooltip

### DIFF
--- a/packages/presets/src/fragments/outline/header/outline-panel-header.ts
+++ b/packages/presets/src/fragments/outline/header/outline-panel-header.ts
@@ -119,7 +119,7 @@ export class OutlinePanelHeader extends WithDisposable(LitElement) {
         </div>
         <edgeless-tool-icon-button
           class="note-sorting-button ${this.enableNotesSorting ? 'active' : ''}"
-          .tooltip=${'Note Sort Options'}
+          .tooltip=${'Visibility and sort'}
           .tipPosition=${'left'}
           .iconContainerPadding=${0}
           .active=${this.enableNotesSorting}


### PR DESCRIPTION
[BS-1631](https://linear.app/affine-design/issue/BS-1631/优化一下tooltips文本显示)