### PR TITLE
fix(blocks): button styling when disabled on embed card edit popup

### DIFF
--- a/packages/blocks/src/_common/components/embed-card/modal/embed-card-edit-modal.ts
+++ b/packages/blocks/src/_common/components/embed-card/modal/embed-card-edit-modal.ts
@@ -133,11 +133,14 @@ export class EmbedCardEditModal extends SignalWatcher(
     .row.actions .button:disabled {
       pointer-events: none;
       color: ${unsafeCSSVarV2('text/disable')};
-      background: ${unsafeCSSVarV2('button/disable')};
     }
     .row.actions .button.save {
       color: ${unsafeCSSVarV2('button/pureWhiteText')};
       background: ${unsafeCSSVarV2('button/primary')};
+    }
+    .row.actions .button[disabled].save,
+    .row.actions .button:disabled.save {
+      opacity: 0.5;
     }
   `;
 


### PR DESCRIPTION
Closes: [BS-2083](https://linear.app/affine-design/issue/BS-2083/button-disable态样式错误)