### PR TITLE
feat(edgeless): add lock property to edgeless block and element

### DIFF
--- a/packages/affine/model/src/blocks/attachment/attachment-model.ts
+++ b/packages/affine/model/src/blocks/attachment/attachment-model.ts
@@ -65,6 +65,7 @@ export const defaultAttachmentProps: AttachmentBlockProps = {
   style: AttachmentBlockStyles[1],
   index: 'a0',
   xywh: '[0,0,0,0]',
+  lockedBySelf: false,
   rotate: 0,
 };
 

--- a/packages/affine/model/src/blocks/bookmark/bookmark-model.ts
+++ b/packages/affine/model/src/blocks/bookmark/bookmark-model.ts
@@ -34,6 +34,7 @@ const defaultBookmarkProps: BookmarkBlockProps = {
 
   index: 'a0',
   xywh: '[0,0,0,0]',
+  lockedBySelf: false,
   rotate: 0,
 };
 

--- a/packages/affine/model/src/blocks/edgeless-text/edgeless-text-model.ts
+++ b/packages/affine/model/src/blocks/edgeless-text/edgeless-text-model.ts
@@ -24,6 +24,7 @@ export const EdgelessTextBlockSchema = defineBlockSchema({
   props: (): EdgelessTextProps => ({
     xywh: '[0,0,16,16]',
     index: 'a0',
+    lockedBySelf: false,
     color: '#000000',
     fontFamily: FontFamily.Inter,
     fontStyle: FontStyle.Normal,

--- a/packages/affine/model/src/blocks/frame/frame-model.ts
+++ b/packages/affine/model/src/blocks/frame/frame-model.ts
@@ -36,6 +36,7 @@ export const FrameBlockSchema = defineBlockSchema({
     index: 'a0',
     childElementIds: Object.create(null),
     presentationIndex: generateKeyBetweenV2(null, null),
+    lockedBySelf: false,
   }),
   metadata: {
     version: 1,

--- a/packages/affine/model/src/blocks/image/image-model.ts
+++ b/packages/affine/model/src/blocks/image/image-model.ts
@@ -24,6 +24,7 @@ const defaultImageProps: ImageBlockProps = {
   height: 0,
   index: 'a0',
   xywh: '[0,0,0,0]',
+  lockedBySelf: false,
   rotate: 0,
   size: -1,
 };

--- a/packages/affine/model/src/blocks/latex/latex-model.ts
+++ b/packages/affine/model/src/blocks/latex/latex-model.ts
@@ -14,6 +14,7 @@ export const LatexBlockSchema = defineBlockSchema({
   props: (): LatexProps => ({
     xywh: '[0,0,16,16]',
     index: 'a0',
+    lockedBySelf: false,
     scale: 1,
     rotate: 0,
     latex: '',

--- a/packages/affine/model/src/blocks/note/note-model.ts
+++ b/packages/affine/model/src/blocks/note/note-model.ts
@@ -26,6 +26,7 @@ export const NoteBlockSchema = defineBlockSchema({
     xywh: `[0,0,${DEFAULT_NOTE_WIDTH},${DEFAULT_NOTE_HEIGHT}]`,
     background: DEFAULT_NOTE_BACKGROUND_COLOR,
     index: 'a0',
+    lockedBySelf: false,
     hidden: false,
     displayMode: NoteDisplayMode.DocAndEdgeless,
     edgeless: {

--- a/packages/affine/model/src/utils/helper.ts
+++ b/packages/affine/model/src/utils/helper.ts
@@ -49,6 +49,7 @@ export function createEmbedBlockSchema<
       return {
         index: 'a0',
         xywh: '[0,0,0,0]',
+        lockedBySelf: false,
         rotate: 0,
         ...userProps,
       } as unknown as EmbedProps<Props>;

--- a/packages/framework/block-std/src/gfx/model/gfx-block-model.ts
+++ b/packages/framework/block-std/src/gfx/model/gfx-block-model.ts
@@ -30,6 +30,7 @@ import type { SurfaceBlockModel } from './surface/surface-model.js';
 export type GfxCompatibleProps = {
   xywh: SerializedXYWH;
   index: string;
+  lockedBySelf?: boolean;
 };
 
 /**

--- a/packages/framework/block-std/src/gfx/model/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/element-model.ts
@@ -45,6 +45,7 @@ import {
 export type BaseElementProps = {
   index: string;
   seed: number;
+  lockedBySelf?: boolean;
 };
 
 export type SerializedElement = Record<string, unknown> & {
@@ -52,6 +53,7 @@ export type SerializedElement = Record<string, unknown> & {
   xywh: SerializedXYWH;
   id: string;
   index: string;
+  lockedBySelf?: boolean;
   props: Record<string, unknown>;
 };
 export abstract class GfxPrimitiveElementModel<
@@ -320,6 +322,9 @@ export abstract class GfxPrimitiveElementModel<
 
   @field()
   accessor index!: string;
+
+  @field()
+  accessor lockedBySelf: boolean | undefined = false;
 
   @local()
   accessor opacity: number = 1;

--- a/packages/framework/block-std/src/view/element/gfx-block-component.ts
+++ b/packages/framework/block-std/src/view/element/gfx-block-component.ts
@@ -1,7 +1,5 @@
-import type { BlockModel } from '@blocksuite/store';
-
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
-import { Bound, type SerializedXYWH } from '@blocksuite/global/utils';
+import { Bound } from '@blocksuite/global/utils';
 import { nothing } from 'lit';
 
 import type { BlockService } from '../../extension/index.js';
@@ -170,10 +168,7 @@ export function toGfxBlockComponent<
       h: number | string;
       zIndex: string;
     } {
-      const { xywh$ } = this.model as BlockModel<{
-        xywh: SerializedXYWH;
-        index: string;
-      }>;
+      const { xywh$ } = this.model;
 
       if (!xywh$) {
         throw new BlockSuiteError(

--- a/tests/attachment.spec.ts
+++ b/tests/attachment.spec.ts
@@ -158,10 +158,12 @@ test('can insert attachment from slash menu', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:attachment
     prop:embed={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:name="${FILE_NAME}"
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
@@ -203,10 +205,12 @@ test('should undo/redo works for attachment', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:attachment
     prop:embed={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:name="${FILE_NAME}"
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
@@ -239,6 +243,7 @@ test('should undo/redo works for attachment', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:paragraph
     prop:text="/"
@@ -268,10 +273,12 @@ test('should undo/redo works for attachment', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:attachment
     prop:embed={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:name="${FILE_NAME}"
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
@@ -354,11 +361,13 @@ test('should turn attachment to image works', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:image
     prop:caption=""
     prop:height={0}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
     prop:sourceId="${FILE_ID}"
@@ -386,11 +395,13 @@ test('should turn attachment to image works', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:attachment
     prop:caption=""
     prop:embed={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:name="${FILE_NAME}"
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
@@ -433,6 +444,7 @@ test('should attachment can be deleted', async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:paragraph
     prop:type="text"
@@ -475,10 +487,12 @@ test.fixme(`support dragging attachment block directly`, async ({ page }) => {
   }
   prop:hidden={false}
   prop:index="a0"
+  prop:lockedBySelf={false}
 >
   <affine:attachment
     prop:embed={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
     prop:name="${FILE_NAME}"
     prop:rotate={0}
     prop:size={${FILE_SIZE}}
@@ -529,6 +543,7 @@ test.fixme(`support dragging attachment block directly`, async ({ page }) => {
     }
     prop:hidden={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
   >
     <affine:attachment
       prop:embed={false}
@@ -583,6 +598,7 @@ test.fixme(`support dragging attachment block directly`, async ({ page }) => {
     }
     prop:hidden={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
   >
     <affine:paragraph
       prop:text="111"

--- a/tests/clipboard/list.spec.ts
+++ b/tests/clipboard/list.spec.ts
@@ -455,6 +455,7 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
     }
     prop:hidden={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
   >
     <affine:database
       prop:columns="Array [2]"
@@ -501,6 +502,7 @@ test(scoped`should copy and paste of database work`, async ({ page }) => {
     }
     prop:hidden={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
   >
     <affine:database
       prop:columns="Array [2]"

--- a/tests/link.spec.ts
+++ b/tests/link.spec.ts
@@ -487,6 +487,7 @@ test.skip('convert link to embed', async ({ page }) => {
     }
     prop:hidden={false}
     prop:index="a0"
+    prop:lockedBySelf={false}
   >
     <affine:paragraph
       prop:text="aaa"

--- a/tests/snapshots/basic.spec.ts/automatic-identify-url-text-final.json
+++ b/tests/snapshots/basic.spec.ts/automatic-identify-url-text-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/basic.spec.ts/basic-test-default.json
+++ b/tests/snapshots/basic.spec.ts/basic-test-default.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/bookmark.spec.ts/copy-bookmark-url-by-copy-button-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-bookmark-url-by-copy-button-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -46,6 +47,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-edgeless-mode-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-edgeless-mode-final.json
@@ -29,6 +29,7 @@
         "xywh": "[0,0,498,234]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -74,6 +75,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-page-mode-final.json
+++ b/tests/snapshots/bookmark.spec.ts/copy-url-to-create-bookmark-in-page-mode-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -64,6 +65,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/bookmark.spec.ts/covert-bookmark-block-to-link-text-final.json
+++ b/tests/snapshots/bookmark.spec.ts/covert-bookmark-block-to-link-text-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/bookmark.spec.ts/create-bookmark-by-slash-menu-final.json
+++ b/tests/snapshots/bookmark.spec.ts/create-bookmark-by-slash-menu-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -46,6 +47,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/bookmark.spec.ts/embed-figma.json
+++ b/tests/snapshots/bookmark.spec.ts/embed-figma.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -39,6 +40,7 @@
           "props": {
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0,
             "style": "figma",
             "url": "https://www.figma.com/design/JuXs6uOAICwf4I4tps0xKZ123",

--- a/tests/snapshots/bookmark.spec.ts/embed-youtube.json
+++ b/tests/snapshots/bookmark.spec.ts/embed-youtube.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -39,6 +40,7 @@
           "props": {
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0,
             "style": "video",
             "url": "https://www.youtube.com/watch?v=fakeid",

--- a/tests/snapshots/bookmark.spec.ts/horizontal-figma.json
+++ b/tests/snapshots/bookmark.spec.ts/horizontal-figma.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -46,6 +47,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/bookmark.spec.ts/horizontal-youtube.json
+++ b/tests/snapshots/bookmark.spec.ts/horizontal-youtube.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -46,6 +47,7 @@
             "title": null,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0
           },
           "children": []

--- a/tests/snapshots/clipboard/clipboard.spec.ts/auto-identify-url-final.json
+++ b/tests/snapshots/clipboard/clipboard.spec.ts/auto-identify-url-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-cut.json
+++ b/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-cut.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-paste.json
+++ b/tests/snapshots/clipboard/list.spec.ts/cut-will-delete-all-content-and-copy-will-reappear-content-after-paste.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-1.json
+++ b/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-1.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-2.json
+++ b/tests/snapshots/clipboard/list.spec.ts/should-keep-paragraph-block-s-type-when-pasting-at-the-start-of-empty-paragraph-block-except-type-text-after-paste-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/copy-paste.spec.ts/code-block-has-content-click-code-block-copy-menu-copy-whole-code-block-pasted.json
+++ b/tests/snapshots/code/copy-paste.spec.ts/code-block-has-content-click-code-block-copy-menu-copy-whole-code-block-pasted.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/copy-paste.spec.ts/code-block-is-empty-click-code-block-copy-menu-copy-the-empty-code-block-pasted.json
+++ b/tests/snapshots/code/copy-paste.spec.ts/code-block-is-empty-click-code-block-copy-menu-copy-the-empty-code-block-pasted.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/delete-code-block-in-more-menu-final.json
+++ b/tests/snapshots/code/crud.spec.ts/delete-code-block-in-more-menu-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/duplicate-code-block-final.json
+++ b/tests/snapshots/code/crud.spec.ts/duplicate-code-block-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-format.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-format.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-init.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-link.json
+++ b/tests/snapshots/code/crud.spec.ts/format-text-in-code-block-link.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-init.json
+++ b/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-markdown-syntax.json
+++ b/tests/snapshots/code/crud.spec.ts/use-markdown-syntax-can-create-code-block-markdown-syntax.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-4.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-4.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-9.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-3-9.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-4-3.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-drag-4-3.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-init.json
+++ b/tests/snapshots/drag.spec.ts/move-to-the-last-block-of-each-level-in-multi-level-nesting-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-add-linked-doc.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-add-linked-doc.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,88.75,50]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -74,6 +75,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-drag.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-drag.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,799.0093994140625,154]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -45,6 +46,7 @@
               "props": {
                 "index": "a0",
                 "xywh": "[0,0,0,0]",
+                "lockedBySelf": false,
                 "rotate": 0,
                 "pageId": "6",
                 "style": "horizontal",
@@ -65,6 +67,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-init.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-init.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,50,26]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -64,6 +65,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card-min-width.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,452.4000244140625,154]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -45,6 +46,7 @@
               "props": {
                 "index": "a0",
                 "xywh": "[0,0,0,0]",
+                "lockedBySelf": false,
                 "rotate": 0,
                 "pageId": "6",
                 "style": "horizontal",
@@ -65,6 +67,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/min-width-limit-for-embed-block-link-to-card.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,754,154]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -45,6 +46,7 @@
               "props": {
                 "index": "a0",
                 "xywh": "[0,0,0,0]",
+                "lockedBySelf": false,
                 "rotate": 0,
                 "pageId": "6",
                 "style": "horizontal",
@@ -65,6 +67,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-finial.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-finial.json
@@ -31,6 +31,7 @@
           "props": {
             "xywh": "[-25,-25,50,26]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -72,6 +73,7 @@
         "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-empty.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-empty.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,50,26]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -68,6 +69,7 @@
         "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-not-empty.json
+++ b/tests/snapshots/edgeless/edgeless-text.spec.ts/press-backspace-at-the-start-of-first-line-when-edgeless-text-exist-note-not-empty.json
@@ -27,6 +27,7 @@
           "props": {
             "xywh": "[-25,-25,50,26]",
             "index": "a1",
+            "lockedBySelf": false,
             "color": "--affine-palette-line-blue",
             "fontFamily": "blocksuite:surface:Inter",
             "fontStyle": "normal",
@@ -68,6 +69,7 @@
         "xywh": "[0,0,498,48]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
+++ b/tests/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -39,6 +40,7 @@
           "props": {
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0,
             "pageId": "5",
             "style": "horizontal",

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-default-color.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-default-color.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-select-all.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-background-color-select-all.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-bulleted.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-bulleted.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-change-to-heading-paragraph-type-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-format-text-when-select-multiple-line-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-finial.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-be-able-to-link-text-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-show-after-convert-to-code-block.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-show-after-convert-to-code-block.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-final.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-init.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-with-block-selection-works-when-update-block-type-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-multiple-block-selection.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-multiple-block-selection.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-single-block-selection.json
+++ b/tests/snapshots/format-bar.spec.ts/should-format-quick-bar-work-in-single-block-selection.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works-undo.json
+++ b/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works-undo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works.json
+++ b/tests/snapshots/hotkey/bracket.spec.ts/should-bracket-complete-with-backtick-works.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/Enter-key-should-as-expected-after-setting-heading-by-shortkey.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-undo.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-cut-work-single-line-undo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-0.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-6.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-8.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-9.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-hotkey-work-in-paragraph-press-d.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/should-single-line-format-hotkey-work-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-1.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-1.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-2.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/type-character-jump-out-code-node-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-at-empty-line-bold.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-at-empty-line-bold.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-ggg.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold-hhh.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-bold.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
+++ b/tests/snapshots/hotkey/hotkey.spec.ts/use-formatted-cursor-with-hotkey-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-redo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/multi-line-rich-text-inline-code-hotkey-undo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-undo.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-cut-work-multiple-line-undo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-finial.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-init.json
+++ b/tests/snapshots/hotkey/multiline.spec.ts/should-multiple-line-format-hotkey-work-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -53,6 +54,7 @@
           "props": {
             "xywh": "[0,0,16,16]",
             "index": "a0",
+            "lockedBySelf": false,
             "scale": 1,
             "rotate": 0,
             "latex": "aaa"

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-enter-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -53,6 +54,7 @@
           "props": {
             "xywh": "[0,0,16,16]",
             "index": "a0",
+            "lockedBySelf": false,
             "scale": 1,
             "rotate": 0,
             "latex": "aaa"

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-markdown-shortcut-with-space-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -39,6 +40,7 @@
           "props": {
             "xywh": "[0,0,16,16]",
             "index": "a0",
+            "lockedBySelf": false,
             "scale": 1,
             "rotate": 0,
             "latex": "aaa"

--- a/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-init.json
+++ b/tests/snapshots/latex/block.spec.ts/add-latex-block-using-slash-menu-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/link.spec.ts/basic-link.json
+++ b/tests/snapshots/link.spec.ts/basic-link.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/link.spec.ts/convert-link-to-card.json
+++ b/tests/snapshots/link.spec.ts/convert-link-to-card.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-final.json
+++ b/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-final.json
@@ -23,6 +23,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-init.json
+++ b/tests/snapshots/linked-page.spec.ts/can-create-linked-page-and-jump-init.json
@@ -23,6 +23,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/duplicated-linked-page-should-paste-as-linked-page.json
+++ b/tests/snapshots/linked-page.spec.ts/duplicated-linked-page-should-paste-as-linked-page.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/paste-linked-page-should-paste-as-linked-page.json
+++ b/tests/snapshots/linked-page.spec.ts/paste-linked-page-should-paste-as-linked-page.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-final.json
+++ b/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-final.json
@@ -23,6 +23,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-init.json
+++ b/tests/snapshots/linked-page.spec.ts/should-create-and-switch-page-work-init.json
@@ -23,6 +23,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-shift-tab.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-shift-tab.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-tab.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-after-tab.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/basic-indent-and-unindent-init.json
+++ b/tests/snapshots/list.spec.ts/basic-indent-and-unindent-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/can-expand-toggle-in-readonly-mode-before-readonly.json
+++ b/tests/snapshots/list.spec.ts/can-expand-toggle-in-readonly-mode-before-readonly.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-init.json
+++ b/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-toggle.json
+++ b/tests/snapshots/list.spec.ts/click-toggle-icon-should-collapsed-list-toggle.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-final.json
+++ b/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-init.json
+++ b/tests/snapshots/list.spec.ts/convert-nested-paragraph-to-list-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-1.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-1.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-2.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-3.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-3.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-4.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-4.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-5.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-5.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-init.json
+++ b/tests/snapshots/list.spec.ts/enter-list-block-with-empty-text-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-finial.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-init.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-toggle.json
+++ b/tests/snapshots/list.spec.ts/indent-item-should-expand-toggle-toggle.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/nested-list-blocks-finial.json
+++ b/tests/snapshots/list.spec.ts/nested-list-blocks-finial.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/nested-list-blocks-init.json
+++ b/tests/snapshots/list.spec.ts/nested-list-blocks-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-final.json
+++ b/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-init.json
+++ b/tests/snapshots/list.spec.ts/should-indent-todo-block-preserve-todo-status-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-final.json
+++ b/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-init.json
+++ b/tests/snapshots/paragraph.spec.ts/delete-empty-text-paragraph-block-should-keep-children-blocks-when-following-custom-blocks-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-2.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-3.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace-3.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-after-press-backspace.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-init.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-indent-and-delete-in-line-start-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-final.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-init.json
+++ b/tests/snapshots/paragraph.spec.ts/paragraph-with-child-block-should-work-at-enter-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-final.json
+++ b/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-init.json
+++ b/tests/snapshots/paragraph.spec.ts/should-delete-paragraph-block-child-can-hold-cursor-in-correct-position-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-2.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-3.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-3.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-4.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent-4.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-indent.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-init.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-1.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-1.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-2.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-2.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-3.json
+++ b/tests/snapshots/paragraph.spec.ts/should-indent-and-unindent-works-with-children-unindent-3.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/block.spec.ts/click-bottom-of-page-and-if-the-last-is-embed-block-editor-should-insert-a-new-editable-block.json
+++ b/tests/snapshots/selection/block.spec.ts/click-bottom-of-page-and-if-the-last-is-embed-block-editor-should-insert-a-new-editable-block.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {
@@ -43,6 +44,7 @@
             "height": 268.5,
             "index": "a0",
             "xywh": "[0,0,0,0]",
+            "lockedBySelf": false,
             "rotate": 0,
             "size": -1
           },

--- a/tests/snapshots/selection/block.spec.ts/should-indent-multi-selection-block.json
+++ b/tests/snapshots/selection/block.spec.ts/should-indent-multi-selection-block.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/block.spec.ts/should-not-draw-rect-for-sub-selected-blocks-when-entering-tab-key.json
+++ b/tests/snapshots/selection/block.spec.ts/should-not-draw-rect-for-sub-selected-blocks-when-entering-tab-key.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-final.json
+++ b/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-final.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-init.json
+++ b/tests/snapshots/selection/block.spec.ts/should-unindent-multi-selection-block-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-backspace.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-backspace.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-redo.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-redo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-undo.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-after-undo.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-init.json
+++ b/tests/snapshots/selection/native.spec.ts/native-range-delete-with-indent-init.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/should-indent-native-multi-selection-block-after-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-indent-native-multi-selection-block-after-tab.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-shift-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-shift-tab.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-tab.json
+++ b/tests/snapshots/selection/native.spec.ts/should-unindent-native-multi-selection-block-after-tab.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {

--- a/tests/snapshots/slash-menu.spec.ts/delete-block-by-slash-menu-should-remove-children.json
+++ b/tests/snapshots/slash-menu.spec.ts/delete-block-by-slash-menu-should-remove-children.json
@@ -19,6 +19,7 @@
         "xywh": "[0,0,498,92]",
         "background": "--affine-note-background-white",
         "index": "a0",
+        "lockedBySelf": false,
         "hidden": false,
         "displayMode": "both",
         "edgeless": {


### PR DESCRIPTION
Close [BS-1882](https://linear.app/affine-design/issue/BS-1882/锁：infra)

This PR added `lockedBySelf` property to all edgeless elements and blocks except `ai-chat-block`, which need to be updated in AFFiNE side.