### PR TITLE
refactor(blocks): shadowless keyboard toolbar

### DIFF
--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
@@ -80,11 +80,6 @@ export type KeyboardToolbarConfig = {
    * @default false
    */
   useScreenHeight?: boolean;
-  /**
-   * @description The safe bottom padding of the keyboard toolbar.
-   * It is useful when the device has a rounded corner screen.
-   */
-  safeBottomPadding?: string;
 };
 
 export type KeyboardToolbarItem =

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/effects.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/effects.ts
@@ -19,3 +19,10 @@ export function effects() {
   customElements.define(AFFINE_KEYBOARD_TOOLBAR, AffineKeyboardToolbar);
   customElements.define(AFFINE_KEYBOARD_TOOL_PANEL, AffineKeyboardToolPanel);
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AFFINE_KEYBOARD_TOOLBAR]: AffineKeyboardToolbar;
+    [AFFINE_KEYBOARD_TOOL_PANEL]: AffineKeyboardToolPanel;
+  }
+}

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
@@ -52,6 +52,7 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<
     if (!this.block.rootComponent) return nothing;
 
     return html`<blocksuite-portal
+      .shadowDom=${false}
       .template=${html`<affine-keyboard-toolbar
         .config=${this.config}
         .rootComponent=${this.block.rootComponent}

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-tool-panel.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/keyboard-tool-panel.ts
@@ -1,6 +1,10 @@
-import { PropTypes, requiredProperties } from '@blocksuite/block-std';
+import {
+  PropTypes,
+  requiredProperties,
+  ShadowlessElement,
+} from '@blocksuite/block-std';
 import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
-import { html, LitElement, nothing, type PropertyValues } from 'lit';
+import { html, nothing, type PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -20,7 +24,7 @@ export const AFFINE_KEYBOARD_TOOL_PANEL = 'affine-keyboard-tool-panel';
   context: PropTypes.object,
 })
 export class AffineKeyboardToolPanel extends SignalWatcher(
-  WithDisposable(LitElement)
+  WithDisposable(ShadowlessElement)
 ) {
   static override styles = keyboardToolPanelStyles;
 
@@ -94,10 +98,4 @@ export class AffineKeyboardToolPanel extends SignalWatcher(
 
   @property({ type: Number })
   accessor height = 0;
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    [AFFINE_KEYBOARD_TOOL_PANEL]: AffineKeyboardToolPanel;
-  }
 }

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
@@ -6,7 +6,7 @@ import { scrollbarStyle } from '../../../_common/components/utils.js';
 export const TOOLBAR_HEIGHT = 46;
 
 export const keyboardToolbarStyles = css`
-  :host {
+  affine-keyboard-toolbar {
     position: fixed;
     display: block;
     width: 100vw;
@@ -59,7 +59,7 @@ export const keyboardToolbarStyles = css`
 `;
 
 export const keyboardToolPanelStyles = css`
-  :host {
+  affine-keyboard-tool-panel {
     display: flex;
     flex-direction: column;
     gap: 24px;
@@ -70,7 +70,7 @@ export const keyboardToolPanelStyles = css`
     background-color: ${unsafeCSSVarV2('layer/background/primary')};
   }
 
-  ${scrollbarStyle(':host')}
+  ${scrollbarStyle('affine-keyboard-tool-panel')}
 
   .keyboard-tool-panel-group {
     display: flex;

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/utils.ts
@@ -1,5 +1,3 @@
-import type { BlockStdScope } from '@blocksuite/block-std';
-
 import type {
   KeyboardSubToolbarConfig,
   KeyboardToolbarActionItem,
@@ -23,22 +21,4 @@ export function isKeyboardToolPanelConfig(
   item: KeyboardToolbarItem
 ): item is KeyboardToolPanelConfig {
   return 'groups' in item;
-}
-
-export function scrollCurrentBlockIntoView(std: BlockStdScope) {
-  std.command
-    .chain()
-    .getSelectedModels()
-    .inline(({ selectedModels }) => {
-      if (!selectedModels?.length) return;
-
-      const block = std.view.getBlock(selectedModels[0].id);
-      if (!block) return;
-
-      block.scrollIntoView({
-        behavior: 'instant',
-        block: 'nearest',
-      });
-    })
-    .run();
 }


### PR DESCRIPTION
Close [BS-1930](https://linear.app/affine-design/issue/BS-1930/移动端回车后页面不会滚动，需要能够滚动到光标输入位置) [BS-1922](https://linear.app/affine-design/issue/BS-1922/slash-menu-需要一个底部额外的padding) [BS-1923](https://linear.app/affine-design/issue/BS-1922/slash-menu-需要一个底部额外的padding)

### What chagnes
- made `affine-keyboard-toolbar` and `affine-keyboard-tool-panel` shadowless
- removed `safeBottomPadding`. It is better to use CSS control the widget style
- fixed auto scroll current block not work