### PR TITLE
fix(edgeless): missing reference info during edgeless card conversion

### DIFF
--- a/packages/affine/block-embed/src/embed-linked-doc-block/embed-edgeless-linked-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/embed-edgeless-linked-doc-block.ts
@@ -11,7 +11,7 @@ export class EmbedEdgelessLinkedDocBlockComponent extends toEdgelessEmbedBlock(
   EmbedLinkedDocBlockComponent
 ) {
   override convertToEmbed = () => {
-    const { id, doc, pageId, caption, xywh } = this.model;
+    const { id, doc, caption, xywh } = this.model;
 
     // synced doc entry controlled by awareness flag
     const isSyncedDocEnabled = doc.awarenessStore.getFlag(
@@ -35,7 +35,7 @@ export class EmbedEdgelessLinkedDocBlockComponent extends toEdgelessEmbedBlock(
     // @ts-expect-error TODO: fix after edgeless refactor
     const newId = edgelessService.addBlock(
       'affine:embed-synced-doc',
-      { pageId, xywh: bound.serialize(), caption },
+      { xywh: bound.serialize(), caption, ...this.referenceInfo },
       // @ts-expect-error TODO: fix after edgeless refactor
       edgelessService.surface
     );

--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-edgeless-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-edgeless-synced-doc-block.ts
@@ -114,7 +114,7 @@ export class EmbedEdgelessSyncedDocBlockComponent extends toEdgelessEmbedBlock(
   };
 
   override convertToCard = () => {
-    const { id, doc, pageId, caption, xywh } = this.model;
+    const { id, doc, caption, xywh } = this.model;
 
     const edgelessService = this.rootService;
     const style = 'vertical';
@@ -129,7 +129,12 @@ export class EmbedEdgelessSyncedDocBlockComponent extends toEdgelessEmbedBlock(
     // @ts-expect-error TODO: fix after edgeless refactor
     const newId = edgelessService.addBlock(
       'affine:embed-linked-doc',
-      { pageId, xywh: bound.serialize(), style, caption },
+      {
+        xywh: bound.serialize(),
+        style,
+        caption,
+        ...this.referenceInfo,
+      },
       // @ts-expect-error TODO: fix after edgeless refactor
       edgelessService.surface
     );

--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -475,11 +475,11 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
     if (this._rootService && !this.linkedMode) {
       const docMode = this._rootService.std.get(DocModeProvider);
       this.syncedDocMode = docMode.getPrimaryMode(this.model.pageId);
-      this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this.syncedDocMode);
+      this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this.editorMode);
       this.disposables.add(
         docMode.onPrimaryModeChange(mode => {
           this.syncedDocMode = mode;
-          this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, mode);
+          this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this.editorMode);
         }, this.model.pageId)
       );
     }


### PR DESCRIPTION
Close [BS-1907](https://linear.app/affine-design/issue/BS-1907/mode=edgeless的cardview转成embed，丢失了mode信息)

This PR fixed the reference information is missing during edgeless card view conversion. The test will be added to AFFiNE side https://github.com/toeverything/AFFiNE/pull/8887