### PR TITLE
fix: remove vitest extension from recommendation list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "runem.lit-plugin",
     "ms-playwright.playwright",
-    "dbaeumer.vscode-eslint",
-    "vitest.explorer"
+    "dbaeumer.vscode-eslint"
   ]
 }


### PR DESCRIPTION
This is removed due to https://github.com/vitest-dev/vitest/issues/6714.