### PR TITLE
feat(edgeless): add views and event support for canvas elements

### DIFF
--- a/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/event-ext.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/event-ext.ts
@@ -1,0 +1,65 @@
+import type { PointerEventState } from '@blocksuite/block-std';
+import type { GfxElementModelView } from '@blocksuite/block-std/gfx';
+
+import { Bound, last } from '@blocksuite/global/utils';
+
+import { DefaultModeDragType, DefaultToolExt } from './ext.js';
+
+export class CanvasElementEventExt extends DefaultToolExt {
+  private _currentStackedElm: GfxElementModelView[] = [];
+
+  override supportedDragTypes: DefaultModeDragType[] = [
+    DefaultModeDragType.None,
+  ];
+
+  private _callInReverseOrder(
+    callback: (view: GfxElementModelView) => void,
+    arr = this._currentStackedElm
+  ) {
+    for (let i = arr.length - 1; i >= 0; i--) {
+      const view = arr[i];
+
+      callback(view);
+    }
+  }
+
+  override click(_evt: PointerEventState): void {
+    last(this._currentStackedElm)?.dispatch('click', _evt);
+  }
+
+  override dblClick(_evt: PointerEventState): void {
+    last(this._currentStackedElm)?.dispatch('dblclick', _evt);
+  }
+
+  override pointerDown(_evt: PointerEventState): void {
+    last(this._currentStackedElm)?.dispatch('pointerdown', _evt);
+  }
+
+  override pointerMove(_evt: PointerEventState): void {
+    const [x, y] = this.gfx.viewport.toModelCoord(_evt.x, _evt.y);
+    const hoveredElmViews = this.gfx.grid
+      .search(new Bound(x, y, 1, 1), {
+        filter: ['canvas', 'local'],
+      })
+      .map(model => this.gfx.view.get(model)) as GfxElementModelView[];
+    const currentStackedViews = new Set(this._currentStackedElm);
+    const visited = new Set<GfxElementModelView>();
+
+    this._callInReverseOrder(view => {
+      if (currentStackedViews.has(view)) {
+        visited.add(view);
+        view.dispatch('pointermove', _evt);
+      } else {
+        view.dispatch('pointerenter', _evt);
+      }
+    }, hoveredElmViews);
+    this._callInReverseOrder(
+      view => !visited.has(view) && view.dispatch('pointerleave', _evt)
+    );
+    this._currentStackedElm = hoveredElmViews;
+  }
+
+  override pointerUp(_evt: PointerEventState): void {
+    last(this._currentStackedElm)?.dispatch('pointerup', _evt);
+  }
+}

