### PR TITLE
feat(blocks): provide a mobile spec patches

### DIFF
--- a/packages/blocks/src/_specs/index.ts
+++ b/packages/blocks/src/_specs/index.ts
@@ -1,6 +1,7 @@
 export * from './group/common.js';
 
 export * from './preset/edgeless-specs.js';
+export * from './preset/mobile-patch.js';
 export * from './preset/page-specs.js';
 export * from './preset/preview-specs.js';
 

--- a/packages/blocks/src/_specs/preset/mobile-patch.ts
+++ b/packages/blocks/src/_specs/preset/mobile-patch.ts
@@ -1,0 +1,103 @@
+import type { Container } from '@blocksuite/global/di';
+
+import {
+  type ReferenceNodeConfig,
+  ReferenceNodeConfigIdentifier,
+} from '@blocksuite/affine-components/rich-text';
+import {
+  type BlockStdScope,
+  LifeCycleWatcher,
+  WidgetViewMapIdentifier,
+  type WidgetViewMapType,
+} from '@blocksuite/block-std';
+
+import { pageRootWidgetViewMap } from '../../root-block/page/page-root-spec.js';
+import { AFFINE_EMBED_CARD_TOOLBAR_WIDGET } from '../../root-block/widgets/embed-card-toolbar/embed-card-toolbar.js';
+import { AFFINE_FORMAT_BAR_WIDGET } from '../../root-block/widgets/format-bar/format-bar.js';
+import { AFFINE_SLASH_MENU_WIDGET } from '../../root-block/widgets/slash-menu/index.js';
+
+export class MobileSpecsPatches extends LifeCycleWatcher {
+  static override key = 'mobile-patches';
+
+  constructor(std: BlockStdScope) {
+    super(std);
+
+    std.doc.awarenessStore.setFlag('enable_mobile_keyboard_toolbar', true);
+    std.doc.awarenessStore.setFlag('enable_mobile_linked_doc_menu', true);
+  }
+
+  static override setup(di: Container) {
+    super.setup(di);
+
+    // Hide reference popup on mobile.
+    {
+      const prev = di.getFactory(ReferenceNodeConfigIdentifier);
+      di.override(ReferenceNodeConfigIdentifier, provider => {
+        return {
+          ...prev?.(provider),
+          hidePopup: true,
+        } satisfies ReferenceNodeConfig;
+      });
+    }
+
+    // Disable some toolbar widgets for mobile.
+    {
+      di.override(WidgetViewMapIdentifier('affine:page'), () => {
+        const ignoreWidgets = [
+          AFFINE_FORMAT_BAR_WIDGET,
+          AFFINE_EMBED_CARD_TOOLBAR_WIDGET,
+          AFFINE_SLASH_MENU_WIDGET,
+        ];
+
+        type pageRootWidgetViewMapKey = keyof typeof pageRootWidgetViewMap;
+        return (
+          Object.keys(pageRootWidgetViewMap) as pageRootWidgetViewMapKey[]
+        ).reduce(
+          (acc, key) => {
+            if (ignoreWidgets.includes(key)) return acc;
+            acc[key] = pageRootWidgetViewMap[key];
+            return acc;
+          },
+          {} as typeof pageRootWidgetViewMap
+        );
+      });
+
+      di.override(
+        WidgetViewMapIdentifier('affine:code'),
+        (): WidgetViewMapType => ({})
+      );
+
+      di.override(
+        WidgetViewMapIdentifier('affine:image'),
+        (): WidgetViewMapType => ({})
+      );
+
+      di.override(
+        WidgetViewMapIdentifier('affine:surface-ref'),
+        (): WidgetViewMapType => ({})
+      );
+    }
+  }
+
+  override mounted() {
+    // remove slash placeholder for mobile: `type / ...`
+    {
+      const paragraphService = this.std.getService('affine:paragraph');
+      if (!paragraphService) return;
+
+      paragraphService.placeholderGenerator = model => {
+        const placeholders = {
+          text: '',
+          h1: 'Heading 1',
+          h2: 'Heading 2',
+          h3: 'Heading 3',
+          h4: 'Heading 4',
+          h5: 'Heading 5',
+          h6: 'Heading 6',
+          quote: '',
+        };
+        return placeholders[model.type];
+      };
+    }
+  }
+}

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -64,6 +64,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
     refNodeSlotsExtension,
     ...specs.edgelessModeSpecs,
   ]);
+
   SpecProvider.getInstance().extendSpec('edgeless:preview', [
     OverrideThemeExtension(themeExtension),
   ]);


### PR DESCRIPTION
This PR provides a mobile patches for better user experience. Close [BS-1824](https://linear.app/affine-design/issue/BS-1824/移动端去除-slash的响应)

### What Changes
- hide inline reference popup
- use `keyboard-toolbar` instead of slash menu and block toolbar widgets
- a new @ menu for mobile
- update paragraph placeholder description

### How to use?
In the setup stage of editor, add this spec patches to editor
```ts
import {  MobileSpecsPatches } from '@blocksuite/blocks';
import { IS_MOBILE } from '@blocksuite/global/env';

if (IS_MOBILE) {
  editor.pageSpecs.push(MobileSpecsPatches);
  editor.edgelessSpecs.push(MobileSpecsPatches);
}
```