### PR TITLE
fix(blocks): toolbar color should be light when app theme is light and edgeless theme is dark

### DIFF
--- a/packages/affine/shared/src/services/theme-service.ts
+++ b/packages/affine/shared/src/services/theme-service.ts
@@ -209,6 +209,8 @@ export const getThemeObserver = (function () {
 
 const toolbarColorKeys: Array<keyof AffineCssVariables> = [
   '--affine-background-overlay-panel-color',
+  '--affine-v2-layer-background-overlayPanel' as never,
+  '--affine-background-error-color',
   '--affine-background-primary-color',
   '--affine-background-tertiary-color',
   '--affine-icon-color',


### PR DESCRIPTION
Before:

![截屏2024-12-17 11.30.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/41232401-dbfc-41f0-94b7-fc764e18dba5.png)

After:

![截屏2024-12-17 11.45.30.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/9a2a2f89-beb4-411b-9404-224bf43b7882.png)

