### PR TITLE
feat(blocks): add plain text block adapter for linked and synced doc block

### DIFF
--- a/packages/affine/block-embed/src/embed-linked-doc-block/adapters/index.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/adapters/index.ts
@@ -1,0 +1,2 @@
+export * from './markdown.js';
+export * from './plain-text.js';

--- a/packages/affine/block-embed/src/embed-linked-doc-block/adapters/plain-text.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/adapters/plain-text.ts
@@ -1,11 +1,11 @@
 import { EmbedLinkedDocBlockSchema } from '@blocksuite/affine-model';
 import {
-  BlockMarkdownAdapterExtension,
-  type BlockMarkdownAdapterMatcher,
+  BlockPlainTextAdapterExtension,
+  type BlockPlainTextAdapterMatcher,
   toURLSearchParams,
 } from '@blocksuite/affine-shared/adapters';
 
-export const embedLinkedDocBlockMarkdownAdapterMatcher: BlockMarkdownAdapterMatcher =
+export const embedLinkedDocBlockPlainTextAdapterMatcher: BlockPlainTextAdapterMatcher =
   {
     flavour: EmbedLinkedDocBlockSchema.model.flavour,
     toMatch: () => false,
@@ -13,7 +13,7 @@ export const embedLinkedDocBlockMarkdownAdapterMatcher: BlockMarkdownAdapterMatc
     toBlockSnapshot: {},
     fromBlockSnapshot: {
       enter: (o, context) => {
-        const { configs, walkerContext } = context;
+        const { configs, textBuffer } = context;
         // Parse as link
         if (!o.node.props.pageId) {
           return;
@@ -24,33 +24,10 @@ export const embedLinkedDocBlockMarkdownAdapterMatcher: BlockMarkdownAdapterMatc
         const query = search?.size ? `?${search.toString()}` : '';
         const baseUrl = configs.get('docLinkBaseUrl') ?? '';
         const url = baseUrl ? `${baseUrl}/${o.node.props.pageId}${query}` : '';
-        walkerContext
-          .openNode(
-            {
-              type: 'paragraph',
-              children: [],
-            },
-            'children'
-          )
-          .openNode(
-            {
-              type: 'link',
-              url,
-              title: o.node.props.caption as string | null,
-              children: [
-                {
-                  type: 'text',
-                  value: title,
-                },
-              ],
-            },
-            'children'
-          )
-          .closeNode()
-          .closeNode();
+        textBuffer.content += `${title}: ${url}\n`;
       },
     },
   };
 
-export const EmbedLinkedDocMarkdownAdapterExtension =
-  BlockMarkdownAdapterExtension(embedLinkedDocBlockMarkdownAdapterMatcher);
+export const EmbedLinkedDocBlockPlainTextAdapterExtension =
+  BlockPlainTextAdapterExtension(embedLinkedDocBlockPlainTextAdapterMatcher);

--- a/packages/affine/block-embed/src/embed-linked-doc-block/index.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/index.ts
@@ -1,4 +1,4 @@
-export * from './adapters/markdown.js';
+export * from './adapters/index.js';
 export * from './embed-linked-doc-block.js';
 export * from './embed-linked-doc-config.js';
 export * from './embed-linked-doc-spec.js';

--- a/packages/affine/block-embed/src/embed-synced-doc-block/adapters/index.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/adapters/index.ts
@@ -1,0 +1,2 @@
+export * from './markdown.js';
+export * from './plain-text.js';

--- a/packages/affine/block-embed/src/embed-synced-doc-block/adapters/plain-text.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/adapters/plain-text.ts
@@ -1,0 +1,62 @@
+import { EmbedSyncedDocBlockSchema } from '@blocksuite/affine-model';
+import {
+  BlockPlainTextAdapterExtension,
+  type BlockPlainTextAdapterMatcher,
+} from '@blocksuite/affine-shared/adapters';
+
+export const embedSyncedDocBlockPlainTextAdapterMatcher: BlockPlainTextAdapterMatcher =
+  {
+    flavour: EmbedSyncedDocBlockSchema.model.flavour,
+    toMatch: () => false,
+    fromMatch: o => o.node.flavour === EmbedSyncedDocBlockSchema.model.flavour,
+    toBlockSnapshot: {},
+    fromBlockSnapshot: {
+      enter: async (o, context) => {
+        const { configs, walker, walkerContext, job, textBuffer } = context;
+        const type = configs.get('embedSyncedDocExportType');
+
+        // this context is used for nested sync block
+        if (
+          walkerContext.getGlobalContext('embed-synced-doc-counter') ===
+          undefined
+        ) {
+          walkerContext.setGlobalContext('embed-synced-doc-counter', 0);
+        }
+        let counter = walkerContext.getGlobalContext(
+          'embed-synced-doc-counter'
+        ) as number;
+        walkerContext.setGlobalContext('embed-synced-doc-counter', ++counter);
+
+        let buffer = '';
+
+        if (type === 'content') {
+          const syncedDocId = o.node.props.pageId as string;
+          const syncedDoc = job.collection.getDoc(syncedDocId);
+          if (!syncedDoc) return;
+
+          if (counter === 1) {
+            const syncedSnapshot = await job.docToSnapshot(syncedDoc);
+            if (syncedSnapshot) {
+              await walker.walkONode(syncedSnapshot.blocks);
+            }
+          } else {
+            buffer = syncedDoc.meta?.title ?? '';
+            if (buffer) {
+              buffer += '\n';
+            }
+          }
+        }
+        textBuffer.content += buffer;
+      },
+      leave: (_, context) => {
+        const { walkerContext } = context;
+        const counter = walkerContext.getGlobalContext(
+          'embed-synced-doc-counter'
+        ) as number;
+        walkerContext.setGlobalContext('embed-synced-doc-counter', counter - 1);
+      },
+    },
+  };
+
+export const EmbedSyncedDocBlockPlainTextAdapterExtension =
+  BlockPlainTextAdapterExtension(embedSyncedDocBlockPlainTextAdapterMatcher);

--- a/packages/affine/block-embed/src/embed-synced-doc-block/index.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/index.ts
@@ -1,4 +1,4 @@
-export * from './adapters/markdown.js';
+export * from './adapters/index.js';
 export * from './embed-synced-doc-block.js';
 export * from './embed-synced-doc-spec.js';
 export { SYNCED_MIN_HEIGHT, SYNCED_MIN_WIDTH } from './styles.js';

--- a/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/packages/blocks/src/__tests__/adapters/markdown.unit.spec.ts
@@ -1758,6 +1758,13 @@ hhh
                     pageId: '4T5ObMgEIMII-4Bexyta1',
                     style: 'horizontal',
                     caption: null,
+                    params: {
+                      mode: 'page',
+                      blockIds: ['abc', '123'],
+                      elementIds: ['def', '456'],
+                      databaseId: 'deadbeef',
+                      databaseRowId: '123',
+                    },
                   },
                   children: [],
                 },
