### PR TITLE
fix(edgeless): connector clone

### DIFF
--- a/packages/affine/model/src/elements/connector/connector.ts
+++ b/packages/affine/model/src/elements/connector/connector.ts
@@ -396,6 +396,8 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   override serialize() {
     const result = super.serialize();
     result.xywh = this.xywh;
+    result.source = structuredClone(this.source);
+    result.target = structuredClone(this.target);
     return result as SerializedConnectorElement;
   }
 


### PR DESCRIPTION
Fixes [BS-1694](https://linear.app/affine-design/issue/BS-1694/[bug]-两个yuan素使用-connector-相连接使用-duplicate-会丢失-connector)