### PR TITLE
fix(editor): brush xywh do not behave predictably when changing lineWidth of the rotated brush element

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -132,3 +132,4 @@ Example:
 - satoren, @satoren, 2024/08/09
 - Nikita Minaev, @majula2111, 2024/09/26
 - Oleg, @OlegDev1, 2024/12/03
+- Egor Titov, @EGRoBBeRTiT, 2025/01/22

--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -138,19 +138,21 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
     instance['_local'].delete('commands');
   })
   @derive((lineWidth: number, instance: Instance) => {
+    const oldBound = Bound.fromXYWH(instance.deserializedXYWH);
+
     if (
       lineWidth === instance.lineWidth ||
-      instance.w === 0 ||
-      instance.h === 0
+      oldBound.w === 0 ||
+      oldBound.h === 0
     )
       return {};
 
     const points = instance.points;
     const transformed = transformPointsToNewBound(
       points.map(([x, y]) => ({ x, y })),
-      instance,
+      oldBound,
       instance.lineWidth / 2,
-      inflateBound(instance, lineWidth - instance.lineWidth),
+      inflateBound(oldBound, lineWidth - instance.lineWidth),
       lineWidth / 2
     );
 

--- a/packages/affine/model/src/elements/brush/brush.ts
+++ b/packages/affine/model/src/elements/brush/brush.ts
@@ -138,21 +138,19 @@ export class BrushElementModel extends GfxPrimitiveElementModel<BrushProps> {
     instance['_local'].delete('commands');
   })
   @derive((lineWidth: number, instance: Instance) => {
-    const oldBound = instance.elementBound;
-
     if (
       lineWidth === instance.lineWidth ||
-      oldBound.w === 0 ||
-      oldBound.h === 0
+      instance.w === 0 ||
+      instance.h === 0
     )
       return {};
 
     const points = instance.points;
     const transformed = transformPointsToNewBound(
       points.map(([x, y]) => ({ x, y })),
-      oldBound,
+      instance,
       instance.lineWidth / 2,
-      inflateBound(oldBound, lineWidth - instance.lineWidth),
+      inflateBound(instance, lineWidth - instance.lineWidth),
       lineWidth / 2
     );
 


### PR DESCRIPTION
This pull request fixes the bug with incorrect calculation xywh of the brush element when changing lineWidth when the element is rotated (see the attached video)

https://github.com/user-attachments/assets/b28a606b-ba0a-40cc-9ec8-13fee1dd9c9f