@@ -1816,6 +1823,8 @@ hhh
                                     mode: 'page',
                                     blockIds: ['abc', '123'],
                                     elementIds: ['def', '456'],
+                                    databaseId: 'deadbeef',
+                                    databaseRowId: '123',
                                   },
                                 },
                               },
@@ -1897,13 +1906,13 @@ hhh
 
 &#x20;   bbb
 
-[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1)
+[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456\\&databaseId=deadbeef\\&databaseRowId=123)
 
 &#x20;   ccc
 
 &#x20;       ddd
 
-&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456)[](https://example.com/foobar)
+&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456\\&databaseId=deadbeef\\&databaseRowId=123)[](https://example.com/foobar)
 
 &#x20;       fff
 

--- a/packages/blocks/src/__tests__/adapters/plain-text.unit.spec.ts
+++ b/packages/blocks/src/__tests__/adapters/plain-text.unit.spec.ts
@@ -1,4 +1,8 @@
-import type { BlockSnapshot, JobMiddleware } from '@blocksuite/store';
+import type {
+  BlockSnapshot,
+  DocSnapshot,
+  JobMiddleware,
+} from '@blocksuite/store';
 
 import {
   DEFAULT_NOTE_BACKGROUND_COLOR,
@@ -7,6 +11,7 @@ import {
 import { describe, expect, test } from 'vitest';
 
 import { PlainTextAdapter } from '../../_common/adapters/plain-text/plain-text.js';
+import { embedSyncedDocMiddleware } from '../../_common/transformers/middlewares.js';
 import { createJob } from '../utils/create-job.js';
 
 describe('snapshot to plain text', () => {
@@ -523,6 +528,8 @@ describe('snapshot to plain text', () => {
                                 mode: 'page',
                                 blockIds: ['abc', '123'],
                                 elementIds: ['def', '456'],
+                                databaseId: 'deadbeef',
+                                databaseRowId: '123',
                               },
                             },
                           },
@@ -565,7 +572,7 @@ describe('snapshot to plain text', () => {
     const plainTextAdapter = new PlainTextAdapter(createJob([middleware]));
 
     const plainText =
-      'aaa: https://affine.pro/\ntest: https://example.com/deadbeef?mode=page&blockIds=abc%2C123&elementIds=def%2C456\nE=mc^2\n';
+      'aaa: https://affine.pro/\ntest: https://example.com/deadbeef?mode=page&blockIds=abc%2C123&elementIds=def%2C456&databaseId=deadbeef&databaseRowId=123\nE=mc^2\n';
     const target = await plainTextAdapter.fromBlockSnapshot({
       snapshot: blockSnapshot,
     });
@@ -671,6 +678,481 @@ describe('snapshot to plain text', () => {
         expect(target.file).toBe(testCase.plainText);
       });
     }
+
+    test('linked doc block', async () => {
+      const blockSnapShot: BlockSnapshot = {
+        type: 'block',
+        id: 'VChAZIX7DM',
+        flavour: 'affine:page',
+        version: 2,
+        props: {
+          title: {
+            '$blocksuite:internal:text$': true,
+            delta: [
+              {
+                insert: 'Test Doc',
+              },
+            ],
+          },
+        },
+        children: [
+          {
+            type: 'block',
+            id: 'uRj8gejH4d',
+            flavour: 'affine:surface',
+            version: 5,
+            props: {
+              elements: {},
+            },
+            children: [],
+          },
+          {
+            type: 'block',
+            id: 'AqFoVDUoW9',
+            flavour: 'affine:note',
+            version: 1,
+            props: {
+              xywh: '[0,0,800,95]',
+              background: DEFAULT_NOTE_BACKGROUND_COLOR,
+              index: 'a0',
+              hidden: false,
+              displayMode: NoteDisplayMode.DocAndEdgeless,
+            },
+            children: [
+              {
+                type: 'block',
+                id: 'C0sH2Ee6cz-MysVNLNrBt',
+                flavour: 'affine:embed-linked-doc',
+                props: {
+                  index: 'a0',
+                  xywh: '[0,0,0,0]',
+                  rotate: 0,
+                  pageId: '4T5ObMgEIMII-4Bexyta1',
+                  style: 'horizontal',
+                  caption: null,
+                  params: {
+                    mode: 'page',
+                    blockIds: ['abc', '123'],
+                    elementIds: ['def', '456'],
+                    databaseId: 'deadbeef',
+                    databaseRowId: '123',
+                  },
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
+
+      const middleware: JobMiddleware = ({ adapterConfigs }) => {
+        adapterConfigs.set('title:4T5ObMgEIMII-4Bexyta1', 'test');
+        adapterConfigs.set('docLinkBaseUrl', 'https://example.com');
+      };
+      const plainText =
+        'test: https://example.com/4T5ObMgEIMII-4Bexyta1?mode=page&blockIds=abc%2C123&elementIds=def%2C456&databaseId=deadbeef&databaseRowId=123\n';
+      const plainTextAdapter = new PlainTextAdapter(createJob([middleware]));
+      const target = await plainTextAdapter.fromBlockSnapshot({
+        snapshot: blockSnapShot,
+      });
+      expect(target.file).toBe(plainText);
+    });
+
+    test('synced doc block', async () => {
+      // doc -> synced doc block -> deepest synced doc block
+      // The deepest synced doc block only export it's title
+
+      const deepestSyncedDocSnapshot: DocSnapshot = {
+        type: 'page',
+        meta: {
+          id: 'deepestSyncedDoc',
+          title: 'Deepest Doc',
+          createDate: 1715762171116,
+          tags: [],
+        },
+        blocks: {
+          type: 'block',
+          id: '8WdJmN5FTT',
+          flavour: 'affine:page',
+          version: 2,
+          props: {
+            title: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Deepest Doc',
+                },
+              ],
+            },
+          },
+          children: [
+            {
+              type: 'block',
+              id: 'zVN1EZFuZe',
+              flavour: 'affine:surface',
+              version: 5,
+              props: {
+                elements: {},
+              },
+              children: [],
+            },
+            {
+              type: 'block',
+              id: '2s9sJlphLH',
+              flavour: 'affine:note',
+              version: 1,
+              props: {
+                xywh: '[0,0,800,95]',
+                background: DEFAULT_NOTE_BACKGROUND_COLOR,
+                index: 'a0',
+                hidden: false,
+                displayMode: 'both',
+                edgeless: {
+                  style: {
+                    borderRadius: 8,
+                    borderSize: 4,
+                    borderStyle: 'solid',
+                    shadowType: '--affine-note-shadow-box',
+                  },
+                },
+              },
+              children: [
+                {
+                  type: 'block',
+                  id: 'vNp5XrR5yw',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'JTdfSl1ygZ',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'Hello, This is deepest doc.',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const syncedDocSnapshot: DocSnapshot = {
+        type: 'page',
+        meta: {
+          id: 'syncedDoc',
+          title: 'Synced Doc',
+          createDate: 1719212435051,
+          tags: [],
+        },
+        blocks: {
+          type: 'block',
+          id: 'AGOahFisBN',
+          flavour: 'affine:page',
+          version: 2,
+          props: {
+            title: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Synced Doc',
+                },
+              ],
+            },
+          },
+          children: [
+            {
+              type: 'block',
+              id: 'gfVzx5tGpB',
+              flavour: 'affine:surface',
+              version: 5,
+              props: {
+                elements: {},
+              },
+              children: [],
+            },
+            {
+              type: 'block',
+              id: 'CzEfaUret4',
+              flavour: 'affine:note',
+              version: 1,
+              props: {
+                xywh: '[0,0,800,95]',
+                background: '--affine-note-background-blue',
+                index: 'a0',
+                hidden: false,
+                displayMode: 'both',
+                edgeless: {
+                  style: {
+                    borderRadius: 0,
+                    borderSize: 4,
+                    borderStyle: 'none',
+                    shadowType: '--affine-note-shadow-sticker',
+                  },
+                },
+              },
+              children: [
+                {
+                  type: 'block',
+                  id: 'yFlNufsgke',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'h1',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'Heading 1',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'oMuLcD6XS3',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'h2',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'heading 2',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'PQ8FhGV6VM',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'paragraph',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'sA9paSrdEN',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'strike',
+                          attributes: {
+                            strike: true,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'DF26giFpKX',
+                  flavour: 'affine:code',
+                  version: 1,
+                  props: {
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'Hello world!',
+                        },
+                      ],
+                    },
+                    language: 'cpp',
+                    wrap: false,
+                    caption: '',
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: '-3bbVQTvI2',
+                  flavour: 'affine:embed-synced-doc',
+                  version: 1,
+                  props: {
+                    index: 'a0',
+                    xywh: '[0,0,0,0]',
+                    rotate: 0,
+                    pageId: 'deepestSyncedDoc',
+                    style: 'syncedDoc',
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const syncedDocPlainText =
+        'Heading 1\nheading 2\nparagraph\nstrike\nHello world!\n';
+
+      const docSnapShot: DocSnapshot = {
+        type: 'page',
+        meta: {
+          id: 'y5nsrywQtr',
+          title: 'Test Doc',
+          createDate: 1719222172042,
+          tags: [],
+        },
+        blocks: {
+          type: 'block',
+          id: 'VChAZIX7DM',
+          flavour: 'affine:page',
+          version: 2,
+          props: {
+            title: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Test Doc',
+                },
+              ],
+            },
+          },
+          children: [
+            {
+              type: 'block',
+              id: 'uRj8gejH4d',
+              flavour: 'affine:surface',
+              version: 5,
+              props: {
+                elements: {},
+              },
+              children: [],
+            },
+            {
+              type: 'block',
+              id: 'AqFoVDUoW9',
+              flavour: 'affine:note',
+              version: 1,
+              props: {
+                xywh: '[0,0,800,95]',
+                background: '--affine-note-background-blue',
+                index: 'a0',
+                hidden: false,
+                displayMode: 'both',
+                edgeless: {
+                  style: {
+                    borderRadius: 0,
+                    borderSize: 4,
+                    borderStyle: 'none',
+                    shadowType: '--affine-note-shadow-sticker',
+                  },
+                },
+              },
+              children: [
+                {
+                  type: 'block',
+                  id: 'cWBI4UGTqh',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'Hello',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'AqFoVxas19',
+                  flavour: 'affine:embed-synced-doc',
+                  version: 1,
+                  props: {
+                    index: 'a0',
+                    xywh: '[0,0,0,0]',
+                    rotate: 0,
+                    pageId: 'syncedDoc',
+                    style: 'syncedDoc',
+                  },
+                  children: [],
+                },
+                {
+                  type: 'block',
+                  id: 'Db976U9v18',
+                  flavour: 'affine:paragraph',
+                  version: 1,
+                  props: {
+                    type: 'text',
+                    text: {
+                      '$blocksuite:internal:text$': true,
+                      delta: [
+                        {
+                          insert: 'World!',
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const docPlainText = `Test Doc\n\nHello\n${syncedDocPlainText}Deepest Doc\nWorld!\n`;
+      const job = createJob([embedSyncedDocMiddleware('content')]);
+
+      // workaround for adding docs to collection
+      await job.snapshotToDoc(deepestSyncedDocSnapshot);
+      await job.snapshotToDoc(syncedDocSnapshot);
+      await job.snapshotToDoc(docSnapShot);
+
+      const mdAdapter = new PlainTextAdapter(job);
+      const target = await mdAdapter.fromDocSnapshot({
+        snapshot: docSnapShot,
+      });
+      expect(target.file).toBe(docPlainText);
+    });
   });
 
   test('latex block', async () => {

--- a/packages/blocks/src/_common/adapters/markdown/delta-converter/inline-delta.ts
+++ b/packages/blocks/src/_common/adapters/markdown/delta-converter/inline-delta.ts
@@ -70,9 +70,9 @@ export const referenceDeltaMarkdownAdapterMatch: InlineDeltaToMarkdownAdapterMat
 
       const { configs } = context;
       const title = configs.get(`title:${reference.pageId}`);
-      const { mode, blockIds, elementIds } = reference.params ?? {};
+      const params = reference.params ?? {};
       const baseUrl = configs.get('docLinkBaseUrl') ?? '';
-      const search = toURLSearchParams({ mode, blockIds, elementIds });
+      const search = toURLSearchParams(params);
       const query = search?.size ? `?${search.toString()}` : '';
       const url = baseUrl ? `${baseUrl}/${reference.pageId}${query}` : '';
       mdast = {

--- a/packages/blocks/src/_common/adapters/plain-text/block-matcher.ts
+++ b/packages/blocks/src/_common/adapters/plain-text/block-matcher.ts
@@ -6,8 +6,12 @@ import {
   embedFigmaBlockPlainTextAdapterMatcher,
   EmbedGithubBlockPlainTextAdapterExtension,
   embedGithubBlockPlainTextAdapterMatcher,
+  EmbedLinkedDocBlockPlainTextAdapterExtension,
+  embedLinkedDocBlockPlainTextAdapterMatcher,
   EmbedLoomBlockPlainTextAdapterExtension,
   embedLoomBlockPlainTextAdapterMatcher,
+  EmbedSyncedDocBlockPlainTextAdapterExtension,
+  embedSyncedDocBlockPlainTextAdapterMatcher,
   EmbedYoutubeBlockPlainTextAdapterExtension,
   embedYoutubeBlockPlainTextAdapterMatcher,
 } from '@blocksuite/affine-block-embed';
@@ -48,6 +52,8 @@ export const defaultBlockPlainTextAdapterMatchers: BlockPlainTextAdapterMatcher[
     embedGithubBlockPlainTextAdapterMatcher,
     embedLoomBlockPlainTextAdapterMatcher,
     embedYoutubeBlockPlainTextAdapterMatcher,
+    embedLinkedDocBlockPlainTextAdapterMatcher,
+    embedSyncedDocBlockPlainTextAdapterMatcher,
     latexBlockPlainTextAdapterMatcher,
   ];
 
@@ -61,5 +67,7 @@ export const BlockPlainTextAdapterExtensions: ExtensionType[] = [
   EmbedGithubBlockPlainTextAdapterExtension,
   EmbedLoomBlockPlainTextAdapterExtension,
   EmbedYoutubeBlockPlainTextAdapterExtension,
+  EmbedLinkedDocBlockPlainTextAdapterExtension,
+  EmbedSyncedDocBlockPlainTextAdapterExtension,
   LatexBlockPlainTextAdapterExtension,
 ];

--- a/packages/blocks/src/_common/adapters/plain-text/delta-converter/inline-delta.ts
+++ b/packages/blocks/src/_common/adapters/plain-text/delta-converter/inline-delta.ts
@@ -19,9 +19,9 @@ export const referenceDeltaMarkdownAdapterMatch: InlineDeltaToPlainTextAdapterMa
 
       const { configs } = context;
       const title = configs.get(`title:${reference.pageId}`) ?? '';
-      const { mode, blockIds, elementIds } = reference.params ?? {};
+      const params = reference.params ?? {};
       const baseUrl = configs.get('docLinkBaseUrl') ?? '';
-      const search = toURLSearchParams({ mode, blockIds, elementIds });
+      const search = toURLSearchParams(params);
       const query = search?.size ? `?${search.toString()}` : '';
       const url = baseUrl ? `${baseUrl}/${reference.pageId}${query}` : '';
       const content = `${title ? `${title}: ` : ''}${url}`;

--- a/packages/blocks/src/_common/adapters/plain-text/plain-text.ts
+++ b/packages/blocks/src/_common/adapters/plain-text/plain-text.ts
@@ -87,6 +87,21 @@ export class PlainTextAdapter extends BaseAdapter<PlainText> {
         }
       }
     });
+    walker.setLeave(async (o, context) => {
+      for (const matcher of this.blockMatchers) {
+        if (matcher.fromMatch(o)) {
+          const adapterContext: AdapterContext<BlockSnapshot, never> = {
+            walker,
+            walkerContext: context,
+            configs: this.configs,
+            job: this.job,
+            deltaConverter: this.deltaConverter,
+            textBuffer,
+          };
+          await matcher.fromBlockSnapshot.leave?.(o, adapterContext);
+        }
+      }
+    });
     await walker.walkONode(snapshot);
     return {
       plaintext: textBuffer.content,

--- a/packages/blocks/src/_common/transformers/middlewares.ts
+++ b/packages/blocks/src/_common/transformers/middlewares.ts
@@ -222,7 +222,7 @@ export const docLinkBaseURLMiddlewareBuilder = (baseUrl: string) => {
   let middleware: JobMiddleware = ({ slots, collection, adapterConfigs }) => {
     slots.beforeExport.on(() => {
       const docLinkBaseUrl = baseUrl
-        ? `${baseUrl}/workspace/${collection.id}/`
+        ? `${baseUrl}/workspace/${collection.id}`
         : '';
       adapterConfigs.set('docLinkBaseUrl', docLinkBaseUrl);
     });
@@ -234,7 +234,7 @@ export const docLinkBaseURLMiddlewareBuilder = (baseUrl: string) => {
       middleware = ({ slots, collection, adapterConfigs }) => {
         slots.beforeExport.on(() => {
           const docLinkBaseUrl = customBaseUrl
-            ? `${customBaseUrl}/workspace/${collection.id}/`
+            ? `${customBaseUrl}/workspace/${collection.id}`
             : '';
           adapterConfigs.set('docLinkBaseUrl', docLinkBaseUrl);
         });

--- a/packages/playground/apps/_common/components/adapters-panel.ts
+++ b/packages/playground/apps/_common/components/adapters-panel.ts
@@ -4,7 +4,9 @@ import type SlTabPanel from '@shoelace-style/shoelace/dist/components/tab-panel/
 import { ShadowlessElement } from '@blocksuite/block-std';
 import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
 import {
-  docLinkBaseURLMiddleware,
+  defaultImageProxyMiddleware,
+  docLinkBaseURLMiddlewareBuilder,
+  embedSyncedDocMiddleware,
   HtmlAdapter,
   MarkdownAdapter,
   PlainTextAdapter,
@@ -60,9 +62,15 @@ export class AdaptersPanel extends WithDisposable(ShadowlessElement) {
   }
 
   private _createJob() {
+    console.log('collection', this.doc.collection.id, this.doc.id);
     return new Job({
       collection: this.doc.collection,
-      middlewares: [docLinkBaseURLMiddleware, titleMiddleware],
+      middlewares: [
+        docLinkBaseURLMiddlewareBuilder('https://example.com').get(),
+        titleMiddleware,
+        embedSyncedDocMiddleware('content'),
+        defaultImageProxyMiddleware,
+      ],
     });
   }
 


### PR DESCRIPTION
[BS-2040](https://linear.app/affine-design/issue/BS-2040/补齐-linked-doc-和-synced-doc-plain-text-adapter)