### PR TITLE
fix(store): optional porp singal may be undefined

### DIFF
--- a/packages/blocks/src/attachment-block/attachment-edgeless-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-edgeless-block.ts
@@ -48,7 +48,7 @@ export class AttachmentEdgelessBlockComponent extends toGfxBlockComponent(
 
   override renderGfxBlock() {
     const { style$ } = this.model;
-    const cardStyle = style$.value ?? AttachmentBlockStyles[1];
+    const cardStyle = style$?.value ?? AttachmentBlockStyles[1];
     const width = EMBED_CARD_WIDTH[cardStyle];
     const height = EMBED_CARD_HEIGHT[cardStyle];
     const bound = this.model.elementBound;

--- a/packages/framework/store/src/__tests__/block.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/block.unit.spec.ts
@@ -2,6 +2,9 @@ import { computed, effect } from '@preact/signals-core';
 import { describe, expect, test, vi } from 'vitest';
 import * as Y from 'yjs';
 
+import type { Boxed } from '../reactive/boxed.js';
+import type { Text } from '../reactive/text.js';
+
 import {
   defineBlockSchema,
   internalPrimitives,
@@ -11,9 +14,18 @@ import {
 import { Block, type YBlock } from '../store/doc/block/index.js';
 import { DocCollection, IdGeneratorType } from '../store/index.js';
 
+type PageProps = {
+  title: Text;
+  count: number;
+  toggle: boolean;
+  style: Record<string, unknown>;
+  boxed: Boxed<Y.Map<unknown>>;
+  optional?: string;
+};
+
 const pageSchema = defineBlockSchema({
   flavour: 'page',
-  props: internal => ({
+  props: (internal): PageProps => ({
     title: internal.Text(),
     count: 0,
     toggle: false,
@@ -58,6 +70,7 @@ test('init block without props should add default props', () => {
   expect(yBlock.get('prop:count')).toBe(0);
   expect(model.count).toBe(0);
   expect(model.style).toEqual({});
+  expect(model.optional).toBeUndefined();
 });
 
 describe('block model should has signal props', () => {
@@ -76,12 +89,16 @@ describe('block model should has signal props', () => {
 
     expect(model.count$.value).toBe(0);
     expect(isOdd.peek()).toBe(false);
+    expect(model.optional$).toBeUndefined();
+    expect(model.optional$?.value).toBeUndefined();
 
     // set prop
     model.count = 1;
     expect(model.count$.value).toBe(1);
     expect(isOdd.peek()).toBe(true);
     expect(yBlock.get('prop:count')).toBe(1);
+    model.optional = 'hello';
+    expect(model.optional$?.value).toBe('hello');
 
     // set signal
     model.count$.value = 2;
@@ -89,7 +106,7 @@ describe('block model should has signal props', () => {
     expect(isOdd.peek()).toBe(false);
     expect(yBlock.get('prop:count')).toBe(2);
 
-    // set prop
+    // set y-prop
     yBlock.set('prop:count', 3);
     expect(model.count).toBe(3);
     expect(model.count$.value).toBe(3);

--- a/packages/framework/store/src/schema/base.ts
+++ b/packages/framework/store/src/schema/base.ts
@@ -131,7 +131,7 @@ export function defineBlockSchema({
 }
 
 type SignaledProps<Props> = Props & {
-  [P in keyof Props & string as `${P}$`]: Signal<Props[P]>;
+  [P in keyof Props as `${Extract<P, string>}$`]: Signal<Props[P]>;
 };
 /**
  * The MagicProps function is used to append the props to the class.


### PR DESCRIPTION
This PR fixed that the signal of optional model property may be undefined.

```ts
type ModelProps = {
  optional?: string;
};

const modelSchema = defineBlockSchema({
  // ...
  props: (): ModelProps => ({
    // if the default value of `optional` is not provied
  })
})

model.optional$ // undefined
// Before
model.optional$.value   // may throw a undefined error
// After
model.optional$?.value  // more type safe
```