### PR TITLE
chore: release patch version

### DIFF
--- a/.changeset/quick-pillows-confess.md
+++ b/.changeset/quick-pillows-confess.md
@@ -1,0 +1,41 @@
+---
+'@blocksuite/affine': patch
+'@blocksuite/affine-block-embed': patch
+'@blocksuite/affine-block-list': patch
+'@blocksuite/affine-block-paragraph': patch
+'@blocksuite/affine-block-surface': patch
+'@blocksuite/affine-components': patch
+'@blocksuite/data-view': patch
+'@blocksuite/affine-model': patch
+'@blocksuite/affine-shared': patch
+'@blocksuite/affine-widget-scroll-anchoring': patch
+'@blocksuite/blocks': patch
+'@blocksuite/docs': patch
+'@blocksuite/block-std': patch
+'@blocksuite/global': patch
+'@blocksuite/inline': patch
+'@blocksuite/store': patch
+'@blocksuite/sync': patch
+'@blocksuite/presets': patch
+---
+
+## Feat
+
+- feat(database): support sorting for linked doc (#8715)
+
+## Fix
+
+- fix(blocks): init collapsed state of list (#8727)
+- fix(blocks): outline header sorting button tooltip (#8730)
+- fix(database): date-picker styles (#8728)
+- fix(blocks): only split paragraphs based on newlines (#8702)
+- fix(edgeless): disable list and paragraph padding in edgeless text (#8723)
+- fix(blocks): surface ref viewport element undefined (#8722)
+- fix(blocks): show keyboard when at menu is triggered by keyboard toolbar (#8721)
+- fix(database): linked doc convert logic (#8714)
+- fix(database): improve the display logic of the row menu button (#8713)
+
+## Chore
+
+- chore: configurable visibility of reference node popup (#8711)
+- chore(blocks): disable dragging in mobile (#8724)


### PR DESCRIPTION
## Feat

- feat(database): support sorting for linked doc (#8715)

## Fix

- fix(blocks): init collapsed state of list (#8727)
- fix(blocks): outline header sorting button tooltip (#8730)
- fix(database): date-picker styles (#8728)
- fix(blocks): only split paragraphs based on newlines (#8702)
- fix(edgeless): disable list and paragraph padding in edgeless text (#8723)
- fix(blocks): surface ref viewport element undefined (#8722)
- fix(blocks): show keyboard when at menu is triggered by keyboard toolbar (#8721)
- fix(database): linked doc convert logic (#8714)
- fix(database): improve the display logic of the row menu button (#8713)

## Chore

- chore: configrable visibility of reference node popup (#8711)
- chore(blocks): disable dragging in mobile (#8724)
