### PR TITLE
feat(edgeless): release frame by clicking ungroup button

### DIFF
--- a/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
+++ b/packages/blocks/src/root-block/widgets/element-toolbar/change-frame-button.ts
@@ -1,4 +1,8 @@
-import { NoteIcon, RenameIcon } from '@blocksuite/affine-components/icons';
+import {
+  NoteIcon,
+  RenameIcon,
+  UngroupButtonIcon,
+} from '@blocksuite/affine-components/icons';
 import { toast } from '@blocksuite/affine-components/toast';
 import { renderToolbarSeparator } from '@blocksuite/affine-components/toolbar';
 import {
@@ -9,6 +13,7 @@ import {
   NoteDisplayMode,
 } from '@blocksuite/affine-model';
 import { matchFlavours } from '@blocksuite/affine-shared/utils';
+import { GfxExtensionIdentifier } from '@blocksuite/block-std/gfx';
 import {
   countBy,
   deserializeXYWH,
@@ -25,6 +30,7 @@ import type { EdgelessColorPickerButton } from '../../edgeless/components/color-
 import type { PickColorEvent } from '../../edgeless/components/color-picker/types.js';
 import type { ColorEvent } from '../../edgeless/components/panel/color-panel.js';
 import type { EdgelessRootBlockComponent } from '../../edgeless/edgeless-root-block.js';
+import type { EdgelessFrameManager } from '../../edgeless/frame-manager.js';
 
 import {
   packColor,
@@ -153,6 +159,29 @@ export class EdgelessChangeFrameButton extends WithDisposable(LitElement) {
               </editor-icon-button>
             `
           : nothing,
+
+        html`
+          <editor-icon-button
+            aria-label="Ungroup"
+            .tooltip=${'Ungroup'}
+            .iconSize=${'20px'}
+            @click=${() => {
+              this.edgeless.doc.captureSync();
+              const frameMgr = this.edgeless.std.get(
+                GfxExtensionIdentifier('frame-manager')
+              ) as EdgelessFrameManager;
+              frames.forEach(frame =>
+                frameMgr.removeAllChildrenFromFrame(frame)
+              );
+              frames.forEach(frame => {
+                this.edgeless.service.removeElement(frame);
+              });
+              this.edgeless.service.selection.clear();
+            }}
+          >
+            ${UngroupButtonIcon}
+          </editor-icon-button>
+        `,
 
         when(
           this.edgeless.doc.awarenessStore.getFlag('enable_color_picker'),

--- a/tests/edgeless/frame/frame.spec.ts
+++ b/tests/edgeless/frame/frame.spec.ts
@@ -13,6 +13,7 @@ import {
   dragBetweenViewCoords,
   edgelessCommonSetup,
   getFirstContainerId,
+  getIds,
   getSelectedIds,
   pickColorAtPoints,
   setEdgelessTool,
@@ -344,7 +345,7 @@ test.describe('resize frame then move ', () => {
   });
 });
 
-test('delete frame', async ({ page }) => {
+test('delete frame should also delete its children', async ({ page }) => {
   await createFrame(page, [50, 50], [450, 450]);
   await createShapeElement(page, [200, 200], [300, 300], Shape.Square);
   await pressEscape(page);
@@ -356,6 +357,28 @@ test('delete frame', async ({ page }) => {
   await expect(page.locator('affine-frame')).toHaveCount(0);
 
   await assertCanvasElementsCount(page, 0);
+});
+
+test('delete frame by click ungroup should not delete its children', async ({
+  page,
+}) => {
+  await createFrame(page, [50, 50], [450, 450]);
+  const shapeId = await createShapeElement(
+    page,
+    [200, 200],
+    [300, 300],
+    Shape.Square
+  );
+  await pressEscape(page);
+
+  const frameTitle = page.locator('affine-frame-title');
+  await frameTitle.click();
+  const elementToolbar = page.locator('edgeless-element-toolbar-widget');
+  const ungroupButton = elementToolbar.getByLabel('Ungroup');
+  await ungroupButton.click();
+
+  await assertCanvasElementsCount(page, 1);
+  expect(await getIds(page)).toEqual([shapeId]);
 });
 
 test('outline should keep updated during a new frame created by frame-tool dragging', async ({


### PR DESCRIPTION
Added an ungroup button for frame that only remove frame without deleteing its children