### PR TITLE
feat: linked doc supports aliases

### DIFF
--- a/packages/affine/block-embed/package.json
+++ b/packages/affine/block-embed/package.json
@@ -25,7 +25,7 @@
     "@blocksuite/affine-shared": "workspace:*",
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/global": "workspace:*",
-    "@blocksuite/icons": "^2.1.70",
+    "@blocksuite/icons": "^2.1.75",
     "@blocksuite/inline": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@floating-ui/dom": "^1.6.10",

--- a/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
@@ -87,6 +87,7 @@ export const styles = css`
 
   ${embedNoteContentStyles}
 
+  .affine-embed-linked-doc-content-note.alias,
   .affine-embed-linked-doc-content-note.default {
     flex: 1;
     display: -webkit-box;
@@ -103,6 +104,10 @@ export const styles = css`
     font-style: normal;
     font-weight: 400;
     line-height: 20px;
+  }
+
+  .affine-embed-linked-doc-content-note.alias {
+    color: var(--affine-text-primary-color);
   }
 
   .affine-embed-linked-doc-card-content-reload,

--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -27,7 +27,12 @@ import {
 } from '@blocksuite/block-std';
 import { GfxControllerIdentifier } from '@blocksuite/block-std/gfx';
 import { assertExists, Bound, getCommonBound } from '@blocksuite/global/utils';
-import { BlockViewType, DocCollection, type Query } from '@blocksuite/store';
+import {
+  BlockViewType,
+  DocCollection,
+  type GetDocOptions,
+  type Query,
+} from '@blocksuite/store';
 import { html, type PropertyValues } from 'lit';
 import { query, state } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
@@ -327,9 +332,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
   }
 
   get docTitle() {
-    return this.syncedDoc?.meta?.title.length
-      ? this.syncedDoc.meta.title
-      : 'Untitled';
+    return this.syncedDoc?.meta?.title || 'Untitled';
   }
 
   get docUpdatedAt() {
@@ -353,14 +356,9 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
   }
 
   get syncedDoc() {
-    return this.isPageMode
-      ? this.std.collection.getDoc(this.model.pageId, {
-          readonly: true,
-          query: this._pageFilter,
-        })
-      : this.std.collection.getDoc(this.model.pageId, {
-          readonly: true,
-        });
+    const options: GetDocOptions = { readonly: true };
+    if (this.isPageMode) options.query = this._pageFilter;
+    return this.std.collection.getDoc(this.model.pageId, options);
   }
 
   private _checkCycle() {

--- a/packages/affine/block-embed/src/index.ts
+++ b/packages/affine/block-embed/src/index.ts
@@ -29,6 +29,7 @@ export {
   LinkPreviewer,
   type LinkPreviewResponseData,
 } from './common/link-previewer.js';
+export { getDocContentWithMaxLength } from './common/render-linked-doc.js';
 export { toEdgelessEmbedBlock } from './common/to-edgeless-embed-block.js';
 
 export * from './embed-figma-block/index.js';

--- a/packages/affine/components/package.json
+++ b/packages/affine/components/package.json
@@ -23,7 +23,7 @@
     "@blocksuite/affine-shared": "workspace:*",
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/global": "workspace:*",
-    "@blocksuite/icons": "^2.1.70",
+    "@blocksuite/icons": "^2.1.75",
     "@blocksuite/inline": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@floating-ui/dom": "^1.6.10",
@@ -53,7 +53,8 @@
     "./date-picker": "./src/date-picker/index.ts",
     "./drag-indicator": "./src/drag-indicator/index.ts",
     "./virtual-keyboard": "./src/virtual-keyboard/index.ts",
-    "./toggle-button": "./src/toggle-button/index.ts"
+    "./toggle-button": "./src/toggle-button/index.ts",
+    "./notification": "./src/notification/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -115,6 +116,10 @@
       "./toggle-button": {
         "types": "./dist/toggle-button/index.d.ts",
         "import": "./dist/toggle-button/index.js"
+      },
+      "./notification": {
+        "types": "./dist/notification/index.d.ts",
+        "import": "./dist/notification/index.js"
       }
     }
   },

--- a/packages/affine/components/src/notification/index.ts
+++ b/packages/affine/components/src/notification/index.ts
@@ -1,0 +1,1 @@
+export * from './linked-doc.js';

--- a/packages/affine/components/src/notification/linked-doc.ts
+++ b/packages/affine/components/src/notification/linked-doc.ts
@@ -1,0 +1,71 @@
+import type { BlockStdScope } from '@blocksuite/block-std';
+
+import { NotificationProvider } from '@blocksuite/affine-shared/services';
+
+import { toast } from '../toast/toast.js';
+
+function notify(std: BlockStdScope, title: string, message: string) {
+  const notification = std.getOptional(NotificationProvider);
+  const { doc, host } = std;
+
+  if (!notification) {
+    toast(host, title);
+    return;
+  }
+
+  const abortController = new AbortController();
+  const clear = () => {
+    doc.history.off('stack-item-added', addHandler);
+    doc.history.off('stack-item-popped', popHandler);
+    disposable.dispose();
+  };
+  const closeNotify = () => {
+    abortController.abort();
+    clear();
+  };
+
+  // edit or undo or switch doc, close notify toast
+  const addHandler = doc.history.on('stack-item-added', closeNotify);
+  const popHandler = doc.history.on('stack-item-popped', closeNotify);
+  const disposable = host.slots.unmounted.on(closeNotify);
+
+  notification.notify({
+    title,
+    message,
+    accent: 'info',
+    duration: 10 * 1000,
+    action: {
+      label: 'Undo',
+      onClick: () => {
+        doc.undo();
+        clear();
+      },
+    },
+    abort: abortController.signal,
+    onClose: clear,
+  });
+}
+
+export function notifyLinkedDocSwitchedToCard(std: BlockStdScope) {
+  notify(
+    std,
+    'View Updated',
+    'The alias modification has disabled sync. The embed has been updated to a card view.'
+  );
+}
+
+export function notifyLinkedDocSwitchedToEmbed(std: BlockStdScope) {
+  notify(
+    std,
+    'Embed View Restored',
+    'Custom alias removed. The linked doc now displays the original title and description.'
+  );
+}
+
+export function notifyLinkedDocClearedAliases(std: BlockStdScope) {
+  notify(
+    std,
+    'Reset successful',
+    `Card view has been restored to original doc title and description. All custom aliases have been removed.`
+  );
+}

