### PR TITLE
feat(blocks): markdown adapter reference serialization and deserialization

### DIFF
--- a/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
@@ -1749,6 +1749,20 @@ hhh
                 },
                 {
                   type: 'block',
+                  id: 'C0sH2Ee6cz-MysVNLNrBt',
+                  flavour: 'affine:embed-linked-doc',
+                  props: {
+                    index: 'a0',
+                    xywh: '[0,0,0,0]',
+                    rotate: 0,
+                    pageId: '4T5ObMgEIMII-4Bexyta1',
+                    style: 'horizontal',
+                    caption: null,
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
                   id: 'block:f-Z6nRrGK_',
                   flavour: 'affine:paragraph',
                   props: {
@@ -1798,6 +1812,20 @@ hhh
                                 reference: {
                                   type: 'LinkedPage',
                                   pageId: 'deadbeef',
+                                  params: {
+                                    mode: 'page',
+                                    blockIds: ['abc', '123'],
+                                    elementIds: ['def', '456'],
+                                  },
+                                },
+                              },
+                            },
+                            {
+                              insert: ' ',
+                              attributes: {
+                                reference: {
+                                  type: 'LinkedPage',
+                                  pageId: 'foobar',
                                 },
                               },
                             },
@@ -1869,11 +1897,13 @@ hhh
 
 &#x20;   bbb
 
+[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1)
+
 &#x20;   ccc
 
 &#x20;       ddd
 
-&#x20;       eee[test]()
+&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456)[](https://example.com/foobar)
 
 &#x20;       fff
 
@@ -1883,6 +1913,7 @@ hhh
 `;
     const middleware: JobMiddleware = ({ adapterConfigs }) => {
       adapterConfigs.set('title:deadbeef', 'test');
+      adapterConfigs.set('docLinkBaseUrl', 'https://example.com');
     };
     const mdAdapter = new MarkdownAdapter(createJob([middleware]));
     const target = await mdAdapter.fromBlockSnapshot({
@@ -3499,6 +3530,204 @@ hhh
     };
 
     const mdAdapter = new MarkdownAdapter(createJob());
+    const rawBlockSnapshot = await mdAdapter.toBlockSnapshot({
+      file: markdown,
+    });
+    expect(nanoidReplacement(rawBlockSnapshot)).toEqual(blockSnapshot);
+  });
+
+  test('reference', async () => {
+    const markdown = `
+aaa
+
+&#x20;   bbb
+
+[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1)
+
+&#x20;   ccc
+
+&#x20;       ddd
+
+&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456)[](https://example.com/foobar)
+
+&#x20;       fff
+
+&#x20;   ggg
+
+hhh
+`;
+    const blockSnapshot: BlockSnapshot = {
+      type: 'block',
+      id: 'matchesReplaceMap[0]',
+      flavour: 'affine:note',
+      props: {
+        xywh: '[0,0,800,95]',
+        background: '--affine-note-background-white',
+        index: 'a0',
+        hidden: false,
+        displayMode: 'both',
+      },
+      children: [
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[1]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: 'aaa' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[2]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: '    bbb' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[3]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: ' ',
+                  attributes: {
+                    reference: {
+                      type: 'LinkedPage',
+                      pageId: '4T5ObMgEIMII-4Bexyta1',
+                      params: {},
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[4]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: '    ccc' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[5]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: '        ddd' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[6]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                { insert: '        eee' },
+                {
+                  insert: ' ',
+                  attributes: {
+                    reference: {
+                      type: 'LinkedPage',
+                      pageId: 'deadbeef',
+                      params: {
+                        mode: 'page',
+                        blockIds: ['abc', '123'],
+                        elementIds: ['def', '456'],
+                      },
+                    },
+                  },
+                },
+                {
+                  insert: ' ',
+                  attributes: {
+                    reference: {
+                      type: 'LinkedPage',
+                      pageId: 'foobar',
+                      params: {},
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[7]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: '        fff' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[8]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: '    ggg' }],
+            },
+          },
+          children: [],
+        },
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[9]',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [{ insert: 'hhh' }],
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+    const middleware: JobMiddleware = ({ adapterConfigs }) => {
+      adapterConfigs.set('docLinkBaseUrl', 'https://example.com');
+    };
+    const mdAdapter = new MarkdownAdapter(createJob([middleware]));
     const rawBlockSnapshot = await mdAdapter.toBlockSnapshot({
       file: markdown,
     });

--- a/packages/blocks/src/_common/test-utils/test-utils.ts
+++ b/packages/blocks/src/_common/test-utils/test-utils.ts
@@ -25,6 +25,8 @@ const escapedSnapshotAttributes = [
   '"conditions"',
   '"iconColumn"',
   '"background"',
+  '"LinkedPage"',
+  '"elementIds"',
 ];
 
 function nanoidReplacementString(snapshotString: string) {


### PR DESCRIPTION
When configured with `docBaseUrl`, `markdownAdapter `can convert doc references in snapshot into markdown link, and can also convert markdown link into doc reference.
