### PR TITLE
fix(playground): adapt docs panel to dark mode

### DIFF
--- a/packages/playground/apps/_common/components/docs-panel.ts
+++ b/packages/playground/apps/_common/components/docs-panel.ts
@@ -31,6 +31,9 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
     .doc-item:hover .delete-doc-icon {
       display: flex;
     }
+    .doc-item {
+      color: var(--affine-text-primary-color);
+    }
     .delete-doc-icon {
       display: none;
       padding: 2px;
@@ -54,6 +57,7 @@ export class DocsPanel extends WithDisposable(ShadowlessElement) {
       align-items: center;
       justify-content: center;
       cursor: pointer;
+      color: var(--affine-text-primary-color);
     }
     .new-doc-button:hover {
       background-color: var(--affine-hover-color);


### PR DESCRIPTION
Before:

<img width="735" alt="image" src="https://github.com/user-attachments/assets/ae5f862b-0d92-460c-9c28-b7a66f63521d">


After:

<img width="719" alt="image" src="https://github.com/user-attachments/assets/71c46042-9497-40ff-86f2-ede5c440d5d2">
