### PR TITLE
fix(blocks): text colors are not saved when importing to html

### DIFF
--- a/packages/blocks/src/_common/adapters/html-adapter/delta-converter/inline-delta.ts
+++ b/packages/blocks/src/_common/adapters/html-adapter/delta-converter/inline-delta.ts
@@ -74,6 +74,33 @@ export const underlineDeltaToHtmlAdapterMatcher: InlineDeltaToHtmlAdapterMatcher
     },
   };
 
+export const backgroundDeltaToHtmlAdapterMatcher: InlineDeltaToHtmlAdapterMatcher =
+  {
+    name: 'background',
+    match: delta => !!delta.attributes?.background,
+    toAST: (_, context) => {
+      return {
+        type: 'element',
+        tagName: 'span',
+        properties: { style: `background-color: ${_.attributes?.background}` },
+        children: [context.current],
+      };
+    },
+  };
+
+export const colorDeltaToHtmlAdapterMatcher: InlineDeltaToHtmlAdapterMatcher = {
+  name: 'color',
+  match: delta => !!delta.attributes?.color,
+  toAST: (_, context) => {
+    return {
+      type: 'element',
+      tagName: 'span',
+      properties: { style: `color: ${_.attributes?.color}` },
+      children: [context.current],
+    };
+  },
+};
+
 export const referenceDeltaToHtmlAdapterMatcher: InlineDeltaToHtmlAdapterMatcher =
   {
     name: 'reference',
@@ -141,6 +168,8 @@ export const inlineDeltaToHtmlAdapterMatchers: InlineDeltaToHtmlAdapterMatcher[]
     strikeDeltaToHtmlAdapterMatcher,
     underlineDeltaToHtmlAdapterMatcher,
     inlineCodeDeltaToMarkdownAdapterMatcher,
+    backgroundDeltaToHtmlAdapterMatcher,
+    colorDeltaToHtmlAdapterMatcher,
     referenceDeltaToHtmlAdapterMatcher,
     linkDeltaToHtmlAdapterMatcher,
   ];


### PR DESCRIPTION
Related issue #8479. I know this issue was assigned to @donteatfriedrice, so if he is currently working on it, feel free to close this PR. 

When exporting to HTML, **text color and text background color are not preserved**. 
**Affine document:**
![Screenshot 2024-12-20 at 18 31 06](https://github.com/user-attachments/assets/55152e9f-a00b-4cd3-a5ec-296c2608e572)
**Exported HTML:**
![Screenshot 2024-12-20 at 18 33 22](https://github.com/user-attachments/assets/47f16255-2a5f-4519-89aa-0c7fa1676974)


## Changes
Text with color or background color is now wrapped into a span with necessary color. Previously, colors were not supported

## Problem 
Although I have encountered a problem. Colors passed to a wrapping span are stored in css variables. There are no css variables in the html, which still leads to no colors in html. *See the screenshots below*
**Before:**
![Screenshot 2024-12-20 at 18 43 26](https://github.com/user-attachments/assets/73ea11af-a895-4b6f-a549-45f49bbac0e2)
**After:**
![image](https://github.com/user-attachments/assets/31c5c649-12e8-40e0-a8be-d786b530c517)

## Question
Should i convert the colors on the go, or better add missing css variables to html? What will you recommend? Any feedback will be highly appreciated!