### PR TITLE
mobile testing infrastructure

### DIFF
--- a/tests/database/kanban.shared.spec.ts
+++ b/tests/database/kanban.shared.spec.ts
@@ -1,0 +1,31 @@
+
+import {
+  enterPlaygroundRoom,
+  initKanbanViewState,
+} from '../utils/actions/index.js';
+import { test } from '../utils/playwright.js';
+import {
+  focusKanbanCardHeader,
+} from './actions.js';
+
+test.describe('kanban view', () => {
+  test('basic rendering of kanban card', async ({ page }) => {
+    await enterPlaygroundRoom(page);
+    await initKanbanViewState(page, {
+      rows: ['row1'],
+      columns: [
+        {
+          type: 'number',
+          value: [1],
+        },
+        {
+          type: 'rich-text',
+          value: ['text'],
+        },
+      ],
+    });
+
+    await focusKanbanCardHeader(page);
+  });
+
+});

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,6 +1,6 @@
 import type { PlaywrightWorkerOptions } from '@playwright/test';
 
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 import process from 'node:process';
 
 export default defineConfig({
@@ -17,6 +17,27 @@ export default defineConfig({
       COVERAGE: process.env.COVERAGE ?? '',
     },
   },
+  projects: [
+    // To avoid burning github actions minutes, we only run interesting tests on mobile.
+    // The rest of the tests are run on desktop.
+    //   .spec.ts files are run on desktop only
+    //   .mobile.spec.ts files are run on mobile only
+    //   .shared.spec.ts files are run on both desktop and mobile
+    {
+      name: 'desktop',
+      testIgnore: 'tests/**/*.mobile.spec.ts',
+    },
+    {
+      name: 'mobile',
+      testMatch: [
+        'tests/**/*.mobile.spec.ts',
+        'tests/**/*.shared.spec.ts',
+      ],
+      // Note: we ignore the BROWSER environment variable here.
+      // We can special-case firefox/webkit in the future if this causes us to miss bugs in CI.
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
   use: {
     browserName:
       (process.env.BROWSER as PlaywrightWorkerOptions['browserName']) ??

--- a/tests/utils/query.ts
+++ b/tests/utils/query.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 import { waitNextFrame } from './actions/misc.js';
 import { assertAlmostEqual } from './asserts.js';
@@ -122,4 +122,27 @@ export function getEmbedCardToolbar(page: Page) {
     cardStyleHorizontalButton,
     cardStyleListButton,
   };
+}
+
+/**
+ * mobile views typically use different component names.
+ *
+ * If you want to write a test that works on both desktop and mobile,
+ * you need to use a different component name on mobile.
+ *
+ * Typically, it is good enough to replace the `affine-data-view-`
+ * prefix and replace it with `mobile-`.
+ *
+ * In the future, we might want to consider using data-testid attributes instead.
+ */
+export function portableLocator(page: Page, selector: string) {
+  if (!selector.startsWith('affine-data-view-')) {
+    throw new Error(`Received invalid selector '${selector}'). Please use a selector starting with affine-data-view-`);
+  }
+
+  if (test.info().project.name === 'mobile') {
+    return page.locator(selector.replaceAll('affine-data-view-', 'mobile-'));
+  }
+
+  return page.locator(selector);
 }


### PR DESCRIPTION
My eventual aim is to make kanban drag and drop work on mobile. I've still not managed that, but I thought I could contribute my testing infrastructure already.

To avoid burning github actions minutes and have a billion failing tests to sort out, I made it only run interesting tests on mobile. The rest of the tests are run on desktop.

* .spec.ts files are run on desktop only
* .mobile.spec.ts files are run on mobile only
* .shared.spec.ts files are run on both desktop and mobile

If you remove the test.skip(), my mobile test does correctly fail. I may need to rewrite it to send touch events once I've implemented the feature, but I will think about that later.