### PR TITLE
fix(blocks): show keyboard toolbar when focus on title and hide on scrolling

### DIFF
--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/config.ts
@@ -120,9 +120,9 @@ export type KeyboardToolbarContext = {
   std: BlockStdScope;
   rootComponent: PageRootBlockComponent;
   /**
-   * Close tool bar
+   * Close tool bar, and blur the focus if blur is true, default is false
    */
-  closeToolbar: () => void;
+  closeToolbar: (blur?: boolean) => void;
   /**
    * Close current tool panel and show virtual keyboard
    */

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/index.ts
@@ -2,6 +2,7 @@ import type { RootBlockModel } from '@blocksuite/affine-model';
 
 import { WidgetComponent } from '@blocksuite/block-std';
 import { IS_MOBILE } from '@blocksuite/global/env';
+import { assertType } from '@blocksuite/global/utils';
 import { signal } from '@preact/signals-core';
 import { html, nothing } from 'lit';
 
@@ -17,7 +18,26 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<
   RootBlockModel,
   PageRootBlockComponent
 > {
+  private _close = (blur: boolean) => {
+    if (blur) {
+      if (document.activeElement === this._docTitle) {
+        this._docTitle?.blur();
+      } else if (document.activeElement === this.block.rootComponent) {
+        this.block.rootComponent?.blur();
+      }
+    }
+    this._show$.value = false;
+  };
+
   private readonly _show$ = signal(false);
+
+  private get _docTitle(): HTMLDivElement | null {
+    const docTitle = this.std.host
+      .closest('.affine-page-viewport')
+      ?.querySelector('doc-title rich-text .inline-editor');
+    assertType<HTMLDivElement | null>(docTitle);
+    return docTitle;
+  }
 
   get config() {
     return {
@@ -30,13 +50,23 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<
     super.connectedCallback();
 
     const { rootComponent } = this.block;
-    if (!rootComponent) return;
-    this.disposables.addFromEvent(rootComponent, 'focus', () => {
-      this._show$.value = true;
-    });
-    this.disposables.addFromEvent(rootComponent, 'blur', () => {
-      this._show$.value = false;
-    });
+    if (rootComponent) {
+      this.disposables.addFromEvent(rootComponent, 'focus', () => {
+        this._show$.value = true;
+      });
+      this.disposables.addFromEvent(rootComponent, 'blur', () => {
+        this._show$.value = false;
+      });
+    }
+
+    if (this._docTitle) {
+      this.disposables.addFromEvent(this._docTitle, 'focus', () => {
+        this._show$.value = true;
+      });
+      this.disposables.addFromEvent(this._docTitle, 'blur', () => {
+        this._show$.value = false;
+      });
+    }
   }
 
   override render() {
@@ -56,9 +86,7 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<
       .template=${html`<affine-keyboard-toolbar
         .config=${this.config}
         .rootComponent=${this.block.rootComponent}
-        .close=${() => {
-          this._show$.value = false;
-        }}
+        .close=${this._close}
       ></affine-keyboard-toolbar> `}
     ></blocksuite-portal>`;
   }

--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
@@ -40,6 +40,7 @@ export const keyboardToolbarStyles = css`
   }
 
   .item-container {
+    flex: 1;
     display: flex;
     overflow-x: auto;
     gap: 8px;
@@ -50,7 +51,9 @@ export const keyboardToolbarStyles = css`
     }
   }
 
-  ${scrollbarStyle('.item-container')}
+  .item-container::-webkit-scrollbar {
+    display: none;
+  }
 
   .divider {
     height: 24px;


### PR DESCRIPTION
Close [BS-2088](https://linear.app/affine-design/issue/BS-2088/ios-移动端-光标会高于键盘toolbar的高度) [BS-1945](https://linear.app/affine-design/issue/BS-1945/标题输入需要有键盘收起按钮) [BS-2113](https://linear.app/affine-design/issue/BS-2113/打开编辑器再回到首页后，底部的-padding-会重置为-0)


### What Changes
- show mobile keyboard toolbar when focus on title
- hide mobile keyboard toolbar when scrolling window
- hide mobile keyboard toolbar when clicking the keyboard button
- hide horizontal scrollbar of keyboard toolbar
