### PR TITLE
feat(edgeless): unlock and unlock button

### DIFF
--- a/packages/blocks/src/frame-block/frame-block.ts
+++ b/packages/blocks/src/frame-block/frame-block.ts
@@ -69,11 +69,6 @@ export class FrameBlockComponent extends GfxBlockComponent<FrameBlockModel> {
     const frameIndex = rootService.layer.getZIndex(model);
 
     return html`
-      <edgeless-frame-title
-        style=${styleMap({
-          zIndex: 2147483647 - -frameIndex,
-        })}
-      ></edgeless-frame-title>
       <div
         class="affine-frame-container"
         style=${styleMap({

--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -569,6 +569,8 @@ export class EdgelessClipboardController extends PageClipboard {
       clipboardData.xywh = newXYWH;
     }
 
+    clipboardData.lockedBySelf = false;
+
     const id = this.host.service.addElement(
       clipboardData.type as CanvasElementType,
       clipboardData
@@ -1272,9 +1274,13 @@ export class EdgelessClipboardController extends PageClipboard {
           continue;
         }
 
+        assertType<GfxCompatibleProps & unknown>(blockSnapshot.props);
+
         blockSnapshot.props.xywh = getNewXYWH(
           blockSnapshot.props.xywh as SerializedXYWH
         );
+        blockSnapshot.props.lockedBySelf = false;
+
         const newId = await config.createFunction(blockSnapshot, context);
         if (!newId) continue;
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-keyboard.ts
@@ -221,7 +221,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           const { selection } = this.rootComponent.service;
           if (
             selection.selectedElements.length === 1 &&
-            selection.firstElement instanceof GroupElementModel
+            selection.firstElement instanceof GroupElementModel &&
+            !selection.firstElement.isLocked()
           ) {
             ctx.get('keyboardState').event.preventDefault();
             rootComponent.service.ungroup(selection.firstElement);
@@ -336,6 +337,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
             const element = elements[0];
             const id = element.id;
 
+            if (element.isLocked()) return;
+
             if (element instanceof ConnectorElementModel) {
               selection.set({
                 elements: [id],
@@ -389,6 +392,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           const { service } = rootComponent;
           const selection = service.selection;
           const elements = selection.selectedElements;
+
+          if (elements.some(e => e.isLocked())) return;
 
           if (!isSelectSingleMindMap(elements)) {
             return;
@@ -507,6 +512,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
     }
 
     const selectedElements = edgeless.service.selection.selectedElements;
+    if (selectedElements.some(e => e.isLocked())) return;
 
     if (isSelectSingleMindMap(selectedElements)) {
       const node = selectedElements[0];
@@ -606,6 +612,8 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
 
       return;
     }
+
+    if (selectedElements.some(e => e.isLocked())) return;
 
     selectedElements.forEach(element => {
       const bound = Bound.deserialize(element.xywh).clone();

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -272,6 +272,10 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
     return groupId;
   }
 
+  /**
+   * Create a group from selected elements, if the selected elements are in the same group
+   * @returns the id of the created group
+   */
   createGroupFromSelected() {
     const { selection } = this;
 

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -283,6 +283,8 @@ export class EdgelessFrameManager extends GfxExtension {
    * Reset parent of elements to the frame
    */
   addElementsToFrame(frame: FrameBlockModel, elements: GfxModel[]) {
+    if (frame.isLocked()) return;
+
     if (frame.childElementIds === undefined) {
       this._addChildrenToLegacyFrame(frame);
     }

--- a/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool.ts
@@ -28,6 +28,7 @@ import {
   BaseTool,
   getTopElements,
   GfxExtensionIdentifier,
+  type GfxModel,
   type GfxPrimitiveElementModel,
   isGfxGroupCompatibleModel,
   type PointTestOptions,
@@ -156,7 +157,7 @@ export class DefaultTool extends BaseTool {
     }
   };
 
-  private _toBeMoved: BlockSuite.EdgelessModel[] = [];
+  private _toBeMoved: GfxModel[] = [];
 
   private _updateSelectingState = (delta: IVec = [0, 0]) => {
     const { gfx } = this;
@@ -209,7 +210,7 @@ export class DefaultTool extends BaseTool {
       return true;
     });
 
-    elements = getTopElements(elements);
+    elements = getTopElements(elements).filter(el => !el.isLocked());
 
     const set = new Set(
       gfx.keyboard.shiftKey$.peek()
@@ -394,7 +395,7 @@ export class DefaultTool extends BaseTool {
     });
   }
 
-  private _isDraggable(element: BlockSuite.EdgelessModel) {
+  private _isDraggable(element: GfxModel) {
     return !(
       element instanceof ConnectorElementModel &&
       !ConnectorUtils.isConnectorAndBindingsAllSelected(
@@ -455,7 +456,7 @@ export class DefaultTool extends BaseTool {
       this._toBeMoved.filter(ele => isFrameBlock(ele))
     );
 
-    this._hoveredFrame
+    this._hoveredFrame && !this._hoveredFrame.isLocked()
       ? this.frameOverlay.highlight(this._hoveredFrame)
       : this.frameOverlay.clear();
   }
@@ -481,6 +482,13 @@ export class DefaultTool extends BaseTool {
   private _pick(x: number, y: number, options?: PointTestOptions) {
     const modelPos = this.gfx.viewport.toModelCoord(x, y);
 
+    const tryGetLockedAncestor = (e: GfxModel | null) => {
+      if (e?.isLockedByAncestor()) {
+        return e.groups.findLast(group => group.isLocked());
+      }
+      return e;
+    };
+
     const frameByPickingTitle = last(
       this.gfx
         .getElementByPoint(modelPos[0], modelPos[1], {
@@ -492,7 +500,7 @@ export class DefaultTool extends BaseTool {
         )
     );
 
-    if (frameByPickingTitle) return frameByPickingTitle;
+    if (frameByPickingTitle) return tryGetLockedAncestor(frameByPickingTitle);
 
     const result = this.gfx.getElementInGroup(
       modelPos[0],
@@ -518,7 +526,7 @@ export class DefaultTool extends BaseTool {
         break;
       }
 
-      return picked[pickedIdx] ?? null;
+      return tryGetLockedAncestor(picked[pickedIdx]) ?? null;
     }
 
     // if the frame has title, it only can be picked by clicking the title
@@ -526,7 +534,7 @@ export class DefaultTool extends BaseTool {
       return null;
     }
 
-    return result;
+    return tryGetLockedAncestor(result);
   }
 
   private _scheduleUpdate(
@@ -643,6 +651,7 @@ export class DefaultTool extends BaseTool {
     const selected = this._pick(e.x, e.y, {
       ignoreTransparent: true,
     });
+
     if (selected) {
       const { selectedIds, surfaceSelections } = this.edgelessSelectionManager;
       const editing = surfaceSelections[0]?.editing ?? false;
@@ -664,8 +673,9 @@ export class DefaultTool extends BaseTool {
         return;
       }
 
-      // click non-active edgeless text block and note block
+      // click non-active edgeless text block and note block, and then enter editing
       if (
+        !selected.isLocked() &&
         !e.keys.shift &&
         selectedIds.length === 1 &&
         (isNoteBlock(selected) || isEdgelessTextBlock(selected)) &&
@@ -779,6 +789,7 @@ export class DefaultTool extends BaseTool {
       });
       return;
     } else {
+      if (selected.isLocked()) return;
       const [x, y] = this.gfx.viewport.toModelCoord(e.x, e.y);
       if (selected instanceof TextElementModel) {
         mountTextElementEditor(selected, this._edgeless, {
@@ -924,6 +935,8 @@ export class DefaultTool extends BaseTool {
     let dragType = this._determineDragType(e);
 
     const elements = this.edgelessSelectionManager.selectedElements;
+    if (elements.some(e => e.isLocked())) return;
+
     const toBeMoved = new Set(elements);
 
     elements.forEach(element => {

--- a/packages/blocks/src/root-block/edgeless/gfx-tool/eraser-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/eraser-tool.ts
@@ -113,6 +113,7 @@ export class EraserTool extends BaseTool {
   override dragMove(e: PointerEventState): void {
     const currentPoint = this.gfx.viewport.toModelCoord(e.point.x, e.point.y);
     this._erasable.forEach(erasable => {
+      if (erasable.isLocked()) return;
       if (this._eraseTargets.has(erasable)) return;
       if (isTopLevelBlock(erasable)) {
         const bound = Bound.deserialize(erasable.xywh);

--- a/packages/blocks/src/root-block/edgeless/gfx-tool/lasso-tool.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/lasso-tool.ts
@@ -149,7 +149,9 @@ export class LassoTool extends BaseTool<LassoToolOption> {
 
   private _updateSelection(e: PointerEventState) {
     // elements inside the lasso selection
-    const elements = this._getElementsInsideLasso().map(el => el.id);
+    const elements = this._getElementsInsideLasso()
+      .filter(el => !el.isLocked())
+      .map(el => el.id);
 
     // current selections
     const selection = this.selection.selectedElements.map(el => el.id);
@@ -176,6 +178,7 @@ export class LassoTool extends BaseTool<LassoToolOption> {
         set = new Set(elements);
         break;
     }
+
     this._setSelectionState(Array.from(set), false);
   }
 

--- a/packages/blocks/src/root-block/edgeless/utils/query.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/query.ts
@@ -26,7 +26,7 @@ import {
   type EmbedLoomModel,
   type EmbedSyncedDocModel,
   type EmbedYoutubeModel,
-  type FrameBlockModel,
+  FrameBlockModel,
   type ImageBlockModel,
   MindmapElementModel,
   type NoteBlockModel,
@@ -269,6 +269,17 @@ export function getSelectedRect(selected: BlockSuite.EdgelessModel[]): DOMRect {
   if (selected.length === 0) {
     return new DOMRect();
   }
+
+  const lockedElementsByFrame = selected
+    .map(selectable => {
+      if (selectable instanceof FrameBlockModel && selectable.isLocked()) {
+        return selectable.descendantElements;
+      }
+      return [];
+    })
+    .flat();
+
+  selected = [...new Set([...selected, ...lockedElementsByFrame])];
 
   if (selected.length === 1) {
     const [x, y, w, h] = deserializeXYWH(selected[0].xywh);

--- a/packages/blocks/src/root-block/widgets/element-toolbar/effects.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/effects.ts
@@ -20,6 +20,7 @@ import {
   EDGELESS_ELEMENT_TOOLBAR_WIDGET,
   EdgelessElementToolbarWidget,
 } from './index.js';
+import { EdgelessLockButton } from './lock-button.js';
 import { EdgelessMoreButton } from './more-menu/button.js';
 import { EdgelessReleaseFromGroupButton } from './release-from-group-button.js';
 
@@ -85,6 +86,7 @@ export function effects() {
     EdgelessReleaseFromGroupButton
   );
   customElements.define('edgeless-more-button', EdgelessMoreButton);
+  customElements.define('edgeless-lock-button', EdgelessLockButton);
 }
 
 declare global {
@@ -107,5 +109,6 @@ declare global {
     'edgeless-change-text-menu': EdgelessChangeTextMenu;
     'edgeless-release-from-group-button': EdgelessReleaseFromGroupButton;
     'edgeless-more-button': EdgelessMoreButton;
+    'edgeless-lock-button': EdgelessLockButton;
   }
 }

--- a/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/index.ts
@@ -196,10 +196,12 @@ export class EdgelessElementToolbarWidget extends WidgetComponent<
     const bound = getCommonBoundWithRotation(elements);
 
     const { width, height } = viewport;
-    const [x, y] = viewport.toViewCoord(bound.x, bound.y);
+    const { x, y, w } = viewport.toViewBound(bound);
 
     let left = x;
     let top = y;
+
+    const hasLocked = elements.some(e => e.isLocked());
 
     let offset = 37 + 12;
     // frame, group, shape
@@ -234,11 +236,116 @@ export class EdgelessElementToolbarWidget extends WidgetComponent<
     requestConnectedFrame(() => {
       const rect = this.getBoundingClientRect();
 
-      left = CommonUtils.clamp(x, 10, width - rect.width - 10);
+      if (hasLocked) {
+        left += 0.5 * (w - rect.width);
+      }
+
+      left = CommonUtils.clamp(left, 10, width - rect.width - 10);
       top = CommonUtils.clamp(top, 10, height - rect.height - 150);
 
       this.style.transform = `translate3d(${left}px, ${top}px, 0)`;
     }, this);
+  }
+
+  private _renderButtons() {
+    if (this.doc.readonly || this._dragging || !this.toolbarVisible) {
+      return [];
+    }
+    const { selectedElements } = this.selection;
+    if (selectedElements.some(e => e.isLocked())) {
+      return [
+        html`<edgeless-lock-button
+          .edgeless=${this.edgeless}
+        ></edgeless-lock-button>`,
+      ];
+    }
+
+    const groupedSelected = this._groupSelected();
+    const { edgeless, selection } = this;
+    const {
+      shape,
+      brush,
+      connector,
+      note,
+      text,
+      frame,
+      group,
+      embedCard,
+      attachment,
+      image,
+      edgelessText,
+      mindmap: mindmaps,
+    } = groupedSelected;
+    const selectedAtLeastTwoTypes = atLeastNMatches(
+      Object.values(groupedSelected),
+      e => !!e.length,
+      2
+    );
+
+    const quickConnectButton =
+      selectedElements.length === 1 && !connector?.length
+        ? this._renderQuickConnectButton()
+        : undefined;
+
+    const generalButtons =
+      selectedElements.length !== connector?.length
+        ? [
+            renderAddFrameButton(edgeless, selectedElements),
+            renderAddGroupButton(edgeless, selectedElements),
+            renderAlignButton(edgeless, selectedElements),
+          ]
+        : [];
+
+    const buttons: (symbol | TemplateResult)[] = selectedAtLeastTwoTypes
+      ? generalButtons
+      : [
+          ...generalButtons,
+          renderMindmapButton(edgeless, mindmaps),
+          renderMindmapButton(edgeless, shape),
+          renderChangeShapeButton(edgeless, shape),
+          renderChangeBrushButton(edgeless, brush),
+          renderConnectorButton(edgeless, connector),
+          renderNoteButton(edgeless, note, quickConnectButton),
+          renderChangeTextButton(edgeless, text),
+          renderChangeEdgelessTextButton(edgeless, edgelessText),
+          renderFrameButton(edgeless, frame),
+          renderGroupButton(edgeless, group),
+          renderEmbedButton(edgeless, embedCard, quickConnectButton),
+          renderAttachmentButton(edgeless, attachment),
+          renderChangeImageButton(edgeless, image),
+        ];
+
+    if (selectedElements.length === 1) {
+      if (selection.firstElement.group instanceof GroupElementModel) {
+        buttons.unshift(renderReleaseFromGroupButton(this.edgeless));
+      }
+
+      if (!connector?.length) {
+        buttons.push(quickConnectButton?.pop() ?? nothing);
+      }
+    }
+
+    buttons.push(
+      html`<edgeless-lock-button
+        .edgeless=${this.edgeless}
+      ></edgeless-lock-button>`
+    );
+
+    this._registeredEntries
+      .filter(entry => entry.when(selectedElements))
+      .map(entry => entry.render(this.edgeless))
+      .forEach(entry => entry && buttons.unshift(entry));
+
+    buttons.push(html`
+      <edgeless-more-button
+        .elements=${selectedElements}
+        .edgeless=${edgeless}
+        .groups=${this.moreGroups}
+        .vertical=${true}
+      ></edgeless-more-button>
+    `);
+
+    return buttons;
   }
 
   private _renderQuickConnectButton() {
@@ -336,89 +443,8 @@ export class EdgelessElementToolbarWidget extends WidgetComponent<
   }
 
   override render() {
-    if (this.doc.readonly || this._dragging || !this.toolbarVisible) {
-      return nothing;
-    }
-
-    const groupedSelected = this._groupSelected();
-    const { edgeless, selection } = this;
-    const {
-      shape,
-      brush,
-      connector,
-      note,
-      text,
-      frame,
-      group,
-      embedCard,
-      attachment,
-      image,
-      edgelessText,
-      mindmap: mindmaps,
-    } = groupedSelected;
-    const { selectedElements } = this.selection;
-    const selectedAtLeastTwoTypes = atLeastNMatches(
-      Object.values(groupedSelected),
-      e => !!e.length,
-      2
-    );
-
-    const quickConnectButton =
-      selectedElements.length === 1 && !connector?.length
-        ? this._renderQuickConnectButton()
-        : undefined;
-
-    const generalButtons =
-      selectedElements.length !== connector?.length
-        ? [
-            renderAddFrameButton(edgeless, selectedElements),
-            renderAddGroupButton(edgeless, selectedElements),
-            renderAlignButton(edgeless, selectedElements),
-          ]
-        : [];
-
-    const buttons: (symbol | TemplateResult)[] = selectedAtLeastTwoTypes
-      ? generalButtons
-      : [
-          ...generalButtons,
-          renderMindmapButton(edgeless, mindmaps),
-          renderMindmapButton(edgeless, shape),
-          renderChangeShapeButton(edgeless, shape),
-          renderChangeBrushButton(edgeless, brush),
-          renderConnectorButton(edgeless, connector),
-          renderNoteButton(edgeless, note, quickConnectButton),
-          renderChangeTextButton(edgeless, text),
-          renderChangeEdgelessTextButton(edgeless, edgelessText),
-          renderFrameButton(edgeless, frame),
-          renderGroupButton(edgeless, group),
-          renderEmbedButton(edgeless, embedCard, quickConnectButton),
-          renderAttachmentButton(edgeless, attachment),
-          renderChangeImageButton(edgeless, image),
-        ];
-
-    if (selectedElements.length === 1) {
-      if (selection.firstElement.group instanceof GroupElementModel) {
-        buttons.unshift(renderReleaseFromGroupButton(this.edgeless));
-      }
-
-      if (!connector?.length) {
-        buttons.push(quickConnectButton?.pop() ?? nothing);
-      }
-    }
-
-    this._registeredEntries
-      .filter(entry => entry.when(selectedElements))
-      .map(entry => entry.render(this.edgeless))
-      .forEach(entry => entry && buttons.unshift(entry));
-
-    buttons.push(html`
-      <edgeless-more-button
-        .elements=${selectedElements}
-        .edgeless=${edgeless}
-        .groups=${this.moreGroups}
-        .vertical=${true}
-      ></edgeless-more-button>
-    `);
+    const buttons = this._renderButtons();
+    if (buttons.length === 0) return nothing;
 
     const appTheme = this.std.get(ThemeProvider).app$.value;
     return html`

--- a/packages/blocks/src/root-block/widgets/element-toolbar/lock-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/lock-button.ts
@@ -1,0 +1,121 @@
+import type { GfxModel } from '@blocksuite/block-std/gfx';
+
+import {
+  GroupElementModel,
+  MindmapElementModel,
+} from '@blocksuite/affine-model';
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
+import { LockIcon, UnlockIcon } from '@blocksuite/icons/lit';
+import { html, LitElement, nothing } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import type { EdgelessRootBlockComponent } from '../../edgeless/index.js';
+
+export class EdgelessLockButton extends SignalWatcher(
+  WithDisposable(LitElement)
+) {
+  private get _selectedElements() {
+    const elements = new Set<GfxModel>();
+    this.edgeless.service.selection.selectedElements.forEach(element => {
+      if (element.group instanceof MindmapElementModel) {
+        elements.add(element.group);
+      } else {
+        elements.add(element);
+      }
+    });
+    return [...elements];
+  }
+
+  private _lock() {
+    const { service, doc } = this.edgeless;
+    doc.captureSync();
+
+    // get most top selected elements(*) from tree, like in a tree below
+    //         G0
+    //        /  \
+    //      E1*  G1
+    //          /  \
+    //        E2*  E3*
+    //
+    // (*) selected elements, [E1, E2, E3]
+    // return [E1]
+
+    const selectedElements = this._selectedElements;
+    const levels = selectedElements.map(element => element.groups.length);
+    const topElement = selectedElements[levels.indexOf(Math.min(...levels))];
+    const otherElements = selectedElements.filter(
+      element => element !== topElement
+    );
+
+    // release other elements from their groups and group with top element
+    otherElements.forEach(element => {
+      // eslint-disable-next-line unicorn/prefer-dom-node-remove
+      element.group?.removeChild(element);
+      topElement.group?.addChild(element);
+    });
+
+    if (otherElements.length === 0) {
+      topElement.lock();
+      this.edgeless.gfx.selection.set({
+        editing: false,
+        elements: [topElement.id],
+      });
+      return;
+    }
+
+    const groupId = service.createGroup([topElement, ...otherElements]);
+
+    if (groupId) {
+      const group = service.getElementById(groupId);
+      if (group) {
+        group.lock();
+        this.edgeless.gfx.selection.set({
+          editing: false,
+          elements: [groupId],
+        });
+        return;
+      }
+    }
+
+    selectedElements.forEach(e => {
+      e.lock();
+    });
+    this.edgeless.gfx.selection.set({
+      editing: false,
+      elements: selectedElements.map(e => e.id),
+    });
+  }
+
+  private _unlock() {
+    const { service, doc } = this.edgeless;
+    doc.captureSync();
+
+    this._selectedElements.forEach(element => {
+      if (element instanceof GroupElementModel) {
+        service.ungroup(element);
+      } else {
+        element.lockedBySelf = false;
+      }
+    });
+  }
+
+  override render() {
+    const hasLocked = this._selectedElements.some(element =>
+      element.isLocked()
+    );
+
+    const icon = hasLocked ? UnlockIcon : LockIcon;
+
+    return html`<editor-icon-button
+      @click=${hasLocked ? this._unlock : this._lock}
+    >
+      ${icon({ width: '20px', height: '20px' })}
+      ${hasLocked
+        ? html`<span class="label medium">Click to unlock</span>`
+        : nothing}
+    </editor-icon-button>`;
+  }
+
+  @property({ attribute: false })
+  accessor edgeless!: EdgelessRootBlockComponent;
+}

--- a/packages/framework/block-std/src/gfx/model/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/element-model.ts
@@ -136,6 +136,9 @@ export abstract class GfxPrimitiveElementModel<
     return this.surface.getGroup(this.id);
   }
 
