### PR TITLE
chore(blocks): remove trigger key '、' from slash menu

### DIFF
--- a/packages/blocks/src/root-block/widgets/slash-menu/config.ts
+++ b/packages/blocks/src/root-block/widgets/slash-menu/config.ts
@@ -119,7 +119,7 @@ export type SlashMenuContext = {
 };
 
 export const defaultSlashMenuConfig: SlashMenuConfig = {
-  triggerKeys: ['/', '、'],
+  triggerKeys: ['/'],
   ignoreBlockTypes: ['affine:code'],
   maxHeight: 344,
   tooltipTimeout: 800,


### PR DESCRIPTION
Close [BS-1757](https://linear.app/affine-design/issue/BS-1757/中文输入法下触发slashmenu问题)

This PR removes the trigger key `、` from the slash menu to improve the CJK user input experience. For users of Sougo Pinyin on macOS, you can disable the auto-transform from `/` to `、` in the IME settings.