### PR TITLE
fix: dnd status error

### DIFF
--- a/packages/framework/block-std/src/event/control/pointer.ts
+++ b/packages/framework/block-std/src/event/control/pointer.ts
@@ -275,6 +275,7 @@ class DragController extends PointerControllerBase {
 
   private _nativeDrop = (event: DragEvent) => {
     this._reset();
+    this._nativeDragging = false;
     const dndEventState = new DndEventState({ event });
     this._dispatcher.run(
       'nativeDrop',


### PR DESCRIPTION
Closes: [BS-2136](https://linear.app/affine-design/issue/BS-2136/attachementbookmark拖拽到白板后，白板所有拖拽都无法工作)
Closes: [BS-2143](https://linear.app/affine-design/issue/BS-2143/block通过drag-handle拖动位置后，无法输入)