### PR TITLE
chore: run headless vitest locally by default

### DIFF
--- a/packages/presets/vitest.config.ts
+++ b/packages/presets/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(_configEnv =>
       include: ['src/__tests__/**/*.spec.ts'],
       browser: {
         enabled: true,
-        headless: true,
+        headless: process.env.CI === 'true',
         name: 'chromium',
         provider: 'playwright',
         isolate: false,


### PR DESCRIPTION
`yarn run test:unit` should use `headless: false` locally now.

For example, to debug group test, simply use `yarn run test:unit group.spec.ts` now.
