### PR TITLE
feat(edgeless): impl lock interface for edgeless element and block

### DIFF
--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -7,7 +7,6 @@ export {
 export {
   canSafeAddToContainer,
   descendantElementsImpl,
-  getAncestorContainersImpl,
   getTopElements,
   hasDescendantElementImpl,
 } from '../utils/tree.js';

--- a/packages/framework/block-std/src/gfx/model/base.ts
+++ b/packages/framework/block-std/src/gfx/model/base.ts
@@ -42,6 +42,23 @@ export interface GfxCompatibleInterface extends IBound, GfxElementGeometry {
   readonly deserializedXYWH: XYWH;
 
   readonly elementBound: Bound;
+
+  /**
+   * Indicates whether the current block is explicitly locked by self.
+   * For checking the lock status of the element, use `isLocked` instead.
+   * For (un)locking the element, use `(un)lock` instead.
+   */
+  lockedBySelf?: boolean;
+
+  /**
+   * Check if the element is locked. It will check the lock status of the element and its ancestors.
+   */
+  isLocked(): boolean;
+  isLockedBySelf(): boolean;
+  isLockedByAncestor(): boolean;
+
+  lock(): void;
+  unlock(): void;
 }
 
 /**

--- a/packages/framework/block-std/src/gfx/model/gfx-block-model.ts
+++ b/packages/framework/block-std/src/gfx/model/gfx-block-model.ts
@@ -24,6 +24,14 @@ import type { GfxCompatibleInterface, PointTestOptions } from './base.js';
 import type { GfxGroupModel } from './model.js';
 import type { SurfaceBlockModel } from './surface/surface-model.js';
 
+import {
+  isLockedByAncestorImpl,
+  isLockedBySelfImpl,
+  isLockedImpl,
+  lockElementImpl,
+  unlockElementImpl,
+} from '../../utils/tree.js';
+
 /**
  * The props that a graphics block model should have.
  */
@@ -183,6 +191,26 @@ export class GfxBlockElementModel<
         this.getLineIntersections(point, points[(i + 1) % points.length])
       )
     );
+  }
+
+  isLocked(): boolean {
+    return isLockedImpl(this);
+  }
+
+  isLockedByAncestor(): boolean {
+    return isLockedByAncestorImpl(this);
+  }
+
+  isLockedBySelf(): boolean {
+    return isLockedBySelfImpl(this);
+  }
+
+  lock() {
+    lockElementImpl(this.doc, this);
+  }
+
+  unlock() {
+    unlockElementImpl(this.doc, this);
   }
 }
 

--- a/packages/framework/block-std/src/gfx/model/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/element-model.ts
@@ -30,6 +30,11 @@ import type { SurfaceBlockModel } from './surface-model.js';
 import {
   descendantElementsImpl,
   hasDescendantElementImpl,
+  isLockedByAncestorImpl,
+  isLockedBySelfImpl,
+  isLockedImpl,
+  lockElementImpl,
+  unlockElementImpl,
 } from '../../../utils/tree.js';
 import { gfxGroupCompatibleSymbol } from '../base.js';
 import {
@@ -231,6 +236,22 @@ export abstract class GfxPrimitiveElementModel<
     );
   }
 
+  isLocked(): boolean {
+    return isLockedImpl(this);
+  }
+
+  isLockedByAncestor(): boolean {
+    return isLockedByAncestorImpl(this);
+  }
+
+  isLockedBySelf(): boolean {
+    return isLockedBySelfImpl(this);
+  }
+
+  lock() {
+    lockElementImpl(this.surface.doc, this);
+  }
+
   onCreated() {}
 
   pop(prop: keyof Props | string) {
@@ -303,6 +324,10 @@ export abstract class GfxPrimitiveElementModel<
         );
       },
     });
+  }
+
+  unlock() {
+    unlockElementImpl(this.surface.doc, this);
   }
 
   @local()

--- a/packages/framework/block-std/src/gfx/model/surface/surface-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/surface-model.ts
@@ -513,9 +513,15 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
 
   getGroups(id: string): GfxGroupModel[] {
     const groups: GfxGroupModel[] = [];
+    const visited = new Set<GfxGroupModel>();
     let group = this.getGroup(id);
 
     while (group) {
+      if (visited.has(group)) {
+        console.warn('Exists a cycle in group relation');
+        break;
+      }
+      visited.add(group);
       groups.push(group);
       group = this.getGroup(group.id);
     }


### PR DESCRIPTION
Close [BS-1882](https://linear.app/affine-design/issue/BS-1882/锁：infra)

This PR implemented the basic edgeless lock feature.
```ts
export interface GfxCompatibleInterface extends IBound, GfxElementGeometry {
  // ......

  /**
   * Indicates whether the current block is explicitly locked by self.
   * For checking the lock status of the element, use `isLocked` instead.
   * For (un)locking the element, use `(un)lock` instead.
   */
  lockedBySelf?: boolean;

  /**
   * Check if the element is locked. It will check the lock status of the element and its ancestors.
   */
  isLocked(): boolean;
  isLockedBySelf(): boolean;
  isLockedByAncestor(): boolean;

  lock(): void;
  unlock(): void;
}
```