### PR TITLE
fix(blocks): missing aliases when duplicating linked doc block on edgeless

### DIFF
--- a/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
+++ b/packages/blocks/src/root-block/edgeless/clipboard/clipboard.ts
@@ -17,6 +17,7 @@ import {
   BookmarkStyles,
   DEFAULT_NOTE_HEIGHT,
   DEFAULT_NOTE_WIDTH,
+  ReferenceInfoSchema,
 } from '@blocksuite/affine-model';
 import {
   EmbedOptionProvider,
@@ -426,10 +427,16 @@ export class EdgelessClipboardController extends PageClipboard {
     this.registerBlock('affine:image', this._createImageBlock);
     this.registerBlock('affine:frame', this._createFrameBlock);
     this.registerBlock('affine:attachment', this._createAttachmentBlock);
+
+    // external links
     this.registerBlock('affine:bookmark', this._createBookmarkBlock);
-    this.registerBlock('affine:embed-github', this._createGithubEmbedBlock);
-    this.registerBlock('affine:embed-youtube', this._createYoutubeEmbedBlock);
     this.registerBlock('affine:embed-figma', this._createFigmaEmbedBlock);
+    this.registerBlock('affine:embed-github', this._createGithubEmbedBlock);
+    this.registerBlock('affine:embed-html', this._createHtmlEmbedBlock);
+    this.registerBlock('affine:embed-loom', this._createLoomEmbedBlock);
+    this.registerBlock('affine:embed-youtube', this._createYoutubeEmbedBlock);
+
+    // internal links
     this.registerBlock(
       'affine:embed-linked-doc',
       this._createLinkedDocEmbedBlock
@@ -438,8 +445,6 @@ export class EdgelessClipboardController extends PageClipboard {
       'affine:embed-synced-doc',
       this._createSyncedDocEmbedBlock
     );
-    this.registerBlock('affine:embed-html', this._createHtmlEmbedBlock);
-    this.registerBlock('affine:embed-loom', this._createLoomEmbedBlock);
   }
 
   private _checkCanContinueToCanvas(
@@ -743,16 +748,23 @@ export class EdgelessClipboardController extends PageClipboard {
   }
 
   private _createLinkedDocEmbedBlock(linkedDocEmbed: BlockSnapshot) {
-    const { xywh, style, caption, pageId, params } = linkedDocEmbed.props;
-    const props: Record<string, unknown> = { xywh, style, caption, pageId };
-
-    if (params) {
-      props.params = { ...params };
-    }
+    const { xywh, style, caption, pageId, params, title, description } =
+      linkedDocEmbed.props;
+    const referenceInfo = ReferenceInfoSchema.parse({
+      pageId,
+      params,
+      title,
+      description,
+    });
 
     return this.host.service.addBlock(
       'affine:embed-linked-doc',
-      props,
+      {
+        xywh,
+        style,
+        caption,
+        ...referenceInfo,
+      },
       this.surface.model.id
     );
   }
@@ -801,7 +813,9 @@ export class EdgelessClipboardController extends PageClipboard {
   }
 
   private _createSyncedDocEmbedBlock(syncedDocEmbed: BlockSnapshot) {
-    const { xywh, style, caption, scale, pageId } = syncedDocEmbed.props;
+    const { xywh, style, caption, scale, pageId, params } =
+      syncedDocEmbed.props;
+    const referenceInfo = ReferenceInfoSchema.parse({ pageId, params });
 
     return this.host.service.addBlock(
       'affine:embed-synced-doc',
@@ -810,7 +824,7 @@ export class EdgelessClipboardController extends PageClipboard {
         style,
         caption,
         scale,
-        pageId,
+        ...referenceInfo,
       },
       this.surface.model.id
     );


### PR DESCRIPTION
Closes: [BS-2100](https://linear.app/affine-design/issue/BS-2100/在白板上，为添加了-alias-信息的-linked-doc-创建副本，会丢失-alias-信息)