### PR TITLE
fix: should show alias icon when title has alias

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-node.ts
@@ -9,6 +9,7 @@ import {
 } from '@blocksuite/block-std';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { WithDisposable } from '@blocksuite/global/utils';
+import { AliasIcon } from '@blocksuite/icons/lit';
 import {
   type DeltaInsert,
   INLINE_ROOT_ATTR,
@@ -241,6 +242,9 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
       return nothing;
     }
 
+    const hasTitleAlias = Boolean(
+      reference?.title && reference.title.length > 0
+    );
     const title = this.customTitle
       ? this.customTitle(this)
       : isDeleted
@@ -252,7 +256,12 @@ export class AffineReference extends WithDisposable(ShadowlessElement) {
       [
         [
           'LinkedPage',
-          () => (this.isLinkToNode() ? BlockLinkIcon : FontLinkedDocIcon),
+          () =>
+            hasTitleAlias
+              ? AliasIcon()
+              : this.isLinkToNode()
+                ? BlockLinkIcon
+                : FontLinkedDocIcon,
         ],
         ['Subpage', () => FontDocIcon],
       ],


### PR DESCRIPTION
Closes: [BS-2066](https://linear.app/affine-design/issue/BS-2066/inline-view-改了-alias-之后没有显示-alias-图标)