### PR TITLE
fix(blocks): should show original doc title when hovering title button

### DIFF
--- a/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-popup.ts
+++ b/packages/affine/components/src/rich-text/inline/presets/nodes/reference-node/reference-popup.ts
@@ -398,7 +398,7 @@ export class ReferencePopup extends WithDisposable(LitElement) {
             aria-label="Doc title"
             .hover=${false}
             .labelHeight=${'20px'}
-            .tooltip=${'Original linked doc title'}
+            .tooltip=${this.docTitle}
             @click=${this._openDoc}
           >
             <span class="label">${this.docTitle}</span>

--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-embed-card-button.ts
@@ -505,6 +505,15 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
     return undefined;
   }
 
+  get _originalDocTitle() {
+    const model = this.model;
+    const doc = isInternalEmbedModel(model)
+      ? this.std.collection.getDoc(model.pageId)
+      : null;
+
+    return doc?.meta?.title || 'Untitled';
+  }
+
   private get _viewType(): 'inline' | 'embed' | 'card' {
     if (this._isCardView) {
       return 'card';
@@ -706,13 +715,10 @@ export class EdgelessChangeEmbedCardButton extends WithDisposable(LitElement) {
               aria-label="Doc title"
               .hover=${false}
               .labelHeight=${'20px'}
-              .tooltip=${'Original linked doc title'}
+              .tooltip=${this._originalDocTitle}
               @click=${this._open}
             >
-              <span class="label"
-                >${this.std.collection.getDoc(model.pageId)?.meta?.title ||
-                'Untitled'}</span
-              >
+              <span class="label">${this._originalDocTitle}</span>
             </editor-icon-button>
           `
         : nothing,

--- a/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
+++ b/packages/blocks/src/root-block/widgets/embed-card-toolbar/embed-card-toolbar.ts
@@ -276,6 +276,17 @@ export class EmbedCardToolbar extends WidgetComponent<
     return undefined;
   }
 
+  get _originalDocTitle() {
+    const model = this.focusModel;
+    if (!model) return undefined;
+
+    const doc = isInternalEmbedModel(model)
+      ? this.std.collection.getDoc(model.pageId)
+      : null;
+
+    return doc?.meta?.title || 'Untitled';
+  }
+
   private get _selection() {
     return this.host.selection;
   }
@@ -758,13 +769,10 @@ export class EmbedCardToolbar extends WidgetComponent<
               aria-label="Doc title"
               .hover=${false}
               .labelHeight=${'20px'}
-              .tooltip=${'Original linked doc title'}
+              .tooltip=${this._originalDocTitle}
               @click=${this.focusBlock?.open}
             >
-              <span class="label"
-                >${this.std.collection.getDoc(model.pageId)?.meta?.title ||
-                'Untitled'}</span
-              >
+              <span class="label">${this._originalDocTitle}</span>
             </editor-icon-button>
           `
         : nothing,


### PR DESCRIPTION
Closes: [BS-2065](https://linear.app/affine-design/issue/BS-2065/这里-hovertips-应该显示-linked-doc-的原始完整标题)