### PR TITLE
fix(std): pan and pinch events were calculate relative to only one finger

### DIFF
--- a/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-block.ts
@@ -224,9 +224,9 @@ export class EdgelessRootBlockComponent extends BlockComponent<
         const [p1, p2] = multiPointersState.pointers;
 
         const dx =
-          (0.5 * (p1.delta.x + p2.delta.x)) / viewport.zoom / viewport.scale;
+          (0.25 * (p1.delta.x + p2.delta.x)) / viewport.zoom / viewport.scale;
         const dy =
-          (0.5 * (p1.delta.y + p2.delta.y)) / viewport.zoom / viewport.scale;
+          (0.25 * (p1.delta.y + p2.delta.y)) / viewport.zoom / viewport.scale;
 
         // direction is opposite
         viewport.applyDeltaCenter(-dx, -dy);

--- a/packages/framework/block-std/src/event/control/pointer.ts
+++ b/packages/framework/block-std/src/event/control/pointer.ts
@@ -1,5 +1,5 @@
 import { IS_IPAD } from '@blocksuite/global/env';
-import { dotProduct, magnitude } from '@blocksuite/global/utils';
+import { Vec } from '@blocksuite/global/utils';
 
 import type { UIEventDispatcher } from '../dispatcher.js';
 
@@ -486,13 +486,16 @@ class PinchController extends DualDragControllerBase {
   override _handleMove(event: PointerEvent, state: MultiPointerEventState) {
     if (event.pointerType !== 'touch') return;
 
-    const deltaFirstPointerVec = state.pointers[0].delta;
-    const deltaSecondPointerVec = state.pointers[1].delta;
+    const deltaFirstPointer = state.pointers[0].delta;
+    const deltaSecondPointer = state.pointers[1].delta;
 
-    const deltaFirstPointerValue = magnitude(deltaFirstPointerVec);
-    const deltaSecondPointerValue = magnitude(deltaSecondPointerVec);
+    const deltaFirstPointerVec = Vec.toVec(deltaFirstPointer);
+    const deltaSecondPointerVec = Vec.toVec(deltaSecondPointer);
 
-    const deltaDotProduct = dotProduct(
+    const deltaFirstPointerValue = Vec.len(deltaFirstPointerVec);
+    const deltaSecondPointerValue = Vec.len(deltaSecondPointerVec);
+
+    const deltaDotProduct = Vec.dpr(
       deltaFirstPointerVec,
       deltaSecondPointerVec
     );
@@ -501,7 +504,7 @@ class PinchController extends DualDragControllerBase {
 
     // the changes of distance between two pointers is not far enough
     if (
-      !isFarEnough(deltaFirstPointerVec, deltaSecondPointerVec) ||
+      !isFarEnough(deltaFirstPointer, deltaSecondPointer) ||
       deltaDotProduct > 0 ||
       deltaFirstPointerValue < deltaValueThreshold ||
       deltaSecondPointerValue < deltaValueThreshold
@@ -516,17 +519,17 @@ class PanController extends DualDragControllerBase {
   override _handleMove(event: PointerEvent, state: MultiPointerEventState) {
     if (event.pointerType !== 'touch') return;
 
-    const deltaFirstPointerVec = state.pointers[0].delta;
-    const deltaSecondPointerVec = state.pointers[1].delta;
+    const deltaFirstPointer = state.pointers[0].delta;
+    const deltaSecondPointer = state.pointers[1].delta;
 
-    const deltaDotProduct = dotProduct(
-      deltaFirstPointerVec,
-      deltaSecondPointerVec
+    const deltaDotProduct = Vec.dpr(
+      Vec.toVec(deltaFirstPointer),
+      Vec.toVec(deltaSecondPointer)
     );
 
     // the center move distance is not far enough
     if (
-      !isFarEnough(deltaFirstPointerVec, deltaSecondPointerVec) &&
+      !isFarEnough(deltaFirstPointer, deltaSecondPointer) &&
       deltaDotProduct < 0
     )
       return;

--- a/packages/framework/global/src/utils/math.ts
+++ b/packages/framework/global/src/utils/math.ts
@@ -1,3 +1,4 @@
+import type { IPoint } from '../utils.js';
 import type { Bound, IBound } from './model/bound.js';
 
 import { PointLocation } from './model/point-location.js';
@@ -535,4 +536,12 @@ export function getCenterAreaBounds(bounds: IBound, ratio: number) {
     h: nh,
     rotate,
   };
+}
+
+export function dotProduct(vectorA: IPoint, vectorB: IPoint) {
+  return vectorA.x * vectorB.x + vectorA.y * vectorB.y;
+}
+
+export function magnitude(vector: IPoint) {
+  return Math.sqrt(vector.x * vector.x + vector.y * vector.y);
 }

--- a/packages/framework/global/src/utils/math.ts
+++ b/packages/framework/global/src/utils/math.ts
@@ -1,4 +1,3 @@
-import type { IPoint } from '../utils.js';
 import type { Bound, IBound } from './model/bound.js';
 
 import { PointLocation } from './model/point-location.js';
@@ -536,12 +535,4 @@ export function getCenterAreaBounds(bounds: IBound, ratio: number) {
     h: nh,
     rotate,
   };
-}
-
-export function dotProduct(vectorA: IPoint, vectorB: IPoint) {
-  return vectorA.x * vectorB.x + vectorA.y * vectorB.y;
-}
-
-export function magnitude(vector: IPoint) {
-  return Math.sqrt(vector.x * vector.x + vector.y * vector.y);
 }

--- a/tests/edgeless/basic.spec.ts
+++ b/tests/edgeless/basic.spec.ts
@@ -139,8 +139,8 @@ test('zoom by pinch', async ({ page }) => {
     { x: CENTER_X + 100, y: CENTER_Y },
   ];
   const to = [
-    { x: CENTER_X - 50, y: CENTER_Y },
-    { x: CENTER_X + 50, y: CENTER_Y },
+    { x: CENTER_X - 50, y: CENTER_Y - 35 },
+    { x: CENTER_X + 50, y: CENTER_Y + 35 },
   ];
   await multiTouchDown(page, from);
   await multiTouchMove(page, from, to);
@@ -166,8 +166,8 @@ test('zoom by pinch when edgeless is readonly', async ({ page }) => {
     { x: CENTER_X + 100, y: CENTER_Y },
   ];
   const to = [
-    { x: CENTER_X - 50, y: CENTER_Y },
-    { x: CENTER_X + 50, y: CENTER_Y },
+    { x: CENTER_X - 50, y: CENTER_Y - 35 },
+    { x: CENTER_X + 50, y: CENTER_Y + 35 },
   ];
   await multiTouchDown(page, from);
   await multiTouchMove(page, from, to);


### PR DESCRIPTION
Improves the calculation of multi-touch gestures and makes them smoother on Android and fixes them on iOS
**master android samsung galaxy s24 chrome:**

https://github.com/user-attachments/assets/5a41d922-bfdd-4743-b445-0cfa69175136

Visible jumps during pan gesture
**current branch with fix android samsung galaxy s24 chrome:**

https://github.com/user-attachments/assets/647bb8e9-0e58-4aaa-bf14-179be74f31a6

Smooth pan gesture with two fingers without jumping

