### PR TITLE
[bug]: brush xywh do not behave predictably when changing lineWidth of the rotated brush element.

### DIFF
--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -138,21 +138,19 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
     instance['_local'].delete('commands');
   })
   @derive((lineWidth: number, instance: Instance) => {
-    const oldBound = instance.elementBound;
-
     if (
       lineWidth === instance.lineWidth ||
-      oldBound.w === 0 ||
-      oldBound.h === 0
+      instance.w === 0 ||
+      instance.h === 0
     )
       return {};
 
     const points = instance.points;
     const transformed = transformPointsToNewBound(
       points.map(([x, y]) => ({ x, y })),
-      oldBound,
+      instance,
       instance.lineWidth / 2,
-      inflateBound(oldBound, lineWidth - instance.lineWidth),
+      inflateBound(instance, lineWidth - instance.lineWidth),
       lineWidth / 2
     );
 


### PR DESCRIPTION
This pull request fixes the bug with incorrect calculation xywh of the brush element when changing lineWidth when the element is rotated (see the attached video)

Uploading Запись экрана 2025-01-22 в 17.46.00.mov…

