### PR TITLE
fix: invoke subscriber.unsubscribe() during cleanup

### DIFF
--- a/packages/framework/sync/src/doc/engine.ts
+++ b/packages/framework/sync/src/doc/engine.ts
@@ -132,12 +132,13 @@ export class DocEngine {
         this.logger
       );
 
-      cleanUp.push(
-        state.mainPeer.onStatusChange.subscribe(() => {
-          if (!signal.aborted)
-            this.updateSyncingState(state.mainPeer, state.shadowPeers);
-        }).unsubscribe
-      );
+      const subscriber = state.mainPeer.onStatusChange.subscribe(() => {
+        if (!signal.aborted)
+          this.updateSyncingState(state.mainPeer, state.shadowPeers);
+      });
+      cleanUp.push(() => {
+        subscriber.unsubscribe();
+      });
 
       this.updateSyncingState(state.mainPeer, state.shadowPeers);
 
@@ -152,12 +153,13 @@ export class DocEngine {
           this.priorityTarget,
           this.logger
         );
-        cleanUp.push(
-          peer.onStatusChange.subscribe(() => {
-            if (!signal.aborted)
-              this.updateSyncingState(state.mainPeer, state.shadowPeers);
-          }).unsubscribe
-        );
+        const subscriber = peer.onStatusChange.subscribe(() => {
+          if (!signal.aborted)
+            this.updateSyncingState(state.mainPeer, state.shadowPeers);
+        });
+        cleanUp.push(() => {
+          subscriber.unsubscribe();
+        });
         return peer;
       });
 


### PR DESCRIPTION
Problem and reason:

The return value of `Subject.subscribe()` is a `Subscriber` (which extends `Subscription`). In the previous codes, `Subscriber`'s member method `unsubscribe()` was invoked with an undefined `this` context, resulting in the following error.


![图片](https://github.com/user-attachments/assets/2ddfa09c-c137-4e06-8b5b-a9bf48c2d80f)
