### PR TITLE
fix(edgeless): connector selected rect width and height is zero

### DIFF
--- a/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/packages/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -1442,11 +1442,8 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
       handlers.push(resizeHandles, connectorHandle, elementHandle);
     }
 
-    if (elements.length === 1 && elements[0] instanceof ConnectorElementModel) {
-      _selectedRect.width = 0;
-      _selectedRect.height = 0;
-      _selectedRect.borderWidth = 0;
-    }
+    const isConnector =
+      elements.length === 1 && elements[0] instanceof ConnectorElementModel;
 
     return html`
       <style>
@@ -1490,7 +1487,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
           width: `${_selectedRect.width}px`,
           height: `${_selectedRect.height}px`,
           borderWidth: `${_selectedRect.borderWidth}px`,
-          borderStyle: _selectedRect.borderStyle,
+          borderStyle: isConnector ? 'none' : _selectedRect.borderStyle,
           transform: `translate(${_selectedRect.left}px, ${_selectedRect.top}px) rotate(${_selectedRect.rotate}deg)`,
         })}
         disabled="true"


### PR DESCRIPTION
Instead of setting the `_selectedRect` state, use CSS `border-style: none` to hide the selected rect border when a connector is selected.