### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Publish npm@canary release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
         language: ['javascript']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check pull request title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: ./.github/actions/setup
 
@@ -37,7 +37,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -22,7 +22,7 @@ jobs:
       CI_JOB_NUMBER: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/sync-blocksuite.yml
+++ b/.github/workflows/sync-blocksuite.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout blocksuite Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
           git commit -m "chore: sync affine blocksuite to packages on $(date)" || exit 0
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 #v7
         with:
           token: ${{ secrets.BS_SYNC_TOKEN }}
           commit-message: 'chore: sync affine blocksuite to packages on $(date)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Install Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/size-report.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/sync-blocksuite.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/canary-release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/pr-title-lint.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/codeql-analysis.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/size-report.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/pr-title-lint.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/canary-release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/sync-blocksuite.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test.yml`
- Pinned `peter-evans/create-pull-request` from `v7` to `22a9089` in `.github/workflows/sync-blocksuite.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/codeql-analysis.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
