### PR TITLE
perf(edgeless): reduce redundant dom query per render

### DIFF
--- a/packages/affine/block-surface/src/renderer/canvas-renderer.ts
+++ b/packages/affine/block-surface/src/renderer/canvas-renderer.ts
@@ -365,6 +365,8 @@ export class CanvasRenderer {
   }
 
   dispose(): void {
+    this._overlays.forEach(overlay => overlay.dispose());
+    this._overlays.clear();
     this._disposables.dispose();
   }
 

--- a/packages/affine/block-surface/src/renderer/overlay.ts
+++ b/packages/affine/block-surface/src/renderer/overlay.ts
@@ -37,6 +37,8 @@ export abstract class Overlay extends Extension {
 
   clear() {}
 
+  dispose() {}
+
   refresh() {
     if (this._renderer) {
       this._renderer.refresh();

--- a/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
+++ b/packages/blocks/src/root-block/edgeless/utils/tool-overlay.ts
@@ -256,7 +256,7 @@ class ToolOverlay extends Overlay {
     );
   }
 
-  dispose(): void {
+  override dispose(): void {
     this.disposables.dispose();
   }
 


### PR DESCRIPTION
This removes the green spikes during zooming, which is caused by per-render DOM queries in connector manager:

![image](https://github.com/user-attachments/assets/112fe601-082b-48ad-9d1b-9b22d44956e6)
