### PR TITLE
fix: mind map opacity

### DIFF
--- a/packages/affine/block-surface/src/renderer/elements/mindmap.ts
+++ b/packages/affine/block-surface/src/renderer/elements/mindmap.ts
@@ -24,6 +24,8 @@ export function mindmap(
 
   matrix = matrix.translate(-dx, -dy);
 
+  const mindmapOpacity = model.opacity;
+
   const traverse = (node: MindmapNode) => {
     const connectors = model.getConnectors(node);
     if (!connectors) return;
@@ -40,10 +42,11 @@ export function mindmap(
       const dx = connector.x - bound.x;
       const dy = connector.y - bound.y;
       const origin = ctx.globalAlpha;
-      const shouldSetGlobalAlpha = origin !== connector.opacity;
+      const shouldSetGlobalAlpha =
+        origin !== connector.opacity * mindmapOpacity;
 
       if (shouldSetGlobalAlpha) {
-        ctx.globalAlpha = connector.opacity;
+        ctx.globalAlpha = connector.opacity * mindmapOpacity;
       }
 
       renderConnector(connector, ctx, matrix.translate(dx, dy), renderer, rc);


### PR DESCRIPTION
Fixes [BS-2030](https://linear.app/affine-design/issue/BS-2030/重叠的-mindmap-连接线没法用-opacity-0-隐藏)