### PR TITLE
fix(store): unobserve Yjs listeners when BlockModel is disposed

### DIFF
--- a/packages/framework/store/src/__tests__/block.unit.spec.ts
+++ b/packages/framework/store/src/__tests__/block.unit.spec.ts
@@ -252,6 +252,35 @@ describe('block model should has signal props', () => {
   });
 });
 
+test('disposed model should not react to yjs children updates', () => {
+  const doc = createTestDoc();
+  const yDoc = new Y.Doc();
+  const yBlock = yDoc.getMap('yBlock') as YBlock;
+  yBlock.set('sys:id', '0');
+  yBlock.set('sys:flavour', 'page');
+  const yChildren = new Y.Array<string>();
+  yBlock.set('sys:children', yChildren);
+
+  const block = new Block(doc.schema, yBlock, doc);
+  const model = block.model as RootModel;
+  model.created.next();
+
+  yChildren.push(['child-a']);
+  expect(model.childMap.value.get('child-a')).toBe(0);
+
+  model.dispose();
+
+  yChildren.push(['child-b']);
+  expect(model.childMap.value.has('child-b')).toBe(false);
+  expect([...model.childMap.value.keys()]).toEqual(['child-a']);
+
+  const replaced = new Y.Array<string>();
+  replaced.push(['child-c']);
+  yBlock.set('sys:children', replaced);
+  expect(model.childMap.value.has('child-c')).toBe(false);
+  expect([...model.childMap.value.keys()]).toEqual(['child-a']);
+});
+
 test('on change', () => {
   const doc = createTestDoc();
   const yDoc = new Y.Doc();

--- a/packages/framework/store/src/model/block/block-model.ts
+++ b/packages/framework/store/src/model/block/block-model.ts
@@ -34,6 +34,8 @@ export class BlockModel<Props extends object = object> {
 
   private readonly _onDeleted: Disposable;
 
+  private _unobserveYjs: (() => void) | null = null;
+
   childMap = computed(() =>
     this._children.value.reduce((map, id, index) => {
       map.set(id, index);
@@ -116,15 +118,23 @@ export class BlockModel<Props extends object = object> {
   constructor() {
     this._onCreated = {
       dispose: this.created.pipe(take(1)).subscribe(() => {
-        this._children.value = this.yBlock.get('sys:children').toArray();
-        this.yBlock.get('sys:children').observe(event => {
+        const yChildren = this.yBlock.get('sys:children');
+        this._children.value = yChildren.toArray();
+        const onYChildren = (event: { target: { toArray: () => string[] } }) => {
           this._children.value = event.target.toArray();
-        });
-        this.yBlock.observe(event => {
+        };
+        const onYBlock = (event: { keysChanged: Set<string> }) => {
           if (event.keysChanged.has('sys:children')) {
             this._children.value = this.yBlock.get('sys:children').toArray();
           }
-        });
+        };
+        yChildren.observe(onYChildren);
+        this.yBlock.observe(onYBlock);
+        this._unobserveYjs = () => {
+          yChildren.unobserve(onYChildren);
+          this.yBlock.unobserve(onYBlock);
+          this._unobserveYjs = null;
+        };
       }).unsubscribe,
     };
     this._onDeleted = {
@@ -135,6 +145,7 @@ export class BlockModel<Props extends object = object> {
   }
 
   dispose() {
+    this._unobserveYjs?.();
     this.created.complete();
     this.deleted.complete();
     this.propsUpdated.complete();
@@ -152,6 +163,7 @@ export class BlockModel<Props extends object = object> {
   }
 
   [Symbol.dispose]() {
+    this._unobserveYjs?.();
     this._onCreated.dispose();
     this._onDeleted.dispose();
   }


### PR DESCRIPTION
## Summary

- `BlockModel` registered observers on `yBlock` and `sys:children` but never called `unobserve`. `dispose()` only completed the RxJS subjects, so deleted blocks kept reacting to Yjs updates.
- Store named observers and remove both in `dispose()` / `[Symbol.dispose]`. The existing RxJS cleanup path is unchanged.
- Fixes #9159

## Test plan

- [x] RED then GREEN: after `dispose()`, mutating `sys:children` or replacing that key no longer updates `childMap`
- [x] `packages/framework/store` unit tests — 56 passed