### PR TITLE
fix(database): move cursor in kanban card title by arrow keys

### DIFF
--- a/packages/affine/data-view/src/view-presets/kanban/pc/controller/hotkeys.ts
+++ b/packages/affine/data-view/src/view-presets/kanban/pc/controller/hotkeys.ts
@@ -42,18 +42,16 @@ export class KanbanHotkeysController implements ReactiveController {
           context.get('keyboardState').raw.preventDefault();
           return true;
         },
-        ArrowLeft: context => {
+        ArrowLeft: () => {
           if (!this.hasSelection) return false;
 
           this.host.selectionController.focusNext('left');
-          context.get('keyboardState').raw.preventDefault();
           return true;
         },
-        ArrowRight: context => {
+        ArrowRight: () => {
           if (!this.hasSelection) return false;
 
           this.host.selectionController.focusNext('right');
-          context.get('keyboardState').raw.preventDefault();
           return true;
         },
         Backspace: () => {

--- a/tests/database/actions.ts
+++ b/tests/database/actions.ts
@@ -462,6 +462,22 @@ export async function focusKanbanCardHeader(page: Page, index = 0) {
   await cardHeader.click();
 }
 
+export async function clickKanbanCardHeader(page: Page, index = 0) {
+  const cardHeader = page.locator('data-view-header-area-text').nth(index);
+  await cardHeader.click();
+  await cardHeader.click();
+}
+
+export async function assertKanbanCardHeaderText(
+  page: Page,
+  text: string,
+  index = 0
+) {
+  const cardHeader = page.locator('data-view-header-area-text').nth(index);
+
+  await expect(cardHeader).toHaveText(text);
+}
+
 export async function assertKanbanCellSelected(
   page: Page,
   {

--- a/tests/database/selection.spec.ts
+++ b/tests/database/selection.spec.ts
@@ -27,9 +27,11 @@ import { test } from '../utils/playwright.js';
 import {
   assertCellsSelection,
   assertDatabaseTitleColumnText,
+  assertKanbanCardHeaderText,
   assertKanbanCardSelected,
   assertKanbanCellSelected,
   assertRowsSelection,
+  clickKanbanCardHeader,
   focusKanbanCardHeader,
   getDatabaseBodyCell,
   getKanbanCard,
@@ -537,5 +539,29 @@ test.describe('kanban view selection', () => {
       groupIndex: 1,
       cardIndex: 0,
     });
+  });
+
+  test("should support move cursor in card's title by arrow key(left&right)", async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initKanbanViewState(page, {
+      rows: ['row1'],
+      columns: [
+        {
+          type: 'rich-text',
+          value: ['text'],
+        },
+      ],
+    });
+
+    await clickKanbanCardHeader(page);
+    await type(page, 'abc');
+    await pressArrowLeft(page, 2);
+    await pressArrowRight(page);
+    await pressBackspace(page);
+    await pressEscape(page);
+
+    await assertKanbanCardHeaderText(page, 'row1ac');
   });
 });


### PR DESCRIPTION
Fixes #8643

- Fixes a bug where a user can not move the cursor with right and left arrow keys, when editing title of kanban cards
- Added an e2e test case

Ran these test cases, they all pass:
`tests/database/selection.spec.ts`
`tests/database/database.spec.ts`