+  /**
+   * Return the ancestor elements in order from the most recent to the earliest.
+   */
   get groups(): GfxGroupModel[] {
     return this.surface.getGroups(this.id);
   }

--- a/packages/framework/block-std/src/utils/tree.ts
+++ b/packages/framework/block-std/src/utils/tree.ts
@@ -1,7 +1,4 @@
 import type { Doc } from '@blocksuite/store';
-import type { Signal } from '@preact/signals-core';
-
-import { assertType } from '@blocksuite/global/utils';
 
 import type { GfxCompatibleInterface } from '../gfx/index.js';
 import type { GfxGroupModel, GfxModel } from '../gfx/model/model.js';
@@ -14,20 +11,20 @@ import {
 /**
  * Get the top elements from the list of elements, which are in some tree structures.
  *
- * For example: a list `[C1, E1, C2, E2, E2, E3, E4, C4, E6]`,
+ * For example: a list `[G1, E1, G2, E2, E3, E4, G4, E5, E6]`,
  * and they are in the elements tree like:
  * ```
- *     C1         C4      E6
+ *     G1         G4      E6
  *    /  \        |
- *  E1   C2       E5
+ *  E1   G2       E5
  *       / \
- *      E2  C3*
+ *      E2  G3*
  *         / \
  *        E3 E4
  * ```
  * where the star symbol `*` denote it is not in the list.
  *
- * The result should be `[F1, F2, E6, E3, E4]`.
+ * The result should be `[G1, G4, E6]`
  */
 export function getTopElements(elements: GfxModel[]): GfxModel[] {
   const results = new Set(elements);
@@ -121,11 +118,6 @@ export function isLockedByAncestorImpl(
 }
 
 export function isLockedBySelfImpl(element: GfxCompatibleInterface): boolean {
-  // This is a workaround for reactive rendering
-  if (`lockedBySelf$` in element) {
-    assertType<Signal<boolean>>(element.lockedBySelf$);
-    return element.lockedBySelf$.value ?? false;
-  }
   return element.lockedBySelf ?? false;
 }
 


### PR DESCRIPTION
Close [BS-1926](https://linear.app/affine-design/issue/PD-1926/[improvement]-lock)

This PR introduces an edgeless element locking feature. An element that is locked typically cannot undergo any operations that affect its data, except for unlocking. Operations that clearly do not affect its data, such as copying or linking the locked element, are still permitted. This functionality is mainly implemented by blocking actions at the user interaction level.

### What Changes:
- Lock and unlock buttons are added to `edgeless-element-toolbar`
  - In mindmap, only the root node can be locked (close [BS-1875](https://linear.app/affine-design/issue/BS-1875/锁：mindmap只能锁根节点)).
- Lock an element will also lock all descendants. （close [BS-1880](https://linear.app/affine-design/issue/BS-1880/锁-锁group和frame会同时锁后代yuan素)） 
- A locked element can not be:
  - moved. (modified in `DefaultTool.dragStart`, close [BS-1879](https://linear.app/affine-design/issue/BS-1879/%E9%94%81%EF%BC%9Ayuan%E7%B4%A0%E4%B8%8D%E5%8F%AF%E7%A7%BB%E5%8A%A8))
  - resized, scaled and rotated. (modified in `EdgelessSelectedRectWidget`， close [BS-1878](https://linear.app/affine-design/issue/BS-1878/锁：yuan素不可缩放旋转))
  - add new element to locked frame. (modified in `FrameManager.addElementsToFrame`, close [BS-1113](https://linear.app/affine-design/issue/BS-1113/%E9%94%81%EF%BC%9A%E6%97%A0%E6%B3%95%E5%90%91frame%E5%A2%9E%E5%8A%A0yuan%E7%B4%A0))
  - editied. (modified in `DefaultTool.click` and `DefaultTool.dbClick`， close [BS-1877](https://linear.app/affine-design/issue/BS-1877/锁：note，edgeless不可被编辑))
  - erased and deleted. (close [BS-1874](https://linear.app/affine-design/issue/BS-1874/%E9%94%81%EF%BC%9A%E4%B8%8D%E5%8F%AF%E8%A2%AB%E6%93%A6%E9%99%A4))
- UI updated:
  - disable highlight of locked frame if a dragged element on above
  - seleceted rect contains descendants bounds (close [BS-1876](https://linear.app/affine-design/issue/BS-1876/锁：frame选择边框包括后代yuan素)).

### Demo

https://github.com/user-attachments/assets/c5535af0-5f86-4def-b464-a07372908c6c

