### PR TITLE
fix(blocks): fix incorrect font family in mobile widgets

### DIFF
--- a/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
+++ b/packages/blocks/src/root-block/widgets/keyboard-toolbar/styles.ts
@@ -87,7 +87,7 @@ export const keyboardToolPanelStyles = css`
     color: ${unsafeCSSVarV2('text/secondary')};
 
     /* Footnote/Emphasized */
-    font-family: 'SF Pro';
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
     font-size: 13px;
     font-style: normal;
     font-weight: 590;
@@ -134,7 +134,7 @@ export const keyboardToolPanelStyles = css`
 
     span {
       width: 100%;
-      font-family: SF Pro;
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
       font-size: 13px;
       font-weight: 400;
       line-height: 18px;

--- a/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
+++ b/packages/blocks/src/root-block/widgets/linked-doc/styles.ts
@@ -123,7 +123,7 @@ export const mobileLinkedDocMenuStyles = css`
       text-align: justify;
       text-overflow: ellipsis;
 
-      font-family: 'SF Pro';
+      font-family: -apple-system, BlinkMacSystemFont, sans-serif;
       font-size: 17px;
       font-style: normal;
       font-weight: 400;


### PR DESCRIPTION
Close [BS-1830](https://linear.app/affine-design/issue/BS-1830/menu-字体错误)

Related: https://stackoverflow.com/questions/32660748/how-to-use-apples-san-francisco-font-on-a-webpage#answer-32660790

>Apple's new system font is not publicly exposed. Apple has started abstracting system font names:
>>The motivation for this abstraction is so the operating system can make better choices on which face to use at a given weight. Apple is also working on font features, such as selectable “6″ and “9″ glyphs or non-monospaced numbers. It’s my guess that they’d like to bring these features to the web, as well.
>>
>Safari and Firefox use SF for -apple-system; Chrome recognizes BlinkMacSystemFont: