### PR TITLE
fix(inline): incorrect caret position in safari when using IME

### DIFF
--- a/packages/framework/inline/src/consts.ts
+++ b/packages/framework/inline/src/consts.ts
@@ -1,4 +1,6 @@
-export const ZERO_WIDTH_SPACE = '\u200B';
+import { IS_SAFARI } from '@blocksuite/global/env';
+
+export const ZERO_WIDTH_SPACE = IS_SAFARI ? '\u200C' : '\u200B';
 // see https://en.wikipedia.org/wiki/Zero-width_non-joiner
 export const ZERO_WIDTH_NON_JOINER = '\u200C';
 


### PR DESCRIPTION
Close [BS-1823](https://linear.app/affine-design/issue/BS-1823/收入首行文字时，关闭高亮的定位有问题)

### Before
when `anchorOffset===0`, the position of caret during IME inputing is not correcte

https://github.com/user-attachments/assets/089f6c42-cd9b-4ee0-9bff-2db5d1067671


### After


https://github.com/user-attachments/assets/b84544aa-3a9f-412b-91b0-dbb10a0be1e4

