### PR TITLE
fix: memory leak on switching from doc to edgeless

### DIFF
--- a/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
+++ b/packages/blocks/src/edgeless-text-block/edgeless-text-block.ts
@@ -93,6 +93,8 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       this.model.propsUpdated.on(({ key }) => {
         this.updateComplete
           .then(() => {
+            if (!this.host) return;
+
             const command = this.host.command;
             const blockSelections = this.model.children.map(child =>
               this.host.selection.create('block', {

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/common/draggable/draggable-element.controller.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/common/draggable/draggable-element.controller.ts
@@ -418,8 +418,8 @@ export class EdgelessDraggableElementController<T>
     const host = options.edgeless.host;
     const { onMouseUp, onMouseMove, onTouchMove, onTouchEnd } = events;
     onMouseUp && window.removeEventListener('mouseup', onMouseUp);
-    onMouseMove && host.removeEventListener('mousemove', onMouseMove);
-    onTouchMove && host.removeEventListener('touchmove', onTouchMove);
+    onMouseMove && host && host.removeEventListener('mousemove', onMouseMove);
+    onTouchMove && host && host.removeEventListener('touchmove', onTouchMove);
     onTouchEnd && window.removeEventListener('touchend', onTouchEnd);
     this.events = {};
   }

--- a/packages/framework/block-std/src/gfx/controller.ts
+++ b/packages/framework/block-std/src/gfx/controller.ts
@@ -271,7 +271,7 @@ export class GfxController extends LifeCycleWatcher {
   }
 
   override mounted() {
-    this.viewport.setViewportElm(this.std.host);
+    this.viewport.setViewportElement(this.std.host);
     this.std.provider.getAll(GfxExtensionIdentifier).forEach(ext => {
       ext.mounted();
     });
@@ -281,6 +281,7 @@ export class GfxController extends LifeCycleWatcher {
     this.std.provider.getAll(GfxExtensionIdentifier).forEach(ext => {
       ext.unmounted();
     });
+    this.viewport.clearViewportElement();
     this._disposables.dispose();
   }
 

--- a/packages/framework/block-std/src/gfx/viewport.ts
+++ b/packages/framework/block-std/src/gfx/viewport.ts
@@ -19,7 +19,7 @@ export const ZOOM_MIN = 0.1;
 export class Viewport {
   protected _center: IPoint = { x: 0, y: 0 };
 
-  protected _el!: HTMLElement;
+  protected _el: HTMLElement | null = null;
 
   protected _height = 0;
 
@@ -51,6 +51,7 @@ export class Viewport {
   ZOOM_MIN = ZOOM_MIN;
 
   get boundingClientRect() {
+    if (!this._el) return new DOMRect(0, 0, 0, 0);
     return this._el.getBoundingClientRect();
   }
 
@@ -90,6 +91,7 @@ export class Viewport {
    * This property is used to calculate the scale of the editor.
    */
   get scale() {
+    if (!this._el) return 1;
     return this.boundingClientRect.width / this._el.offsetWidth;
   }
 
@@ -154,6 +156,10 @@ export class Viewport {
     this.setCenter(this.centerX + deltaX, this.centerY + deltaY);
   }
 
+  clearViewportElement() {
+    this._el = null;
+  }
+
   dispose() {
     this.sizeUpdated.dispose();
     this.viewportMoved.dispose();
@@ -197,6 +203,7 @@ export class Viewport {
   }
 
   onResize() {
+    if (!this._el) return;
     const { centerX, centerY, zoom, width: oldWidth, height: oldHeight } = this;
     const { left, top } = this._el.getBoundingClientRect();
     const { offsetWidth: width, offsetHeight: height } = this._el;
@@ -272,12 +279,12 @@ export class Viewport {
     this.setViewport(zoom, center, smooth);
   }
 
-  setViewportElm(elm: HTMLElement) {
-    const rect = elm.getBoundingClientRect();
+  setViewportElement(el: HTMLElement) {
+    const rect = el.getBoundingClientRect();
 
-    this._el = elm;
+    this._el = el;
 
-    this.setRect(rect.left, rect.top, elm.offsetWidth, elm.offsetHeight);
+    this.setRect(rect.left, rect.top, el.offsetWidth, el.offsetHeight);
   }
 
   setZoom(zoom: number, focusPoint?: IPoint) {

--- a/packages/framework/block-std/src/scope/block-std-scope.ts
+++ b/packages/framework/block-std/src/scope/block-std-scope.ts
@@ -190,6 +190,7 @@ export class BlockStdScope {
     this._lifeCycleWatchers.forEach(watcher => {
       watcher.unmounted.call(watcher);
     });
+    this._getHost = () => null as unknown as EditorHost;
   }
 }
 

--- a/packages/framework/block-std/src/view/element/lit-host.ts
+++ b/packages/framework/block-std/src/view/element/lit-host.ts
@@ -144,6 +144,7 @@ export class EditorHost extends SignalWatcher(
     super.disconnectedCallback();
     this.std.unmount();
     this.slots.unmounted.emit();
+    this.slots.unmounted.dispose();
   }
 
   override async getUpdateComplete(): Promise<boolean> {

--- a/tests/edgeless/edgeless-text.spec.ts
+++ b/tests/edgeless/edgeless-text.spec.ts
@@ -574,6 +574,7 @@ test('press backspace at the start of first line when edgeless text exist', asyn
   await waitNextFrame(page);
   await type(page, 'aaa');
 
+  await waitNextFrame(page);
   await switchEditorMode(page);
 
   expect(await getPageSnapshot(page, true)).toMatchSnapshot(


### PR DESCRIPTION
Before (`<editor-host>` is detached after switching editor mode, causing significant memory surge for large docs):

<img width="1943" alt="image" src="https://github.com/user-attachments/assets/166cb218-299c-4510-a015-ba5cfbfe0b5d">

After (no detached `<editor-host>`):

<img width="1943" alt="image" src="https://github.com/user-attachments/assets/1f73e60e-6d8b-48bb-b9b4-38070fe02212">
