### PR TITLE
fix(database): crash in edgeless on mobile safari

### DIFF
--- a/packages/affine/data-view/src/view-presets/table/table-view.ts
+++ b/packages/affine/data-view/src/view-presets/table/table-view.ts
@@ -61,6 +61,17 @@ const styles = css`
     overflow-y: hidden;
   }
 
+  /* Disable horizontal scrolling to prevent crashes on iOS Safari */
+  affine-edgeless-root .affine-database-block-table {
+    @media (pointer: coarse) {
+      overflow: hidden;
+    }
+    @media (pointer: fine) {
+      overflow-x: scroll;
+      overflow-y: hidden;
+    }
+  }
+
   .affine-database-block-table:hover {
     padding-bottom: 0px;
   }


### PR DESCRIPTION
This behavior should be disabled to prevent crash on mobile safari (same root cause with #8680):

https://github.com/user-attachments/assets/22a40c9b-5bae-4cf4-8b47-c291d4af881a

Meanwhile, this fix won't affect horizontal scrolling of database block in doc mode.
