### PR TITLE
fix(blocks): hide the thumb for bookmark if its width is less than 375

### DIFF
--- a/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
+++ b/packages/affine/block-embed/src/embed-linked-doc-block/styles.ts
@@ -186,7 +186,7 @@ export const styles = css`
 
   .affine-embed-linked-doc-block:not(.in-canvas) {
     max-width: 100%;
-    min-width: ${EMBED_CARD_MIN_WIDTH}px;
+    min-width: calc(min(${EMBED_CARD_MIN_WIDTH}px, 100%));
   }
 
   .affine-embed-linked-doc-block.loading {

--- a/packages/blocks/src/bookmark-block/styles.ts
+++ b/packages/blocks/src/bookmark-block/styles.ts
@@ -6,6 +6,7 @@ import { EMBED_CARD_HEIGHT, EMBED_CARD_WIDTH } from '../_common/consts.js';
 
 export const styles = css`
   .affine-bookmark-card {
+    container: affine-bookmark-card / inline-size;
     margin: 0 auto;
     box-sizing: border-box;
     display: flex;
@@ -269,6 +270,15 @@ export const styles = css`
       display: none;
     }
 
+    .affine-bookmark-banner {
+      display: none;
+    }
+  }
+
+  @container affine-bookmark-card (width < 375px) {
+    .affine-bookmark-content {
+      width: 100%;
+    }
     .affine-bookmark-banner {
       display: none;
     }


### PR DESCRIPTION
close BS-1942, BS-2089

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/LakojjjzZNf6ogjOVwKE/004809e0-5e7a-4703-9346-e50c8484bb43.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/LakojjjzZNf6ogjOVwKE/004809e0-5e7a-4703-9346-e50c8484bb43.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/004809e0-5e7a-4703-9346-e50c8484bb43.mp4">CleanShot 2024-12-10 at 11.35.38.mp4</video>

