### PR TITLE
fix(edgeless): frame overlay is not updated during dragging a new frame

### DIFF
--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -17,6 +17,7 @@ import {
   deserializeXYWH,
   DisposableGroup,
   type IVec,
+  type SerializedXYWH,
 } from '@blocksuite/global/utils';
 import { DocCollection, Text } from '@blocksuite/store';
 
@@ -38,6 +39,8 @@ export class FrameOverlay extends Overlay {
   private _frame: FrameBlockModel | null = null;
 
   private _innerElements = new Set<GfxModel>();
+
+  private _prevXYWH: SerializedXYWH | null = null;
 
   private get _frameManager() {
     return this.gfx.std.get(
@@ -72,7 +75,7 @@ export class FrameOverlay extends Overlay {
 
     let needRefresh = false;
 
-    if (highlightOutline && this._frame !== frame) {
+    if (highlightOutline && this._prevXYWH !== frame.xywh) {
       needRefresh = true;
     }
 

--- a/tests/edgeless/frame/frame.spec.ts
+++ b/tests/edgeless/frame/frame.spec.ts
@@ -14,6 +14,7 @@ import {
   edgelessCommonSetup,
   getFirstContainerId,
   getSelectedIds,
+  pickColorAtPoints,
   setEdgelessTool,
   Shape,
   shiftClickView,
@@ -361,4 +362,21 @@ test('delete frame', async ({ page }) => {
   await expect(page.locator('affine-frame')).toHaveCount(0);
 
   await assertCanvasElementsCount(page, 0);
+});
+
+test('outline should keep updated during a new frame created by frame-tool dragging', async ({
+  page,
+}) => {
+  await page.keyboard.press('f');
+
+  const start = await toViewCoord(page, [0, 0]);
+  const end = await toViewCoord(page, [100, 100]);
+  await page.mouse.move(start[0], start[1]);
+  await page.mouse.down();
+  await page.mouse.move(end[0], end[1], { steps: 10 });
+  await page.waitForTimeout(50);
+
+  expect(
+    await pickColorAtPoints(page, [start, [end[0] - 1, end[1] - 1]])
+  ).toEqual(['#1e96eb', '#1e96eb']);
 });


### PR DESCRIPTION
Close [BS-1756](https://linear.app/affine-design/issue/BS-1756/[bug]-frame-拖出选区的时候，选中状态没有随着-frame-的大小实时更新)

Fixed frame outline rendering during frame-tool dragging creation by tracking previous XYWH state.

### What changed?
- Added a `_prevXYWH` property to `FrameOverlay` class to track the previous frame dimensions, and refresh canvas when it changed.
- Added a test to test the matching between color of dragging point and outline overlay.

