### PR TITLE
fix(playground): starter debug menu theming

### DIFF
--- a/packages/playground/apps/_common/components/collab-debug-menu.ts
+++ b/packages/playground/apps/_common/components/collab-debug-menu.ts
@@ -44,8 +44,8 @@ const basePath =
   'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.11.2/dist/';
 setBasePath(basePath);
 
-@customElement('quick-edgeless-menu')
-export class QuickEdgelessMenu extends SignalWatcher(ShadowlessElement) {
+@customElement('collab-debug-menu')
+export class CollabDebugMenu extends SignalWatcher(ShadowlessElement) {
   static override styles = css`
     :root {
       --sl-font-size-medium: var(--affine-font-xs);
@@ -320,7 +320,7 @@ export class QuickEdgelessMenu extends SignalWatcher(ShadowlessElement) {
   override render() {
     return html`
       <style>
-        .quick-edgeless-menu {
+        .collab-debug-menu {
           display: flex;
           flex-wrap: nowrap;
           position: fixed;
@@ -333,7 +333,7 @@ export class QuickEdgelessMenu extends SignalWatcher(ShadowlessElement) {
         }
 
         @media print {
-          .quick-edgeless-menu {
+          .collab-debug-menu {
             display: none;
           }
         }
@@ -372,7 +372,7 @@ export class QuickEdgelessMenu extends SignalWatcher(ShadowlessElement) {
           margin-right: 4px;
         }
       </style>
-      <div class="quick-edgeless-menu default">
+      <div class="collab-debug-menu default">
         <div class="default-toolbar">
           <div class="top-container">
             <sl-dropdown placement="bottom" hoist>
@@ -621,6 +621,6 @@ export class QuickEdgelessMenu extends SignalWatcher(ShadowlessElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'quick-edgeless-menu': QuickEdgelessMenu;
+    'collab-debug-menu': CollabDebugMenu;
   }
 }

--- a/packages/playground/apps/_common/components/starter-debug-menu.ts
+++ b/packages/playground/apps/_common/components/starter-debug-menu.ts
@@ -46,8 +46,8 @@ import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';
 import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
-import '@shoelace-style/shoelace/dist/themes/dark.css';
 import '@shoelace-style/shoelace/dist/themes/light.css';
+import '@shoelace-style/shoelace/dist/themes/dark.css';
 import { AffineEditorContainer, type CommentPanel } from '@blocksuite/presets';
 import { type DocCollection, Job, Text } from '@blocksuite/store';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
@@ -177,8 +177,8 @@ interface AdapterConfig {
   indexFileName: string;
 }
 
-@customElement('debug-menu')
-export class DebugMenu extends ShadowlessElement {
+@customElement('starter-debug-menu')
+export class StarterDebugMenu extends ShadowlessElement {
   static override styles = css`
     :root {
       --sl-font-size-medium: var(--affine-font-xs);
@@ -1032,6 +1032,6 @@ export class DebugMenu extends ShadowlessElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'debug-menu': DebugMenu;
+    'starter-debug-menu': StarterDebugMenu;
   }
 }

--- a/packages/playground/apps/default/utils/collection.ts
+++ b/packages/playground/apps/default/utils/collection.ts
@@ -51,7 +51,7 @@ export async function createDefaultDocCollection() {
           shadows: [new BroadcastChannelDocSource()],
         };
         awarenessSources = [
-          new BroadcastChannelAwarenessSource('quickEdgeless'),
+          new BroadcastChannelAwarenessSource('collabPlayground'),
         ];
       });
   }
@@ -63,11 +63,11 @@ export async function createDefaultDocCollection() {
   );
 
   const options: DocCollectionOptions = {
-    id: 'quickEdgeless',
+    id: 'collabPlayground',
     schema,
     idGenerator,
     blobSources: {
-      main: new IndexedDBBlobSource('quickEdgeless'),
+      main: new IndexedDBBlobSource('collabPlayground'),
     },
     docSources,
     awarenessSources,

--- a/packages/playground/apps/default/utils/editor.ts
+++ b/packages/playground/apps/default/utils/editor.ts
@@ -18,9 +18,9 @@ import {
 import { AffineEditorContainer } from '@blocksuite/presets';
 
 import { AttachmentViewerPanel } from '../../_common/components/attachment-viewer-panel.js';
+import { CollabDebugMenu } from '../../_common/components/collab-debug-menu.js';
 import { DocsPanel } from '../../_common/components/docs-panel.js';
 import { LeftSidePanel } from '../../_common/components/left-side-panel.js';
-import { QuickEdgelessMenu } from '../../_common/components/quick-edgeless-menu.js';
 import {
   getDocFromUrlParams,
   listenHashChange,
@@ -93,15 +93,15 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   const docsPanel = new DocsPanel();
   docsPanel.editor = editor;
 
-  const quickEdgelessMenu = new QuickEdgelessMenu();
-  quickEdgelessMenu.collection = collection;
-  quickEdgelessMenu.editor = editor;
-  quickEdgelessMenu.leftSidePanel = leftSidePanel;
-  quickEdgelessMenu.docsPanel = docsPanel;
+  const collabDebugMenu = new CollabDebugMenu();
+  collabDebugMenu.collection = collection;
+  collabDebugMenu.editor = editor;
+  collabDebugMenu.leftSidePanel = leftSidePanel;
+  collabDebugMenu.docsPanel = docsPanel;
 
   document.body.append(attachmentViewerPanel);
   document.body.append(leftSidePanel);
-  document.body.append(quickEdgelessMenu);
+  document.body.append(collabDebugMenu);
 
   // debug info
   window.editor = editor;

--- a/packages/playground/apps/starter/utils/editor.ts
+++ b/packages/playground/apps/starter/utils/editor.ts
@@ -28,10 +28,10 @@ import { AttachmentViewerPanel } from '../../_common/components/attachment-viewe
 import { CustomFramePanel } from '../../_common/components/custom-frame-panel.js';
 import { CustomOutlinePanel } from '../../_common/components/custom-outline-panel.js';
 import { CustomOutlineViewer } from '../../_common/components/custom-outline-viewer.js';
-import { DebugMenu } from '../../_common/components/debug-menu.js';
 import { DocsPanel } from '../../_common/components/docs-panel.js';
 import { LeftSidePanel } from '../../_common/components/left-side-panel.js';
 import { SidePanel } from '../../_common/components/side-panel.js';
+import { StarterDebugMenu } from '../../_common/components/starter-debug-menu.js';
 import {
   getDocFromUrlParams,
   listenHashChange,
@@ -154,7 +154,7 @@ export async function mountDefaultDocEditor(collection: DocCollection) {
   const commentPanel = new CommentPanel();
   commentPanel.editor = editor;
 
-  const debugMenu = new DebugMenu();
+  const debugMenu = new StarterDebugMenu();
   debugMenu.collection = collection;
   debugMenu.editor = editor;
   debugMenu.outlinePanel = outlinePanel;

--- a/tests/utils/actions/misc.ts
+++ b/tests/utils/actions/misc.ts
@@ -6,8 +6,8 @@ import type { InlineRange, InlineRootElement } from '@inline/index.js';
 import type { CustomFramePanel } from '@playground/apps/_common/components/custom-frame-panel.js';
 import type { CustomOutlinePanel } from '@playground/apps/_common/components/custom-outline-panel.js';
 import type { CustomOutlineViewer } from '@playground/apps/_common/components/custom-outline-viewer.js';
-import type { DebugMenu } from '@playground/apps/_common/components/debug-menu.js';
 import type { DocsPanel } from '@playground/apps/_common/components/docs-panel.js';
+import type { StarterDebugMenu } from '@playground/apps/_common/components/starter-debug-menu.js';
 import type { ConsoleMessage, Locator, Page } from '@playwright/test';
 import type { BlockModel } from '@store/schema/index.js';
 
@@ -144,7 +144,8 @@ async function initEmptyEditor({
 
         editor.updateComplete
           .then(() => {
-            const debugMenu: DebugMenu = document.createElement('debug-menu');
+            const debugMenu: StarterDebugMenu =
+              document.createElement('debug-menu');
             const docsPanel: DocsPanel = document.createElement('docs-panel');
             const framePanel: CustomFramePanel =
               document.createElement('custom-frame-panel');

--- a/tests/utils/declare-test-window.ts
+++ b/tests/utils/declare-test-window.ts
@@ -5,7 +5,7 @@ import type {
   WidgetViewMapIdentifier,
 } from '@blocksuite/block-std';
 import type { AffineEditorContainer } from '@blocksuite/presets';
-import type { DebugMenu } from '@playground/apps/_common/components/debug-menu.js';
+import type { StarterDebugMenu } from '@playground/apps/_common/components/starter-debug-menu.js';
 import type { BlockModel, Doc, DocCollection, Job } from '@store/index.js';
 
 declare global {
@@ -39,7 +39,7 @@ declare global {
     collection: DocCollection;
     blockSchema: Record<string, typeof BlockModel>;
     doc: Doc;
-    debugMenu: DebugMenu;
+    debugMenu: StarterDebugMenu;
     editor: AffineEditorContainer;
     host: EditorHost;
     testUtils: TestUtils;


### PR DESCRIPTION
Before:

<img width="843" alt="image" src="https://github.com/user-attachments/assets/69f4d5de-b9e0-4709-a05e-c0390bd36ab0">

After:

<img width="862" alt="image" src="https://github.com/user-attachments/assets/d66dc342-2eef-40c0-b7eb-7201673a51f5">

Naming updates for debug menus:

* `DebugMenu` (used in `starter` entry) -> `StarterDebugMenu`
* `QuickEdgelessMenu` (used in `default` entry) -> `CollabDebugMenu`
