### PR TITLE
fix: attachment, bookmark and embed blocks should be draggable

### DIFF
--- a/packages/affine/block-embed/src/common/embed-block-element.ts
+++ b/packages/affine/block-embed/src/common/embed-block-element.ts
@@ -108,6 +108,7 @@ export class EmbedBlockComponent<
     const selected = !!this.selected?.is('block');
     return html`
       <div
+        draggable="true"
         class=${classMap({
           'embed-block-container': true,
           'selected-style': selected,

--- a/packages/blocks/src/attachment-block/attachment-block.ts
+++ b/packages/blocks/src/attachment-block/attachment-block.ts
@@ -227,6 +227,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<
       <div
         ${this._whenHover ? ref(this._whenHover.setReference) : nothing}
         class="affine-attachment-container"
+        draggable="true"
         style=${this.containerStyleMap}
       >
         ${embedView

--- a/packages/blocks/src/bookmark-block/bookmark-block.ts
+++ b/packages/blocks/src/bookmark-block/bookmark-block.ts
@@ -75,6 +75,7 @@ export class BookmarkBlockComponent extends CaptionedBlockComponent<
     const selected = !!this.selected?.is('block');
     return html`
       <div
+        draggable="true"
         class=${classMap({
           'affine-bookmark-container': true,
           'selected-style': selected,


### PR DESCRIPTION
Closes: [BS-2012](https://linear.app/affine-design/issue/BS-2012/card-view-和-embed-view-本身不支持拖拽)