### PR TITLE
feat: generate url service

### DIFF
--- a/packages/affine/shared/src/services/generate-url-service.ts
+++ b/packages/affine/shared/src/services/generate-url-service.ts
@@ -1,0 +1,22 @@
+import type { ReferenceParams } from '@blocksuite/affine-model';
+import type { ExtensionType } from '@blocksuite/block-std';
+
+import { createIdentifier } from '@blocksuite/global/di';
+
+export interface GenerateDocUrlService {
+  generateDocUrl: (docId: string, params?: ReferenceParams) => string | void;
+}
+
+export const GenerateDocUrlProvider = createIdentifier<GenerateDocUrlService>(
+  'GenerateDocUrlService'
+);
+
+export function GenerateDocUrlExtension(
+  generateDocUrlProvider: GenerateDocUrlService
+): ExtensionType {
+  return {
+    setup: di => {
+      di.addImpl(GenerateDocUrlProvider, generateDocUrlProvider);
+    },
+  };
+}

--- a/packages/affine/shared/src/services/index.ts
+++ b/packages/affine/shared/src/services/index.ts
@@ -4,6 +4,7 @@ export * from './edit-props-store.js';
 export * from './editor-setting-service.js';
 export * from './embed-option-service.js';
 export * from './font-loader/index.js';
+export * from './generate-url-service.js';
 export * from './notification-service.js';
 export * from './parse-url-service.js';
 export * from './quick-search-service.js';

--- a/packages/playground/apps/_common/components/docs-panel.ts
+++ b/packages/playground/apps/_common/components/docs-panel.ts
@@ -1,8 +1,12 @@
 import type { AffineEditorContainer } from '@blocksuite/presets';
-import type { DocCollection } from '@blocksuite/store';
+import type { BlockCollection, DocCollection } from '@blocksuite/store';
 
 import { ShadowlessElement } from '@blocksuite/block-std';
-import { CloseIcon, createDefaultDoc } from '@blocksuite/blocks';
+import {
+  CloseIcon,
+  createDefaultDoc,
+  GenerateDocUrlProvider,
+} from '@blocksuite/blocks';
 import { WithDisposable } from '@blocksuite/global/utils';
 import { css, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -60,6 +64,18 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
     createDocBlock(this.editor.doc.collection);
   };
 
+  gotoDoc = (doc: BlockCollection) => {
+    const url = this.editor.std
+      .get(GenerateDocUrlProvider)
+      .generateDocUrl(doc.id);
+    if (url) history.pushState({}, '', url);
+
+    this.editor.doc = doc.getDoc();
+    this.editor.doc.load();
+    this.editor.doc.resetHistory();
+    this.requestUpdate();
+  };
+
   private get collection() {
     return this.editor.doc.collection;
   }
@@ -97,10 +113,7 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
             justifyContent: 'space-between',
           });
           const click = () => {
-            this.editor.doc = doc.getDoc();
-            this.editor.doc.load();
-            this.editor.doc.resetHistory();
-            this.requestUpdate();
+            this.gotoDoc(doc);
           };
           const deleteDoc = (e: MouseEvent) => {
             e.stopPropagation();

--- a/packages/playground/apps/_common/mock-services.ts
+++ b/packages/playground/apps/_common/mock-services.ts
@@ -11,9 +11,11 @@ import {
   ColorScheme,
   type DocMode,
   type DocModeProvider,
+  type GenerateDocUrlService,
   matchFlavours,
   type NotificationService,
   type ParseDocUrlService,
+  type ReferenceParams,
   type ThemeExtension,
   toast,
 } from '@blocksuite/blocks';
@@ -109,12 +111,10 @@ export function mockParseDocUrlService(collection: DocCollection) {
   const parseDocUrlService: ParseDocUrlService = {
     parseDocUrl: (url: string) => {
       if (url && URL.canParse(url)) {
-        const path = new URL(url).pathname;
+        const path = decodeURIComponent(new URL(url).hash.slice(1));
         const item =
-          path.length > 1
-            ? [...collection.docs.values()].find(doc => {
-                return doc.meta?.title === path.slice(1);
-              })
+          path.length > 0
+            ? [...collection.docs.values()].find(doc => doc.id === path)
             : null;
         if (item) {
           return {
@@ -180,4 +180,25 @@ export function mockPeekViewExtension(
       return Promise.resolve();
     },
   } satisfies PeekViewService);
+}
+
+export function mockGenerateDocUrlService(collection: DocCollection) {
+  const generateDocUrlService: GenerateDocUrlService = {
+    generateDocUrl: (docId: string, params?: ReferenceParams) => {
+      const doc = collection.getDoc(docId);
+      if (!doc) return;
+
+      const url = new URL(location.origin);
+      if (params) {
+        const search = url.searchParams;
+        for (const [key, value] of Object.entries(params)) {
+          search.set(key, Array.isArray(value) ? value.join(',') : value);
+        }
+      }
+      url.hash = encodeURIComponent(docId);
+
+      return url.toString();
+    },
+  };
+  return generateDocUrlService;
 }


### PR DESCRIPTION
Closes: [BS-1961](https://linear.app/affine-design/issue/BS-1961/实现-generatedocurlservice)

### What's Changed

In the `Alias` ​​function, we need to copy the link, and need a service that can generate a complete link.

Complementary with `ParseDocUrlService`.


https://github.com/user-attachments/assets/7c5c1927-f942-4f05-9b1f-1f1c1cb6d740

