### PR TITLE
fix(edgeless): export template job and image upload api

### DIFF
--- a/packages/affine/shared/src/services/telemetry-service/types.ts
+++ b/packages/affine/shared/src/services/telemetry-service/types.ts
@@ -35,7 +35,7 @@ export interface DocCreatedEvent extends TelemetryEvent {
 
 export interface ElementCreationEvent extends TelemetryEvent {
   segment?: 'toolbar' | 'whiteboard' | 'right sidebar';
-  page: 'whiteboard editor';
+  page?: 'doc editor' | 'whiteboard editor';
   module?: 'toolbar' | 'canvas' | 'ai chat panel';
   control?: ElementCreationSource;
 }

--- a/packages/blocks/src/image-block/index.ts
+++ b/packages/blocks/src/image-block/index.ts
@@ -2,4 +2,5 @@ export * from './adapters/markdown.js';
 export * from './image-block.js';
 export * from './image-edgeless-block.js';
 export * from './image-service.js';
+export { uploadBlobForImage } from './utils.js';
 export { ImageSelection } from '@blocksuite/affine-shared/selection';

--- a/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-type.ts
+++ b/packages/blocks/src/root-block/edgeless/components/toolbar/template/template-type.ts
@@ -23,7 +23,7 @@ export type Template = {
    * `template`: normal template, looks like an article
    * `sticker`: sticker template, only contains one image block under surface block
    */
-  type: string;
+  type: 'template' | 'sticker';
 };
 
 export type TemplateCategory = {

--- a/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
+++ b/packages/blocks/src/root-block/edgeless/edgeless-root-service.ts
@@ -6,7 +6,6 @@ import type {
   PointTestOptions,
   ReorderingDirection,
 } from '@blocksuite/block-std/gfx';
-import type { IBound } from '@blocksuite/global/utils';
 
 import {
   type ElementRenderer,
@@ -314,15 +313,17 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
     return groupId;
   }
 
-  createTemplateJob(type: 'template' | 'sticker') {
+  createTemplateJob(
+    type: 'template' | 'sticker',
+    center?: { x: number; y: number }
+  ) {
     const middlewares: ((job: TemplateJob) => void)[] = [];
 
     if (type === 'template') {
-      const currentContentBound = getCommonBound(
-        (
-          this.blocks.map(block => Bound.deserialize(block.xywh)) as IBound[]
-        ).concat(this.elements)
+      const bounds = [...this.blocks, ...this.elements].map(i =>
+        Bound.deserialize(i.xywh)
       );
+      const currentContentBound = getCommonBound(bounds);
 
       if (currentContentBound) {
         currentContentBound.x +=
@@ -337,7 +338,7 @@ export class EdgelessRootService extends RootService implements SurfaceContext {
 
     if (type === 'sticker') {
       middlewares.push(
-        createStickerMiddleware(this.viewport.center, () =>
+        createStickerMiddleware(center || this.viewport.center, () =>
           this.layer.generateIndex()
         )
       );

--- a/packages/blocks/src/root-block/index.ts
+++ b/packages/blocks/src/root-block/index.ts
@@ -3,6 +3,8 @@ export * from './clipboard/index.js';
 export * from './configs/index.js';
 export * from './edgeless/edgeless-root-spec.js';
 export * from './edgeless/index.js';
+export { TemplateJob } from './edgeless/services/template.js';
+export * as TemplateMiddlewares from './edgeless/services/template-middlewares.js';
 export * from './page/page-root-block.js';
 export { PageRootService } from './page/page-root-service.js';
 export * from './page/page-root-spec.js';

--- a/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.ts
+++ b/packages/blocks/src/surface-block/mini-mindmap/mindmap-preview.ts
@@ -135,10 +135,7 @@ export class MiniMindmapPreview extends WithDisposable(LitElement) {
       this._mindmap!.style = style;
     });
 
-    this.ctx.set({
-      ...this.ctx.get(),
-      style,
-    });
+    this.ctx.set({ style });
     this.requestUpdate();
   }
 


### PR DESCRIPTION
### What changed?
- Exposed `uploadBlobForImage` utility function
- Refactor `createTemplateJob` for reuse
- Exposed `TemplateJob` and `TemplateMiddlewares` APIs

Support issue [BS-2085](https://linear.app/affine-design/issue/BS-2085).
