### PR TITLE
fix(blocks): fix title and icon display issue in embed synced doc block

### DIFF
--- a/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/packages/affine/block-embed/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -1,7 +1,3 @@
-import {
-  EmbedEdgelessIcon,
-  EmbedPageIcon,
-} from '@blocksuite/affine-components/icons';
 import { Peekable } from '@blocksuite/affine-components/peek';
 import {
   REFERENCE_NODE,
@@ -206,8 +202,6 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
       ]);
     };
 
-    const icon = isPageMode ? EmbedPageIcon : EmbedEdgelessIcon;
-
     return this.renderEmbed(
       () => html`
         <div
@@ -240,10 +234,10 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
             })}
           >
             <div class="affine-embed-synced-doc-header">
-              <span class="affine-embed-synced-doc-icon">${icon}</span>
-              <span class="affine-embed-synced-doc-title">
-                ${this.docTitle}
-              </span>
+              <span class="affine-embed-synced-doc-icon"
+                >${this.icon$.value}</span
+              >
+              <span class="affine-embed-synced-doc-title">${this.title$}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Before
<img width="859" alt="Screenshot 2024-12-19 at 19 24 54" src="https://github.com/user-attachments/assets/d7171168-7090-469c-9022-3339f3cb88a7" />

### After
<img width="855" alt="Screenshot 2024-12-19 at 19 25 26" src="https://github.com/user-attachments/assets/f6ea0f68-25db-40e3-ac01-69fc4cc4c6d2" />