--- a/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/ext.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/ext.ts
@@ -27,6 +27,8 @@ export type DragState = {
 };
 
 export class DefaultToolExt {
+  readonly supportedDragTypes: DefaultModeDragType[] = [];
+
   get gfx() {
     return this.defaultTool.gfx;
   }
@@ -37,6 +39,10 @@ export class DefaultToolExt {
 
   constructor(protected defaultTool: DefaultTool) {}
 
+  click(_evt: PointerEventState) {}
+
+  dblClick(_evt: PointerEventState) {}
+
   initDrag(_: DragState): {
     dragStart?: (evt: PointerEventState) => void;
     dragMove?: (evt: PointerEventState) => void;
@@ -46,6 +52,12 @@ export class DefaultToolExt {
   }
 
   mounted() {}
+
+  pointerDown(_evt: PointerEventState) {}
+
+  pointerMove(_evt: PointerEventState) {}
+
+  pointerUp(_evt: PointerEventState) {}
 
   unmounted() {}
 }

--- a/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/mind-map-ext/mind-map-ext.ts
+++ b/packages/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/mind-map-ext/mind-map-ext.ts
@@ -39,6 +39,10 @@ type DragMindMapCtx = {
 export class MindMapExt extends DefaultToolExt {
   private _responseAreaUpdated = new Set<MindmapElementModel>();
 
+  override supportedDragTypes: DefaultModeDragType[] = [
+    DefaultModeDragType.ContentMoving,
+  ];
+
   private get _indicatorOverlay() {
     return this.std.getOptional(
       OverlayIdentifier('mindmap-indicator')

--- a/packages/framework/block-std/src/gfx/index.ts
+++ b/packages/framework/block-std/src/gfx/index.ts
@@ -75,7 +75,14 @@ export {
   type GfxToolsMap,
   type GfxToolsOption,
 } from './tool/tool.js';
+
 export { MouseButton, ToolController } from './tool/tool-controller.js';
+export {
+  type EventsHandlerMap,
+  GfxElementModelView,
+  type SupportedEvent,
+} from './view/view.js';
+export { ViewManager } from './view/view-manager.js';
 export * from './viewport.js';
 export { GfxViewportElement } from './viewport-element.js';
 export { generateKeyBetween, generateNKeysBetween } from 'fractional-indexing';

--- a/packages/framework/block-std/src/gfx/model/surface/element-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/element-model.ts
@@ -1,5 +1,9 @@
-import type { IVec, SerializedXYWH, XYWH } from '@blocksuite/global/utils';
-
+import {
+  type IVec,
+  type SerializedXYWH,
+  Slot,
+  type XYWH,
+} from '@blocksuite/global/utils';
 import {
   Bound,
   deserializeXYWH,
@@ -85,6 +89,8 @@ export abstract class GfxPrimitiveElementModel<
   protected _preserved = new Map<string, unknown>();
 
   protected _stashed: Map<keyof Props | string, unknown>;
+
+  propsUpdated = new Slot<{ key: string }>();
 
   abstract rotate: number;
 

--- a/packages/framework/block-std/src/gfx/model/surface/surface-model.ts
+++ b/packages/framework/block-std/src/gfx/model/surface/surface-model.ts
@@ -279,7 +279,12 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
                     element.get('id') as string,
                     element,
                     {
-                      onChange: payload => this.elementUpdated.emit(payload),
+                      onChange: payload => {
+                        this.elementUpdated.emit(payload);
+                        Object.keys(payload.props).forEach(key => {
+                          model.model.propsUpdated.emit({ key });
+                        });
+                      },
                       skipFieldInit: true,
                     }
                   );
@@ -321,7 +326,12 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
         val.get('id') as string,
         val,
         {
-          onChange: payload => this.elementUpdated.emit(payload),
+          onChange: payload => {
+            this.elementUpdated.emit(payload),
+              Object.keys(payload.props).forEach(key => {
+                model.model.propsUpdated.emit({ key });
+              });
+          },
           skipFieldInit: true,
         }
       );
@@ -443,7 +453,12 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
     props.id = id;
 
     const elementModel = this._createElementFromProps(props, {
-      onChange: payload => this.elementUpdated.emit(payload),
+      onChange: payload => {
+        this.elementUpdated.emit(payload);
+        Object.keys(payload.props).forEach(key => {
+          elementModel.model.propsUpdated.emit({ key });
+        });
+      },
     });
 
     this._elementModels.set(id, elementModel);

--- a/packages/framework/block-std/src/gfx/surface-middleware.ts
+++ b/packages/framework/block-std/src/gfx/surface-middleware.ts
@@ -52,9 +52,10 @@ export class SurfaceMiddlewareExtension extends LifeCycleWatcher {
       this.std.provider.getAll(SurfaceMiddlewareBuilderIdentifier).values()
     );
 
-    onSurfaceAdded(this.std.doc, surface => {
+    const dispose = onSurfaceAdded(this.std.doc, surface => {
       if (surface) {
         surface.applyMiddlewares(builders.map(builder => builder.middleware));
+        queueMicrotask(() => dispose());
       }
     });
   }

--- a/packages/framework/block-std/src/gfx/view/view-manager.ts
+++ b/packages/framework/block-std/src/gfx/view/view-manager.ts
@@ -1,0 +1,131 @@
+import { DisposableGroup } from '@blocksuite/global/utils';
+
+import type { GfxController } from '../controller.js';
+import type { GfxModel } from '../model/model.js';
+import type { GfxLocalElementModel } from '../model/surface/local-element-model.js';
+import type { SurfaceBlockModel } from '../model/surface/surface-model.js';
+
+import { onSurfaceAdded } from '../../utils/gfx.js';
+import { GfxExtension, GfxExtensionIdentifier } from '../extension.js';
+import { GfxBlockElementModel } from '../model/gfx-block-model.js';
+import {
+  GfxElementModelView,
+  GfxElementModelViewExtIdentifier,
+} from './view.js';
+
+export class ViewManager extends GfxExtension {
+  static override key = 'viewManager';
+
+  private _disposable = new DisposableGroup();
+
+  private _viewCtorMap = new Map<string, typeof GfxElementModelView>();
+
+  private _viewMap = new Map<string, GfxElementModelView>();
+
+  constructor(gfx: GfxController) {
+    super(gfx);
+  }
+
+  static override extendGfx(gfx: GfxController): void {
+    Object.defineProperty(gfx, 'view', {
+      get() {
+        return this.std.get(GfxExtensionIdentifier('viewManager'));
+      },
+    });
+  }
+
+  get(model: GfxModel | GfxLocalElementModel | string) {
+    if (typeof model === 'string') {
+      if (this._viewMap.has(model)) {
+        return this._viewMap.get(model);
+      }
+
+      return this.std.view.getBlock(model) ?? null;
+    } else {
+      if (model instanceof GfxBlockElementModel) {
+        return this.std.view.getBlock(model.id) ?? null;
+      } else {
+        return this._viewMap.get(model.id) ?? null;
+      }
+    }
+  }
+
+  override mounted(): void {
+    this.std.provider
+      .getAll(GfxElementModelViewExtIdentifier)
+      .forEach(viewCtor => {
+        this._viewCtorMap.set(viewCtor.type, viewCtor);
+      });
+
+    const updateViewOnElementChange = (surface: SurfaceBlockModel) => {
+      this._disposable.add(
+        surface.elementAdded.on(payload => {
+          const model = surface.getElementById(payload.id)!;
+          const View = this._viewCtorMap.get(model.type) ?? GfxElementModelView;
+
+          this._viewMap.set(model.id, new View(model, this.gfx));
+        })
+      );
+
+      this._disposable.add(
+        surface.elementRemoved.on(elem => {
+          const view = this._viewMap.get(elem.id);
+          this._viewMap.delete(elem.id);
+          view?.onDestroyed();
+        })
+      );
+
+      this._disposable.add(
+        surface.localElementAdded.on(model => {
+          const View = this._viewCtorMap.get(model.type) ?? GfxElementModelView;
+
+          this._viewMap.set(model.id, new View(model, this.gfx));
+        })
+      );
+
+      this._disposable.add(
+        surface.localElementDeleted.on(model => {
+          const view = this._viewMap.get(model.id);
+          this._viewMap.delete(model.id);
+          view?.onDestroyed();
+        })
+      );
+
+      surface.localElementModels.forEach(model => {
+        const View = this._viewCtorMap.get(model.type) ?? GfxElementModelView;
+
+        this._viewMap.set(model.id, new View(model, this.gfx));
+      });
+
+      surface.elementModels.forEach(model => {
+        const View = this._viewCtorMap.get(model.type) ?? GfxElementModelView;
+
+        this._viewMap.set(model.id, new View(model, this.gfx));
+      });
+    };
+
+    if (this.gfx.surface) {
+      updateViewOnElementChange(this.gfx.surface);
+    } else {
+      this._disposable.add(
+        onSurfaceAdded(this.std.doc, surface => {
+          if (surface) {
+            updateViewOnElementChange(surface);
+          }
+        })
+      );
+    }
+  }
+
+  override unmounted(): void {
+    this._disposable.dispose();
+    this._viewMap.forEach(view => view.onDestroyed());
+    this._viewMap.clear();
+  }
+}
+
+declare module '../controller.js' {
+  interface GfxController {
+    readonly view: ViewManager;
+  }
+}

--- a/packages/framework/block-std/src/gfx/view/view.ts
+++ b/packages/framework/block-std/src/gfx/view/view.ts
@@ -1,0 +1,174 @@
+import { type Container, createIdentifier } from '@blocksuite/global/di';
+import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
+import {
+  type Bound,
+  DisposableGroup,
+  type IVec,
+} from '@blocksuite/global/utils';
+
+import type { PointerEventState } from '../../event/index.js';
+import type { Extension } from '../../extension/extension.js';
+import type { EditorHost } from '../../view/index.js';
+import type { GfxController } from '../index.js';
+import type { GfxElementGeometry, PointTestOptions } from '../model/base.js';
+import type { GfxPrimitiveElementModel } from '../model/surface/element-model.js';
+import type { GfxLocalElementModel } from '../model/surface/local-element-model.js';
+
+export type EventsHandlerMap = {
+  click: (e: PointerEventState) => void;
+  dblclick: (e: PointerEventState) => void;
+  pointerdown: (e: PointerEventState) => void;
+  pointerenter: (e: PointerEventState) => void;
+  pointerleave: (e: PointerEventState) => void;
+  pointermove: (e: PointerEventState) => void;
+  pointerup: (e: PointerEventState) => void;
+};
+
+export type SupportedEvent = keyof EventsHandlerMap;
+
+export const GfxElementModelViewExtIdentifier = createIdentifier<
+  typeof GfxElementModelView
+>('GfxElementModelView');
+
+export class GfxElementModelView<
+    T extends GfxLocalElementModel | GfxPrimitiveElementModel =
+      | GfxPrimitiveElementModel
+      | GfxLocalElementModel,
+    RendererContext = object,
+  >
+  implements GfxElementGeometry, Extension
+{
+  static type: string;
+
+  private _handlers = new Map<
+    keyof EventsHandlerMap,
+    ((evt: unknown) => void)[]
+  >();
+
+  private _isConnected = true;
+
+  protected disposable = new DisposableGroup();
+
+  readonly model: T;
+
+  get isConnected() {
+    return this._isConnected;
+  }
+
+  get rotate() {
+    return this.model.rotate;
+  }
+
+  get surface() {
+    return this.model.surface;
+  }
+
+  get type() {
+    return this.model.type;
+  }
+
+  constructor(
+    model: T,
+    readonly gfx: GfxController
+  ) {
+    this.model = model;
+    this.onCreated();
+  }
+
+  static setup(di: Container): void {
+    if (!this.type) {
+      throw new BlockSuiteError(
+        ErrorCode.ValueNotExists,
+        'The GfxElementModelView should have a static `type` property.'
+      );
+    }
+
+    di.addImpl(GfxElementModelViewExtIdentifier(this.type), () => this);
+  }
+
+  containsBound(bounds: Bound): boolean {
+    return this.model.containsBound(bounds);
+  }
+
+  dispatch<K extends keyof EventsHandlerMap>(
+    event: K,
+    evt: Parameters<EventsHandlerMap[K]>[0]
+  ) {
+    this._handlers.get(event)?.forEach(callback => callback(evt));
+  }
+
+  getLineIntersections(start: IVec, end: IVec) {
+    return this.model.getLineIntersections(start, end);
+  }
+
+  getNearestPoint(point: IVec) {
+    return this.model.getNearestPoint(point);
+  }
+
+  getRelativePointLocation(relativePoint: IVec) {
+    return this.model.getRelativePointLocation(relativePoint);
+  }
+
+  includesPoint(
+    x: number,
+    y: number,
+    _: PointTestOptions,
+    __: EditorHost
+  ): boolean {
+    return this.model.includesPoint(x, y, _, __);
+  }
+
+  intersectsBound(bound: Bound): boolean {
+    return (
+      this.containsBound(bound) ||
+      bound.points.some((point, i, points) =>
+        this.getLineIntersections(point, points[(i + 1) % points.length])
+      )
+    );
+  }
+
+  off<K extends keyof EventsHandlerMap>(event: K, callback: () => void) {
+    if (!this._handlers.has(event)) {
+      return;
+    }
+
+    const callbacks = this._handlers.get(event)!;
+    const index = callbacks.indexOf(callback);
+
+    if (index !== -1) {
+      callbacks.splice(index, 1);
+    }
+  }
+
+  on<K extends keyof EventsHandlerMap>(event: K, callback: () => void) {
+    if (!this._handlers.has(event)) {
+      this._handlers.set(event, []);
+    }
+
+    this._handlers.get(event)!.push(callback);
+
+    return () => this.off(event, callback);
+  }
+
+  once<K extends keyof EventsHandlerMap>(event: K, callback: () => void) {
+    const off = this.on(event, () => {
+      off();
+      callback();
+    });
+
+    return off;
+  }
+
+  onCreated() {}
+
+  /**
+   * Called when the view is destroyed.
+   * Override this method requires calling `super.onDestroyed()`.
+   */
+  onDestroyed() {
+    this._isConnected = false;
+    this.disposable.dispose();
+  }
+
+  render(_: RendererContext) {}
+}

--- a/packages/framework/block-std/src/scope/block-std-scope.ts
+++ b/packages/framework/block-std/src/scope/block-std-scope.ts
@@ -12,6 +12,7 @@ import { UIEventDispatcher } from '../event/index.js';
 import { GfxController } from '../gfx/controller.js';
 import { GfxSelectionManager } from '../gfx/selection.js';
 import { SurfaceMiddlewareExtension } from '../gfx/surface-middleware.js';
+import { ViewManager } from '../gfx/view/view-manager.js';
 import {
   BlockServiceIdentifier,
   BlockViewIdentifier,
@@ -51,6 +52,7 @@ const internalExtensions = [
   CursorSelectionExtension,
   GfxSelectionManager,
   SurfaceMiddlewareExtension,
+  ViewManager,
 ];
 
 export class BlockStdScope {


### PR DESCRIPTION
### **Introducing Views for Canvas Elements**

This PR introduces the concept of views for canvas elements. Each canvas element, including those local element added via `addLocalElement`, now has an associated view instance. Views handle logic related to the view layer, such as binding mouse events to elements.

```typescript
const modelView = std.gfx.view.get(model);

view.on('pointerenter', () => {
  console.log('mouse entered the element.');
});
```

You don’t need to manually instantiate views for elements. They are automatically managed by the `ViewManager`.

### **Custom View Classes**

By default, each element's view is an instance of the `GfxElementModelView` class. However, you can define custom view classes for specific element types

```typescript
import { GfxElementModelView } from '@blocksuite/block-std/gfx';

export class ShapeView extends GfxElementModelView {
  // Required static property: the model type this view is associated with
  static override type = 'shape';

  onCreated() {
    this.on('click', () => {
      enterShapeTextEditor(this.model);
    });
  }
}

// surface-spec.ts
export surfaceSpec = [
  //... other extensions
  ShapeView
];
```

### **Supported Events**

The following mouse events are currently supported by views:

- `click`
- `dblclick`
- `pointerdown`
- `pointerenter`
- `pointerleave`
- `pointermove`
- `pointerup`