### PR TITLE
fix(blocks): missing aliases when converting from embed to card

### DIFF
--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-edgeless-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-edgeless-synced-doc-block.ts
@@ -1,3 +1,5 @@
+import type { AliasInfo } from '@blocksuite/affine-model';
+
 import {
   EMBED_CARD_HEIGHT,
   EMBED_CARD_WIDTH,
@@ -113,7 +115,7 @@ export class EmbedEdgelessSyncedDocBlockComponent extends toEdgelessEmbedBlock(
     );
   };
 
-  override convertToCard = () => {
+  override convertToCard = (aliasInfo?: AliasInfo) => {
     const { id, doc, caption, xywh } = this.model;
 
     const edgelessService = this.rootService;
@@ -134,6 +136,7 @@ export class EmbedEdgelessSyncedDocBlockComponent extends toEdgelessEmbedBlock(
         style,
         caption,
         ...this.referenceInfo,
+        ...aliasInfo,
       },
       // @ts-expect-error TODO: fix after edgeless refactor
       edgelessService.surface

--- a/tests/linked-page.spec.ts
+++ b/tests/linked-page.spec.ts
@@ -1147,4 +1147,64 @@ test.describe('Customize linked doc title and description', () => {
       linkedDocBlock.locator('.affine-embed-linked-doc-content-note.alias')
     ).toHaveText('This is a new description');
   });
+
+  // Embed View
+  test('should automatically switch to card view and set a custom title and description on edgeless', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    await initEmptyEdgelessState(page);
+    await focusRichText(page);
+    await createAndConvertToEmbedLinkedDoc(page);
+
+    await switchEditorMode(page);
+    await page.mouse.dblclick(450, 450);
+
+    await dragBlockToPoint(page, '9', { x: 200, y: 200 });
+
+    await waitNextFrame(page);
+
+    const toolbar = page.locator('editor-toolbar');
+    await toolbar.getByRole('button', { name: 'Switch view' }).click();
+    await toolbar.getByRole('button', { name: 'Embed view' }).click();
+
+    await waitNextFrame(page);
+
+    await toolbar.getByRole('button', { name: 'Edit' }).click();
+
+    await waitNextFrame(page);
+    const editModal = page.locator('embed-card-edit-modal');
+    const saveButton = editModal.getByRole('button', { name: 'Save' });
+
+    // title alias
+    await type(page, 'page0-title0');
+    await page.keyboard.press('Tab');
+    // description alias
+    await type(page, 'This is a new description');
+
+    // saves aliases
+    await saveButton.click();
+
+    await waitNextFrame(page);
+
+    const syncedDocBlock = page.locator(
+      'affine-embed-edgeless-synced-doc-block'
+    );
+
+    await expect(syncedDocBlock).toBeHidden();
+
+    const linkedDocBlock = page.locator(
+      'affine-embed-edgeless-linked-doc-block'
+    );
+
+    await expect(linkedDocBlock).toBeVisible();
+
+    const linkedDocBlockTitle = linkedDocBlock.locator(
+      '.affine-embed-linked-doc-content-title-text'
+    );
+    await expect(linkedDocBlockTitle).toHaveText('page0-title0');
+    await expect(
+      linkedDocBlock.locator('.affine-embed-linked-doc-content-note.alias')
+    ).toHaveText('This is a new description');
+  });
 });


### PR DESCRIPTION
Closes: [BS-2099](https://linear.app/affine-design/issue/BS-2099/在白板上，插入的-embed-view，在编辑了-alias-之后会丢失信息)