### PR TITLE
feat(edgeless): improve local element support

### DIFF
--- a/packages/affine/block-surface/src/renderer/canvas-renderer.ts
+++ b/packages/affine/block-surface/src/renderer/canvas-renderer.ts
@@ -15,10 +15,10 @@ import {
   Slot,
 } from '@blocksuite/global/utils';
 
+import type { SurfaceElementModel } from '../element-model/base.js';
 import type { ElementRenderer } from './elements/index.js';
 import type { Overlay } from './overlay.js';
 
-import { SurfaceElementModel } from '../element-model/base.js';
 import { RoughCanvas } from '../utils/rough/canvas.js';
 
 type EnvProvider = {
@@ -271,8 +271,8 @@ export class CanvasRenderer {
 
     const elements =
       surfaceElements ??
-      (this.grid.search(bound, undefined, {
-        filter: el => el instanceof SurfaceElementModel,
+      (this.grid.search(bound, {
+        filter: ['canvas', 'local'],
       }) as SurfaceElementModel[]);
     for (const element of elements) {
       ctx.save();

--- a/packages/affine/model/src/elements/connector/local-connector.ts
+++ b/packages/affine/model/src/elements/connector/local-connector.ts
@@ -1,4 +1,4 @@
-import type { PointLocation, SerializedXYWH } from '@blocksuite/global/utils';
+import type { PointLocation } from '@blocksuite/global/utils';
 
 import { GfxLocalElementModel } from '@blocksuite/block-std/gfx';
 
@@ -19,19 +19,13 @@ export class LocalConnectorElementModel extends GfxLocalElementModel {
 
   frontEndpointStyle!: PointStyle;
 
-  id: string = '';
-
   mode: ConnectorMode = ConnectorMode.Orthogonal;
 
   rearEndpointStyle!: PointStyle;
 
-  rotate: number = 0;
-
   rough?: boolean;
 
   roughness: number = DEFAULT_ROUGHNESS;
-
-  seed: number = Math.random();
 
   source: Connection = {
     position: [0, 0],
@@ -48,8 +42,6 @@ export class LocalConnectorElementModel extends GfxLocalElementModel {
   };
 
   updatingPath = false;
-
-  xywh: SerializedXYWH = '[0,0,0,0]';
 
   get path(): PointLocation[] {
     return this._path;

--- a/packages/affine/model/src/elements/mindmap/mindmap.ts
+++ b/packages/affine/model/src/elements/mindmap/mindmap.ts
@@ -264,7 +264,10 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
     const id = `#${from.id}-${to.id}`;
 
     if (extra) {
-      this.extraConnectors.set(id, new LocalConnectorElementModel());
+      this.extraConnectors.set(
+        id,
+        new LocalConnectorElementModel(this.surface)
+      );
     } else if (this.connectors.has(id)) {
       const connector = this.connectors.get(id)!;
       const { outdated } = this._isConnectorOutdated({
@@ -278,7 +281,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
         return connector;
       }
     } else {
-      const connector = new LocalConnectorElementModel();
+      const connector = new LocalConnectorElementModel(this.surface);
       // update cache key
       this._isConnectorOutdated({
         connector,

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -26,7 +26,6 @@ import {
 } from '@blocksuite/affine-shared/utils';
 import { BlockComponent } from '@blocksuite/block-std';
 import {
-  GfxBlockElementModel,
   GfxControllerIdentifier,
   type GfxViewportElement,
 } from '@blocksuite/block-std/gfx';
@@ -540,10 +539,9 @@ export class EdgelessRootBlockComponent extends BlockComponent<
           .getModelsInViewport=${() => {
             const blocks = this.gfx.grid.search(
               this.gfx.viewport.viewportBounds,
-              undefined,
               {
                 useSet: true,
-                filter: model => model instanceof GfxBlockElementModel,
+                filter: ['block'],
               }
             );
 

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-preview-block.ts
@@ -7,16 +7,13 @@ import type {
   GfxBlockComponent,
   SurfaceSelection,
 } from '@blocksuite/block-std';
+import type { GfxViewportElement } from '@blocksuite/block-std/gfx';
 
 import {
   FontLoaderService,
   ThemeProvider,
 } from '@blocksuite/affine-shared/services';
 import { BlockComponent } from '@blocksuite/block-std';
-import {
-  GfxBlockElementModel,
-  type GfxViewportElement,
-} from '@blocksuite/block-std/gfx';
 import { assertExists } from '@blocksuite/global/utils';
 import { css, html } from 'lit';
 import { query, state } from 'lit/decorators.js';
@@ -225,10 +222,9 @@ export class EdgelessRootPreviewBlockComponent extends BlockComponent<
           .getModelsInViewport=${() => {
             const blocks = this.service.gfx.grid.search(
               this.service.viewport.viewportBounds,
-              undefined,
               {
                 useSet: true,
-                filter: model => model instanceof GfxBlockElementModel,
+                filter: ['block'],
               }
             );
             return blocks;

--- a/packages/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/packages/blocks/src/root-block/edgeless/frame-manager.ts
@@ -402,7 +402,7 @@ export class EdgelessFrameManager extends GfxExtension {
   getElementsInFrameBound(frame: FrameBlockModel, fullyContained = true) {
     const bound = Bound.deserialize(frame.xywh);
     const elements: GfxModel[] = this.gfx.grid
-      .search(bound, fullyContained)
+      .search(bound, { strict: fullyContained })
       .filter(element => element !== frame);
 
     return elements;

--- a/packages/framework/block-std/src/gfx/grid.ts
+++ b/packages/framework/block-std/src/gfx/grid.ts
@@ -5,13 +5,14 @@ import {
   Bound,
   getBoundWithRotation,
   intersects,
-  isPointIn,
 } from '@blocksuite/global/utils';
 
 import type { GfxModel } from './model/model.js';
 
 import { compare } from '../utils/layer.js';
 import { GfxBlockElementModel } from './model/gfx-block-model.js';
+import { GfxPrimitiveElementModel } from './model/surface/element-model.js';
+import { GfxLocalElementModel } from './model/surface/local-element-model.js';
 import { SurfaceBlockModel } from './model/surface/surface-model.js';
 
 function getGridIndex(val: number) {
@@ -27,7 +28,7 @@ function rangeFromBound(a: IBound): number[] {
   return [minRow, maxRow, minCol, maxCol];
 }
 
-function rangeFromElement(ele: GfxModel): number[] {
+function rangeFromElement(ele: GfxModel | GfxLocalElementModel): number[] {
   const bound = ele.elementBound;
   const minRow = getGridIndex(bound.x);
   const maxRow = getGridIndex(bound.maxX);
@@ -49,14 +50,28 @@ function rangeFromElementExternal(ele: GfxModel): number[] | null {
 
 export const DEFAULT_GRID_SIZE = 3000;
 
+const typeFilters = {
+  block: (model: GfxModel | GfxLocalElementModel) =>
+    model instanceof GfxBlockElementModel,
+  canvas: (model: GfxModel | GfxLocalElementModel) =>
+    model instanceof GfxPrimitiveElementModel,
+  local: (model: GfxModel | GfxLocalElementModel) =>
+    model instanceof GfxLocalElementModel,
+};
+
+type FilterFunc = (model: GfxModel | GfxLocalElementModel) => boolean;
+
 export class GridManager {
-  private _elementToGrids = new Map<GfxModel, Set<Set<GfxModel>>>();
+  private _elementToGrids = new Map<
+    GfxModel | GfxLocalElementModel,
+    Set<Set<GfxModel | GfxLocalElementModel>>
+  >();
 
   private _externalElementToGrids = new Map<GfxModel, Set<Set<GfxModel>>>();
 
   private _externalGrids = new Map<string, Set<GfxModel>>();
 
-  private _grids = new Map<string, Set<GfxModel>>();
+  private _grids = new Map<string, Set<GfxModel | GfxLocalElementModel>>();
 
   get isEmpty() {
     return this._grids.size === 0;
@@ -146,11 +161,24 @@ export class GridManager {
     return results;
   }
 
-  add(element: GfxModel) {
-    this._addToExternalGrids(element);
+  private _toFilterFuncs(filters: (keyof typeof typeFilters | FilterFunc)[]) {
+    const filterFuncs: FilterFunc[] = filters.map(filter => {
+      if (typeof filter === 'function') {
+        return filter;
+      }
+      return typeFilters[filter];
+    });
+    return (model: GfxModel | GfxLocalElementModel) =>
+      filterFuncs.some(filter => filter(model));
+  }
+
+  add(element: GfxModel | GfxLocalElementModel) {
+    if (!(element instanceof GfxLocalElementModel)) {
+      this._addToExternalGrids(element);
+    }
 
     const [minRow, maxRow, minCol, maxCol] = rangeFromElement(element);
-    const grids = new Set<Set<GfxModel>>();
+    const grids = new Set<Set<GfxModel | GfxLocalElementModel>>();
     this._elementToGrids.set(element, grids);
 
     for (let i = minRow; i <= maxRow; i++) {
@@ -187,7 +215,7 @@ export class GridManager {
     bound: IBound,
     strict: boolean = false,
     reverseChecking: boolean = false,
-    filter?: (model: GfxModel) => boolean
+    filter?: (model: GfxModel | GfxLocalElementModel) => boolean
   ) {
     const [minRow, maxRow, minCol, maxCol] = rangeFromBound(bound);
     const b = Bound.from(bound);
@@ -214,25 +242,7 @@ export class GridManager {
     return false;
   }
 
-  pick(x: number, y: number): GfxModel[] {
-    const row = getGridIndex(x);
-    const col = getGridIndex(y);
-    const gridElements = this._getGrid(row, col);
-    if (!gridElements) return [];
-
-    const results: GfxModel[] = [];
-    for (const element of gridElements) {
-      if (
-        isPointIn(getBoundWithRotation(Bound.deserialize(element.xywh)), x, y)
-      ) {
-        results.push(element);
-      }
-    }
-
-    return results;
-  }
-
-  remove(element: GfxModel) {
+  remove(element: GfxModel | GfxLocalElementModel) {
     const grids = this._elementToGrids.get(element);
     if (grids) {
       for (const grid of grids) {
@@ -241,43 +251,66 @@ export class GridManager {
     }
     this._elementToGrids.delete(element);
 
-    this._removeFromExternalGrids(element);
+    if (!(element instanceof GfxLocalElementModel)) {
+      this._removeFromExternalGrids(element);
+    }
   }
-  search(
-    bound: IBound,
-    strict?: boolean,
-    options?: {
-      useSet?: false;
-      filter?: (model: GfxModel) => boolean;
-    }
-  ): GfxModel[];
-  search(
-    bound: IBound,
-    strict: boolean | undefined,
-    options: {
-      useSet: true;
-      filter?: (model: GfxModel) => boolean;
-    }
-  ): Set<GfxModel>;
 
-  search(
+  /**
+   * Search for elements in a bound.
+   * @param bound
+   * @param options
+   */
+  search<T extends keyof typeof typeFilters>(
     bound: IBound,
-    strict = false,
-    options: {
+    options?: {
+      /**
+       * If true, only return elements that are completely inside the bound.
+       * Default is false.
+       */
+      strict?: boolean;
       /**
        * If true, return a set of elements instead of an array
        */
+      useSet?: false;
+      /**
+       * Use this to filter the elements, if not provided, it will return blocks and canvas elements by default
+       */
+      filter?: (T | FilterFunc)[] | FilterFunc;
+    }
+  ): T extends 'local'[] ? (GfxModel | GfxLocalElementModel)[] : GfxModel[];
+  search<T extends keyof typeof typeFilters>(
+    bound: IBound,
+    options: {
+      strict?: boolean | undefined;
+      useSet: true;
+      filter?: (T | FilterFunc)[] | FilterFunc;
+    }
+  ): T extends 'local'[] ? Set<GfxModel | GfxLocalElementModel> : Set<GfxModel>;
+  search<T extends keyof typeof typeFilters>(
+    bound: IBound,
+    options: {
+      strict?: boolean;
       useSet?: boolean;
-      filter?: (model: GfxModel) => boolean;
+      filter?: (T | FilterFunc)[] | FilterFunc;
     } = {
       useSet: false,
     }
-  ): GfxModel[] | Set<GfxModel> {
-    const results: Set<GfxModel> = this._searchExternal(bound, strict);
+  ):
+    | (GfxModel | GfxLocalElementModel)[]
+    | Set<GfxModel | GfxLocalElementModel> {
+    const strict = options.strict ?? false;
+    const results: Set<GfxModel | GfxLocalElementModel> = this._searchExternal(
+      bound,
+      strict
+    );
     const [minRow, maxRow, minCol, maxCol] = rangeFromBound(bound);
     const b = Bound.from(bound);
     const returnSet = options.useSet ?? false;
-    const filter = options.filter;
+    const filter =
+      (Array.isArray(options.filter)
+        ? this._toFilterFuncs(options.filter)
+        : options.filter) ?? this._toFilterFuncs(['canvas', 'block']);
 
     for (let i = minRow; i <= maxRow; i++) {
       for (let j = minCol; j <= maxCol; j++) {
@@ -285,9 +318,10 @@ export class GridManager {
         if (!gridElements) continue;
         for (const element of gridElements) {
           if (
-            (!filter || filter(element)) && strict
+            filter(element) &&
+            (strict
               ? b.contains(element.elementBound)
-              : intersects(element.elementBound, b)
+              : intersects(element.elementBound, b))
           ) {
             results.add(element);
           }
@@ -303,7 +337,7 @@ export class GridManager {
     return sorted;
   }
 
-  update(element: GfxModel) {
+  update(element: GfxModel | GfxLocalElementModel) {
     this.remove(element);
     this.add(element);
   }
@@ -383,6 +417,26 @@ export class GridManager {
           if (payload.props['xywh'] || payload.props['externalXYWH']) {
             this.update(surface.getElementById(payload.id)!);
           }
+        })
+      );
+
+      disposables.push(
+        surface.localElementAdded.on(elm => {
+          this.add(elm);
+        })
+      );
+
+      disposables.push(
+        surface.localElementUpdated.on(payload => {
+          if (payload.props['xywh']) {
+            this.update(payload.model);
+          }
+        })
+      );
+
+      disposables.push(
+        surface.localElementDeleted.on(elm => {
+          this.remove(elm);
         })
       );
 

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -49,10 +49,13 @@ export {
 export {
   type BaseElementProps,
   GfxGroupLikeElementModel,
-  GfxLocalElementModel,
   GfxPrimitiveElementModel,
   type SerializedElement,
 } from './model/surface/element-model.js';
+export {
+  GfxLocalElementModel,
+  prop,
+} from './model/surface/local-element-model.js';
 export {
   SurfaceBlockModel,
   type SurfaceBlockProps,

--- a/packages/framework/block-std/src/gfx/layer.ts
+++ b/packages/framework/block-std/src/gfx/layer.ts
@@ -28,6 +28,7 @@ import {
 } from './model/base.js';
 import { GfxBlockElementModel } from './model/gfx-block-model.js';
 import { GfxPrimitiveElementModel } from './model/surface/element-model.js';
+import { GfxLocalElementModel } from './model/surface/local-element-model.js';
 import { SurfaceBlockModel } from './model/surface/surface-model.js';
 
 export type ReorderingDirection = 'front' | 'forward' | 'backward' | 'back';
@@ -96,7 +97,7 @@ export class LayerManager {
   slots = {
     layerUpdated: new Slot<{
       type: 'delete' | 'add' | 'update';
-      initiatingElement: GfxModel;
+      initiatingElement: GfxModel | GfxLocalElementModel;
     }>(),
   };
 
@@ -143,8 +144,13 @@ export class LayerManager {
     this.canvasLayers = canvasLayers;
   }
 
-  private _getModelType(element: GfxModel): 'block' | 'canvas' {
-    return 'flavour' in element ? 'block' : 'canvas';
+  private _getModelType(
+    element: GfxModel | GfxLocalElementModel
+  ): 'block' | 'canvas' {
+    return element instanceof GfxLocalElementModel ||
+      element instanceof GfxPrimitiveElementModel
+      ? 'canvas'
+      : 'block';
   }
 
   private _initLayers() {
@@ -282,6 +288,7 @@ export class LayerManager {
     }
 
     this.layers = layers;
+    this._surface?.localElementModels.forEach(el => this.add(el));
   }
 
   private _insertIntoLayer(target: GfxModel, type: 'block' | 'canvas') {
@@ -414,7 +421,10 @@ export class LayerManager {
     }
   }
 
-  private _removeFromLayer(target: GfxModel, type: 'block' | 'canvas') {
+  private _removeFromLayer(
+    target: GfxModel | GfxLocalElementModel,
+    type: 'block' | 'canvas'
+  ) {
     const layers = this.layers;
     const index = layers.findIndex(layer => {
       if (layer.type !== type) return false;
@@ -502,8 +512,12 @@ export class LayerManager {
   /**
    * @returns a boolean value to indicate whether the layers have been updated
    */
-  private _updateLayer(element: GfxModel, props?: Record<string, unknown>) {
+  private _updateLayer(
+    element: GfxModel | GfxLocalElementModel,
+    props?: Record<string, unknown>
+  ) {
     const modelType = this._getModelType(element);
+    const isLocalElem = element instanceof GfxLocalElementModel;
 
     const indexChanged = !props || 'index' in props;
     const childIdsChanged = props && 'childIds' in props;
@@ -520,10 +534,12 @@ export class LayerManager {
       return true;
     }
 
-    if (modelType === 'canvas') {
-      updateArray(this.canvasElements, element);
-    } else {
-      updateArray(this.blocks, element);
+    if (!isLocalElem) {
+      if (modelType === 'canvas') {
+        updateArray(this.canvasElements, element);
+      } else {
+        updateArray(this.blocks, element);
+      }
     }
 
     if (indexChanged || childIdsChanged) {
@@ -535,9 +551,10 @@ export class LayerManager {
     return false;
   }
 
-  add(element: GfxModel) {
+  add(element: GfxModel | GfxLocalElementModel) {
     const modelType = this._getModelType(element);
     const isContainer = isGfxGroupCompatibleModel(element);
+    const isLocalElem = element instanceof GfxLocalElementModel;
 
     if (isContainer) {
       element.childElements.forEach(child => {
@@ -549,10 +566,12 @@ export class LayerManager {
       });
     }
 
-    insertToOrderedArray(
-      modelType === 'canvas' ? this.canvasElements : this.blocks,
-      element
-    );
+    if (!isLocalElem) {
+      insertToOrderedArray(
+        modelType === 'canvas' ? this.canvasElements : this.blocks,
+        element
+      );
+    }
     this._insertIntoLayer(element as GfxModel, modelType);
 
     if (isContainer) {
@@ -615,9 +634,10 @@ export class LayerManager {
     };
   }
 
-  delete(element: GfxModel) {
+  delete(element: GfxModel | GfxLocalElementModel) {
     let deleteType: 'canvas' | 'block' | undefined = undefined;
     const isGroup = isGfxGroupCompatibleModel(element);
+    const isLocalElem = element instanceof GfxLocalElementModel;
 
     if (isGroup) {
       this._reset();
@@ -628,15 +648,21 @@ export class LayerManager {
       return;
     }
 
-    if (element instanceof GfxPrimitiveElementModel) {
+    if (
+      element instanceof GfxPrimitiveElementModel ||
+      element instanceof GfxLocalElementModel
+    ) {
       deleteType = 'canvas';
-      removeFromOrderedArray(this.canvasElements, element);
+      if (!isLocalElem) {
+        removeFromOrderedArray(this.canvasElements, element);
+      }
     } else {
       deleteType = 'block';
       removeFromOrderedArray(this.blocks, element);
     }
 
     this._removeFromLayer(element, deleteType);
+
     this._buildCanvasLayers();
     this.slots.layerUpdated.emit({
       type: 'delete',
@@ -742,7 +768,10 @@ export class LayerManager {
     return layer.zIndex + layer.elements.indexOf(element);
   }
 
-  update(element: GfxModel, props?: Record<string, unknown>) {
+  update(
+    element: GfxModel | GfxLocalElementModel,
+    props?: Record<string, unknown>
+  ) {
     if (this._updateLayer(element, props)) {
       this._buildCanvasLayers();
       this.slots.layerUpdated.emit({
@@ -823,6 +852,23 @@ export class LayerManager {
       );
       this._disposable.add(
         surface.elementRemoved.on(payload => this.delete(payload.model!))
+      );
+      this._disposable.add(
+        surface.localElementAdded.on(elm => {
+          this.add(elm);
+        })
+      );
+      this._disposable.add(
+        this._surface.localElementUpdated.on(payload => {
+          if (payload.props['index'] || payload.props['groupId']) {
+            this.update(payload.model, payload.props);
+          }
+        })
+      );
+      this._disposable.add(
+        surface.localElementDeleted.on(elm => {
+          this.delete(elm);
+        })
       );
 
       surface.elementModels.forEach(el => this.add(el));

--- a/packages/framework/block-std/src/gfx/model/base.ts
+++ b/packages/framework/block-std/src/gfx/model/base.ts
@@ -99,11 +99,11 @@ export interface GfxGroupCompatibleInterface extends GfxCompatibleInterface {
 
   descendantElements: GfxModel[];
 
-  addChild(element: GfxModel): void;
-  removeChild(element: GfxModel): void;
-  hasChild(element: GfxModel): boolean;
+  addChild(element: GfxCompatibleInterface): void;
+  removeChild(element: GfxCompatibleInterface): void;
+  hasChild(element: GfxCompatibleInterface): boolean;
 
-  hasDescendant(element: GfxModel): boolean;
+  hasDescendant(element: GfxCompatibleInterface): boolean;
 }
 
 /**

--- a/packages/framework/block-std/src/gfx/model/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/element-model.ts
@@ -452,21 +452,21 @@ export abstract class GfxGroupLikeElementModel<
    * The actual field that stores the children of the group.
    * It should be a ymap decorated with `@field`.
    */
-  hasChild(element: GfxModel) {
-    return this.childElements.includes(element);
+  hasChild(element: GfxCompatibleInterface) {
+    return this.childElements.includes(element as GfxModel);
   }
 
   /**
    * Check if the group has the given descendant.
    */
-  hasDescendant(element: GfxModel): boolean {
+  hasDescendant(element: GfxCompatibleInterface): boolean {
     return hasDescendantElementImpl(this, element);
   }
 
   /**
    * Remove the child from the group
    */
-  abstract removeChild(element: GfxModel): void;
+  abstract removeChild(element: GfxCompatibleInterface): void;
 
   /**
    * Set the new value of the childIds
@@ -486,44 +486,6 @@ export abstract class GfxGroupLikeElementModel<
       },
       local: fromLocal,
     });
-  }
-}
-
-export abstract class GfxLocalElementModel {
-  private _lastXYWH: SerializedXYWH = '[0,0,-1,-1]';
-
-  protected _local = new Map<string | symbol, unknown>();
-
-  opacity: number = 1;
-
-  abstract rotate: number;
-
-  abstract xywh: SerializedXYWH;
-
-  get deserializedXYWH() {
-    if (this.xywh !== this._lastXYWH) {
-      const xywh = this.xywh;
-      this._local.set('deserializedXYWH', deserializeXYWH(xywh));
-      this._lastXYWH = xywh;
-    }
-
-    return this._local.get('deserializedXYWH') as XYWH;
-  }
-
-  get h() {
-    return this.deserializedXYWH[3];
-  }
-
-  get w() {
-    return this.deserializedXYWH[2];
-  }
-
-  get x() {
-    return this.deserializedXYWH[0];
-  }
-
-  get y() {
-    return this.deserializedXYWH[1];
   }
 }
 

--- a/packages/framework/block-std/src/gfx/model/surface/local-element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/local-element-model.ts
@@ -1,0 +1,244 @@
+import type { IVec, SerializedXYWH, XYWH } from '@blocksuite/global/utils';
+
+import {
+  Bound,
+  deserializeXYWH,
+  getPointsFromBoundWithRotation,
+  linePolygonIntersects,
+  PointLocation,
+  polygonGetPointTangent,
+  polygonNearestPoint,
+  rotatePoints,
+} from '@blocksuite/global/utils';
+import { mutex } from 'lib0';
+
+import type { EditorHost } from '../../../view/index.js';
+import type { GfxCompatibleInterface, PointTestOptions } from '../base.js';
+import type { GfxGroupModel } from '../model.js';
+import type { SurfaceBlockModel } from './surface-model.js';
+
+export function prop<V, T extends GfxLocalElementModel>() {
+  return function propDecorator(
+    _target: ClassAccessorDecoratorTarget<T, V>,
+    context: ClassAccessorDecoratorContext
+  ) {
+    const prop = context.name;
+
+    return {
+      init(this: T, val: unknown) {
+        this._props.add(prop);
+        this._local.set(prop, val);
+      },
+      get(this: T) {
+        return this._local.get(prop);
+      },
+      set(this: T, val: V) {
+        this._local.set(prop, val);
+      },
+    } as ClassAccessorDecoratorResult<T, V>;
+  };
+}
+
+export abstract class GfxLocalElementModel implements GfxCompatibleInterface {
+  private _mutex: mutex.mutex = mutex.createMutex();
+
+  protected _local = new Map<string | symbol, unknown>();
+
+  /**
+   * Used to store all the name of the properties that have been decorated
+   * with the `@prop`
+   */
+  protected _props = new Set<string | symbol>();
+
+  protected _surface: SurfaceBlockModel;
+
+  /**
+   * used to store the properties' cache key
+   * when the properties required heavy computation
+   */
+  cache = new Map<string | symbol, unknown>();
+
+  id: string = '';
+
+  abstract readonly type: string;
+
+  get deserializedXYWH() {
+    if (!this._local.has('deserializedXYWH')) {
+      const xywh = this.xywh;
+      const deserialized = deserializeXYWH(xywh);
+
+      this._local.set('deserializedXYWH', deserialized);
+    }
+
+    return this._local.get('deserializedXYWH') as XYWH;
+  }
+
+  get elementBound() {
+    return new Bound(this.x, this.y, this.w, this.h);
+  }
+
+  get group() {
+    return (
+      this.groupId ? this._surface.getElementById(this.groupId) : null
+    ) as GfxGroupModel | null;
+  }
+
+  get groups() {
+    if (this.group) {
+      const groups = this._surface.getGroups(this.group.id);
+      groups.unshift(this.group);
+
+      return groups;
+    }
+
+    return [];
+  }
+
+  get h() {
+    return this.deserializedXYWH[3];
+  }
+
+  get surface() {
+    return this._surface;
+  }
+
+  get w() {
+    return this.deserializedXYWH[2];
+  }
+
+  get x() {
+    return this.deserializedXYWH[0];
+  }
+
+  get y() {
+    return this.deserializedXYWH[1];
+  }
+
+  constructor(surfaceModel: SurfaceBlockModel) {
+    this._surface = surfaceModel;
+
+    const p = new Proxy(this, {
+      set: (target, prop, value) => {
+        if (prop === 'xywh') {
+          this._local.delete('deserializedXYWH');
+        }
+
+        // @ts-ignore
+        const oldValue = target[prop as string];
+
+        if (oldValue === value) {
+          return true;
+        }
+
+        // @ts-ignore
+        target[prop as string] = value;
+
+        if (!this._props.has(prop)) {
+          return true;
+        }
+
+        if (surfaceModel.localElementModels.has(p)) {
+          this._mutex(() => {
+            surfaceModel.localElementUpdated.emit({
+              model: p,
+              props: {
+                [prop as string]: value,
+              },
+              oldValues: {
+                [prop as string]: oldValue,
+              },
+            });
+          });
+        }
+
+        return true;
+      },
+    });
+
+    return p;
+  }
+
+  containsBound(bounds: Bound): boolean {
+    return getPointsFromBoundWithRotation(this).some(point =>
+      bounds.containsPoint(point)
+    );
+  }
+
+  getLineIntersections(start: IVec, end: IVec) {
+    const points = getPointsFromBoundWithRotation(this);
+    return linePolygonIntersects(start, end, points);
+  }
+
+  getNearestPoint(point: IVec) {
+    const points = getPointsFromBoundWithRotation(this);
+    return polygonNearestPoint(points, point);
+  }
+
+  getRelativePointLocation(relativePoint: IVec) {
+    const bound = Bound.deserialize(this.xywh);
+    const point = bound.getRelativePoint(relativePoint);
+    const rotatePoint = rotatePoints([point], bound.center, this.rotate)[0];
+    const points = rotatePoints(bound.points, bound.center, this.rotate);
+    const tangent = polygonGetPointTangent(points, rotatePoint);
+    return new PointLocation(rotatePoint, tangent);
+  }
+
+  includesPoint(
+    x: number,
+    y: number,
+    _: PointTestOptions,
+    __: EditorHost
+  ): boolean {
+    return this.elementBound.isPointInBound([x, y]);
+  }
+
+  intersectsBound(bound: Bound): boolean {
+    return (
+      this.containsBound(bound) ||
+      bound.points.some((point, i, points) =>
+        this.getLineIntersections(point, points[(i + 1) % points.length])
+      )
+    );
+  }
+
+  isLocked() {
+    return false;
+  }
+
+  isLockedByAncestor() {
+    return false;
+  }
+
+  isLockedBySelf() {
+    return false;
+  }
+
+  lock() {
+    return;
+  }
+
+  unlock() {
+    return;
+  }
+
+  @prop()
+  accessor groupId: string = '';
+
+  @prop()
+  accessor hidden: boolean = false;
+
+  @prop()
+  accessor index: string = 'a0';
+
+  @prop()
+  accessor opacity: number = 1;
+
+  @prop()
+  accessor rotate: number = 0;
+
+  @prop()
+  accessor seed: number = Math.random();
+
+  @prop()
+  accessor xywh: SerializedXYWH = '[0,0,0,0]';
+}

--- a/packages/framework/block-std/src/utils/layer.ts
+++ b/packages/framework/block-std/src/utils/layer.ts
@@ -2,6 +2,7 @@ import type { Doc } from '@blocksuite/store';
 
 import { nToLast } from '@blocksuite/global/utils';
 
+import type { GfxLocalElementModel } from '../gfx/index.js';
 import type { Layer } from '../gfx/layer.js';
 import type { GfxBlockElementModel } from '../gfx/model/gfx-block-model.js';
 import type { GfxModel } from '../gfx/model/model.js';
@@ -97,27 +98,29 @@ export function renderableInEdgeless(
  * SortOrder.AFTER means a should be rendered after b and so on.
  * @returns
  */
-export function compare(a: GfxModel, b: GfxModel) {
-  const surface = a.surface ?? b.surface;
-  if (!surface) return SortOrder.SAME;
-
-  if (isGfxGroupCompatibleModel(a) && a.hasDescendant(b)) {
+export function compare(
+  a: GfxModel | GfxLocalElementModel,
+  b: GfxModel | GfxLocalElementModel
+) {
+  if (isGfxGroupCompatibleModel(a) && b.groups.includes(a)) {
     return SortOrder.BEFORE;
-  } else if (isGfxGroupCompatibleModel(b) && b.hasDescendant(a)) {
+  } else if (isGfxGroupCompatibleModel(b) && a.groups.includes(b)) {
     return SortOrder.AFTER;
   } else {
     const aGroups = a.groups as GfxGroupCompatibleInterface[];
     const bGroups = b.groups as GfxGroupCompatibleInterface[];
 
     let i = 1;
-    let aGroup: GfxModel | GfxGroupCompatibleInterface | undefined = nToLast(
-      aGroups,
-      i
-    );
-    let bGroup: GfxModel | GfxGroupCompatibleInterface | undefined = nToLast(
-      bGroups,
-      i
-    );
+    let aGroup:
+      | GfxModel
+      | GfxGroupCompatibleInterface
+      | GfxLocalElementModel
+      | undefined = nToLast(aGroups, i);
+    let bGroup:
+      | GfxModel
+      | GfxGroupCompatibleInterface
+      | GfxLocalElementModel
+      | undefined = nToLast(bGroups, i);
 
     while (aGroup === bGroup && aGroup) {
       ++i;

--- a/packages/framework/block-std/src/utils/tree.ts
+++ b/packages/framework/block-std/src/utils/tree.ts
@@ -1,9 +1,9 @@
 import type { Doc } from '@blocksuite/store';
 
-import type { GfxCompatibleInterface } from '../gfx/index.js';
 import type { GfxGroupModel, GfxModel } from '../gfx/model/model.js';
 
 import {
+  type GfxCompatibleInterface,
   type GfxGroupCompatibleInterface,
   isGfxGroupCompatibleModel,
 } from '../gfx/model/base.js';
@@ -85,7 +85,7 @@ export function descendantElementsImpl(
 
 export function hasDescendantElementImpl(
   container: GfxGroupCompatibleInterface,
-  element: GfxModel
+  element: GfxCompatibleInterface
 ): boolean {
   let _container = element.group;
   while (_container) {
@@ -100,7 +100,7 @@ export function hasDescendantElementImpl(
  */
 export function canSafeAddToContainer(
   container: GfxGroupModel,
-  element: GfxModel
+  element: GfxCompatibleInterface
 ) {
   if (
     element === container ||

--- a/tests/utils/actions/edgeless.ts
+++ b/tests/utils/actions/edgeless.ts
@@ -1776,8 +1776,8 @@ export async function getSortedIdsInViewport(page: Page) {
     if (!container) throw new Error('container not found');
     const { service } = container;
     return service.gfx.grid
-      .search(service.viewport.viewportBounds, undefined, {
-        filter: model => !('flavour' in model),
+      .search(service.viewport.viewportBounds, {
+        filter: ['canvas'],
       })
       .map(e => e.id);
   });


### PR DESCRIPTION
### Defining a New Local Element

To define a local element, create a class that extends `GfxLocalElementModel`, and use the `@prop` decorator on any field that you want to track changes for via `localElementUpdated`.

Note: Do **not** use any Yjs data structures, as local elements are intended for local data only. 

Example:

```typescript
import { GfxLocalElementModel, prop } from '@blocksuite/block-std/gfx';

export class LocalTextElement extends GfxLocalElementModel {
  get type() {
    return 'text'
  }

  @prop()
  accessor text: string = '';
}
```
Once the class is defined, create an instance with `const localText = new LocalTextElement(surfaceModel)`. You can then use its render function to manually render the model.

To watch `@prop` decorated property changes, use `surface.localElementUpdated` to listen for updates.

### Adding to surface model

Add instances to the surface using the `surface.addLocalElement` method. This enables event support and automatic rendering—there’s no need to call the render function manually.

When the element is no longer needed, remove it from the surface with `surface.deleteLocalElement`.

Calling `addLocalElement` and `deleteLocalElement` will trigger `localElementAdded` and `localElementDeleted` slot respectively.

Note: Adding to the surface is **not** required if a local instance is sufficient for your needs.