### PR TITLE
fix(blocks): should paste text content as note on edgeless when copy from doc mode

### DIFF
--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -1085,12 +1085,14 @@ export class EdgelessClipboardController extends PageClipboard {
       });
     } else {
       for (let index = 0; index < content.length; index++) {
-        await this.onBlockSnapshotPaste(
-          content[index],
-          this.doc,
-          noteId,
-          index
-        );
+        const blockSnapshot = content[index];
+        if (blockSnapshot.flavour === 'affine:note') {
+          for (const child of blockSnapshot.children) {
+            await this.onBlockSnapshotPaste(child, this.doc, noteId);
+          }
+          continue;
+        }
+        await this.onBlockSnapshotPaste(content[index], this.doc, noteId);
       }
     }
 

--- a/tests/edgeless/paste-block.spec.ts
+++ b/tests/edgeless/paste-block.spec.ts
@@ -13,6 +13,7 @@ import {
   pressEnter,
   pressEnterWithShortkey,
   pressEscape,
+  selectAllByKeyboard,
   setEdgelessTool,
   switchEditorMode,
   type,
@@ -93,5 +94,34 @@ test.describe('pasting blocks', () => {
     await expect(blocks.nth(1).locator('.resizable-img')).toBeVisible();
     await expect(blocks.nth(2)).toContainText('world');
     await expect(blocks.nth(3)).toContainText('code');
+  });
+
+  test('pasting a note block from doc mode', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await focusRichText(page);
+    await type(page, 'hello world');
+
+    await selectAllByKeyboard(page);
+    await copyByKeyboard(page);
+
+    await switchEditorMode(page);
+    await click(page, {
+      x: 100,
+      y: 100,
+    });
+    await pasteByKeyboard(page);
+
+    // not equal to noteId
+    const noteIds = await getAllEdgelessNoteIds(page);
+    expect(noteIds.length).toBe(2);
+
+    const newNoteId = noteIds[1];
+    const newNote = page.locator(
+      `affine-edgeless-note[data-block-id="${newNoteId}"]`
+    );
+    await expect(newNote).toBeVisible();
+    const blocks = newNote.locator('[data-block-id]');
+    await expect(blocks.nth(0)).toContainText('hello world');
   });
 });


### PR DESCRIPTION
To fix [BS-1979](https://linear.app/affine-design/issue/BS-1979/从-page-模式复制到-edgeless-模式功能故障)