--- a/packages/affine/components/src/rich-text/effects.ts
+++ b/packages/affine/components/src/rich-text/effects.ts
@@ -23,6 +23,7 @@ import { LatexEditorMenu } from './inline/presets/nodes/latex-node/latex-editor-
 import { LatexEditorUnit } from './inline/presets/nodes/latex-node/latex-editor-unit.js';
 import { AffineLatexNode } from './inline/presets/nodes/latex-node/latex-node.js';
 import { LinkPopup } from './inline/presets/nodes/link-node/link-popup/link-popup.js';
+import { ReferenceAliasPopup } from './inline/presets/nodes/reference-node/reference-alias-popup.js';
 import { ReferencePopup } from './inline/presets/nodes/reference-node/reference-popup.js';
 import { RichText } from './rich-text.js';
 
@@ -35,6 +36,7 @@ export function effects() {
   customElements.define('link-popup', LinkPopup);
   customElements.define('affine-link', AffineLink);
   customElements.define('reference-popup', ReferencePopup);
+  customElements.define('reference-alias-popup', ReferenceAliasPopup);
   customElements.define('affine-reference', AffineReference);
 }
 
@@ -46,6 +48,7 @@ declare global {
     'affine-text': AffineText;
     'rich-text': RichText;
     'reference-popup': ReferencePopup;
+    'reference-alias-popup': ReferenceAliasPopup;
     'latex-editor-unit': LatexEditorUnit;
     'latex-editor-menu': LatexEditorMenu;
     'link-popup': LinkPopup;

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/link-popup.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/link-node/link-popup/link-popup.ts
@@ -6,6 +6,7 @@ import {
   getHostName,
   isValidUrl,
   normalizeUrl,
+  stopPropagation,
 } from '@blocksuite/affine-shared/utils';
 import { BLOCK_ID_ATTR, type BlockComponent } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/global/utils';
@@ -174,7 +175,7 @@ export class LinkPopup extends WithDisposable(LitElement) {
         <editor-icon-button
           aria-label="Copy"
           data-testid="copy-link"
-          .tooltip=${'Click to copy link'}
+          .tooltip=${'Copy link'}
           @click=${this._copyUrl}
         >
           ${CopyIcon}
@@ -528,15 +529,9 @@ export class LinkPopup extends WithDisposable(LitElement) {
   protected override firstUpdated() {
     if (!this.linkInput) return;
 
-    this._disposables.addFromEvent(this.linkInput, 'copy', e => {
-      e.stopPropagation();
-    });
-    this._disposables.addFromEvent(this.linkInput, 'cut', e => {
-      e.stopPropagation();
-    });
-    this._disposables.addFromEvent(this.linkInput, 'paste', e => {
-      e.stopPropagation();
-    });
+    this._disposables.addFromEvent(this.linkInput, 'copy', stopPropagation);
+    this._disposables.addFromEvent(this.linkInput, 'cut', stopPropagation);
+    this._disposables.addFromEvent(this.linkInput, 'paste', stopPropagation);
   }
 
   override render() {

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-alias-popup.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-alias-popup.ts
@@ -1,0 +1,259 @@
+import type { ReferenceInfo } from '@blocksuite/affine-model';
+import type { AffineTextAttributes } from '@blocksuite/affine-shared/types';
+import type { DeltaInsert, InlineRange } from '@blocksuite/inline';
+
+import { FONT_XS, PANEL_BASE } from '@blocksuite/affine-shared/styles';
+import { ShadowlessElement } from '@blocksuite/block-std';
+import {
+  assertExists,
+  SignalWatcher,
+  WithDisposable,
+} from '@blocksuite/global/utils';
+import { DoneIcon, ResetIcon } from '@blocksuite/icons/lit';
+import { computePosition, inline, offset, shift } from '@floating-ui/dom';
+import { signal } from '@preact/signals-core';
+import { css, html } from 'lit';
+import { property, query } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
+
+import type { EditorIconButton } from '../../../../../toolbar/index.js';
+import type { AffineInlineEditor } from '../../affine-inline-specs.js';
+
+import { REFERENCE_NODE } from '../consts.js';
+
+export class ReferenceAliasPopup extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
+  static override styles = css`
+    :host {
+      box-sizing: border-box;
+    }
+
+    .overlay-mask {
+      position: fixed;
+      z-index: var(--affine-z-index-popover);
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+    }
+
+    .alias-form-popup {
+      ${PANEL_BASE};
+      position: absolute;
+      display: flex;
+      width: 321px;
+      height: 37px;
+      gap: 8px;
+      box-sizing: content-box;
+      justify-content: space-between;
+      align-items: center;
+      animation: affine-popover-fade-in 0.2s ease;
+      z-index: var(--affine-z-index-popover);
+    }
+
+    @keyframes affine-popover-fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(-3px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    input {
+      display: flex;
+      flex: 1;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: var(--affine-text-primary-color);
+      ${FONT_XS};
+    }
+    input::placeholder {
+      color: var(--affine-placeholder-color);
+    }
+    input:focus {
+      outline: none;
+    }
+
+    editor-icon-button.save .label {
+      ${FONT_XS};
+      color: inherit;
+      text-transform: none;
+    }
+  `;
+
+  private _onSave = () => {
+    const title = this.title$.value.trim();
+    if (!title) {
+      this.remove();
+      return;
+    }
+
+    this._setTitle(title);
+
+    this.remove();
+  };
+
+  private _updateTitle = (e: InputEvent) => {
+    const target = e.target as HTMLInputElement;
+    const value = target.value;
+    this.title$.value = value;
+  };
+
+  private _onKeydown(e: KeyboardEvent) {
+    e.stopPropagation();
+    if (!e.isComposing) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.remove();
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        this._onSave();
+      }
+    }
+  }
+
+  private _onReset() {
+    this.title$.value = this.docTitle;
+
+    this._setTitle();
+
+    this.remove();
+  }
+
+  private _setTitle(title?: string) {
+    const reference: AffineTextAttributes['reference'] = {
+      type: 'LinkedPage',
+      ...this.referenceInfo,
+    };
+
+    if (title) {
+      reference.title = title;
+    } else {
+      delete reference.title;
+      delete reference.description;
+    }
+
+    this.inlineEditor.insertText(this.inlineRange, REFERENCE_NODE, {
+      reference,
+    });
+    this.inlineEditor.setInlineRange({
+      index: this.inlineRange.index + REFERENCE_NODE.length,
+      length: 0,
+    });
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    this.title$.value = this.referenceInfo.title ?? this.docTitle;
+  }
+
+  override firstUpdated() {
+    this.disposables.addFromEvent(this.overlayMask, 'click', e => {
+      e.stopPropagation();
+      this.remove();
+    });
+    this.disposables.addFromEvent(this, 'keydown', this._onKeydown);
+
+    this.inputElement.focus();
+    this.inputElement.select();
+  }
+
+  override render() {
+    return html`
+      <div class="overlay-root">
+        <div class="overlay-mask"></div>
+        <div class="alias-form-popup">
+          <input
+            id="alias-title"
+            type="text"
+            placeholder="Add a custom title"
+            .value=${live(this.title$.value)}
+            @input=${this._updateTitle}
+          />
+          <editor-icon-button
+            aria-label="Reset"
+            class="reset"
+            .iconContainerPadding=${4}
+            .tooltip=${'Reset'}
+            @click=${this._onReset}
+          >
+            ${ResetIcon({ width: '16px', height: '16px' })}
+          </editor-icon-button>
+          <editor-toolbar-separator></editor-toolbar-separator>
+          <editor-icon-button
+            aria-label="Save"
+            class="save"
+            .active=${true}
+            @click=${this._onSave}
+          >
+            ${DoneIcon({ width: '16px', height: '16px' })}
+            <span class="label">Save</span>
+          </editor-icon-button>
+        </div>
+      </div>
+    `;
+  }
+
+  override updated() {
+    const range = this.inlineEditor.toDomRange(this.inlineRange);
+    assertExists(range);
+
+    const visualElement = {
+      getBoundingClientRect: () => range.getBoundingClientRect(),
+      getClientRects: () => range.getClientRects(),
+    };
+    computePosition(visualElement, this.popupContainer, {
+      middleware: [
+        offset(10),
+        inline(),
+        shift({
+          padding: 6,
+        }),
+      ],
+    })
+      .then(({ x, y }) => {
+        const popupContainer = this.popupContainer;
+        if (!popupContainer) return;
+        popupContainer.style.left = `${x}px`;
+        popupContainer.style.top = `${y}px`;
+      })
+      .catch(console.error);
+  }
+
+  @property({ type: Object })
+  accessor delta!: DeltaInsert<AffineTextAttributes>;
+
+  @property({ attribute: false })
+  accessor docTitle!: string;
+
+  @property({ attribute: false })
+  accessor inlineEditor!: AffineInlineEditor;
+
+  @property({ attribute: false })
+  accessor inlineRange!: InlineRange;
+
+  @query('input#alias-title')
+  accessor inputElement!: HTMLInputElement;
+
+  @query('.overlay-mask')
+  accessor overlayMask!: HTMLDivElement;
+
+  @query('.alias-form-popup')
+  accessor popupContainer!: HTMLDivElement;
+
+  @property({ type: Object })
+  accessor referenceInfo!: ReferenceInfo;
+
+  @query('editor-icon-button.save')
+  accessor saveButton!: EditorIconButton;
+
+  accessor title$ = signal<string>('');
+}

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
@@ -235,8 +235,9 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
     const isDeleted = !refMeta;
 
     const attributes = this.delta.attributes;
-    const type = attributes?.reference?.type;
-    if (!type) {
+    const reference = attributes?.reference;
+    const type = reference?.type;
+    if (!attributes || !type) {
       return nothing;
     }
 
@@ -244,9 +245,7 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
       ? this.customTitle(this)
       : isDeleted
         ? 'Deleted doc'
-        : refMeta.title.length > 0
-          ? refMeta.title
-          : DEFAULT_DOC_NAME;
+        : reference?.title || refMeta.title || DEFAULT_DOC_NAME;
 
     const icon = choose(
       type,

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/styles.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/styles.ts
@@ -21,4 +21,24 @@ export const styles = css`
       transform: translateY(0);
     }
   }
+
+  editor-icon-button.doc-title .label {
+    max-width: 110px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+    color: var(--affine-link-color);
+    font-feature-settings:
+      'clig' off,
+      'liga' off;
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-sm);
+    font-style: normal;
+    font-weight: 400;
+    text-decoration: none;
+    text-wrap: nowrap;
+  }
 `;

--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/utils.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/utils.ts
@@ -5,10 +5,16 @@ import cloneDeep from 'lodash.clonedeep';
 /**
  * Clones reference info.
  */
-export function cloneReferenceInfo({ pageId, params }: ReferenceInfo) {
+export function cloneReferenceInfo({
+  pageId,
+  params,
+  title,
+  description,
+}: ReferenceInfo) {
   const info: ReferenceInfo = { pageId };
-  if (!params) return info;
-  info.params = cloneDeep(params);
+  if (params) info.params = cloneDeep(params);
+  if (title) info.title = title;
+  if (description) info.description = description;
   return info;
 }
 

--- a/packages/affine/data-view/package.json
+++ b/packages/affine/data-view/package.json
@@ -23,7 +23,7 @@
     "@blocksuite/affine-shared": "workspace:*",
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/global": "workspace:*",
-    "@blocksuite/icons": "^2.1.70",
+    "@blocksuite/icons": "^2.1.75",
     "@blocksuite/store": "workspace:*",
     "@emotion/hash": "^0.9.2",
     "@floating-ui/dom": "^1.6.10",

--- a/packages/affine/model/src/blocks/embed/linked-doc/linked-doc-schema.ts
+++ b/packages/affine/model/src/blocks/embed/linked-doc/linked-doc-schema.ts
@@ -9,6 +9,9 @@ const defaultEmbedLinkedDocBlockProps: EmbedLinkedDocBlockProps = {
   pageId: '',
   style: EmbedLinkedDocStyles[1],
   caption: null,
+  // title & description aliases
+  title: undefined,
+  description: undefined,
 };
 
 export const EmbedLinkedDocBlockSchema = createEmbedBlockSchema({

--- a/packages/affine/model/src/blocks/embed/synced-doc/synced-doc-schema.ts
+++ b/packages/affine/model/src/blocks/embed/synced-doc/synced-doc-schema.ts
@@ -10,6 +10,9 @@ export const defaultEmbedSyncedDocBlockProps: EmbedSyncedDocBlockProps = {
   style: EmbedSyncedDocStyles[0],
   caption: undefined,
   scale: undefined,
+  // title & description aliases
+  title: undefined,
+  description: undefined,
 };
 
 export const EmbedSyncedDocBlockSchema = createEmbedBlockSchema({

--- a/packages/affine/model/src/consts/doc.ts
+++ b/packages/affine/model/src/consts/doc.ts
@@ -4,6 +4,24 @@ export type DocMode = 'edgeless' | 'page';
 
 export const DocModes = ['edgeless', 'page'] as const;
 
+/**
+ * Custom title and description information.
+ *
+ * Supports the following blocks:
+ *
+ * 1. Inline View: `AffineReference` - title
+ * 2. Card View: `EmbedLinkedDocBlock` - title & description
+ * 3. Embed View: `EmbedSyncedDocBlock` - title
+ */
+export const AliasInfoSchema = z
+  .object({
+    title: z.string().nullable(),
+    description: z.string().nullable(),
+  })
+  .partial();
+
+export type AliasInfo = z.infer<typeof AliasInfoSchema>;
+
 export const ReferenceParamsSchema = z
   .object({
     mode: z.enum(DocModes),
@@ -16,9 +34,11 @@ export const ReferenceParamsSchema = z
 
 export type ReferenceParams = z.infer<typeof ReferenceParamsSchema>;
 
-export const ReferenceInfoSchema = z.object({
-  pageId: z.string(),
-  params: ReferenceParamsSchema.optional(),
-});
+export const ReferenceInfoSchema = z
+  .object({
+    pageId: z.string(),
+    params: ReferenceParamsSchema.optional(),
+  })
+  .merge(AliasInfoSchema);
 
 export type ReferenceInfo = z.infer<typeof ReferenceInfoSchema>;

--- a/packages/affine/shared/src/styles/panel.ts
+++ b/packages/affine/shared/src/styles/panel.ts
@@ -1,11 +1,12 @@
+import { cssVarV2 } from '@toeverything/theme/v2';
 import { unsafeCSS } from 'lit';
 
 import { FONT_SM } from './font.js';
 
 export const PANEL_BASE_COLORS = unsafeCSS(`
   color: var(--affine-icon-color);
-  background: var(--affine-background-overlay-panel-color);
   box-shadow: var(--affine-overlay-shadow);
+  background: ${cssVarV2('layer/background/overlayPanel')};
 `);
 
 export const PANEL_BASE = unsafeCSS(`
@@ -15,7 +16,7 @@ export const PANEL_BASE = unsafeCSS(`
   width: max-content;
   padding: 0 6px;
   border-radius: 4px;
-  border: 0.5px solid var(--affine-border-color);
+  border: 0.5px solid ${cssVarV2('layer/insideBorder/border')};
 
   ${PANEL_BASE_COLORS};
   ${FONT_SM};

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -31,7 +31,7 @@
     "@blocksuite/block-std": "workspace:*",
     "@blocksuite/data-view": "workspace:*",
     "@blocksuite/global": "workspace:*",
-    "@blocksuite/icons": "^2.1.70",
+    "@blocksuite/icons": "^2.1.75",
     "@blocksuite/inline": "workspace:*",
     "@blocksuite/store": "workspace:*",
     "@floating-ui/dom": "^1.6.10",

--- a/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
+++ b/packages/blocks/src/_common/components/embed-card/embed-card-more-menu-popper.ts
@@ -13,7 +13,7 @@ import { Slice } from '@blocksuite/store';
 import { css, html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import type { EmbedToolbarBlockComponent } from './type.js';
+import type { EmbedBlockComponent } from './type.js';
 
 import {
   isEmbedLinkedDocBlock,
@@ -213,7 +213,7 @@ export class EmbedCardMoreMenu extends WithDisposable(LitElement) {
   accessor abortController!: AbortController;
 
   @property({ attribute: false })
-  accessor block!: EmbedToolbarBlockComponent;
+  accessor block!: EmbedBlockComponent;
 }
 
 declare global {

--- a/packages/blocks/src/_common/components/embed-card/modal/embed-card-edit-modal.ts
+++ b/packages/blocks/src/_common/components/embed-card/modal/embed-card-edit-modal.ts
@@ -1,141 +1,400 @@
-import type {
-  BookmarkBlockModel,
-  EmbedFigmaModel,
-  EmbedGithubModel,
-  EmbedLoomModel,
-  EmbedYoutubeModel,
-} from '@blocksuite/affine-model';
-import type { EditorHost } from '@blocksuite/block-std';
+import type { AliasInfo } from '@blocksuite/affine-model';
+import type { BlockComponent, EditorHost } from '@blocksuite/block-std';
+import type { BlockProps } from '@blocksuite/store';
 
+import {
+  EmbedLinkedDocBlockComponent,
+  EmbedSyncedDocBlockComponent,
+} from '@blocksuite/affine-block-embed';
+import {
+  notifyLinkedDocClearedAliases,
+  notifyLinkedDocSwitchedToCard,
+} from '@blocksuite/affine-components/notification';
 import { toast } from '@blocksuite/affine-components/toast';
-import { ShadowlessElement } from '@blocksuite/block-std';
-import { WithDisposable } from '@blocksuite/global/utils';
-import { html } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import {
+  EmbedLinkedDocModel,
+  EmbedSyncedDocModel,
+} from '@blocksuite/affine-model';
+import { FONT_SM, FONT_XS } from '@blocksuite/affine-shared/styles';
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
+import {
+  listenClickAway,
+  stopPropagation,
+} from '@blocksuite/affine-shared/utils';
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
+import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
+import { computed, signal } from '@preact/signals-core';
+import { css, html, LitElement } from 'lit';
+import { property, query } from 'lit/decorators.js';
+import { choose } from 'lit/directives/choose.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { live } from 'lit/directives/live.js';
 
-import { embedCardModalStyles } from './styles.js';
+import type { LinkableEmbedModel } from '../type.js';
 
-type EmbedCardModel =
-  | BookmarkBlockModel
-  | EmbedGithubModel
-  | EmbedYoutubeModel
-  | EmbedFigmaModel
-  | EmbedLoomModel;
+import { isInternalEmbedModel } from '../type.js';
 
-export class EmbedCardEditModal extends WithDisposable(ShadowlessElement) {
-  static override styles = embedCardModalStyles;
+export class EmbedCardEditModal extends SignalWatcher(
+  WithDisposable(LitElement)
+) {
+  static override styles = css`
+    :host {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: var(--affine-z-index-popover);
+      animation: affine-popover-fade-in 0.2s ease;
+    }
 
-  private _handleInput(e: InputEvent) {
-    const target = e.target as HTMLInputElement;
-    this._titleInputValue = target.value;
-  }
+    @keyframes affine-popover-fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(-3px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
 
-  private _onDocumentKeydown(e: KeyboardEvent) {
+    .embed-card-modal-wrapper {
+      display: flex;
+      padding: 12px;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-start;
+      gap: 12px;
+      width: 421px;
+
+      color: var(--affine-icon-color);
+      box-shadow: var(--affine-overlay-shadow);
+      background: ${unsafeCSSVarV2('layer/background/overlayPanel')};
+      border-radius: 4px;
+      border: 0.5px solid ${unsafeCSSVarV2('layer/insideBorder/border')};
+    }
+
+    .row {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .row .input {
+      display: flex;
+      padding: 4px 10px;
+      width: 100%;
+      min-width: 100%;
+      box-sizing: border-box;
+      border-radius: 4px;
+      user-select: none;
+      background: transparent;
+      border: 1px solid ${unsafeCSSVarV2('input/border/default')};
+      color: var(--affine-text-primary-color);
+      ${FONT_SM};
+    }
+    .input::placeholder {
+      color: var(--affine-placeholder-color);
+    }
+    .input:focus {
+      border-color: ${unsafeCSSVarV2('input/border/active')};
+      outline: none;
+    }
+
+    textarea.input {
+      min-height: 80px;
+      resize: none;
+    }
+
+    .row.actions {
+      justify-content: flex-end;
+    }
+
+    .row.actions .button {
+      display: flex;
+      padding: 4px 12px;
+      align-items: center;
+      gap: 4px;
+      border-radius: 4px;
+      border: 1px solid ${unsafeCSSVarV2('button/innerBlackBorder')};
+      background: ${unsafeCSSVarV2('button/secondary')};
+      ${FONT_XS};
+      color: ${unsafeCSSVarV2('text/primary')};
+    }
+    .row.actions .button[disabled],
+    .row.actions .button:disabled {
+      pointer-events: none;
+      color: ${unsafeCSSVarV2('text/disable')};
+      background: ${unsafeCSSVarV2('button/disable')};
+    }
+    .row.actions .button.save {
+      color: ${unsafeCSSVarV2('button/pureWhiteText')};
+      background: ${unsafeCSSVarV2('button/primary')};
+    }
+  `;
+
+  private _blockComponent: BlockComponent | null = null;
+
+  private _hide = () => {
+    this.remove();
+  };
+
+  private _onKeydown = (e: KeyboardEvent) => {
     e.stopPropagation();
-    if (e.key === 'Enter' && !e.isComposing) {
+    if (e.key === 'Enter' && !(e.isComposing || e.shiftKey)) {
       this._onSave();
     }
     if (e.key === 'Escape') {
+      e.preventDefault();
       this.remove();
     }
-  }
+  };
 
-  private _onSave() {
-    const title = this.titleInput.value;
+  private _onReset = () => {
+    this.model.doc.updateBlock(this.model, { title: null, description: null });
+
+    const blockComponent = this._blockComponent;
+    if (
+      this.isEmbedLinkedDocModel &&
+      blockComponent instanceof EmbedLinkedDocBlockComponent
+    ) {
+      const std = blockComponent.std;
+
+      blockComponent.refreshData();
+
+      notifyLinkedDocClearedAliases(std);
+    }
+    blockComponent?.requestUpdate();
+
+    this.remove();
+  };
+
+  private _onSave = () => {
+    const title = this.title$.value.trim();
     if (title.length === 0) {
-      toast(this.host, 'Link title can not be empty');
+      toast(this.host, 'Title can not be empty');
       return;
     }
 
-    this.model.doc.updateBlock(this.model, {
-      title,
-      description: this.descInput.value,
-    });
+    const description = this.description$.value.trim();
+
+    const props: Partial<BlockProps> = { title };
+    if (description) props.description = description;
+
+    this.model.doc.updateBlock(this.model, props);
+
+    const blockComponent = this._blockComponent;
+
+    if (
+      this.isEmbedSyncedDocModel &&
+      blockComponent instanceof EmbedSyncedDocBlockComponent
+    ) {
+      const std = blockComponent.std;
+
+      blockComponent.convertToCard();
+
+      notifyLinkedDocSwitchedToCard(std);
+    } else {
+      blockComponent?.requestUpdate();
+    }
+
     this.remove();
+  };
+
+  private _updateDescription = (e: InputEvent) => {
+    const target = e.target as HTMLTextAreaElement;
+    this.description$.value = target.value;
+  };
+
+  private _updateTitle = (e: InputEvent) => {
+    const target = e.target as HTMLInputElement;
+    this.title$.value = target.value;
+  };
+
+  get isEmbedLinkedDocModel() {
+    return this.model instanceof EmbedLinkedDocModel;
+  }
+
+  get isEmbedSyncedDocModel() {
+    return this.model instanceof EmbedSyncedDocModel;
+  }
+
+  get isInternalEmbedModel() {
+    return isInternalEmbedModel(this.model);
+  }
+
+  get modelType(): 'linked' | 'synced' | null {
+    if (this.isEmbedLinkedDocModel) return 'linked';
+    if (this.isEmbedSyncedDocModel) return 'synced';
+    return null;
+  }
+
+  get placeholders() {
+    if (this.isInternalEmbedModel) {
+      return {
+        title: 'Add title alias',
+        description:
+          'Add description alias (empty to inherit document content)',
+      };
+    }
+
+    return {
+      title: 'Write a title',
+      description: 'Write a description...',
+    };
+  }
+
+  private _updateInfo() {
+    const title = this.model.title || this.originalDocInfo?.title || '';
+    const description =
+      this.model.description || this.originalDocInfo?.description || '';
+
+    this.title$.value = title;
+    this.description$.value = description;
   }
 
   override connectedCallback() {
     super.connectedCallback();
 
-    this.updateComplete
-      .then(() => {
-        this.titleInput.focus();
-        this.titleInput.setSelectionRange(0, this.titleInput.value.length);
+    this._updateInfo();
+  }
+
+  override firstUpdated() {
+    const blockComponent = this.host.std.view.getBlock(this.model.id);
+    if (!blockComponent) return;
+
+    this._blockComponent = blockComponent;
+
+    this.disposables.add(
+      autoUpdate(blockComponent, this, () => {
+        computePosition(blockComponent, this, {
+          placement: 'top-start',
+          middleware: [flip(), offset(8)],
+        })
+          .then(({ x, y }) => {
+            this.style.left = `${x}px`;
+            this.style.top = `${y}px`;
+          })
+          .catch(console.error);
       })
-      .catch(console.error);
+    );
 
-    this.disposables.addFromEvent(this, 'keydown', this._onDocumentKeydown);
+    this.disposables.add(listenClickAway(this, this._hide));
+    this.disposables.addFromEvent(this, 'keydown', this._onKeydown);
+    this.disposables.addFromEvent(this, 'pointerdown', stopPropagation);
 
-    this._titleInputValue = this.model.title ?? '';
+    this.titleInput.focus();
+    this.titleInput.select();
   }
 
   override render() {
     return html`
-      <div class="embed-card-modal">
-        <div class="embed-card-modal-mask" @click=${() => this.remove()}></div>
-        <div class="embed-card-modal-wrapper">
-          <div class="embed-card-modal-row">
-            <label for="card-title">Text</label>
-            <input
-              class="embed-card-modal-input title"
-              id="card-title"
-              type="text"
-              placeholder="Title"
-              value=${this._titleInputValue}
-              @input=${this._handleInput}
-            />
-          </div>
-          <div class="embed-card-modal-row">
-            <label for="card-description">Description</label>
-            <textarea
-              class="embed-card-modal-input description"
-              id="card-description"
-              placeholder="Write a description..."
-              .value=${this.model.description ?? ''}
-            ></textarea>
-          </div>
-          <div class="embed-card-modal-row">
-            <button
-              class=${classMap({
-                'embed-card-modal-button': true,
-                save: true,
-              })}
-              ?disabled=${this._titleInputValue.length === 0}
-              @click=${() => this._onSave()}
-            >
-              Save
-            </button>
-          </div>
+      <div class="embed-card-modal-wrapper">
+        <div class="row">
+          <input
+            class="input title"
+            type="text"
+            placeholder=${this.placeholders.title}
+            .value=${live(this.title$.value)}
+            @input=${this._updateTitle}
+          />
+        </div>
+        <div class="row">
+          <textarea
+            class="input description"
+            maxlength="500"
+            placeholder=${this.placeholders.description}
+            .value=${live(this.description$.value)}
+            @input=${this._updateDescription}
+          ></textarea>
+        </div>
+        <div class="row actions">
+          ${choose(this.modelType, [
+            [
+              'linked',
+              () => html`
+                <button
+                  class=${classMap({
+                    button: true,
+                    reset: true,
+                  })}
+                  .disabled=${this.resetButtonDisabled$.value}
+                  @click=${this._onReset}
+                >
+                  Reset
+                </button>
+              `,
+            ],
+            [
+              'synced',
+              () => html`
+                <button
+                  class=${classMap({
+                    button: true,
+                    cancel: true,
+                  })}
+                  @click=${this._hide}
+                >
+                  Cancel
+                </button>
+              `,
+            ],
+          ])}
+          <button
+            class=${classMap({
+              button: true,
+              save: true,
+            })}
+            .disabled=${this.saveButtonDisabled$.value}
+            @click=${this._onSave}
+          >
+            Save
+          </button>
         </div>
       </div>
     `;
   }
 
-  @state()
-  private accessor _titleInputValue = '';
-
-  @query('.embed-card-modal-input.description')
-  accessor descInput!: HTMLTextAreaElement;
+  accessor description$ = signal<string>('');
 
   @property({ attribute: false })
   accessor host!: EditorHost;
 
   @property({ attribute: false })
-  accessor model!: EmbedCardModel;
+  accessor model!: LinkableEmbedModel;
 
-  @query('.embed-card-modal-input.title')
+  @property({ attribute: false })
+  accessor originalDocInfo: AliasInfo | undefined = undefined;
+
+  accessor resetButtonDisabled$ = computed<boolean>(
+    () =>
+      !(
+        Boolean(this.model.title$.value?.length) ||
+        Boolean(this.model.description$.value?.length)
+      )
+  );
+
+  accessor saveButtonDisabled$ = computed<boolean>(
+    () => this.title$.value.trim().length === 0
+  );
+
+  accessor title$ = signal<string>('');
+
+  @query('.input.title')
   accessor titleInput!: HTMLInputElement;
 }
 
 export function toggleEmbedCardEditModal(
   host: EditorHost,
-  embedCardModel: EmbedCardModel
+  embedCardModel: LinkableEmbedModel,
+  originalDocInfo?: AliasInfo
 ) {
-  host.selection.clear();
+  document.body.querySelector('embed-card-edit-modal')?.remove();
+
   const embedCardEditModal = new EmbedCardEditModal();
   embedCardEditModal.model = embedCardModel;
   embedCardEditModal.host = host;
+  embedCardEditModal.originalDocInfo = originalDocInfo;
   document.body.append(embedCardEditModal);
 }
 

--- a/packages/blocks/src/_common/components/embed-card/modal/styles.ts
+++ b/packages/blocks/src/_common/components/embed-card/modal/styles.ts
@@ -74,13 +74,15 @@ export const embedCardModalStyles = css`
   .embed-card-modal-row:has(.embed-card-modal-button) {
     flex-direction: row;
     gap: 4px;
-    align-self: flex-end;
+    justify-content: flex-end;
+  }
+  .embed-card-modal-row:has(.embed-card-modal-button.reset) {
+    justify-content: space-between;
   }
 
   .embed-card-modal-button {
     padding: 4px 18px;
     border-radius: 8px;
-    align-self: self-end;
     box-sizing: border-box;
   }
   .embed-card-modal-button.save {
@@ -93,6 +95,14 @@ export const embedCardModalStyles = css`
     cursor: not-allowed;
     color: var(--affine-text-disable-color);
     background: transparent;
+  }
+  .embed-card-modal-button.reset {
+    padding: 4px 0;
+    border: none;
+    background: transparent;
+    text-decoration: underline;
+    color: var(--affine-secondary-color);
+    user-select: none;
   }
 
   .embed-card-modal-title {

--- a/packages/blocks/src/_common/components/embed-card/type.ts
+++ b/packages/blocks/src/_common/components/embed-card/type.ts
@@ -2,9 +2,8 @@ import type {
   BookmarkBlockModel,
   EmbedFigmaModel,
   EmbedGithubModel,
-  EmbedLinkedDocModel,
+  EmbedHtmlModel,
   EmbedLoomModel,
-  EmbedSyncedDocModel,
   EmbedYoutubeModel,
 } from '@blocksuite/affine-model';
 import type { BlockComponent } from '@blocksuite/block-std';
@@ -12,42 +11,70 @@ import type { BlockComponent } from '@blocksuite/block-std';
 import {
   EmbedFigmaBlockComponent,
   EmbedGithubBlockComponent,
+  EmbedHtmlBlockComponent,
   EmbedLinkedDocBlockComponent,
   EmbedLoomBlockComponent,
   EmbedSyncedDocBlockComponent,
   EmbedYoutubeBlockComponent,
 } from '@blocksuite/affine-block-embed';
+import {
+  EmbedLinkedDocModel,
+  EmbedSyncedDocModel,
+} from '@blocksuite/affine-model';
 
 import { BookmarkBlockComponent } from '../../../bookmark-block/bookmark-block.js';
 
-export type EmbedToolbarBlockComponent =
+export type ExternalEmbedBlockComponent =
   | BookmarkBlockComponent
-  | EmbedGithubBlockComponent
-  | EmbedYoutubeBlockComponent
   | EmbedFigmaBlockComponent
-  | EmbedLinkedDocBlockComponent
-  | EmbedSyncedDocBlockComponent
-  | EmbedLoomBlockComponent;
+  | EmbedGithubBlockComponent
+  | EmbedLoomBlockComponent
+  | EmbedYoutubeBlockComponent;
 
-export type EmbedToolbarModel =
+export type InternalEmbedBlockComponent =
+  | EmbedLinkedDocBlockComponent
+  | EmbedSyncedDocBlockComponent;
+
+export type LinkableEmbedBlockComponent =
+  | ExternalEmbedBlockComponent
+  | InternalEmbedBlockComponent;
+
+export type EmbedBlockComponent =
+  | LinkableEmbedBlockComponent
+  | EmbedHtmlBlockComponent;
+
+export type ExternalEmbedModel =
   | BookmarkBlockModel
-  | EmbedGithubModel
-  | EmbedYoutubeModel
   | EmbedFigmaModel
-  | EmbedLinkedDocModel
-  | EmbedSyncedDocModel
-  | EmbedLoomModel;
+  | EmbedGithubModel
+  | EmbedLoomModel
+  | EmbedYoutubeModel;
+
+export type InternalEmbedModel = EmbedLinkedDocModel | EmbedSyncedDocModel;
+
+export type LinkableEmbedModel = ExternalEmbedModel | InternalEmbedModel;
+
+export type EmbedModel = LinkableEmbedModel | EmbedHtmlModel;
 
 export function isEmbedCardBlockComponent(
   block: BlockComponent
-): block is EmbedToolbarBlockComponent {
+): block is EmbedBlockComponent {
   return (
     block instanceof BookmarkBlockComponent ||
-    block instanceof EmbedGithubBlockComponent ||
-    block instanceof EmbedYoutubeBlockComponent ||
     block instanceof EmbedFigmaBlockComponent ||
+    block instanceof EmbedGithubBlockComponent ||
+    block instanceof EmbedHtmlBlockComponent ||
+    block instanceof EmbedLoomBlockComponent ||
+    block instanceof EmbedYoutubeBlockComponent ||
     block instanceof EmbedLinkedDocBlockComponent ||
-    block instanceof EmbedSyncedDocBlockComponent ||
-    block instanceof EmbedLoomBlockComponent
+    block instanceof EmbedSyncedDocBlockComponent
+  );
+}
+
+export function isInternalEmbedModel(
+  model: EmbedModel
+): model is InternalEmbedModel {
+  return (
+    model instanceof EmbedLinkedDocModel || model instanceof EmbedSyncedDocModel
   );
 }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -1,16 +1,8 @@
 import type {
   AttachmentBlockModel,
-  BookmarkBlockModel,
   BrushElementModel,
   ConnectorElementModel,
   EdgelessTextBlockModel,
-  EmbedFigmaModel,
-  EmbedGithubModel,
-  EmbedHtmlModel,
-  EmbedLinkedDocModel,
-  EmbedLoomModel,
-  EmbedSyncedDocModel,
-  EmbedYoutubeModel,
   FrameBlockModel,
   ImageBlockModel,
   MindmapElementModel,
@@ -48,6 +40,7 @@ import { css, html, nothing, type TemplateResult, unsafeCSS } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { join } from 'lit/directives/join.js';
 
+import type { EmbedModel } from '../../../_common/components/embed-card/type.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
 import type { ElementToolbarMoreMenuContext } from './more-menu/context.js';
 
@@ -90,14 +83,7 @@ type CategorizedElements = {
   image?: ImageBlockModel[];
   attachment?: AttachmentBlockModel[];
   mindmap?: MindmapElementModel[];
-  embedCard?: BookmarkBlockModel[] &
-    EmbedGithubModel[] &
-    EmbedYoutubeModel[] &
-    EmbedFigmaModel[] &
-    EmbedLinkedDocModel[] &
-    EmbedSyncedDocModel[] &
-    EmbedHtmlModel[] &
-    EmbedLoomModel[];
+  embedCard?: EmbedModel[];
   edgelessText?: EdgelessTextBlockModel[];
 };
 

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/context.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/context.ts
@@ -1,4 +1,4 @@
-import type { EmbedToolbarBlockComponent } from '../../../_common/components/embed-card/type.js';
+import type { EmbedBlockComponent } from '../../../_common/components/embed-card/type.js';
 
 import { MenuContext } from '../../configs/toolbar.js';
 
@@ -25,7 +25,7 @@ export class EmbedCardToolbarContext extends MenuContext {
   }
 
   constructor(
-    public blockComponent: EmbedToolbarBlockComponent,
+    public blockComponent: EmbedBlockComponent,
     public abortController: AbortController
   ) {
     super();

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/styles.ts
@@ -44,4 +44,24 @@ export const embedCardToolbarStyle = css`
   .card-style-select icon-button.selected {
     border: 1px solid var(--affine-brand-color);
   }
+
+  editor-icon-button.doc-title .label {
+    max-width: 110px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+    color: var(--affine-link-color);
+    font-feature-settings:
+      'clig' off,
+      'liga' off;
+    font-family: var(--affine-font-family);
+    font-size: var(--affine-font-sm);
+    font-style: normal;
+    font-weight: 400;
+    text-decoration: none;
+    text-wrap: nowrap;
+  }
 `;

--- a/packages/framework/block-std/src/range/range-binding.ts
+++ b/packages/framework/block-std/src/range/range-binding.ts
@@ -170,6 +170,7 @@ export class RangeBinding {
 
   private _onNativeSelectionChanged = async () => {
     if (this.isComposing) return;
+    if (!this.host) return; // Unstable when switching views, card <-> embed
 
     await this.host.updateComplete;
 

--- a/packages/playground/apps/_common/components/docs-panel.ts
+++ b/packages/playground/apps/_common/components/docs-panel.ts
@@ -65,13 +65,10 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
   };
 
   gotoDoc = (doc: BlockCollection) => {
-    const generateDocUrlProvider = this.editor.std.getOptional(
-      GenerateDocUrlProvider
-    );
-    if (generateDocUrlProvider) {
-      const url = generateDocUrlProvider.generateDocUrl(doc.id);
-      if (url) history.pushState({}, '', url);
-    }
+    const url = this.editor.std
+      .getOptional(GenerateDocUrlProvider)
+      ?.generateDocUrl(doc.id);
+    if (url) history.pushState({}, '', url);
 
     this.editor.doc = doc.getDoc();
     this.editor.doc.load();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,7 +1482,7 @@ __metadata:
     "@blocksuite/affine-shared": "workspace:*"
     "@blocksuite/block-std": "workspace:*"
     "@blocksuite/global": "workspace:*"
-    "@blocksuite/icons": "npm:^2.1.70"
+    "@blocksuite/icons": "npm:^2.1.75"
     "@blocksuite/inline": "workspace:*"
     "@blocksuite/store": "workspace:*"
     "@floating-ui/dom": "npm:^1.6.10"
@@ -1571,7 +1571,7 @@ __metadata:
     "@blocksuite/affine-shared": "workspace:*"
     "@blocksuite/block-std": "workspace:*"
     "@blocksuite/global": "workspace:*"
-    "@blocksuite/icons": "npm:^2.1.70"
+    "@blocksuite/icons": "npm:^2.1.75"
     "@blocksuite/inline": "workspace:*"
     "@blocksuite/store": "workspace:*"
     "@floating-ui/dom": "npm:^1.6.10"
@@ -1692,7 +1692,7 @@ __metadata:
     "@blocksuite/block-std": "workspace:*"
     "@blocksuite/data-view": "workspace:*"
     "@blocksuite/global": "workspace:*"
-    "@blocksuite/icons": "npm:^2.1.70"
+    "@blocksuite/icons": "npm:^2.1.75"
     "@blocksuite/inline": "workspace:*"
     "@blocksuite/store": "workspace:*"
     "@floating-ui/dom": "npm:^1.6.10"
@@ -1745,7 +1745,7 @@ __metadata:
     "@blocksuite/affine-shared": "workspace:*"
     "@blocksuite/block-std": "workspace:*"
     "@blocksuite/global": "workspace:*"
-    "@blocksuite/icons": "npm:^2.1.70"
+    "@blocksuite/icons": "npm:^2.1.75"
     "@blocksuite/store": "workspace:*"
     "@emotion/hash": "npm:^0.9.2"
     "@floating-ui/dom": "npm:^1.6.10"
@@ -1798,9 +1798,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@blocksuite/icons@npm:^2.1.70":
-  version: 2.1.74
-  resolution: "@blocksuite/icons@npm:2.1.74"
+"@blocksuite/icons@npm:^2.1.75":
+  version: 2.1.75
+  resolution: "@blocksuite/icons@npm:2.1.75"
   peerDependencies:
     "@types/react": ^18.0.25
     lit: ^3.1.1
@@ -1810,7 +1810,7 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 10/84bdcab64c09d5a15fdbe97d753a9b994bdf00b1606c7672417e199b031a8d2f3f549b6f913ee786259739b11e9f61a44f997ac41950afa4a327151ab140c5ba
+  checksum: 10/25e8c25630690b7b1b13761593d9f776c3e78a7be6db4bd30f2c3a25134acd22a41a3258e324ac843ea04cfc9a2c29456563a254a6e7e627043b5248a82cb778
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes: [BS-1946](https://linear.app/affine-design/issue/BS-1946/实现-inlinecardembed-view-alias-功能)

### What's Changed!

* extends `ReferenceInfo`, adding two new fields: `title` and `description`
* adds `Copy` and `Edit` buttons to toolbar
  * `Copy`: copy link
  * `Edit`: custom title and description 
* organizes embed models and components, distinguish between external and internal