### PR TITLE
fix(blocks): should prevent default if drop event is handled

### DIFF
--- a/packages/blocks/src/root-block/widgets/drag-handle/watchers/drag-event-watcher.ts
+++ b/packages/blocks/src/root-block/widgets/drag-handle/watchers/drag-event-watcher.ts
@@ -251,6 +251,7 @@ export class DragEventWatcher {
 
     const index =
       parent.children.indexOf(model) + (result.type === 'before' ? 0 : 1);
+    event.preventDefault();
     this._deserializeData(state, parent.id, index).catch(console.error);
   };
 


### PR DESCRIPTION
drag from an external app and drop to blocksuite will invoking default behavior. for example, dropping an link will open the link in place